### PR TITLE
Netty 4 server adapter

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -25,6 +25,7 @@
         <dep.guice.version>3.0</dep.guice.version>
         <dep.jboss-el.version>1.0_02.CR4</dep.jboss-el.version>
         <dep.netty.version>3.6.4.Final</dep.netty.version>
+        <dep.netty4.version>4.0.6.Final</dep.netty4.version>
     </properties>
 
     <url>http://rest-easy.org</url>

--- a/jaxrs/server-adapters/pom.xml
+++ b/jaxrs/server-adapters/pom.xml
@@ -16,5 +16,6 @@
     <modules>
         <module>resteasy-jdk-http</module>
         <module>resteasy-netty</module>
+        <module>resteasy-netty4</module>
     </modules>
 </project>

--- a/jaxrs/server-adapters/resteasy-netty4/pom.xml
+++ b/jaxrs/server-adapters/resteasy-netty4/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<project>
+    <parent>
+        <artifactId>resteasy-jaxrs-all</artifactId>
+        <groupId>org.jboss.resteasy</groupId>
+        <version>3.0.3.Final</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>resteasy-netty4</artifactId>
+    <name>RESTEasy Netty 4 Integration</name>
+    <description/>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxrs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>${dep.netty4.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpRequest.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpRequest.java
@@ -1,0 +1,221 @@
+package org.jboss.resteasy.plugins.server.netty;
+
+import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.core.SynchronousExecutionContext;
+import org.jboss.resteasy.plugins.providers.FormUrlEncodedProvider;
+import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
+import org.jboss.resteasy.spi.NotImplementedYetException;
+import org.jboss.resteasy.spi.ResteasyAsynchronousContext;
+import org.jboss.resteasy.spi.ResteasyUriInfo;
+import org.jboss.resteasy.util.Encode;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Abstraction for an inbound http request on the server, or a response from a server to a client
+ * <p/>
+ * We have this abstraction so that we can reuse marshalling objects in a client framework and serverside framework
+ *
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @author Norman Maurer
+ * @version $Revision: 1 $
+ */
+public class NettyHttpRequest implements org.jboss.resteasy.spi.HttpRequest
+{
+   protected ResteasyHttpHeaders httpHeaders;
+   protected SynchronousDispatcher dispatcher;
+   protected ResteasyUriInfo uriInfo;
+   protected String httpMethod;
+   protected MultivaluedMap<String, String> formParameters;
+   protected MultivaluedMap<String, String> decodedFormParameters;
+   protected InputStream inputStream;
+   protected Map<String, Object> attributes = new HashMap<String, Object>();
+   protected NettyHttpResponse httpResponse;
+   private final boolean is100ContinueExpected;
+
+
+   public NettyHttpRequest(ResteasyHttpHeaders httpHeaders, ResteasyUriInfo uri, String httpMethod, SynchronousDispatcher dispatcher, NettyHttpResponse httpResponse, boolean is100ContinueExpected)
+   {
+      this.is100ContinueExpected = is100ContinueExpected;
+      this.httpResponse = httpResponse;
+      this.dispatcher = dispatcher;
+      this.httpHeaders = httpHeaders;
+      this.httpMethod = httpMethod;
+      this.uriInfo = uri;
+
+   }
+
+   @Override
+   public MultivaluedMap<String, String> getMutableHeaders()
+   {
+      return httpHeaders.getMutableHeaders();
+   }
+
+   @Override
+   public void setHttpMethod(String method)
+   {
+      this.httpMethod = method;
+   }
+
+   @Override
+   public Enumeration<String> getAttributeNames()
+   {
+      Enumeration<String> en = new Enumeration<String>()
+      {
+         private Iterator<String> it = attributes.keySet().iterator();
+         @Override
+         public boolean hasMoreElements()
+         {
+            return it.hasNext();
+         }
+
+         @Override
+         public String nextElement()
+         {
+            return it.next();
+         }
+      };
+      return en;
+   }
+
+   @Override
+   public ResteasyAsynchronousContext getAsyncContext()
+   {
+      return new SynchronousExecutionContext(dispatcher, this, httpResponse);
+   }
+
+   @Override
+   public MultivaluedMap<String, String> getFormParameters()
+   {
+      if (formParameters != null) return formParameters;
+      if (getHttpHeaders().getMediaType().isCompatible(MediaType.valueOf("application/x-www-form-urlencoded")))
+      {
+         try
+         {
+            formParameters = FormUrlEncodedProvider.parseForm(getInputStream());
+         }
+         catch (IOException e)
+         {
+            throw new RuntimeException(e);
+         }
+      }
+      else
+      {
+         throw new IllegalArgumentException("Request media type is not application/x-www-form-urlencoded");
+      }
+      return formParameters;
+   }
+
+   @Override
+   public MultivaluedMap<String, String> getDecodedFormParameters()
+   {
+      if (decodedFormParameters != null) return decodedFormParameters;
+      decodedFormParameters = Encode.decode(getFormParameters());
+      return decodedFormParameters;
+   }
+
+
+   @Override
+   public Object getAttribute(String attribute)
+   {
+      return attributes.get(attribute);
+   }
+
+   @Override
+   public void setAttribute(String name, Object value)
+   {
+      attributes.put(name, value);
+   }
+
+   @Override
+   public void removeAttribute(String name)
+   {
+      attributes.remove(name);
+   }
+
+   @Override
+   public HttpHeaders getHttpHeaders()
+   {
+      return httpHeaders;
+   }
+
+   @Override
+   public InputStream getInputStream()
+   {
+      return inputStream;
+   }
+
+   @Override
+   public void setInputStream(InputStream stream)
+   {
+      this.inputStream = stream;
+   }
+
+   @Override
+   public ResteasyUriInfo getUri()
+   {
+      return uriInfo;
+   }
+
+   @Override
+   public String getHttpMethod()
+   {
+      return httpMethod;
+   }
+
+   @Override
+   public void setRequestUri(URI requestUri) throws IllegalStateException
+   {
+      uriInfo = uriInfo.setRequestUri(requestUri);
+   }
+
+   @Override
+   public void setRequestUri(URI baseUri, URI requestUri) throws IllegalStateException
+   {
+      uriInfo = new ResteasyUriInfo(baseUri.resolve(requestUri));
+   }
+
+
+   @Override
+   public boolean isInitial()
+   {
+      return true;
+   }
+
+   public NettyHttpResponse getResponse()
+   {
+       return httpResponse;
+   }
+
+   public boolean isKeepAlive()
+   {
+       return httpResponse.isKeepAlive();
+   }
+
+   public boolean is100ContinueExpected()
+   {
+       return is100ContinueExpected;
+   }
+
+   @Override
+   public void forward(String path)
+   {
+      throw new NotImplementedYetException();
+   }
+
+   @Override
+   public boolean wasForwarded()
+   {
+      return false;
+   }
+
+}

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpResponse.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpResponse.java
@@ -1,0 +1,142 @@
+package org.jboss.resteasy.plugins.server.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaders.Values;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
+import org.jboss.resteasy.spi.HttpResponse;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class NettyHttpResponse implements HttpResponse
+{
+   private int status = 200;
+   private ByteBuf byteBuf;
+   private OutputStream os;
+   private MultivaluedMap<String, Object> outputHeaders;
+   private final ChannelHandlerContext ctx;
+   private boolean committed;
+   private boolean keepAlive;
+
+   public NettyHttpResponse(ChannelHandlerContext ctx, boolean keepAlive)
+   {
+      outputHeaders = new MultivaluedMapImpl<String, Object>();
+      byteBuf = Unpooled.buffer();
+      os = new ByteBufOutputStream(byteBuf);
+      this.ctx = ctx;
+      this.keepAlive = keepAlive;
+   }
+
+   @Override
+   public void setOutputStream(OutputStream os)
+   {
+      this.os = os;
+   }
+
+   public ByteBuf getBuffer()
+   {
+      return byteBuf;
+   }
+
+   @Override
+   public int getStatus()
+   {
+      return status;
+   }
+
+   @Override
+   public void setStatus(int status)
+   {
+      this.status = status;
+   }
+
+   @Override
+   public MultivaluedMap<String, Object> getOutputHeaders()
+   {
+      return outputHeaders;
+   }
+
+   @Override
+   public OutputStream getOutputStream() throws IOException
+   {
+      return os;
+   }
+
+   @Override
+   public void addNewCookie(NewCookie cookie)
+   {
+      outputHeaders.add(HttpHeaders.SET_COOKIE, cookie);
+   }
+
+   @Override
+   public void sendError(int status) throws IOException
+   {
+      sendError(status, null);
+   }
+
+   @Override
+   public void sendError(int status, String message) throws IOException
+   {
+       if (committed)
+       {
+           throw new IllegalStateException();
+       }
+
+       final HttpResponseStatus responseStatus;
+       if (message != null)
+       {
+           responseStatus = new HttpResponseStatus(status, message);
+           setStatus(status);
+       }
+       else
+       {
+           responseStatus = HttpResponseStatus.valueOf(status);
+           setStatus(status);
+       }
+       final io.netty.handler.codec.http.HttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, responseStatus);
+       if (keepAlive)
+       {
+           // Add keep alive and content length if needed
+           response.headers().add(Names.CONNECTION, Values.KEEP_ALIVE);
+           response.headers().add(Names.CONTENT_LENGTH, 0);
+       }
+       ctx.writeAndFlush(response);
+       committed = true;
+   }
+
+   @Override
+   public boolean isCommitted()
+   {
+      return committed;
+   }
+
+   @Override
+   public void reset()
+   {
+      if (committed)
+      {
+          throw new IllegalStateException("Already committed");
+      }
+      outputHeaders.clear();
+      byteBuf.clear();
+      outputHeaders.clear();
+   }
+
+   public boolean isKeepAlive() {
+       return keepAlive;
+   }
+}

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
@@ -1,0 +1,188 @@
+package org.jboss.resteasy.plugins.server.netty;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.util.concurrent.EventExecutor;
+import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.plugins.server.embedded.EmbeddedJaxrsServer;
+import org.jboss.resteasy.plugins.server.embedded.SecurityDomain;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+import resteasy.plugins.server.netty.RequestDispatcher;
+import resteasy.plugins.server.netty.RequestHandler;
+import resteasy.plugins.server.netty.RestEasyHttpRequestDecoder;
+import resteasy.plugins.server.netty.RestEasyHttpRequestDecoder.Protocol;
+import resteasy.plugins.server.netty.RestEasyHttpResponseEncoder;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+
+/**
+ * An HTTP server that sends back the content of the received HTTP request
+ * in a pretty plaintext form.
+ *
+ * @author <a href="http://www.jboss.org/netty/">The Netty Project</a>
+ * @author Andy Taylor (andy.taylor@jboss.org)
+ * @author <a href="http://gleamynode.net/">Trustin Lee</a>
+ * @author Norman Maurer
+ * @version $Rev: 2080 $, $Date: 2010-01-26 18:04:19 +0900 (Tue, 26 Jan 2010) $
+ */
+public class NettyJaxrsServer implements EmbeddedJaxrsServer
+{
+   protected ServerBootstrap bootstrap = new ServerBootstrap();
+   protected int port = 8080;
+   protected ResteasyDeployment deployment = new ResteasyDeployment();
+   protected String root = "";
+   protected SecurityDomain domain;
+   private EventLoopGroup bossGroup;
+   private EventLoopGroup workerGroup;
+   private EventLoopGroup eventExecutor;
+   private int ioWorkerCount = Runtime.getRuntime().availableProcessors() * 2;
+   private int executorThreadCount = 16;
+   private SSLContext sslContext;
+   private int maxRequestSize = 1024 * 1024 * 10;
+
+   public void setSSLContext(SSLContext sslContext)
+   {
+      this.sslContext = sslContext;
+   }
+
+   /**
+    * Specify the worker count to use. For more information about this please see the javadocs of {@link EventLoopGroup}
+    *
+    * @param ioWorkerCount
+    */
+   public void setIoWorkerCount(int ioWorkerCount)
+   {
+       this.ioWorkerCount = ioWorkerCount;
+   }
+
+   /**
+    * Set the number of threads to use for the EventExecutor. For more information please see the javadocs of {@link EventExecutor}.
+    * If you want to disable the use of the {@link EventExecutor} specify a value <= 0.  This should only be done if you are 100% sure that you don't have any blocking
+    * code in there.
+    *
+    *
+    * @param executorThreadCount
+    */
+   public void setExecutorThreadCount(int executorThreadCount)
+   {
+       this.executorThreadCount = executorThreadCount;
+   }
+
+   /**
+    * Set the max. request size in bytes. If this size is exceed we will send a "413 Request Entity Too Large" to the client.
+    *
+    * @param maxRequestSize the max request size. This is 10mb by default.
+    */
+   public void setMaxRequestSize(int maxRequestSize)
+   {
+       this.maxRequestSize  = maxRequestSize;
+   }
+
+   public int getPort()
+   {
+      return port;
+   }
+
+   public void setPort(int port)
+   {
+      this.port = port;
+   }
+
+   @Override
+   public void setDeployment(ResteasyDeployment deployment)
+   {
+      this.deployment = deployment;
+   }
+
+   @Override
+   public void setRootResourcePath(String rootResourcePath)
+   {
+      root = rootResourcePath;
+      if (root != null && root.equals("/")) root = "";
+   }
+
+   @Override
+   public ResteasyDeployment getDeployment()
+   {
+      return deployment;
+   }
+
+   @Override
+   public void setSecurityDomain(SecurityDomain sc)
+   {
+      this.domain = sc;
+   }
+
+   @Override
+   public void start()
+   {
+      bossGroup = new NioEventLoopGroup();
+      workerGroup = new NioEventLoopGroup(ioWorkerCount);
+      eventExecutor = new NioEventLoopGroup(executorThreadCount);
+
+      deployment.start();
+      final RequestDispatcher dispatcher = new RequestDispatcher((SynchronousDispatcher)deployment.getDispatcher(), deployment.getProviderFactory(), domain);
+       // Configure the server.
+       if (sslContext == null) {
+           bootstrap.group(bossGroup, workerGroup)
+                   .channel(NioServerSocketChannel.class)
+                   .childHandler(new ChannelInitializer<SocketChannel>() {
+                       @Override
+                       public void initChannel(SocketChannel ch) throws Exception {
+                           ch.pipeline().addLast(new HttpRequestDecoder());
+                           ch.pipeline().addLast(new HttpObjectAggregator(maxRequestSize));
+                           ch.pipeline().addLast(new HttpResponseEncoder());
+                           ch.pipeline().addLast(new RestEasyHttpRequestDecoder(dispatcher.getDispatcher(), root, Protocol.HTTP));
+                           ch.pipeline().addLast(new RestEasyHttpResponseEncoder(dispatcher));
+                           ch.pipeline().addLast(eventExecutor, new RequestHandler(dispatcher));
+                       }
+                   })
+                   .option(ChannelOption.SO_BACKLOG, 128)
+                   .childOption(ChannelOption.SO_KEEPALIVE, true);
+       } else {
+           final SSLEngine engine = sslContext.createSSLEngine();
+           engine.setUseClientMode(false);
+           bootstrap.group(bossGroup, workerGroup)
+                   .channel(NioServerSocketChannel.class)
+                   .childHandler(new ChannelInitializer<SocketChannel>() {
+                       @Override
+                       public void initChannel(SocketChannel ch) throws Exception {
+                           ch.pipeline().addFirst(new SslHandler(engine));
+                           ch.pipeline().addLast(new HttpRequestDecoder());
+                           ch.pipeline().addLast(new HttpObjectAggregator(maxRequestSize));
+                           ch.pipeline().addLast(new HttpResponseEncoder());
+                           ch.pipeline().addLast(new RestEasyHttpRequestDecoder(dispatcher.getDispatcher(), root, Protocol.HTTPS));
+                           ch.pipeline().addLast(new RestEasyHttpResponseEncoder(dispatcher));
+                           ch.pipeline().addLast(eventExecutor, new RequestHandler(dispatcher));
+
+                       }
+                   })
+                   .option(ChannelOption.SO_BACKLOG, 128)
+                   .childOption(ChannelOption.SO_KEEPALIVE, true);
+       }
+
+       try {
+           bootstrap.bind(port).sync();
+       } catch (InterruptedException e) {
+           // ignore
+       }
+   }
+
+   @Override
+   public void stop()
+   {
+       workerGroup.shutdownGracefully();
+       bossGroup.shutdownGracefully();
+       eventExecutor.shutdownGracefully();
+   }
+}

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettySecurityContext.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettySecurityContext.java
@@ -1,0 +1,54 @@
+package org.jboss.resteasy.plugins.server.netty;
+
+import org.jboss.resteasy.plugins.server.embedded.SecurityDomain;
+
+import javax.ws.rs.core.SecurityContext;
+import java.security.Principal;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class NettySecurityContext implements SecurityContext
+{
+   protected final Principal principal;
+   protected final SecurityDomain domain;
+   protected final String authScheme;
+   protected final boolean isSecure;
+
+   public NettySecurityContext(Principal principal, SecurityDomain domain, String authScheme, boolean secure)
+   {
+      this.principal = principal;
+      this.domain = domain;
+      this.authScheme = authScheme;
+      isSecure = secure;
+   }
+   public NettySecurityContext() {
+       this(null, null, null, false);
+   }
+
+   @Override
+   public Principal getUserPrincipal()
+   {
+      return principal;
+   }
+
+   @Override
+   public boolean isUserInRole(String role)
+   {
+      if (domain == null) return false;
+      return domain.isUserInRoll(principal, role);
+   }
+
+   @Override
+   public boolean isSecure()
+   {
+      return isSecure;
+   }
+
+   @Override
+   public String getAuthenticationScheme()
+   {
+      return authScheme;
+   }
+}

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyUtil.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyUtil.java
@@ -1,0 +1,124 @@
+package org.jboss.resteasy.plugins.server.netty;
+
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import org.jboss.resteasy.core.Headers;
+import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
+import org.jboss.resteasy.spi.ResteasyUriInfo;
+import org.jboss.resteasy.util.HttpHeaderNames;
+import org.jboss.resteasy.util.MediaTypeHelper;
+import org.jboss.resteasy.util.PathHelper;
+
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class NettyUtil
+{
+   public static ResteasyUriInfo extractUriInfo(HttpRequest request, String contextPath, String protocol)
+   {
+      String host = HttpHeaders.getHost(request, "unknown");
+      String uri = request.getUri();
+
+      URI absoluteURI = URI.create(protocol + "://" + host + uri);
+
+      String path = PathHelper.getEncodedPathInfo(absoluteURI.getRawPath(), contextPath);
+      if (!path.startsWith("/"))
+      {
+         path = "/" + path;
+      }
+
+      URI baseURI = absoluteURI;
+      if (!path.trim().equals(""))
+      {
+         String tmpContextPath = contextPath;
+         if (!tmpContextPath.endsWith("/")) tmpContextPath += "/";
+         baseURI = UriBuilder.fromUri(absoluteURI).replacePath(tmpContextPath).replaceQuery(null).build();
+      }
+      else
+      {
+         baseURI = UriBuilder.fromUri(absoluteURI).replaceQuery(null).build();
+      }
+      URI relativeURI = UriBuilder.fromUri(path).replaceQuery(absoluteURI.getRawQuery()).build();
+      //System.out.println("path: " + path);
+      //System.out.println("query string: " + request.getQueryString());
+      ResteasyUriInfo uriInfo = new ResteasyUriInfo(baseURI, relativeURI);
+      return uriInfo;
+   }
+
+   public static ResteasyHttpHeaders extractHttpHeaders(HttpRequest request)
+   {
+
+      MultivaluedMap<String, String> requestHeaders = extractRequestHeaders(request);
+      ResteasyHttpHeaders headers = new ResteasyHttpHeaders(requestHeaders);
+
+      Map<String, Cookie> cookies = extractCookies(requestHeaders);
+      headers.setCookies(cookies);
+      // test parsing should throw an exception on error
+      headers.testParsing();
+      return headers;
+
+   }
+
+   static Map<String, Cookie> extractCookies(MultivaluedMap<String, String> headers)
+   {
+      Map<String, Cookie> cookies = new HashMap<String, Cookie>();
+      List<String> cookieHeaders = headers.get("Cookie");
+      if (cookieHeaders == null) return cookies;
+
+      for (String cookieVal : cookieHeaders)
+      {
+         Cookie cookie = Cookie.valueOf(cookieVal);
+         cookies.put(cookie.getName(), cookie);
+      }
+      return cookies;
+   }
+
+   public static List<MediaType> extractAccepts(MultivaluedMap<String, String> requestHeaders)
+   {
+      List<MediaType> acceptableMediaTypes = new ArrayList<MediaType>();
+      List<String> accepts = requestHeaders.get(HttpHeaderNames.ACCEPT);
+      if (accepts == null) return acceptableMediaTypes;
+
+      for (String accept : accepts)
+      {
+         acceptableMediaTypes.addAll(MediaTypeHelper.parseHeader(accept));
+      }
+      return acceptableMediaTypes;
+   }
+
+   public static List<String> extractLanguages(MultivaluedMap<String, String> requestHeaders)
+   {
+      List<String> acceptable = new ArrayList<String>();
+      List<String> accepts = requestHeaders.get(HttpHeaderNames.ACCEPT_LANGUAGE);
+      if (accepts == null) return acceptable;
+
+      for (String accept : accepts)
+      {
+         String[] splits = accept.split(",");
+         for (String split : splits) acceptable.add(split.trim());
+      }
+      return acceptable;
+   }
+
+   public static MultivaluedMap<String, String> extractRequestHeaders(HttpRequest request)
+   {
+      Headers<String> requestHeaders = new Headers<String>();
+
+      for (Map.Entry<String, String> header : request.headers())
+      {
+         requestHeaders.add(header.getKey(), header.getValue());
+      }
+      return requestHeaders;
+   }
+}

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestDispatcher.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestDispatcher.java
@@ -1,0 +1,141 @@
+package org.jboss.resteasy.plugins.server.netty;
+
+import org.apache.commons.codec.binary.Base64;
+import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.core.ThreadLocalResteasyProviderFactory;
+import org.jboss.resteasy.plugins.server.embedded.SecurityDomain;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.util.HttpHeaderNames;
+import org.jboss.resteasy.util.HttpResponseCodes;
+
+import javax.ws.rs.core.SecurityContext;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.List;
+
+/**
+ * Helper/delegate class to unify Servlet and Filter dispatcher implementations
+ *
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @author Norman Maurer
+ * @version $Revision: 1 $
+ */
+public class RequestDispatcher
+{
+   protected final SynchronousDispatcher dispatcher;
+   protected final ResteasyProviderFactory providerFactory;
+   protected final SecurityDomain domain;
+
+   public RequestDispatcher(SynchronousDispatcher dispatcher, ResteasyProviderFactory providerFactory, SecurityDomain domain)
+   {
+      this.dispatcher = dispatcher;
+      this.providerFactory = providerFactory;
+      this.domain = domain;
+   }
+
+   public SynchronousDispatcher getDispatcher()
+   {
+      return dispatcher;
+   }
+
+   public SecurityDomain getDomain()
+   {
+      return domain;
+   }
+
+   public ResteasyProviderFactory getProviderFactory()
+   {
+      return providerFactory;
+   }
+
+   public void service(HttpRequest request, HttpResponse response, boolean handleNotFound) throws IOException
+   {
+
+      try
+      {
+         ResteasyProviderFactory defaultInstance = ResteasyProviderFactory.getInstance();
+         if (defaultInstance instanceof ThreadLocalResteasyProviderFactory)
+         {
+            ThreadLocalResteasyProviderFactory.push(providerFactory);
+         }
+
+         SecurityContext securityContext;
+         if (domain != null)
+         {
+            securityContext = basicAuthentication(request, response);
+            if (securityContext == null) // not authenticated
+            {
+               return;
+            }
+         } else {
+            securityContext = new NettySecurityContext();
+         }
+         try
+         {
+
+            ResteasyProviderFactory.pushContext(SecurityContext.class, securityContext);
+            if (handleNotFound)
+            {
+               dispatcher.invoke(request, response);
+            }
+            else
+            {
+               dispatcher.invokePropagateNotFound(request, response);
+            }
+         }
+         finally
+         {
+            ResteasyProviderFactory.clearContextData();
+         }
+      }
+      finally
+      {
+         ResteasyProviderFactory defaultInstance = ResteasyProviderFactory.getInstance();
+         if (defaultInstance instanceof ThreadLocalResteasyProviderFactory)
+         {
+            ThreadLocalResteasyProviderFactory.pop();
+         }
+
+      }
+   }
+
+   private SecurityContext basicAuthentication(HttpRequest request, HttpResponse response) throws IOException
+   {
+      List<String> headers = request.getHttpHeaders().getRequestHeader(HttpHeaderNames.AUTHORIZATION);
+      if (!headers.isEmpty()) {
+         String auth = headers.get(0);
+         if (auth.length() > 5)
+         {
+            String type = auth.substring(0, 5);
+            type = type.toLowerCase();
+            if ("basic".equals(type))
+            {
+               String cookie = auth.substring(6);
+               cookie = new String(Base64.decodeBase64(cookie.getBytes()));
+               String[] split = cookie.split(":");
+               Principal user = null;
+               try
+               {
+                  user = domain.authenticate(split[0], split[1]);
+                  return new NettySecurityContext(user, domain, "BASIC", true);
+               }
+               catch (SecurityException e)
+               {
+                  response.sendError(HttpResponseCodes.SC_UNAUTHORIZED);
+                  return null;
+               }
+            }
+            else
+            {
+               response.sendError(HttpResponseCodes.SC_UNAUTHORIZED);
+               return null;
+            }
+         }
+      }
+      return null;
+   }
+
+
+}

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
@@ -1,0 +1,104 @@
+package org.jboss.resteasy.plugins.server.netty;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.TooLongFrameException;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpResponse;
+import org.jboss.resteasy.logging.Logger;
+import org.jboss.resteasy.spi.Failure;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
+import static io.netty.handler.codec.http.HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+/**
+ * {@link ChannelInboundHandlerAdapter} which handles the requests and dispatch them.
+ *
+ * This class is {@link Sharable}.
+ *
+ * @author <a href="http://www.jboss.org/netty/">The Netty Project</a>
+ * @author Andy Taylor (andy.taylor@jboss.org)
+ * @author <a href="http://gleamynode.net/">Trustin Lee</a>
+ * @author Norman Maurer
+ * @version $Rev: 2368 $, $Date: 2010-10-18 17:19:03 +0900 (Mon, 18 Oct 2010) $
+ */
+@Sharable
+public class RequestHandler extends ChannelInboundHandlerAdapter
+{
+   protected final RequestDispatcher dispatcher;
+   private final static Logger logger = Logger.getLogger(RequestHandler.class);
+
+   public RequestHandler(RequestDispatcher dispatcher)
+   {
+      this.dispatcher = dispatcher;
+   }
+
+   @Override
+   public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception
+   {
+      if (msg instanceof NettyHttpRequest) {
+          NettyHttpRequest request = (NettyHttpRequest) msg;
+
+          if (request.is100ContinueExpected())
+          {
+             send100Continue(ctx);
+          }
+
+          NettyHttpResponse response = request.getResponse();
+          try
+          {
+             dispatcher.service(request, response, true);
+          }
+          catch (Failure e1)
+          {
+             response.reset();
+             response.setStatus(e1.getErrorCode());
+             return;
+          }
+          catch (Exception ex)
+          {
+             response.reset();
+             response.setStatus(500);
+             logger.error("Unexpected", ex);
+             return;
+          }
+
+          // Write the response.
+          ChannelFuture future = ctx.writeAndFlush(response);
+
+          // Close the non-keep-alive connection after the write operation is done.
+          if (!request.isKeepAlive())
+          {
+             future.addListener(ChannelFutureListener.CLOSE);
+          }
+      }
+   }
+
+   private void send100Continue(ChannelHandlerContext ctx)
+   {
+      HttpResponse response = new DefaultHttpResponse(HTTP_1_1, CONTINUE);
+      ctx.writeAndFlush(response);
+   }
+
+   @Override
+   public void exceptionCaught(ChannelHandlerContext ctx, Throwable e)
+           throws Exception
+   {
+      // handle the case of to big requests.
+      if (e.getCause() instanceof TooLongFrameException)
+      {
+          DefaultHttpResponse response = new DefaultHttpResponse(HTTP_1_1, REQUEST_ENTITY_TOO_LARGE);
+          ctx.write(response).addListener(ChannelFutureListener.CLOSE);
+      }
+      else
+      {
+          e.getCause().printStackTrace();
+          ctx.close();
+      }
+
+   }
+}

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpRequestDecoder.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpRequestDecoder.java
@@ -1,0 +1,86 @@
+package org.jboss.resteasy.plugins.server.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaders;
+import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.logging.Logger;
+import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
+import org.jboss.resteasy.spi.ResteasyUriInfo;
+
+import java.util.List;
+
+import static io.netty.handler.codec.http.HttpHeaders.is100ContinueExpected;
+
+/**
+ * This {@link MessageToMessageDecoder} is responsible for decode {@link io.netty.handler.codec.http.HttpRequest}
+ * to {@link NettyHttpRequest}'s
+ *
+ * This implementation is {@link Sharable}
+ *
+ * @author Norman Maurer
+ *
+ */
+@Sharable
+public class RestEasyHttpRequestDecoder extends MessageToMessageDecoder<io.netty.handler.codec.http.HttpRequest>
+{
+    private final static Logger logger = Logger.getLogger(RestEasyHttpRequestDecoder.class);
+
+    private final SynchronousDispatcher dispatcher;
+    private final String servletMappingPrefix;
+    private final String proto;
+
+    public enum Protocol
+    {
+        HTTPS,
+        HTTP
+    }
+
+    public RestEasyHttpRequestDecoder(SynchronousDispatcher dispatcher, String servletMappingPrefix, Protocol protocol)
+    {
+        this.dispatcher = dispatcher;
+        this.servletMappingPrefix = servletMappingPrefix;
+        if (protocol == Protocol.HTTP)
+        {
+            proto = "http";
+        }
+        else
+        {
+            proto = "https";
+        }
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, io.netty.handler.codec.http.HttpRequest request, List<Object> out) throws Exception
+    {
+        boolean keepAlive = HttpHeaders.isKeepAlive(request);
+        NettyHttpResponse response = new NettyHttpResponse(ctx, keepAlive);
+        ResteasyHttpHeaders headers = null;
+        ResteasyUriInfo uriInfo = null;
+        try
+        {
+           headers = NettyUtil.extractHttpHeaders(request);
+
+           uriInfo = NettyUtil.extractUriInfo(request, servletMappingPrefix, proto);
+           NettyHttpRequest nettyRequest = new NettyHttpRequest(headers, uriInfo, request.getMethod().name(), dispatcher, response, is100ContinueExpected(request) );
+           if (request instanceof HttpContent)
+           {
+               HttpContent content = (HttpContent) request;
+               ByteBuf buf = content.content().copy();
+               ByteBufInputStream in = new ByteBufInputStream(buf);
+               nettyRequest.setInputStream(in);
+               out.add(nettyRequest);
+           }
+        }
+        catch (Exception e)
+        {
+           response.sendError(400);
+           // made it warn so that people can filter this.
+           logger.warn("Failed to parse request.", e);
+        }
+    }
+}

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpResponseEncoder.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpResponseEncoder.java
@@ -1,0 +1,76 @@
+package org.jboss.resteasy.plugins.server.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaders.Values;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.ws.rs.ext.RuntimeDelegate;
+import java.util.List;
+import java.util.Map;
+
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+
+/**
+ * {@link MessageToMessageEncoder} implementation which encodes {@link org.jboss.resteasy.spi.HttpResponse}'s to
+ * {@link HttpResponse}'s
+ *
+ * This implementation is {@link Sharable}
+ *
+ * @author Norman Maurer
+ *
+ */
+@Sharable
+public class RestEasyHttpResponseEncoder extends MessageToMessageEncoder<NettyHttpResponse>
+{
+
+    private final RequestDispatcher dispatcher;
+
+    public RestEasyHttpResponseEncoder(RequestDispatcher dispatcher)
+    {
+        this.dispatcher = dispatcher;
+    }
+
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    protected void encode(ChannelHandlerContext ctx, NettyHttpResponse nettyResponse, List<Object> out) throws Exception
+    {
+        // Build the response object.
+        HttpResponseStatus status = HttpResponseStatus.valueOf(nettyResponse.getStatus());
+        ByteBuf buffer = nettyResponse.getBuffer();
+        HttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, status, buffer);
+
+        for (Map.Entry<String, List<Object>> entry : nettyResponse.getOutputHeaders().entrySet())
+        {
+           String key = entry.getKey();
+           for (Object value : entry.getValue())
+           {
+              RuntimeDelegate.HeaderDelegate delegate = dispatcher.providerFactory.getHeaderDelegate(value.getClass());
+              if (delegate != null)
+              {
+                  response.headers().add(key, delegate.toString(value));
+              }
+              else
+              {
+                 response.headers().set(key, value.toString());
+              }
+           }
+        }
+
+        if (nettyResponse.isKeepAlive())
+        {
+            // Add content length and connection header if needed
+            response.headers().set(Names.CONTENT_LENGTH, buffer.readableBytes());
+            response.headers().set(Names.CONNECTION, Values.KEEP_ALIVE);
+        }
+        out.add(response);
+    }
+
+}

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/test/NettyContainer.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/test/NettyContainer.java
@@ -1,0 +1,72 @@
+package org.jboss.resteasy.test;
+
+import org.jboss.resteasy.plugins.server.embedded.SecurityDomain;
+import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class NettyContainer
+{
+   public static NettyJaxrsServer netty;
+
+   public static ResteasyDeployment start() throws Exception
+   {
+      return start("");
+   }
+
+   public static ResteasyDeployment start(String bindPath) throws Exception
+   {
+      return start(bindPath, null);
+   }
+
+   public static void start(ResteasyDeployment deployment) throws Exception
+   {
+      netty = new NettyJaxrsServer();
+      netty.setDeployment(deployment);
+      netty.setPort(TestPortProvider.getPort());
+      netty.setRootResourcePath("");
+      netty.setSecurityDomain(null);
+      netty.start();
+   }
+
+   public static ResteasyDeployment start(String bindPath, SecurityDomain domain) throws Exception
+   {
+      ResteasyDeployment deployment = new ResteasyDeployment();
+      deployment.setSecurityEnabled(true);
+      return start(bindPath, domain, deployment);
+   }
+
+   public static ResteasyDeployment start(String bindPath, SecurityDomain domain, ResteasyDeployment deployment) throws Exception
+   {
+      netty = new NettyJaxrsServer();
+      netty.setDeployment(deployment);
+      netty.setPort(TestPortProvider.getPort());
+      netty.setRootResourcePath(bindPath);
+      netty.setSecurityDomain(domain);
+      netty.start();
+      return netty.getDeployment();
+   }
+
+   public static void stop() throws Exception
+   {
+      if (netty != null)
+      {
+         try
+         {
+            netty.stop();
+         }
+         catch (Exception e)
+         {
+
+         }
+      }
+      netty = null;
+   }
+
+   public static void main(String args[]) throws Exception {
+       start();
+   }
+}


### PR DESCRIPTION
Netty 4.0.6.Final server adapter that pass all tests in resteasy-jaxrs-testsuite by switching TJWSServletContainer to NettyJaxrsServer. Async responses is not implemented at the moment.
