### PR TITLE
Fixes authentication example in Client documentation

### DIFF
--- a/jaxrs/docbook/reference/en/en-US/modules/RESTEasy_Client_Framework.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/RESTEasy_Client_Framework.xml
@@ -239,17 +239,17 @@ ResteasyClient client = new ResteasyClientBuilder().httpEngine(engine).build();
 AuthCache authCache = new BasicAuthCache();
  
 // 2. Generate BASIC scheme object and add it to the local auth cache
-BasicScheme basicAuth = new BasicScheme();
-authCache.put("com.bluemonkeydiamond.sippycups", basicAuth);
+AuthScheme basicAuth = new BasicScheme();
+authCache.put(new HttpHost("sippycups.bluemonkeydiamond.com"), basicAuth);
  
 // 3. Add AuthCache to the execution context
 BasicHttpContext localContext = new BasicHttpContext();
 localContext.setAttribute(ClientContext.AUTH_CACHE, authCache);
  
 // 4. Create client executor and proxy
-httpClient = new DefaultHttpClient();
+DefaultHttpClient httpClient = new DefaultHttpClient();
 ApacheHttpClient4Engine engine = new ApacheHttpClient4Engine(httpClient, localContext);
-ResteasyClient client = new RestasyClientBuilder().httpEngine(engine).build();
+ResteasyClient client = new ResteasyClientBuilder().httpEngine(engine).build();
      </programlisting>
 
      <para>


### PR DESCRIPTION
Fixes documentation so that it actually compiles (and works) with HttpClient prior to 4.3 (which is what RESTeasy currently depends on)
