### PR TITLE
filename support

### DIFF
--- a/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/AbstractMultipartFormDataWriter.java
+++ b/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/AbstractMultipartFormDataWriter.java
@@ -28,9 +28,19 @@ public class AbstractMultipartFormDataWriter extends AbstractMultipartWriter {
 				continue;
 			MultivaluedMap<String, Object> headers = new MultivaluedMapImpl<String, Object>();
 			headers.putSingle("Content-Disposition", "form-data; name=\""
-					+ entry.getKey() + "\"");
+					+ entry.getKey() + "\""
+					+ getFilename(entry.getValue()));
 			writePart(entityStream, boundaryBytes, entry.getValue(), headers);
 		}
 
 	}
+	
+	private String getFilename(OutputPart part) {
+		String filename = part.getFilename(); 
+		if (filename == null) {
+			return "";
+		} else {
+			return "; filename=\"" + filename + "\"";
+		}
+	}	
 }

--- a/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartFormDataOutput.java
+++ b/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartFormDataOutput.java
@@ -21,6 +21,13 @@ public class MultipartFormDataOutput extends MultipartOutput
       formData.put(key, part);
       return part;
    }
+   
+   public OutputPart addFormData(String key, Object entity, MediaType mediaType, String filename)
+   {
+      OutputPart part = super.addPart(entity, mediaType, filename);
+      formData.put(key, part);
+      return part;
+   }   
 
    public OutputPart addFormData(String key, Object entity, GenericType<?> type, MediaType mediaType)
    {
@@ -28,6 +35,13 @@ public class MultipartFormDataOutput extends MultipartOutput
       formData.put(key, part);
       return part;
    }
+   
+   public OutputPart addFormData(String key, Object entity, GenericType<?> type, MediaType mediaType, String filename)
+   {
+      OutputPart part = super.addPart(entity, type, mediaType, filename);
+      formData.put(key, part);
+      return part;
+   }   
 
    public OutputPart addFormData(String key, Object entity, Class<?> type, Type genericType, MediaType mediaType)
    {
@@ -35,6 +49,13 @@ public class MultipartFormDataOutput extends MultipartOutput
       formData.put(key, part);
       return part;
    }
+   
+   public OutputPart addFormData(String key, Object entity, Class<?> type, Type genericType, MediaType mediaType, String filename)
+   {
+      OutputPart part = super.addPart(entity, type, genericType, mediaType, filename);
+      formData.put(key, part);
+      return part;
+   }   
 
    public Map<String, OutputPart> getFormData()
    {

--- a/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartOutput.java
+++ b/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartOutput.java
@@ -24,6 +24,13 @@ public class MultipartOutput
       parts.add(outputPart);
       return outputPart;
    }
+   
+   public OutputPart addPart(Object entity, MediaType mediaType, String filename)
+   {
+      OutputPart outputPart = new OutputPart(entity, entity.getClass(), null, mediaType, filename);
+      parts.add(outputPart);
+      return outputPart;
+   }   
 
    public OutputPart addPart(Object entity, GenericType<?> type, MediaType mediaType)
    {
@@ -31,6 +38,13 @@ public class MultipartOutput
       parts.add(outputPart);
       return outputPart;
    }
+   
+   public OutputPart addPart(Object entity, GenericType<?> type, MediaType mediaType, String filename)
+   {
+      OutputPart outputPart = new OutputPart(entity, type.getType(), type.getGenericType(), mediaType, filename);
+      parts.add(outputPart);
+      return outputPart;
+   }   
 
    public OutputPart addPart(Object entity, Class<?> type, Type genericType, MediaType mediaType)
    {
@@ -38,6 +52,13 @@ public class MultipartOutput
       parts.add(outputPart);
       return outputPart;
    }
+   
+   public OutputPart addPart(Object entity, Class<?> type, Type genericType, MediaType mediaType, String filename)
+   {
+      OutputPart outputPart = new OutputPart(entity, type, genericType, mediaType, filename);
+      parts.add(outputPart);
+      return outputPart;
+   }   
 
    public List<OutputPart> getParts()
    {

--- a/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/OutputPart.java
+++ b/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/OutputPart.java
@@ -17,13 +17,20 @@ public class OutputPart
    private Class<?> type;
    private Type genericType;
    private MediaType mediaType;
-
+   private String filename;
+   
    public OutputPart(Object entity, Class<?> type, Type genericType, MediaType mediaType)
+   {
+	   this(entity, type, genericType, mediaType, null);
+   }
+
+   public OutputPart(Object entity, Class<?> type, Type genericType, MediaType mediaType, String filename)
    {
       this.entity = entity;
       this.type = type;
       this.genericType = genericType;
       this.mediaType = mediaType;
+      this.filename = filename;
    }
 
    public MultivaluedMap<String, Object> getHeaders()
@@ -49,5 +56,10 @@ public class OutputPart
    public MediaType getMediaType()
    {
       return mediaType;
+   }
+   
+   public String getFilename() 
+   {
+	   return filename;
    }
 }


### PR DESCRIPTION
The answer in
http://stackoverflow.com/questions/10808246/resteasy-client-framework-file-upload
shows how to make file uploads with Resteasy client framework.

The problems is that Resteasy does not let us set the filename parameter
value. This problem has been talked about in
https://community.jboss.org/message/615095?tstart=0 and
http://sourceforge.net/mailarchive/message.php?msg_id=28164081.

The following modifications let the filename parameter value to be set
by the user and this value will be sent in the content-disposition
header of the multipart/form-data request.
