### PR TITLE
Fixes issue with PathParam replacement in client proxy

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/SubResourceInvoker.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/SubResourceInvoker.java
@@ -37,7 +37,7 @@ public class SubResourceInvoker implements MethodInvoker
 				if (a instanceof PathParam)
 				{
 					String name = ((PathParam) a).value();
-					path = path.replace("{" + name + "}", "%" + index + "$s");
+					path = path.replaceFirst("\\{" + name + "(\\s)*(:.*)?\\}", "%" + index + "\\$s");
 					break;
 				}
 			}


### PR DESCRIPTION
Whenever a `PathParam` annotation contains a regexp, name replacement wasn't performed properly and resulted in URI malformed exception during `invoke` phase.

Replacement now properly deals with an optional path regexp.

The following mimics actual code.

```
        int index = 1;
        String path = "{id   : [a-z]*}";
        String name = "id";
        path = path.replaceFirst("\\{" + name + "(\\s)*(:.*)?\\}", "%" + index + "\\$s");
        path = String.format(path, "foo");

        assertEquals("foo", path);
```
