### PR TITLE
Spring fix. Add missing imports.

### DIFF
--- a/jaxrs/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringContextLoaderListener.java
+++ b/jaxrs/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringContextLoaderListener.java
@@ -1,8 +1,10 @@
 package org.jboss.resteasy.plugins.spring;
 
+import org.springframework.web.context.ConfigurableWebApplicationContext;
 import org.springframework.web.context.ContextLoader;
 import org.springframework.web.context.ContextLoaderListener;
 
+import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 
 /**
@@ -11,8 +13,10 @@ import javax.servlet.ServletContextEvent;
  */
 public class SpringContextLoaderListener extends ContextLoaderListener
 {
+   private SpringContextLoaderSupport springContextLoaderSupport = new SpringContextLoaderSupport();
+
    @Override
-   public void contextInitialized(ServletContextEvent event)
+   public void contextInitialized(git statServletContextEvent event)
    {
       boolean scanProviders = false;
       boolean scanResources = false;
@@ -51,7 +55,6 @@ public class SpringContextLoaderListener extends ContextLoaderListener
    
    @Override
 	protected void customizeContext(ServletContext servletContext, ConfigurableWebApplicationContext configurableWebApplicationContext) {
-
 		super.customizeContext(servletContext, configurableWebApplicationContext);
 		this.springContextLoaderSupport.customizeContext(servletContext, configurableWebApplicationContext);
 	}


### PR DESCRIPTION
I could not build master.

See [Issue 1084](https://issues.jboss.org/browse/RESTEASY-1084) for more info.

This fixed it for me. However, the private springContextLoaderSupport variable added to the class. Maybe it should not be there. Where is it used?
