### PR TITLE
Make keep-alive configurable

### DIFF
--- a/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/HttpServerPipelineFactory.java
+++ b/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/HttpServerPipelineFactory.java
@@ -30,9 +30,9 @@ public class HttpServerPipelineFactory implements ChannelPipelineFactory
    private final ChannelHandler executionHandler;
    private final int maxRequestSize;
    
-   public HttpServerPipelineFactory(RequestDispatcher dispatcher, String root, int executorThreadCount, int maxRequestSize)
+   public HttpServerPipelineFactory(RequestDispatcher dispatcher, String root, int executorThreadCount, int maxRequestSize, boolean isKeepAlive)
    {
-      this.resteasyDecoder = new RestEasyHttpRequestDecoder(dispatcher.getDispatcher(), root, getProtocol());
+      this.resteasyDecoder = new RestEasyHttpRequestDecoder(dispatcher.getDispatcher(), root, getProtocol(), isKeepAlive);
       this.resteasyEncoder = new RestEasyHttpResponseEncoder(dispatcher);
       this.resteasyRequestHandler = new RequestHandler(dispatcher);
       if (executorThreadCount > 0) 
@@ -44,7 +44,6 @@ public class HttpServerPipelineFactory implements ChannelPipelineFactory
           this.executionHandler = null;
       }
       this.maxRequestSize = maxRequestSize;
-      
    }
 
    @Override

--- a/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/HttpsServerPipelineFactory.java
+++ b/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/HttpsServerPipelineFactory.java
@@ -18,9 +18,9 @@ public class HttpsServerPipelineFactory extends HttpServerPipelineFactory
 
     private final SSLContext context;
 
-    public HttpsServerPipelineFactory(RequestDispatcher dispatcher, String root, int executorThreadCount, int maxRequestSize, SSLContext context) 
+    public HttpsServerPipelineFactory(RequestDispatcher dispatcher, String root, int executorThreadCount, int maxRequestSize, boolean isKeepAlive, SSLContext context) 
     {
-        super(dispatcher, root, executorThreadCount, maxRequestSize);
+        super(dispatcher, root, executorThreadCount, maxRequestSize, isKeepAlive);
         this.context = context;
     }
 

--- a/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
+++ b/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
@@ -39,6 +39,7 @@ public class NettyJaxrsServer implements EmbeddedJaxrsServer
    private int executorThreadCount = 16;
    private SSLContext sslContext;
    private int maxRequestSize = 1024 * 1024 * 10;
+   private boolean isKeepAlive = true;
 
    static final ChannelGroup allChannels = new DefaultChannelGroup("NettyJaxrsServer");
 
@@ -78,6 +79,11 @@ public class NettyJaxrsServer implements EmbeddedJaxrsServer
    public void setMaxRequestSize(int maxRequestSize) 
    {
        this.maxRequestSize  = maxRequestSize;
+   }
+   
+   public void setKeepAlive(boolean isKeepAlive) 
+   {
+       this.isKeepAlive = isKeepAlive;
    }
    
    public int getPort()
@@ -130,9 +136,9 @@ public class NettyJaxrsServer implements EmbeddedJaxrsServer
 
       ChannelPipelineFactory factory;
       if (sslContext == null) {
-          factory = new HttpServerPipelineFactory(dispatcher, root, executorThreadCount, maxRequestSize);
+          factory = new HttpServerPipelineFactory(dispatcher, root, executorThreadCount, maxRequestSize, isKeepAlive);
       } else {
-          factory = new HttpsServerPipelineFactory(dispatcher, root, executorThreadCount, maxRequestSize, sslContext);
+          factory = new HttpsServerPipelineFactory(dispatcher, root, executorThreadCount, maxRequestSize, isKeepAlive, sslContext);
       }
       // Set up the event pipeline factory.
       bootstrap.setPipelineFactory(factory);

--- a/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpRequestDecoder.java
+++ b/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpRequestDecoder.java
@@ -28,6 +28,7 @@ public class RestEasyHttpRequestDecoder extends OneToOneDecoder
     private final SynchronousDispatcher dispatcher;
     private final String servletMappingPrefix;
     private final String proto;
+    private final boolean isKeepAlive;
     
     public enum Protocol 
     {
@@ -35,7 +36,7 @@ public class RestEasyHttpRequestDecoder extends OneToOneDecoder
         HTTP
     }
     
-    public RestEasyHttpRequestDecoder(SynchronousDispatcher dispatcher, String servletMappingPrefix, Protocol protocol) 
+    public RestEasyHttpRequestDecoder(SynchronousDispatcher dispatcher, String servletMappingPrefix, Protocol protocol, boolean isKeepAlive) 
     {
         this.dispatcher = dispatcher;
         this.servletMappingPrefix = servletMappingPrefix;
@@ -47,6 +48,7 @@ public class RestEasyHttpRequestDecoder extends OneToOneDecoder
         {
             proto = "https";
         }
+        this.isKeepAlive = isKeepAlive;
     }
     
     @Override
@@ -58,7 +60,7 @@ public class RestEasyHttpRequestDecoder extends OneToOneDecoder
         }
         
         org.jboss.netty.handler.codec.http.HttpRequest request = (org.jboss.netty.handler.codec.http.HttpRequest) msg;
-        boolean keepAlive = org.jboss.netty.handler.codec.http.HttpHeaders.isKeepAlive(request);
+        boolean keepAlive = org.jboss.netty.handler.codec.http.HttpHeaders.isKeepAlive(request) & isKeepAlive;
 
         NettyHttpResponse response = new NettyHttpResponse(channel, keepAlive);
 


### PR DESCRIPTION
Make keep-alive configurable from the server side.
(Resteasy-netty's keep-alive always follows client's header but there is no way to control it in the server side.)
