### PR TITLE
(resteasy-761) JAXB Context incomplete in AtomFeedProvider

### DIFF
--- a/jaxrs/providers/resteasy-atom/src/main/java/org/jboss/resteasy/plugins/providers/atom/AtomFeedProvider.java
+++ b/jaxrs/providers/resteasy-atom/src/main/java/org/jboss/resteasy/plugins/providers/atom/AtomFeedProvider.java
@@ -95,6 +95,10 @@ public class AtomFeedProvider implements MessageBodyReader<Feed>, MessageBodyWri
       set.add(Feed.class);
       for (Entry entry : feed.getEntries())
       {
+         if (entry.getAnyOtherJAXBObject() != null)
+         {
+            set.add(entry.getAnyOtherJAXBObject().getClass());
+         }
          if (entry.getContent() != null && entry.getContent().getJAXBObject() != null)
          {
             set.add(entry.getContent().getJAXBObject().getClass());


### PR DESCRIPTION
Include the any-other-jaxb-object class in the JAXB context for marshalling Atom Feeds.
