### PR TITLE
Add ChannelHandlerContext to Resteasy for Netty4.

### DIFF
--- a/jaxrs/server-adapters/resteasy-netty4-cdi/src/main/java/org/jboss/resteasy/plugins/server/netty/cdi/CdiRequestDispatcher.java
+++ b/jaxrs/server-adapters/resteasy-netty4-cdi/src/main/java/org/jboss/resteasy/plugins/server/netty/cdi/CdiRequestDispatcher.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.plugins.server.netty.cdi;
 
+import io.netty.channel.ChannelHandlerContext;
 import org.jboss.resteasy.core.SynchronousDispatcher;
 import org.jboss.resteasy.plugins.server.embedded.SecurityDomain;
 import org.jboss.resteasy.plugins.server.netty.RequestDispatcher;
@@ -24,14 +25,14 @@ public class CdiRequestDispatcher extends RequestDispatcher {
     }
 
     @Override
-    public void service(HttpRequest request, HttpResponse response, boolean handleNotFound) throws IOException {
+    public void service(ChannelHandlerContext ctx, HttpRequest request, HttpResponse response, boolean handleNotFound) throws IOException {
         BoundRequestContext context = CDI.current().select(BoundRequestContext.class).get();
         Map<String,Object> contextMap = new HashMap<String,Object>();
         context.associate(contextMap);
         context.activate();
         try
         {
-            super.service(request,response,handleNotFound);
+            super.service(ctx, request,response,handleNotFound);
         }
         finally
         {

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestDispatcher.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestDispatcher.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.plugins.server.netty;
 
+import io.netty.channel.ChannelHandlerContext;
 import org.apache.commons.codec.binary.Base64;
 import org.jboss.resteasy.core.SynchronousDispatcher;
 import org.jboss.resteasy.core.ThreadLocalResteasyProviderFactory;
@@ -50,7 +51,7 @@ public class RequestDispatcher
       return providerFactory;
    }
 
-   public void service(HttpRequest request, HttpResponse response, boolean handleNotFound) throws IOException
+   public void service(ChannelHandlerContext ctx, HttpRequest request, HttpResponse response, boolean handleNotFound) throws IOException
    {
 
       try
@@ -76,7 +77,8 @@ public class RequestDispatcher
          {
 
             ResteasyProviderFactory.pushContext(SecurityContext.class, securityContext);
-            if (handleNotFound)
+            ResteasyProviderFactory.pushContext(ChannelHandlerContext.class, ctx);
+             if (handleNotFound)
             {
                dispatcher.invoke(request, response);
             }

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
@@ -1,8 +1,5 @@
 package org.jboss.resteasy.plugins.server.netty;
 
-import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
-import static io.netty.handler.codec.http.HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
-import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
@@ -10,9 +7,12 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpResponse;
-
 import org.jboss.resteasy.logging.Logger;
 import org.jboss.resteasy.spi.Failure;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
+import static io.netty.handler.codec.http.HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 /**
  * {@link SimpleChannelInboundHandler} which handles the requests and dispatch them.
@@ -50,7 +50,7 @@ public class RequestHandler extends SimpleChannelInboundHandler
           NettyHttpResponse response = request.getResponse();
           try
           {
-             dispatcher.service(request, response, true);
+             dispatcher.service(ctx, request, response, true);
           }
           catch (Failure e1)
           {

--- a/jaxrs/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/NettyTest.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/NettyTest.java
@@ -1,8 +1,6 @@
 package org.jboss.resteasy.test;
 
-import org.jboss.resteasy.client.jaxrs.ResteasyClient;
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import io.netty.channel.ChannelHandlerContext;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -14,6 +12,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 import static org.jboss.resteasy.test.TestPortProvider.generateURL;
@@ -57,6 +56,13 @@ public class NettyTest
             buf.append(i);
          }
          return buf.toString();
+      }
+
+      @GET
+      @Path("/context")
+      @Produces("text/plain")
+      public String context(@Context ChannelHandlerContext context) {
+          return context.channel().toString();
       }
    }
 
@@ -142,4 +148,12 @@ public class NettyTest
          resp.close();
       }
    }
+
+    @Test
+    public void testChannelContext() throws Exception {
+        WebTarget target = client.target(generateURL("/context"));
+        String val = target.request().get(String.class);
+        Assert.assertNotNull(val);
+        Assert.assertFalse(val.isEmpty());
+    }
 }


### PR DESCRIPTION
This is simply propagating the change I submitted in #483 to be available in the Netty 4 plugin as well.
