### PR TITLE
Allow external code to startup RestEasy within Netty

### DIFF
--- a/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpRequestDecoder.java
+++ b/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpRequestDecoder.java
@@ -30,7 +30,7 @@ public class RestEasyHttpRequestDecoder extends OneToOneDecoder
     private final String servletMappingPrefix;
     private final String proto;
     
-    enum Protocol 
+    public enum Protocol 
     {
         HTTPS,
         HTTP


### PR DESCRIPTION
Leaving Protocol non-public prevent RestEasyHttpRequestDecoder to be instanciable and then prevent anyone wanting to create it own startup class with it's own ChannelHandler to use ReatEasy in Netty
