### PR TITLE
Failing sub sub resource

### DIFF
--- a/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/resource/WildcardResourceMatchingTest.java
+++ b/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/resource/WildcardResourceMatchingTest.java
@@ -39,7 +39,7 @@ import java.util.Map;
 import static org.jboss.resteasy.test.TestPortProvider.generateURL;
 
 /**
- * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @author Justin Santa Barbara
  * @version $Revision: 1 $
  */
 public class WildcardResourceMatchingTest extends BaseResourceTest


### PR DESCRIPTION
This unit test demonstrates Resteasy failing to match sub-sub-resources with wildcards

This worked with JAX-RS 1, and I don't see a change that would make it invalid with JAX-RS 1.
