### PR TITLE
Interceptors marked with an @NameBinding should only be applied to Resource methods with the same @NameBinding

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/JaxrsInterceptorRegistry.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/JaxrsInterceptorRegistry.java
@@ -6,6 +6,7 @@ import org.jboss.resteasy.spi.interception.AcceptedByMethod;
 import javax.ws.rs.BindingPriority;
 import javax.ws.rs.NameBinding;
 import javax.ws.rs.container.PreMatching;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Array;
@@ -48,10 +49,7 @@ public class JaxrsInterceptorRegistry<T>
       {
          if (annotation.annotationType().isAnnotationPresent(NameBinding.class))
          {
-            if (nameBound == null)
-            {
-               nameBound.add(annotation.annotationType());
-            }
+             nameBound.add(annotation.annotationType());
          }
       }
       return nameBound;

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/core/interception/JaxrsInterceptorRegistryTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/core/interception/JaxrsInterceptorRegistryTest.java
@@ -1,0 +1,77 @@
+package org.jboss.resteasy.test.core.interception;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.Assert.assertEquals;
+
+import org.jboss.resteasy.core.interception.JaxrsInterceptorRegistry;
+import org.junit.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.NameBinding;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.ext.Provider;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JaxrsInterceptorRegistryTest
+{
+
+    @NameBinding
+    @Retention(RUNTIME)
+    public static @interface JaxrsInterceptorRegistryTestNameBinding {
+        
+    }
+    
+    @JaxrsInterceptorRegistryTestNameBinding
+    @Provider
+    public static class JaxrsInterceptorRegistryTestFilter implements ContainerRequestFilter {
+        @Override
+        public void filter(ContainerRequestContext requestContext) throws IOException
+        {
+
+        }
+    }
+    
+    @Path("/")
+    public static class JaxrsInterceptorRegistryTestResource {
+        
+        @JaxrsInterceptorRegistryTestNameBinding
+        @GET
+        public void get() {
+            
+        }
+    }
+
+    @Test
+    public void shouldUseNameBindingAnnotation() throws Exception {
+        final List<Class<? extends Annotation>> bound = new ArrayList<Class<? extends Annotation>>();
+        JaxrsInterceptorRegistry<JaxrsInterceptorRegistryTestFilter> jaxrsInterceptorRegistry = new JaxrsInterceptorRegistry<JaxrsInterceptorRegistryTestFilter>(null, JaxrsInterceptorRegistryTestFilter.class);
+        jaxrsInterceptorRegistry.new AbstractInterceptorFactory(JaxrsInterceptorRegistryTestFilter.class)
+        {
+            {
+                setPrecedence(JaxrsInterceptorRegistryTestFilter.class);
+                bound.addAll(nameBound);
+            }
+
+            @Override
+            protected void initialize()
+            {
+                
+            }
+
+            @Override
+            protected Object getInterceptor()
+            {
+                return null;
+            }
+        };
+        
+        assertEquals(JaxrsInterceptorRegistryTestNameBinding.class, bound.get(0));
+    }
+}


### PR DESCRIPTION
The nameBound list was not being populated, so interceptors with a @NameBinding were applied globally.
