### PR TITLE
Resteasy query

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/Query.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/Query.java
@@ -1,0 +1,14 @@
+package org.jboss.resteasy.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Created by Simon Ström on 7/11/14.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+public @interface Query {
+}

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/InjectorFactoryImpl.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/InjectorFactoryImpl.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.core;
 
 import org.jboss.resteasy.annotations.Form;
+import org.jboss.resteasy.annotations.Query;
 import org.jboss.resteasy.annotations.Suspend;
 import org.jboss.resteasy.spi.ConstructorInjector;
 import org.jboss.resteasy.spi.InjectorFactory;
@@ -83,6 +84,8 @@ public class InjectorFactoryImpl implements InjectorFactory
       {
          case QUERY_PARAM:
             return new QueryParamInjector(parameter.getType(), parameter.getGenericType(), parameter.getAccessibleObject(), parameter.getParamName(), parameter.getDefaultValue(), parameter.isEncoded(), parameter.getAnnotations(), providerFactory);
+         case QUERY:
+            return new QueryInjector(parameter.getType(), providerFactory);
          case HEADER_PARAM:
             return new HeaderParamInjector(parameter.getType(), parameter.getGenericType(), parameter.getAccessibleObject(), parameter.getParamName(), parameter.getDefaultValue(), parameter.getAnnotations(), providerFactory);
          case FORM_PARAM:
@@ -145,7 +148,7 @@ public class InjectorFactoryImpl implements InjectorFactory
       String defaultVal = null;
       if (defaultValue != null) defaultVal = defaultValue.value();
 
-      QueryParam query;
+      QueryParam queryParam;
       HeaderParam header;
       MatrixParam matrix;
       PathParam uriParam;
@@ -154,11 +157,15 @@ public class InjectorFactoryImpl implements InjectorFactory
       Form form;
       Suspend suspend;
       Suspended suspended;
+      Query query;
 
 
-      if ((query = findAnnotation(annotations, QueryParam.class)) != null)
+      if ((queryParam = findAnnotation(annotations, QueryParam.class)) != null)
       {
-         return new QueryParamInjector(type, genericType, injectTarget, query.value(), defaultVal, encode, annotations, providerFactory);
+         return new QueryParamInjector(type, genericType, injectTarget, queryParam.value(), defaultVal, encode, annotations, providerFactory);
+      }
+      else if((query = findAnnotation(annotations, Query.class)) != null) {
+         return new QueryInjector(type, providerFactory);
       }
       else if ((header = findAnnotation(annotations, HeaderParam.class)) != null)
       {

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/QueryInjector.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/QueryInjector.java
@@ -1,0 +1,44 @@
+package org.jboss.resteasy.core;
+
+import org.jboss.resteasy.spi.*;
+
+import java.lang.reflect.Constructor;
+
+/**
+ * Created by Simon Ström on 7/17/14.
+ */
+public class QueryInjector implements ValueInjector {
+
+   private Class type;
+   private ConstructorInjector constructorInjector;
+   private PropertyInjector propertyInjector;
+
+   public QueryInjector(Class type, ResteasyProviderFactory factory) {
+      this.type = type;
+      Constructor<?> constructor;
+
+      try
+      {
+         constructor = type.getConstructor();
+      }
+      catch (NoSuchMethodException e)
+      {
+         throw new RuntimeException("Unable to instantiate @Query class. No no-arg constructor.");
+      }
+
+      constructorInjector = factory.getInjectorFactory().createConstructor(constructor, factory);
+      propertyInjector = factory.getInjectorFactory().createPropertyInjector(type, factory);
+   }
+
+   @Override
+   public Object inject() {
+      throw new IllegalStateException("You cannot inject outside the scope of an HTTP request");
+   }
+
+   @Override
+   public Object inject(HttpRequest request, HttpResponse response) {
+      Object target = constructorInjector.construct();
+      propertyInjector.inject(request, response, target);
+      return target;
+   }
+}

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/Parameter.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/Parameter.java
@@ -28,6 +28,7 @@ abstract public class Parameter
       UNKNOWN,
       // resteasy specific
       FORM,
+      QUERY,
       SUSPEND // deprecated
    }
 

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
@@ -2,6 +2,7 @@ package org.jboss.resteasy.spi.metadata;
 
 import org.jboss.resteasy.annotations.Body;
 import org.jboss.resteasy.annotations.Form;
+import org.jboss.resteasy.annotations.Query;
 import org.jboss.resteasy.annotations.Suspend;
 import org.jboss.resteasy.specimpl.ResteasyUriBuilder;
 import org.jboss.resteasy.util.IsHttpMethod;
@@ -243,7 +244,8 @@ public class ResourceBuilder
          DefaultValue defaultValue = findAnnotation(annotations, DefaultValue.class);
          if (defaultValue != null) parameter.defaultValue = defaultValue.value();
 
-         QueryParam query;
+         QueryParam queryParam;
+         Query query;
          HeaderParam header;
          MatrixParam matrix;
          PathParam uriParam;
@@ -254,10 +256,15 @@ public class ResourceBuilder
          Suspended suspended;
 
 
-         if ((query = findAnnotation(annotations, QueryParam.class)) != null)
+         if ((queryParam = findAnnotation(annotations, QueryParam.class)) != null)
          {
             parameter.paramType = Parameter.ParamType.QUERY_PARAM;
-            parameter.paramName = query.value();
+            parameter.paramName = queryParam.value();
+         }
+         else if(( query = findAnnotation(annotations, Query.class))!= null)
+         {
+            parameter.paramType = Parameter.ParamType.QUERY;
+            parameter.paramName = ""; // TODO query.prefix();
          }
          else if ((header = findAnnotation(annotations, HeaderParam.class)) != null)
          {

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/methodparams/QueryParamTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/methodparams/QueryParamTest.java
@@ -59,6 +59,6 @@ public class QueryParamTest {
       dispatcher.invoke(request, response);
 
       Assert.assertEquals(200, response.getStatus());
-      Assert.assertEquals("term: 't1', order: 'ASC', limit: ''", response.getContentAsString());
+      Assert.assertEquals("term: 't1', order: 'ASC', limit: 'null'", response.getContentAsString());
    }
 }

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/methodparams/QueryParamTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/methodparams/QueryParamTest.java
@@ -1,0 +1,64 @@
+package org.jboss.resteasy.test.finegrain.methodparams;
+
+import junit.framework.Assert;
+import org.jboss.resteasy.annotations.Form;
+import org.jboss.resteasy.annotations.Query;
+import org.jboss.resteasy.core.Dispatcher;
+import org.jboss.resteasy.mock.MockDispatcherFactory;
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.jboss.resteasy.mock.MockHttpResponse;
+import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
+import org.junit.Test;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Created by Simon Ström on 7/11/14.
+ */
+public class QueryParamTest {
+   public static class SearchQuery
+   {
+
+      @QueryParam("term")
+      private String term;
+
+      @QueryParam("order")
+      private String order;
+
+      @QueryParam("limit")
+      private String limit;
+
+      @Override
+      public String toString()
+      {
+         return new StringBuilder("term: '").append(term).append("', order: '").append(order).append("', limit: '").append(limit).append("'").toString();
+      }
+   }
+
+   @Path("search")
+   public static class MyResource
+   {
+      @GET
+      @Produces(MediaType.TEXT_PLAIN)
+      @Consumes(MediaType.TEXT_PLAIN)
+      public String get(@Query SearchQuery searchQuery)
+      {
+         return searchQuery.toString();
+      }
+   }
+
+   @Test
+   public void testQueryParamPrefix() throws Exception {
+      Dispatcher dispatcher = MockDispatcherFactory.createDispatcher();
+      dispatcher.getRegistry().addResourceFactory(new POJOResourceFactory(MyResource.class));
+
+      MockHttpRequest request = MockHttpRequest.get("/search?term=t1&order=ASC");
+      MockHttpResponse response = new MockHttpResponse();
+
+      dispatcher.invoke(request, response);
+
+      Assert.assertEquals(200, response.getStatus());
+      Assert.assertEquals("term: 't1', order: 'ASC', limit: ''", response.getContentAsString());
+   }
+}

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/methodparams/QueryTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/methodparams/QueryTest.java
@@ -16,7 +16,7 @@ import javax.ws.rs.core.MediaType;
 /**
  * Created by Simon Ström on 7/11/14.
  */
-public class QueryParamTest {
+public class QueryTest{
    public static class SearchQuery
    {
 


### PR DESCRIPTION
Add an option to use a @Query parameter to map parameters to an object.

I started out with [Issue-715](https://issues.jboss.org/browse/RESTEASY-715), but ended up doing this instead.
I know this is not what is asked for in the issue, but maybe it could be handy?

