### PR TITLE
https://issues.jboss.org/browse/JBPAPP-7871

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodRegistry.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodRegistry.java
@@ -1,15 +1,12 @@
 package org.jboss.resteasy.core;
 
 import org.jboss.resteasy.core.registry.RootSegment;
+import org.jboss.resteasy.logging.Logger;
 import org.jboss.resteasy.plugins.server.resourcefactory.JndiResourceFactory;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
 import org.jboss.resteasy.plugins.server.resourcefactory.SingletonResource;
 import org.jboss.resteasy.specimpl.UriBuilderImpl;
-import org.jboss.resteasy.spi.HttpRequest;
-import org.jboss.resteasy.spi.InjectorFactory;
-import org.jboss.resteasy.spi.Registry;
-import org.jboss.resteasy.spi.ResourceFactory;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.*;
 import org.jboss.resteasy.util.GetRestful;
 import org.jboss.resteasy.util.IsHttpMethod;
 import org.jboss.resteasy.util.Types;
@@ -31,6 +28,8 @@ public class ResourceMethodRegistry implements Registry
 
    protected ResteasyProviderFactory providerFactory;
    protected RootSegment rootSegment = new RootSegment();
+
+   private final static Logger logger = Logger.getLogger(ResourceMethodRegistry.class);
 
    public ResourceMethodRegistry(ResteasyProviderFactory providerFactory)
    {
@@ -124,6 +123,18 @@ public class ResourceMethodRegistry implements Registry
     	  if(!method.isSynthetic())
     		  processMethod(ref, base, clazz, method);
 
+      }
+
+      // https://issues.jboss.org/browse/JBPAPP-7871
+      for (Method method : clazz.getDeclaredMethods()) {
+           Method _method = findAnnotatedMethod(clazz, method);
+           if (_method != null) {
+               try {
+                   clazz.getMethod(_method.getName(), _method.getParameterTypes());
+               } catch (NoSuchMethodException e) {
+                   logger.warn("JAX-RS annotations found at non-public method: " + method.getDeclaringClass().getName() + "." + method.getName() + "(); Only public methods may be exposed as resource methods.");
+               }
+           }
       }
    }
 


### PR DESCRIPTION
Section 3.3.1 of JAX-RS 1.1. standard:

<cite>
3.3.1 Visibility
Only public methods may be exposed as resource methods. An implementation SHOULD warn users if a non-public method carries a method designator or @Path annotation.
</cite>
