### PR TITLE
[RESTEASY-881]

### DIFF
--- a/jaxrs/jboss-modules/build-wf8.xml
+++ b/jaxrs/jboss-modules/build-wf8.xml
@@ -92,6 +92,7 @@
         <module-def name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider">
             <maven-resource group="com.fasterxml.jackson.jaxrs" artifact="jackson-jaxrs-json-provider"/>
             <maven-resource group="com.fasterxml.jackson.jaxrs" artifact="jackson-jaxrs-base"/>
+            <maven-resource group="com.fasterxml.jackson.jaxrs" artifact="jackson-module-jaxb-annotations"/>
         </module-def>
 
         <module-def name="javax.ws.rs.api">

--- a/jaxrs/jboss-modules/build.xml
+++ b/jaxrs/jboss-modules/build.xml
@@ -92,6 +92,7 @@
         <module-def name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider">
             <maven-resource group="com.fasterxml.jackson.jaxrs" artifact="jackson-jaxrs-json-provider"/>
             <maven-resource group="com.fasterxml.jackson.jaxrs" artifact="jackson-jaxrs-base" />
+            <maven-resource group="com.fasterxml.jackson.jaxrs" artifact="jackson-module-jaxb-annotations" />
         </module-def>
 
         <module-def name="javax.ws.rs.api">

--- a/jaxrs/jboss-modules/pom.xml
+++ b/jaxrs/jboss-modules/pom.xml
@@ -82,6 +82,10 @@
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-base</artifactId>
         </dependency>
+        <dependency> 
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-jaxb-annotations</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcmail-jdk16</artifactId>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -284,6 +284,12 @@
                 <artifactId>jackson-jaxrs-base</artifactId>
                 <version>2.2.1</version>
             </dependency>
+            <!-- also need JAXB annotation support -->
+            <dependency> 
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-jaxb-annotations</artifactId>
+                <version>2.2.1</version>
+            </dependency>
             <dependency>
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-core-asl</artifactId>


### PR DESCRIPTION
[RESTEASY-881](https://issues.jboss.org/browse/RESTEASY-881) Added jackson-jaxrs-base v2.2.1 dependency for the JBoss modules generation
