### PR TITLE
Remove profiling module

### DIFF
--- a/jaxrs/profiling-tests/src/test/java/org/jboss/resteasy/test/profiling/MockedProfilingTest.java
+++ b/jaxrs/profiling-tests/src/test/java/org/jboss/resteasy/test/profiling/MockedProfilingTest.java
@@ -54,10 +54,10 @@ public class MockedProfilingTest
    @Test
    public void testCleartext() throws Exception
    {
-      //final int WARMUP = 10;
-      //final int INTERATIONS = 100;
-      final int WARMUP = 1000;
-      final int INTERATIONS = 1000000;
+      final int WARMUP = 10;
+      final int INTERATIONS = 100;
+      //final int WARMUP = 1000;
+      //final int INTERATIONS = 1000000;
 
       ResteasyDeployment deployment = new ResteasyDeployment();
       deployment.start();


### PR DESCRIPTION
The module profiling-tests contains a couple of test cases, non contains assertions.

Do we need it? And if we do, what does it test?

It takes 15seconds to run on my machine.
