### PR TITLE
RESTEASY-1033: ClientResponse, buffered entity is now available if the response is closed.

### DIFF
--- a/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientResponse.java
+++ b/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientResponse.java
@@ -313,4 +313,10 @@ public abstract class ClientResponse extends BuiltResponse
       return true;
    }
 
+   @Override
+   public void abortIfClosed()
+   {
+       if (bufferedEntity == null) super.abortIfClosed();
+   }
+
 }

--- a/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/client/ExceptionHandlingTest.java
+++ b/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/client/ExceptionHandlingTest.java
@@ -1,0 +1,58 @@
+package org.jboss.resteasy.test.client;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.test.BaseResourceTest;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+import static org.jboss.resteasy.test.TestPortProvider.generateURL;
+
+public class ExceptionHandlingTest extends BaseResourceTest
+{
+   @Path("/")
+   public static class ThrowsExceptionResource
+   {
+      @Path("test")
+      @POST
+      public void post() throws Exception { throw new Exception("test"); }
+   }
+
+   @Path("/")
+   public interface ThrowsExceptionInterface
+   {
+      @Path("test")
+      @POST
+      public void post() throws Exception;
+   }
+
+   @BeforeClass
+   public static void setup() throws Exception
+   {
+      addPerRequestResource(ThrowsExceptionResource.class);
+   }
+
+   @Test
+   public void testThrowsException() throws Exception
+   {
+      ResteasyClient client = new ResteasyClientBuilder().build();
+
+      ThrowsExceptionInterface proxy = client.target(generateURL("/")).proxy(ThrowsExceptionInterface.class);
+      try {
+          proxy.post();
+      } catch (InternalServerErrorException e) {
+          Response response = e.getResponse();
+          String errorText = response.readEntity(String.class);
+          Assert.assertNotNull(errorText);
+      }
+
+      client.close();
+   }
+
+}


### PR DESCRIPTION
It seems acceptable to access an entity in a closed response if it was buffered.
I added it because otherwise it's not possible to access an entity for an exception in a method that returns void. See details in JIRA.
