### PR TITLE
ServerResponse not setting entityClass

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ServerResponse.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ServerResponse.java
@@ -14,7 +14,7 @@ public class ServerResponse extends BuiltResponse
 
    public ServerResponse(Object entity, int status, Headers<Object> metadata)
    {
-      this.entity = entity;
+      this.setEntity(entity);
       this.status = status;
       this.metadata = metadata;
    }


### PR DESCRIPTION
The constructor of ServerResponse that takes an entity as an argument
doesn't set the entityClass.
