### PR TITLE
Check for & run @PostConstruct and @PreDestroy methods on Reasteasy-Guice modules

### DIFF
--- a/jaxrs/resteasy-guice/pom.xml
+++ b/jaxrs/resteasy-guice/pom.xml
@@ -40,6 +40,11 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>jsr250-api</artifactId>
+            <version>1.0</version>
+        </dependency>
         <!--
         <dependency>
            <groupId>tjws</groupId>

--- a/jaxrs/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/GuiceResteasyBootstrapServletContextListener.java
+++ b/jaxrs/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/GuiceResteasyBootstrapServletContextListener.java
@@ -7,15 +7,22 @@ import org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap;
 import org.jboss.resteasy.spi.Registry;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
 public class GuiceResteasyBootstrapServletContextListener extends ResteasyBootstrap implements ServletContextListener
 {
    private final static Logger logger = Logger.getLogger(GuiceResteasyBootstrapServletContextListener.class);
+
+   private List<Module> modules;
 
    public void contextInitialized(final ServletContextEvent event)
    {
@@ -34,6 +41,8 @@ public class GuiceResteasyBootstrapServletContextListener extends ResteasyBootst
       {
          processor.process(stage, modules);
       }
+      this.modules = modules;
+      triggerAnnotatedMethods(this.modules, PostConstruct.class);
    }
 
    private Stage getStage(ServletContext context)
@@ -90,5 +99,33 @@ public class GuiceResteasyBootstrapServletContextListener extends ResteasyBootst
 
    public void contextDestroyed(final ServletContextEvent event)
    {
+      triggerAnnotatedMethods(this.modules, PreDestroy.class);
+   }
+
+   private void triggerAnnotatedMethods(final List<Module> modules, final Class<? extends Annotation> annotationClass)
+   {
+      for (Module module : this.modules)
+      {
+         final Method[] methods = module.getClass().getMethods();
+         for (Method method : methods)
+         {
+            if (method.isAnnotationPresent(annotationClass))
+            {
+               if(method.getParameterTypes().length > 0)
+               {
+                  logger.warn("Cannot execute expected module {}'s @{} method {} because it has unexpected parameters: skipping.", module.getClass().getSimpleName(), annotationClass.getSimpleName(), method.getName());
+                  continue;
+               }
+               try
+               {
+                  method.invoke(module);
+               } catch (InvocationTargetException ex) {
+                  logger.warn("Problem running annotation method @" + annotationClass.getSimpleName(), ex);
+               } catch (IllegalAccessException ex) {
+                  logger.warn("Problem running annotation method @" + annotationClass.getSimpleName(), ex);
+               }
+            }
+         }
+      }
    }
 }


### PR DESCRIPTION
JSR250 specifies common annotations; look for use of it's `@PostConstruct` and `@PreDestroy` annotations on methods in Guice Modules in resteasy-guice and fire them off at the end of `GuiceResteasyBootstrapServletContextListener.contextInitalized` and `GuiceResteasyBootstrapServletContextListener.contextDestroyed`.

This will allow Guice modules to perform cleanup when the servlet context is destroyed. 
