### PR TITLE
Guice module can be configured via Injector

### DIFF
--- a/jaxrs/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/GuiceInjectorResteasyBootstrapServletContextListener.java
+++ b/jaxrs/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/GuiceInjectorResteasyBootstrapServletContextListener.java
@@ -1,0 +1,27 @@
+package org.jboss.resteasy.plugins.guice;
+
+import com.google.inject.Injector;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap;
+import org.jboss.resteasy.spi.Registry;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+public abstract class GuiceInjectorResteasyBootstrapServletContextListener extends ResteasyBootstrap implements ServletContextListener
+{
+   protected abstract Injector getInjector();
+
+   @Override
+   public void contextInitialized(final ServletContextEvent event)
+   {
+      super.contextInitialized(event);
+      final ServletContext context = event.getServletContext();
+      final Registry registry = (Registry) context.getAttribute(Registry.class.getName());
+      final ResteasyProviderFactory providerFactory = (ResteasyProviderFactory) context.getAttribute(ResteasyProviderFactory.class.getName());
+      final ModuleProcessor processor = new ModuleProcessor(registry, providerFactory);
+      processor.processInjector(getInjector());
+   }
+}

--- a/jaxrs/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/ModuleProcessor.java
+++ b/jaxrs/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/ModuleProcessor.java
@@ -5,14 +5,16 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Stage;
+
 import org.jboss.resteasy.logging.Logger;
 import org.jboss.resteasy.spi.Registry;
 import org.jboss.resteasy.spi.ResourceFactory;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.util.GetRestful;
 
-import javax.ws.rs.ext.Provider;
 import java.lang.reflect.Type;
+
+import javax.ws.rs.ext.Provider;
 
 public class ModuleProcessor
 {
@@ -51,7 +53,7 @@ public class ModuleProcessor
       processInjector(injector);
    }
 
-   private void processInjector(final Injector injector)
+   public void processInjector(final Injector injector)
    {
       for (final Binding<?> binding : injector.getBindings().values())
       {


### PR DESCRIPTION
Let me know if there are things you want me to change. If not, I'll add JavaDoc and update the documentation.

I added a GuiceInjectorResteasyBootstrapServletContextListener that allows the user to create their own Injector, rather than simply pass in a list of Module class names.

The user extends the new class, implements the abstract getInjector() method and registers their listener instead of GuiceResteasyBootstrapServletContextListener, much like Guice-Servlet's ServletContextListener. This allows for more sophisticated Guice configuration.

My usecase was using Guice-Persist, in which the JpaPersistModule's constructor takes a String. I considered simply adding a dedicated configuration option, but that would not allow for multiple persistence units.
