### PR TITLE
Fixed condition for response filter iteration.

### DIFF
--- a/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
+++ b/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
@@ -389,7 +389,7 @@ public class ClientInvocation implements Invocation
          response.setProperties(configuration.getMutableProperties());
 
          ClientResponseFilter[] responseFilters = getResponseFilters();
-         if (requestFilters != null && requestFilters.length > 0)
+         if (responseFilters != null && responseFilters.length > 0)
          {
             ClientResponseContextImpl responseContext = new ClientResponseContextImpl(response);
             for (ClientResponseFilter filter : responseFilters)


### PR DESCRIPTION
The pre response filter iteration condition was against the requestFilters variable, not the resposeFIlters.

This could result in NullPointerException later on.

Moreover, if one will not set request filters, no response filters will be applied.
