### PR TITLE
resteasy-643

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodRegistry.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodRegistry.java
@@ -7,11 +7,13 @@ import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
 import org.jboss.resteasy.plugins.server.resourcefactory.SingletonResource;
 import org.jboss.resteasy.specimpl.UriBuilderImpl;
 import org.jboss.resteasy.spi.*;
+import org.jboss.resteasy.util.FindAnnotation;
 import org.jboss.resteasy.util.GetRestful;
 import org.jboss.resteasy.util.IsHttpMethod;
 import org.jboss.resteasy.util.Types;
 
 import javax.ws.rs.Path;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Set;
@@ -212,6 +214,21 @@ public class ResourceMethodRegistry implements Registry
 		Method method = findAnnotatedMethod(clazz, implementation);
 		if (method != null)
 		{
+
+            Annotation[][] paramAnnotations = method.getParameterAnnotations();
+
+            int notAnnotatedParamCount = 0;
+
+            for (Annotation[] paramAnnotation : paramAnnotations) {
+                if (FindAnnotation.findJaxRSAnnotations(paramAnnotation).length == 0) {
+                    notAnnotatedParamCount++;
+                    if (notAnnotatedParamCount > 1) {
+                        logger.warn(implementation.getDeclaringClass().getName() + "." + implementation.getName() + "(): Resource methods MUST NOT have more than one parameter that is not annotated with one of the JAX-RS Annotations.");
+                        break;
+                    }
+                }
+            }
+
 			Path path = method.getAnnotation(Path.class);
 			Set<String> httpMethods = IsHttpMethod.getHttpMethods(method);
 

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/FindAnnotation.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/FindAnnotation.java
@@ -1,10 +1,6 @@
 package org.jboss.resteasy.util;
 
-import javax.ws.rs.CookieParam;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.MatrixParam;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -30,7 +26,8 @@ public final class FindAnnotation
                    CookieParam.class,
                    PathParam.class,
                    MatrixParam.class,
-                   Context.class
+                   Context.class,
+                   FormParam.class
            };
 
    private static final Class[] findJaxRSAnnotations_TYPE = new Class[]{};


### PR DESCRIPTION
This is for trunk, if it's fine I'll submit patches for Branch_2_3. I've changed the code from:

```
if (notAnnotatedParamCount > 1) {
    logger.warn(implementation.getDeclaringClass().getName() + "." + implementation.getName() + "(): Resource methods MUST NOT have more than one parameter that is not annotated with one of the JAX-RS Annotations.");
    return;
}
```

to:

```
if (notAnnotatedParamCount > 1) {
    logger.warn(implementation.getDeclaringClass().getName() + "." + implementation.getName() + "(): Resource methods MUST NOT have more than one parameter that is not annotated with one of the JAX-RS Annotations.");
    break;
}
```

Because we have other extended annotations that will actually work correctly though it violates the spec. Such as:

```
@Suspend
@MultipartForm
@Form
```

And @MultipartForm is in multipart provider. We may also have more extended annotations in the future.
