### PR TITLE
Range and Content-Range headers must start with "bytes"

### DIFF
--- a/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/resource/RangeTest.java
+++ b/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/resource/RangeTest.java
@@ -100,7 +100,7 @@ public class RangeTest extends BaseResourceTest
    public void testRange0to3()
    {
       Response response = client.target(generateURL("/file")).request()
-              .header("Range", "0-3").get();
+              .header("Range", "bytes=0-3").get();
       Assert.assertEquals(response.getStatus(), 206);
       Assert.assertEquals(4, response.getLength());
       System.out.println("Content-Range: " + response.getHeaderString("Content-Range"));
@@ -112,7 +112,7 @@ public class RangeTest extends BaseResourceTest
    public void testRange1to4()
    {
       Response response = client.target(generateURL("/file")).request()
-              .header("Range", "1-4").get();
+              .header("Range", "bytes=1-4").get();
       Assert.assertEquals(response.getStatus(), 206);
       Assert.assertEquals(4, response.getLength());
       System.out.println("Content-Range: " + response.getHeaderString("Content-Range"));
@@ -124,7 +124,7 @@ public class RangeTest extends BaseResourceTest
    public void testRange0to3000()
    {
       Response response = client.target(generateURL("/file")).request()
-              .header("Range", "0-3000").get();
+              .header("Range", "bytes=0-3000").get();
       Assert.assertEquals(response.getStatus(), 206);
       Assert.assertEquals(3001, response.getLength());
       System.out.println("Content-Range: " + response.getHeaderString("Content-Range"));
@@ -137,7 +137,7 @@ public class RangeTest extends BaseResourceTest
    public void testNegative4()
    {
       Response response = client.target(generateURL("/file")).request()
-              .header("Range", "-4").get();
+              .header("Range", "bytes=-4").get();
       Assert.assertEquals(response.getStatus(), 206);
       Assert.assertEquals(4, response.getLength());
       System.out.println("Content-Range: " + response.getHeaderString("Content-Range"));
@@ -149,7 +149,7 @@ public class RangeTest extends BaseResourceTest
    public void testNegative6000()
    {
       Response response = client.target(generateURL("/file")).request()
-              .header("Range", "-6000").get();
+              .header("Range", "bytes=-6000").get();
       Assert.assertEquals(response.getStatus(), 200);
       response.close();
    }

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/FileProvider.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/FileProvider.java
@@ -124,6 +124,14 @@ public class FileProvider implements MessageBodyReader<File>,
          return;
       }
       range = range.trim();
+      int byteUnit = range.indexOf("bytes=");
+      if ( byteUnit < 0)
+      {
+    	  //must start with 'bytes'
+          writeIt(uploadFile, entityStream);
+          return;
+      }
+      range = range.substring("bytes=".length());
       if (range.indexOf(',') > -1)
       {
          // we don't support this

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/FileRangeWriter.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/FileRangeWriter.java
@@ -32,7 +32,7 @@ public class FileRangeWriter implements MessageBodyWriter<FileRange>
    public void writeTo(FileRange fileRange, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException
    {
       long fileSize = fileRange.getFile().length();
-      String contentRange = fileRange.getBegin() + "-" + fileRange.getEnd() + "/" + fileSize;
+      String contentRange = "bytes " + fileRange.getBegin() + "-" + fileRange.getEnd() + "/" + fileSize;
       long length = (fileRange.getEnd() - fileRange.getBegin()) + 1;
       httpHeaders.putSingle("Content-Range", contentRange);
       httpHeaders.putSingle("Content-Length", length);


### PR DESCRIPTION
The sent/parsed values for [Content-Range](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.16) and [Range](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35) are not valid, causing the whole file to always be sent (clients will send through a value of bytes=0-499 resulting in a number format exception).

Content-Type should be:
`byte-content-range-spec = bytes-unit SP byte-range-resp-spec "/" ( instance-length | "*" )`

Range should be:
`byte-ranges-specifier = bytes-unit "=" byte-range-set`

Where [bytes-unit](http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.12) is "bytes".
