### PR TITLE
RESTEASY-1095-OPTION-2

### DIFF
--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpRequestDecoder.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpRequestDecoder.java
@@ -69,8 +69,7 @@ public class RestEasyHttpRequestDecoder extends MessageToMessageDecoder<io.netty
            if (request instanceof HttpContent)
            {
                HttpContent content = (HttpContent) request;
-               ByteBuf buf = content.content().retain();
-               ByteBufInputStream in = new ByteBufInputStream(buf);
+               ByteBufInputStream in = new ByteBufInputStream(content.content());
                nettyRequest.setInputStream(in);
                out.add(nettyRequest);
            }


### PR DESCRIPTION
- Removed bytebuf retain from http request decoder
- Another option here: https://github.com/resteasy/Resteasy/pull/555
- Link to bug: https://issues.jboss.org/browse/RESTEASY-1095
