### PR TITLE
Adding Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: java
 jdk:
 - oraclejdk7
-- openjdk6


### PR DESCRIPTION
Added a travis configuration to build the project on Java7 (Oracle's JVM).

In order to activate this, you need to sign in to travis (w/ GH account), and activate the service hook for Travis, on your profile page --> https://travis-ci.org/profile

If you wish, you can also add more metadata to the `yml` file, like IRC notifications etc
