### PR TITLE
RESTEASY-1049 Check availability of CDI classes

### DIFF
--- a/jaxrs/providers/resteasy-validator-provider-11/src/main/java/org/jboss/resteasy/plugins/validation/GeneralValidatorImpl.java
+++ b/jaxrs/providers/resteasy-validator-provider-11/src/main/java/org/jboss/resteasy/plugins/validation/GeneralValidatorImpl.java
@@ -1,5 +1,8 @@
 package org.jboss.resteasy.plugins.validation;
 
+import java.lang.Class;
+import java.lang.ClassLoader;
+import java.lang.ClassNotFoundException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -212,11 +215,12 @@ public class GeneralValidatorImpl implements GeneralValidatorCDI
    @Override
    public boolean isValidatable(Class<?> clazz, InjectorFactory injectorFactory)
    {
-      // Called from resteasy-jaxrs.
-      if (injectorFactory instanceof CdiInjectorFactory)
-      {
-         return false;
-      }
+      // assure that CdiInjectorFactory is available
+      try {
+         Class<?> c = getClass().getClassLoader().loadClass("org.jboss.resteasy.cdi.CdiInjectorFactory");
+         // Called from resteasy-jaxrs.
+         return !(injectorFactory instanceof CdiInjectorFactory);
+      } catch (ClassNotFoundException ignored) {}
       return true;
    }
 


### PR DESCRIPTION
This should fix the problem indicated in [the comment on RESTEASY-1049](https://issues.jboss.org/browse/RESTEASY-1049?focusedCommentId=12965334&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-12965334) by assuring that the class used in the instanceof check is available.
