### PR TITLE
RESTEASY-991 CDI integration - make use of @WithAnnotations (CDI 1.1)

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -21,7 +21,7 @@
         <dep.javax.persistence.version>1.0.1.Final</dep.javax.persistence.version>
         <dep.spring-webmvc.version>3.0.6.RELEASE</dep.spring-webmvc.version>
         <dep.snakeyaml.version>1.8</dep.snakeyaml.version>
-        <dep.cdi-api.version>1.0-SP1</dep.cdi-api.version>
+        <dep.cdi-api.version>1.1</dep.cdi-api.version>
         <dep.jboss-ejb-api_3.1_spec.version>1.0.0.CR2</dep.jboss-ejb-api_3.1_spec.version>
         <dep.guice.version>3.0</dep.guice.version>
         <dep.jboss-el.version>1.0_02.CR6</dep.jboss-el.version>
@@ -190,7 +190,7 @@
                 <artifactId>FastInfoset</artifactId>
                 <version>1.2.7</version>
             </dependency>
-            
+
             <dependency>
         		<groupId>org.hibernate.javax.persistence</groupId>
             	<artifactId>hibernate-jpa-2.0-api</artifactId>
@@ -312,7 +312,7 @@
                 <version>2.2.1</version>
             </dependency>
             <!-- also need JAXB annotation support -->
-            <dependency> 
+            <dependency>
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-jaxb-annotations</artifactId>
                 <version>2.2.1</version>


### PR DESCRIPTION
Note that this change should not make the integration code CDI 1.0 incompatible as annotations should have no direct effect on the operation of the code and so @WithAnnotations should be silently ignored.

I did not add an integration test because I was not sure where such test should be placed? The extension was tested on the current WidFly master and I also sent a pull request with integration test to WildFly repo [1]. However, I think it would make sense to have integration tests for both CDI 1.0 and CDI 1.1 containers in RESTEasy codebase.

[1]
https://github.com/wildfly/wildfly/pull/5565
