### PR TITLE
RESTEASY 809: Guice servlet context listener inheritance

### DIFF
--- a/jaxrs/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/GuiceResteasyBootstrapServletContextListener.java
+++ b/jaxrs/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/GuiceResteasyBootstrapServletContextListener.java
@@ -54,7 +54,7 @@ public class GuiceResteasyBootstrapServletContextListener extends ResteasyBootst
       }
    }
 
-   private List<Module> getModules(final ServletContext context)
+   protected List<Module> getModules(final ServletContext context)
    {
       final List<Module> result = new ArrayList<Module>();
       final String modulesString = context.getInitParameter("resteasy.guice.modules");


### PR DESCRIPTION
Allow inheritance of the listener so inherited classes will be able to add modules initialized by their own way, for example with parameters in constructor.
