### PR TITLE
[RESTEASY-1020] Fix MockHttprequest.cookie()

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/mock/MockHttpRequest.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/mock/MockHttpRequest.java
@@ -68,13 +68,13 @@ public class MockHttpRequest implements HttpRequest
       MockHttpRequest request = new MockHttpRequest();
       request.httpHeaders = new ResteasyHttpHeaders(new CaseInsensitiveMap<String>());
       //request.uri = new UriInfoImpl(absoluteUri, absoluteUri, absoluteUri.getPath(), absoluteUri.getQuery(), PathSegmentImpl.parseSegments(absoluteUri.getPath()));
-      
+
       // remove query part
       URI absolutePath = UriBuilder.fromUri(absoluteUri).replaceQuery(null).build();
       // path must be relative to the application's base uri
-	   URI relativeUri = baseUri.relativize(absoluteUri);
+      URI relativeUri = baseUri.relativize(absoluteUri);
       relativeUri = UriBuilder.fromUri(relativeUri.getRawPath()).replaceQuery(absoluteUri.getRawQuery()).build();
-		
+
       request.uri = new ResteasyUriInfo(baseUri, relativeUri);
       return request;
    }
@@ -200,7 +200,7 @@ public class MockHttpRequest implements HttpRequest
    public MockHttpRequest cookie(String name, String value)
    {
       Cookie cookie = new Cookie(name, value);
-      httpHeaders.getCookies().put(name, cookie);
+      httpHeaders.getMutableCookies().put(name, cookie);
       return this;
    }
 

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResteasyHttpHeaders.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResteasyHttpHeaders.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -25,12 +26,18 @@ import java.util.StringTokenizer;
 public class ResteasyHttpHeaders implements HttpHeaders
 {
 
-   private MultivaluedMap<String, String> requestHeaders = new CaseInsensitiveMap<String>();
-   private Map<String, Cookie> cookies = Collections.emptyMap();
+   private MultivaluedMap<String, String> requestHeaders;
+   private Map<String, Cookie> cookies;
 
    public ResteasyHttpHeaders(MultivaluedMap<String, String> requestHeaders)
    {
+      this(requestHeaders, new HashMap<String, Cookie>());
+   }
+
+   public ResteasyHttpHeaders(MultivaluedMap<String, String> requestHeaders, Map<String, Cookie> cookies)
+   {
       this.requestHeaders = requestHeaders;
+      this.cookies = cookies;
    }
 
    @Override
@@ -65,12 +72,17 @@ public class ResteasyHttpHeaders implements HttpHeaders
    @Override
    public Map<String, Cookie> getCookies()
    {
+      return Collections.unmodifiableMap(cookies);
+   }
+
+   public Map<String, Cookie> getMutableCookies()
+   {
       return cookies;
    }
 
    public void setCookies(Map<String, Cookie> cookies)
    {
-      this.cookies = Collections.unmodifiableMap(cookies);
+      this.cookies = cookies;
    }
 
    @Override


### PR DESCRIPTION
Introduce a getMutableCookies() method in ResteasyHttpHeaders.

The tests fail on my machine (even on _master_) so I cannot check that I didn't break anything, but on the other hand, I haven't changed the semantics of the existing methods.
