### PR TITLE
[RESTEASY-1006] Fix unhandled exception handling in Netty 4

### DIFF
--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
@@ -57,14 +57,12 @@ public class RequestHandler extends SimpleChannelInboundHandler
           {
              response.reset();
              response.setStatus(e1.getErrorCode());
-             return;
           }
           catch (Exception ex)
           {
              response.reset();
              response.setStatus(500);
              logger.error("Unexpected", ex);
-             return;
           }
           ChannelFuture future = null;
           if (!request.getAsyncContext().isSuspended()) {


### PR DESCRIPTION
This change was missing in 18bc8d7, failing (hanging) the added test.
