### PR TITLE
Fixing occasional failures in ClientCacheTest, TestStats and TJWSServletServerTest 

### DIFF
--- a/jaxrs/providers/jaxb/src/test/java/org/jboss/resteasy/test/TestStats.java
+++ b/jaxrs/providers/jaxb/src/test/java/org/jboss/resteasy/test/TestStats.java
@@ -1,5 +1,8 @@
 package org.jboss.resteasy.test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import junit.framework.Assert;
 import org.jboss.resteasy.client.ProxyFactory;
 import org.jboss.resteasy.plugins.stats.DeleteResourceMethod;
@@ -21,6 +24,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import org.jboss.resteasy.plugins.stats.ResourceMethodEntry;
 
 import static org.jboss.resteasy.test.TestPortProvider.generateBaseUrl;
 
@@ -87,8 +91,9 @@ public class TestStats extends BaseResourceTest {
         for (RegistryEntry entry : data.getEntries()) {
             if (entry.getUriTemplate().equals("/entry/{foo:.*}")) {
                 Assert.assertEquals(2, entry.getMethods().size());
-                //Assert.assertTrue(entry.getMethods().get(0) instanceof PutResourceMethod);
-                //Assert.assertTrue(entry.getMethods().get(1) instanceof PostResourceMethod);
+                List<Class> prepareRequiredTypes = prepareRequiredTypes(PostResourceMethod.class, PutResourceMethod.class);
+                Assert.assertTrue(testMethodTypes(entry.getMethods().get(0), prepareRequiredTypes));
+                Assert.assertTrue(testMethodTypes(entry.getMethods().get(1), prepareRequiredTypes));
                 found = true;
                 break;
             }
@@ -98,8 +103,9 @@ public class TestStats extends BaseResourceTest {
         for (RegistryEntry entry : data.getEntries()) {
             if (entry.getUriTemplate().equals("/resource")) {
                 Assert.assertEquals(2, entry.getMethods().size());
-                //Assert.assertTrue(entry.getMethods().get(0) instanceof DeleteResourceMethod);
-                //Assert.assertTrue(entry.getMethods().get(1) instanceof HeadResourceMethod);
+                List<Class> prepareRequiredTypes = prepareRequiredTypes(HeadResourceMethod.class, DeleteResourceMethod.class);
+                Assert.assertTrue(testMethodTypes(entry.getMethods().get(0), prepareRequiredTypes));
+                Assert.assertTrue(testMethodTypes(entry.getMethods().get(1), prepareRequiredTypes));
                 found = true;
                 break;
             }
@@ -125,5 +131,18 @@ public class TestStats extends BaseResourceTest {
         }
         Assert.assertTrue(found);
 
+    }
+    
+    private boolean testMethodTypes(ResourceMethodEntry entry, List<Class> types) {
+        if (types.contains(entry.getClass())) {
+            types.remove(entry.getClass());
+            return true;
+        } else {
+            return false;
+        }
+    }
+    
+    private List<Class> prepareRequiredTypes(Class... types) {
+        return Arrays.asList(types);
     }
 }

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/plugins/server/tjws/TJWSServletServerTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/plugins/server/tjws/TJWSServletServerTest.java
@@ -13,6 +13,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 
 public class TJWSServletServerTest
@@ -59,8 +60,9 @@ public class TJWSServletServerTest
    public void testFile() throws Exception
    {
       URL root = getClass().getClassLoader().getResource(".");
+      URI uri = new URI(root.getFile());
 
-      server.server.addFileMapping("/", new File(root.getFile()));
+      server.server.addFileMapping("/", new File(uri.getPath()));
       server.start();
 
       checkText("/test.txt", "Hello, World!");

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/client/cache/ClientCacheTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/client/cache/ClientCacheTest.java
@@ -105,6 +105,7 @@ public class ClientCacheTest extends BaseResourceTest
    {
       @GET
       @Produces("text/plain")
+      @Cache(maxAge = 2)
       public String get();
 
       @Path("/etag/always/good")
@@ -148,6 +149,8 @@ public class ClientCacheTest extends BaseResourceTest
    {
       MyProxy proxy = ProxyFactory.create(MyProxy.class, generateBaseUrl());
       CacheFactory.makeCacheable(proxy);
+      
+      count = 0;
       String rtn = null;
       rtn = proxy.get();
       Assert.assertEquals("hello world" + 1, rtn);


### PR DESCRIPTION
These issues are reported on JIRA as:

RESTEASY-859, RESTEASY-860, RESTEASY-861

with explanations and patches
