### PR TITLE
RESTEASY-704

### DIFF
--- a/jaxrs/providers/resteasy-atom/src/main/java/org/jboss/resteasy/plugins/providers/atom/AtomEntryProvider.java
+++ b/jaxrs/providers/resteasy-atom/src/main/java/org/jboss/resteasy/plugins/providers/atom/AtomEntryProvider.java
@@ -63,6 +63,7 @@ public class AtomEntryProvider implements MessageBodyReader<Entry>, MessageBodyW
          JAXBContext ctx = finder.findCachedContext(Entry.class, mediaType, annotations);
          Entry entry = (Entry) ctx.createUnmarshaller().unmarshal(entityStream);
          if (entry.getContent() != null) entry.getContent().setFinder(finder);
+         entry.setFinder(finder);
          return entry;
       }
       catch (JAXBException e)
@@ -90,6 +91,10 @@ public class AtomEntryProvider implements MessageBodyReader<Entry>, MessageBodyW
       }
       HashSet<Class> set = new HashSet<Class>();
       set.add(Entry.class);
+      
+      if (entry.getAnyOtherJAXBObject() != null) {
+          set.add(entry.getAnyOtherJAXBObject().getClass());
+      }
       if (entry.getContent() != null && entry.getContent().getJAXBObject() != null)
       {
          set.add(entry.getContent().getJAXBObject().getClass());


### PR DESCRIPTION
http://tools.ietf.org/html/rfc4287#section-6.4

Defines Extension Elements

"Atom allows foreign markup anywhere in an Atom document, except where
it is explicitly forbidden. Child elements of atom:entry, atom:feed,
atom:source, and Person constructs are considered Metadata elements
and are described below. Child elements of Person constructs are
considered to apply to the construct. The role of other foreign
markup is undefined by this specification."

This patch adds support for (text|anyElement)*. This is half of the implementation of Structured Extension Elements, and is all I need at this point. I followed the same implementation as was done for the Content
Element, where the JAXB integration is very slick.

Cheers,

--Kurt
