### PR TITLE
Spring 3.2+ support(include Spring 4.x)

### DIFF
--- a/jaxrs/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringContextLoaderListener.java
+++ b/jaxrs/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringContextLoaderListener.java
@@ -48,4 +48,11 @@ public class SpringContextLoaderListener extends ContextLoaderListener
    {
       return new SpringContextLoader();
    }
+   
+   @Override
+	protected void customizeContext(ServletContext servletContext, ConfigurableWebApplicationContext configurableWebApplicationContext) {
+
+		super.customizeContext(servletContext, configurableWebApplicationContext);
+		this.springContextLoaderSupport.customizeContext(servletContext, configurableWebApplicationContext);
+	}
 }


### PR DESCRIPTION
Now spring framework doesn't call SpringContextLoaderListener.createContextLoader(). Therefore It should be updated.
