### PR TITLE
eagledns fix to compile with JDK 1.7

### DIFF
--- a/eagledns/src/main/java/se/unlogic/standardutils/dao/SimpleDataSource.java
+++ b/eagledns/src/main/java/se/unlogic/standardutils/dao/SimpleDataSource.java
@@ -11,6 +11,8 @@ import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
 
 import javax.sql.DataSource;
 
@@ -69,4 +71,8 @@ public class SimpleDataSource implements DataSource {
 	public <T> T unwrap(Class<T> arg0) throws SQLException {
 		return null;
 	}
+
+	public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+		return null;
+	} 
 }


### PR DESCRIPTION
Upstream fix tracked in https://issues.jboss.org/browse/RESTEASY-835, part of https://github.com/resteasy/Resteasy/commit/0f3a897ebdf3760e2e11453bb9a717c6bdcc5414 commit
