### PR TITLE
fixed npe when stopping netty-jaxrs-server

### DIFF
--- a/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
+++ b/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
@@ -119,7 +119,7 @@ public class NettyJaxrsServer implements EmbeddedJaxrsServer
       RequestDispatcher dispatcher = new RequestDispatcher((SynchronousDispatcher)deployment.getDispatcher(), deployment.getProviderFactory(), domain);
 
       // Configure the server.
-      ServerBootstrap bootstrap = new ServerBootstrap(
+      bootstrap = new ServerBootstrap(
               new NioServerSocketChannelFactory(
                       Executors.newCachedThreadPool(),
                       Executors.newCachedThreadPool(), 


### PR DESCRIPTION
Closing the NetyyJaxrsServer gives npe because the bootstrap is not set when starting the server; this commit fixes that
