### PR TITLE
Added request scope to Guice module.

### DIFF
--- a/jaxrs/docbook/reference/en/en-US/modules/Guice.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/Guice.xml
@@ -67,6 +67,29 @@ public class HelloModule implements Module
     resteasy.guice.modules context-param.  This can take a comma delimited list of class names that
     are Guice Modules.</para>
     <section>
+      <title>Request Scope</title>
+      <para>
+        The Guice integration allows objects to be scoped to the HTTP request by adding the @RequestScoped annotation to your class.
+        All the objects injectable via the @Context annotation are also injectable, except ServletConfig and ServletContext.
+      </para>
+<programlisting>
+<![CDATA[
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Context;
+
+import org.jboss.resteasy.plugins.guice.RequestScoped;
+
+@RequestScoped
+public class MyClass
+{
+    @Inject @Context
+    private HttpRequest request;
+}
+]]>
+</programlisting>
+    </section>
+    <section>
         <title>Configuring Stage</title>
         <para>
             You can configure the stage Guice uses to deploy your modules by specific a context param, resteasy.guice.stage.

--- a/jaxrs/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/RequestScoped.java
+++ b/jaxrs/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/RequestScoped.java
@@ -1,0 +1,15 @@
+package org.jboss.resteasy.plugins.guice;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.inject.Scope;
+
+/**
+ * Provides an instance-per-request.
+ */
+@Scope
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequestScoped
+{
+}

--- a/jaxrs/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/ext/RequestScopeModule.java
+++ b/jaxrs/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/ext/RequestScopeModule.java
@@ -1,0 +1,82 @@
+package org.jboss.resteasy.plugins.guice.ext;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Key;
+import com.google.inject.Provider;
+import com.google.inject.Scope;
+
+import org.jboss.resteasy.plugins.guice.RequestScoped;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * Binds the {@link RequestScoped} to the current HTTP request and
+ * makes all the classes available via the {@link Context} annotation injectable.
+ */
+public class RequestScopeModule extends AbstractModule
+{
+   @Override
+   protected void configure()
+   {
+      bindScope(RequestScoped.class, new Scope()
+      {
+         @Override
+         public <T> Provider<T> scope(final Key<T> key, final Provider<T> creator)
+         {
+            return new Provider<T>()
+            {
+               @SuppressWarnings("unchecked")
+               @Override
+               public T get()
+               {
+                  Class<T> instanceClass = (Class<T>) key.getTypeLiteral().getType();
+                  T instance = ResteasyProviderFactory.getContextData(instanceClass);
+
+                  if (instance == null) {
+                     instance = creator.get();
+                     ResteasyProviderFactory.pushContext(instanceClass, instance);
+                  }
+
+                  return instance;
+               }
+
+               @Override
+               public String toString() {
+                  return String.format("%s[%s]", creator, this);
+               }
+            };
+         }
+      });
+
+      bind(HttpServletRequest.class).toProvider(new ResteasyContextProvider<HttpServletRequest>(HttpServletRequest.class)).in(RequestScoped.class);
+      bind(HttpServletResponse.class).toProvider(new ResteasyContextProvider<HttpServletResponse>(HttpServletResponse.class)).in(RequestScoped.class);
+      bind(Request.class).toProvider(new ResteasyContextProvider<Request>(Request.class)).in(RequestScoped.class);
+      bind(HttpHeaders.class).toProvider(new ResteasyContextProvider<HttpHeaders>(HttpHeaders.class)).in(RequestScoped.class);
+      bind(UriInfo.class).toProvider(new ResteasyContextProvider<UriInfo>(UriInfo.class)).in(RequestScoped.class);
+      bind(SecurityContext.class).toProvider(new ResteasyContextProvider<SecurityContext>(SecurityContext.class)).in(RequestScoped.class);
+//      bind(ServletConfig.class).toProvider(new ResteasyContextProvider<ServletConfig>(ServletConfig.class)).in(Singleton.class);
+//      bind(ServletContext.class).toProvider(new ResteasyContextProvider<ServletContext>(ServletContext.class)).in(Singleton.class);
+   }
+
+   private static class ResteasyContextProvider<T> implements Provider<T> {
+
+      private final Class<T> instanceClass;
+
+      public ResteasyContextProvider(Class<T> instanceClass)
+      {
+         this.instanceClass = instanceClass;
+      }
+
+      @Override
+      public T get() {
+         return ResteasyProviderFactory.getContextData(instanceClass);
+      }
+   }
+}

