### PR TITLE
Allow NettyJaxrsServer to bind to a specific hostname

### DIFF
--- a/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
+++ b/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
@@ -31,6 +31,7 @@ public class NettyJaxrsServer implements EmbeddedJaxrsServer
 {
    protected ServerBootstrap bootstrap;
    protected Channel channel;
+   protected String hostname = null;
    protected int port = 8080;
    protected ResteasyDeployment deployment = new ResteasyDeployment();
    protected String root = "";
@@ -85,7 +86,15 @@ public class NettyJaxrsServer implements EmbeddedJaxrsServer
    {
        this.isKeepAlive = isKeepAlive;
    }
-   
+
+   public String getHostname() {
+       return hostname;
+   }
+
+   public void setHostname(String hostname) {
+       this.hostname = hostname;
+   }
+
    public int getPort()
    {
       return port;
@@ -144,7 +153,14 @@ public class NettyJaxrsServer implements EmbeddedJaxrsServer
       bootstrap.setPipelineFactory(factory);
 
       // Bind and start to accept incoming connections.
-      channel = bootstrap.bind(new InetSocketAddress(port));
+      final InetSocketAddress socketAddress;
+      if(null == hostname || hostname.isEmpty()) {
+          socketAddress = new InetSocketAddress(port);
+      } else {
+          socketAddress = new InetSocketAddress(hostname, port);
+      }
+
+      channel = bootstrap.bind(socketAddress);
       allChannels.add(channel);
    }
 

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
@@ -19,6 +19,7 @@ import org.jboss.resteasy.spi.ResteasyDeployment;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import java.net.InetSocketAddress;
 
 /**
  * An HTTP server that sends back the content of the received HTTP request
@@ -33,6 +34,7 @@ import javax.net.ssl.SSLEngine;
 public class NettyJaxrsServer implements EmbeddedJaxrsServer
 {
    protected ServerBootstrap bootstrap = new ServerBootstrap();
+   protected String hostname = null;
    protected int port = 8080;
    protected ResteasyDeployment deployment = new ResteasyDeployment();
    protected String root = "";
@@ -80,6 +82,14 @@ public class NettyJaxrsServer implements EmbeddedJaxrsServer
    public void setMaxRequestSize(int maxRequestSize)
    {
        this.maxRequestSize  = maxRequestSize;
+   }
+
+   public String getHostname() {
+       return hostname;
+   }
+
+   public void setHostname(String hostname) {
+       this.hostname = hostname;
    }
 
    public int getPort()
@@ -174,7 +184,14 @@ public class NettyJaxrsServer implements EmbeddedJaxrsServer
                    .childOption(ChannelOption.SO_KEEPALIVE, true);
        }
 
-        bootstrap.bind(port).syncUninterruptibly();
+       final InetSocketAddress socketAddress;
+       if(null == hostname || hostname.isEmpty()) {
+           socketAddress = new InetSocketAddress(port);
+       } else {
+           socketAddress = new InetSocketAddress(hostname, port);
+       }
+
+       bootstrap.bind(socketAddress).syncUninterruptibly();
    }
 
    @Override


### PR DESCRIPTION
Allow to set the hostname of `NettyJaxrsServer` (see [`InetSocketAddress`](http://docs.oracle.com/javase/8/docs/api/java/net/InetSocketAddress.html)) instead
of binding to all available network interfaces (`0.0.0.0`).
