### PR TITLE
AS7-3051

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/servlet/ConfigurationBootstrap.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/servlet/ConfigurationBootstrap.java
@@ -87,7 +87,7 @@ abstract public class ConfigurationBootstrap implements ResteasyConfiguration
 
       String providers = getParameter(ResteasyContextParameters.RESTEASY_PROVIDERS);
 
-      if (providers != null)
+      if (providers != null && ! "".equals(providers.trim()))
       {
          String[] p = providers.split(",");
          for (String pr : p) deployment.getProviderClasses().add(pr.trim());
@@ -207,7 +207,7 @@ abstract public class ConfigurationBootstrap implements ResteasyConfiguration
 
 
       String jndiResources = getParameter(ResteasyContextParameters.RESTEASY_JNDI_RESOURCES);
-      if (jndiResources != null)
+      if (jndiResources != null && ! "".equals(jndiResources.trim()))
       {
          processJndiResources(jndiResources);
       }
@@ -219,7 +219,7 @@ abstract public class ConfigurationBootstrap implements ResteasyConfiguration
       }
 
       String resources = getParameter(ResteasyContextParameters.RESTEASY_RESOURCES);
-      if (resources != null)
+      if (resources != null && ! "".equals(resources.trim()))
       {
          processResources(resources);
       }


### PR DESCRIPTION
RESTEasy can be configured through several configuration options in WAR application deployment file WEB-INF/web.xml. These options which are type of list of fully qualified classes should accommodate also empty list as valid input. Present behavior is raising exception "java.lang.StringIndexOutOfBoundsException: String index out of range: 0", it is not so good.

Affected options are:

```
resteasy.providers
resteasy.resources
resteasy.jndi.resources
```
