### PR TITLE
Wrong groupId for jackson-module-jaxb-annotations.

### DIFF
--- a/jaxrs/jboss-modules/build-wf8.xml
+++ b/jaxrs/jboss-modules/build-wf8.xml
@@ -92,7 +92,7 @@
         <module-def name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider">
             <maven-resource group="com.fasterxml.jackson.jaxrs" artifact="jackson-jaxrs-json-provider"/>
             <maven-resource group="com.fasterxml.jackson.jaxrs" artifact="jackson-jaxrs-base"/>
-            <maven-resource group="com.fasterxml.jackson.jaxrs" artifact="jackson-module-jaxb-annotations"/>
+            <maven-resource group="com.fasterxml.jackson.module" artifact="jackson-module-jaxb-annotations"/>
         </module-def>
 
         <module-def name="javax.ws.rs.api">

--- a/jaxrs/jboss-modules/build.xml
+++ b/jaxrs/jboss-modules/build.xml
@@ -92,7 +92,7 @@
         <module-def name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider">
             <maven-resource group="com.fasterxml.jackson.jaxrs" artifact="jackson-jaxrs-json-provider"/>
             <maven-resource group="com.fasterxml.jackson.jaxrs" artifact="jackson-jaxrs-base" />
-            <maven-resource group="com.fasterxml.jackson.jaxrs" artifact="jackson-module-jaxb-annotations" />
+            <maven-resource group="com.fasterxml.jackson.module" artifact="jackson-module-jaxb-annotations" />
         </module-def>
 
         <module-def name="javax.ws.rs.api">


### PR DESCRIPTION
Wrong groupId for jackson-module-jaxb-annotations,in jboss-modules ant files, is breaking the build.
