### PR TITLE
ResponseBuilder.lastModified not handling null (630)

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResponseBuilderImpl.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResponseBuilderImpl.java
@@ -227,7 +227,11 @@ public class ResponseBuilderImpl extends Response.ResponseBuilder
    @Override
    public Response.ResponseBuilder lastModified(Date lastModified)
    {
-      if (lastModified == null) metadata.remove(HttpHeaderNames.LAST_MODIFIED);
+      if (lastModified == null)
+      {
+         metadata.remove(HttpHeaderNames.LAST_MODIFIED);
+         return this;
+      }
       metadata.putSingle(HttpHeaderNames.LAST_MODIFIED, DateUtil.formatDate(lastModified));
       return this;
    }


### PR DESCRIPTION
lastModified wasn't handling null.  It didn't return after clearing the header, and threw an exception:

java.lang.IllegalArgumentException: date is null
    at org.jboss.resteasy.util.DateUtil.formatDate(DateUtil.java:200)
    at org.jboss.resteasy.util.DateUtil.formatDate(DateUtil.java:184)
    at org.jboss.resteasy.specimpl.ResponseBuilderImpl.lastModified(ResponseBuilderImpl.java:223)

I've changed it to be like the other methods that accept null.
