### PR TITLE
Upgrades Netty to 3.6.3.Final

### DIFF
--- a/jaxrs/server-adapters/resteasy-netty/pom.xml
+++ b/jaxrs/server-adapters/resteasy-netty/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
-            <version>3.4.4.Final</version>
+            <version>3.6.3.Final</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Hi,

I've just upgraded Netty to its latest version, thought it could be nice to benefit from many bug fixes since 3.4.4.Final. (I've encountered one, with Channel not properly closed)

Cheers,
