### PR TITLE
resteasy-jsapi: Clear XHR handler after success.

### DIFF
--- a/jaxrs/resteasy-jsapi/src/main/resources/resteasy-client.js
+++ b/jaxrs/resteasy-jsapi/src/main/resources/resteasy-client.js
@@ -255,6 +255,7 @@ REST._complete = function(request, callback){
 		REST.log("Request status: "+request.status);
 		REST.log("Request response: "+request.responseText);
 		if(request.status >= 200 && request.status < 300){
+			request.onreadystatechange = null;
 			var contentType = request.getResponseHeader("Content-Type");
 			if(contentType != null){
 				if(REST._isXMLMIME(contentType))


### PR DESCRIPTION
The problem I encoutered that the onreadystatechange handler is called multiple
times on iOS 6. I can try to provide a simplified scenario but the idea is that
in the ajax callback I add two images to the HTML page. This caused the handler
to be called three times.

Some (especially older) browsers leak memory due to the cyclic reference
between the XMLHttpRequest object and the callback. This
[article](http://nullprogram.com/blog/2013/02/08/) dicusses this problem.