--- a/jaxrs/resteasy-guice/src/test/java/org/jboss/resteasy/plugins/guice/ext/RequestScopeModuleTest.java
+++ b/jaxrs/resteasy-guice/src/test/java/org/jboss/resteasy/plugins/guice/ext/RequestScopeModuleTest.java
@@ -1,0 +1,103 @@
+package org.jboss.resteasy.plugins.guice.ext;
+
+import static org.jboss.resteasy.test.TestPortProvider.generateBaseUrl;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+import org.jboss.resteasy.client.ProxyFactory;
+import org.jboss.resteasy.core.Dispatcher;
+import org.jboss.resteasy.plugins.guice.ModuleProcessor;
+import org.jboss.resteasy.test.EmbeddedContainer;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class RequestScopeModuleTest
+{
+   private static Dispatcher dispatcher;
+
+   @BeforeClass
+   public static void beforeClass() throws Exception
+   {
+      dispatcher = EmbeddedContainer.start().getDispatcher();
+   }
+
+   @AfterClass
+   public static void afterClass() throws Exception
+   {
+      EmbeddedContainer.stop();
+   }
+
+   @Test
+   public void testInjection()
+   {
+      final Module module = new Module()
+      {
+         @Override
+         public void configure(final Binder binder)
+         {
+            binder.bind(TestResource.class).to(RequestScopeTestResource.class);
+         }
+      };
+      final ModuleProcessor processor = new ModuleProcessor(dispatcher.getRegistry(), dispatcher.getProviderFactory());
+      processor.process(module, new RequestScopeModule());
+      final TestResource resource = ProxyFactory.create(TestResource.class, generateBaseUrl());
+      Assert.assertEquals("ok", resource.getName());
+      dispatcher.getRegistry().removeRegistrations(TestResource.class);
+   }
+
+   @Path("test")
+   public interface TestResource
+   {
+      @GET
+      public String getName();
+   }
+
+   public static class RequestScopeTestResource implements TestResource
+   {
+      private final HttpServletRequest httpServletRequest;
+      private final HttpServletResponse httpServletResponse;
+      private final Request request;
+      private final HttpHeaders httpHeaders;
+      private final UriInfo uriInfo;
+      private final SecurityContext securityContext;
+
+      @Inject
+      public RequestScopeTestResource(HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse, Request request,
+            HttpHeaders httpHeaders, UriInfo uriInfo, SecurityContext securityContext)
+      {
+         this.httpServletRequest = httpServletRequest;
+         this.httpServletResponse = httpServletResponse;
+         this.request = request;
+         this.httpHeaders = httpHeaders;
+         this.uriInfo = uriInfo;
+         this.securityContext = securityContext;
+      }
+
+      @Override
+      public String getName()
+      {
+         Assert.assertNotNull(httpServletRequest);
+         Assert.assertNotNull(httpServletResponse);
+         Assert.assertNotNull(request);
+         Assert.assertNotNull(httpHeaders);
+         Assert.assertNotNull(uriInfo);
+         Assert.assertNotNull(securityContext);
+         return "ok";
+      }
+   }
+}


### PR DESCRIPTION
Adds @RequestScoped and RequestScopeModule, which provides the classes usually obtained with @Context in resource methods.

However, ServletContext and ServletConfig aren't injectable because I can't figure out how to get a hold of the Dispatcher's default context objects map, where they seem to be stored. Any pointers?
