### PR TITLE
Netty Http Chunk Aggregator must come before the RESTEasy Http Decoder.

### DIFF
--- a/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/HttpServerPipelineFactory.java
+++ b/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/HttpServerPipelineFactory.java
@@ -54,10 +54,9 @@ public class HttpServerPipelineFactory implements ChannelPipelineFactory
       ChannelPipeline pipeline = pipeline();
 
       pipeline.addLast("decoder", new HttpRequestDecoder());
-      pipeline.addLast("resteasyDecoder", resteasyDecoder);
-      
       pipeline.addLast("aggregator", new HttpChunkAggregator(maxRequestSize));
-      
+      pipeline.addLast("resteasyDecoder", resteasyDecoder);
+
       pipeline.addLast("encoder", new HttpResponseEncoder());
       pipeline.addLast("resteasyEncoder", resteasyEncoder);
 


### PR DESCRIPTION
Like the description says. Currently if you send a large http request to RESTEasy it will fail "with received HttpChunk without HttpMessage". Putting the aggregator before RESTEasy solves the problem.
