### PR TITLE
Fix NPE in OAuthFilter when required OAuth params are not passed in

### DIFF
--- a/jaxrs/security/resteasy-oauth/src/main/java/org/jboss/resteasy/auth/oauth/OAuthUtils.java
+++ b/jaxrs/security/resteasy-oauth/src/main/java/org/jboss/resteasy/auth/oauth/OAuthUtils.java
@@ -121,7 +121,7 @@ public class OAuthUtils {
 		resp.getWriter().append(message);
 		resp.setStatus(httpCode);
 		String headerValue = "OAuth";
-		if (provider.getRealm() != null && provider.getRealm().length() > 0) {
+		if (provider != null && provider.getRealm() != null && provider.getRealm().length() > 0) {
 		    headerValue += (" realm=\"" + provider.getRealm() + "\"");
 		}
 		resp.setHeader(AUTHENTICATE_HEADER, headerValue);


### PR DESCRIPTION
If all required OAuth parameters are not passed in to a REST api that is mapped with the OAuth filter, an OAuthProblemException is thrown. Since the provider has not been loaded yet a NPE occurs in OAuthUtils.makeErrorResponse on the call to provider.getRealm();
