### PR TITLE
New protected method createConnection(...) of URLConnectionClientExecutor class

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/executors/URLConnectionClientExecutor.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/executors/URLConnectionClientExecutor.java
@@ -27,12 +27,8 @@ public class URLConnectionClientExecutor implements ClientExecutor
 
    public ClientResponse execute(ClientRequest request) throws Exception
    {
-      String uri = request.getUri();
-      String httpMethod = request.getHttpMethod();
+      HttpURLConnection connection = createConnection(request);
 
-      HttpURLConnection connection = (HttpURLConnection) new URL(uri)
-              .openConnection();
-      connection.setRequestMethod(httpMethod);
       setupRequest(request, connection);
       return execute(request, connection);
    }
@@ -88,6 +84,15 @@ public class URLConnectionClientExecutor implements ClientExecutor
       return new ClientRequest(uriBuilder, this);
    }
 
+   protected HttpURLConnection createConnection(ClientRequest request) throws Exception
+   {
+	  String uri = request.getUri();
+	  String httpMethod = request.getHttpMethod();
+
+	  HttpURLConnection connection = (HttpURLConnection) new URL(uri).openConnection();
+	  connection.setRequestMethod(httpMethod);
+	  return connection;
+   }
 
    private ClientResponse execute(ClientRequest request, final HttpURLConnection connection) throws IOException
    {


### PR DESCRIPTION
Giving the chance to override the connection creation. This patch could be applied on 2.3 branch too.
