### PR TITLE
Bug 1078186 - Connection re-used in a inconsistent state despite 'Connec...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dep.jettison.version>1.3.1</dep.jettison.version>
 
         <version.commons-httpclient.commons-httpclient>3.1</version.commons-httpclient.commons-httpclient>
-        <version.org.apache.httpcomponents>4.1.2</version.org.apache.httpcomponents>
+        <version.org.apache.httpcomponents>4.2.6</version.org.apache.httpcomponents>
         <version.org.jboss.arquillian>1.0.2.Final</version.org.jboss.arquillian>
         <version.org.jboss.resteasy.arquillian-deployment-scenario-provider>1.0.0.Final</version.org.jboss.resteasy.arquillian-deployment-scenario-provider>
         <version.org.jboss.shrinkwrap.resolver>2.1.0</version.org.jboss.shrinkwrap.resolver>


### PR DESCRIPTION
Connection re-used in a inconsistent state despite 'Connection: close' after successful authentication

Shaun Appleton 2014-03-19 07:04:07 EDT
Customer is using RestEasy and see the issue described in https://issues.apache.org/jira/browse/HTTPCLIENT-1340 : Connection re-used in a inconsistent state despite 'Connection: close' after successful authentication 

One solution here could be to upgrade httpclient and httpcore to 4.2.6 
(see https://bugzilla.redhat.com/show_bug.cgi?id=1076434)
