### PR TITLE
Branch 2 3

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/executors/URLConnectionClientExecutor.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/executors/URLConnectionClientExecutor.java
@@ -36,7 +36,7 @@ public class URLConnectionClientExecutor implements ClientExecutor
       return execute(request, connection);
    }
 
-   private void setupRequest(ClientRequest request, HttpURLConnection connection)
+   protected void setupRequest(ClientRequest request, HttpURLConnection connection)
            throws ProtocolException
    {
       boolean isGet = "GET".equals(request.getHttpMethod());


### PR DESCRIPTION
Fixing the unchecked warnings and allowing child classes to modify the behavior of the setupRequest method, for example:

public class MyClientExecutor extends URLConnectionClientExecutor {

```
@Override
protected void setupRequest(ClientRequest request, HttpURLConnection connection) throws ProtocolException {

    String username = "myusername";
    String password = "mypassword";

    String authString = username + ":" + password;
    String authStringBase64 = Base64.encodeBytes(authString.getBytes());

    connection.addRequestProperty("Authorization", "Basic " + authStringBase64);

    super.setupRequest(request, connection);
}
```

}

It is very useful ;)
