### PR TITLE
Bugfix: QueryParam values are no longer truncated as soon as a = appears

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyUriInfo.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyUriInfo.java
@@ -244,7 +244,7 @@ public class ResteasyUriInfo implements UriInfo
       {
          if (param.indexOf('=') >= 0)
          {
-            String[] nv = param.split("=",2);
+            String[] nv = param.split("=", 2);
             try
             {
                String name = URLDecoder.decode(nv[0], "UTF-8");


### PR DESCRIPTION
https://issues.jboss.org/browse/RESTEASY-820 bugfix
