### PR TITLE
Resteasy 1090

### DIFF
--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpResponse.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpResponse.java
@@ -32,7 +32,7 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 public class NettyHttpResponse implements HttpResponse
 {
    private static final int EMPTY_CONTENT_LENGTH = 0;
-private int status = 200;
+   private int status = 200;
    private OutputStream os;
    private MultivaluedMap<String, Object> outputHeaders;
    private final ChannelHandlerContext ctx;


### PR DESCRIPTION
- Content-Length is now written for empty responses
- DefaultHttpResonse object is used for empty responses
- Removed unused import
