### PR TITLE
SpringBeanProcessor: cope with non-public @Bean methods

### DIFF
--- a/jaxrs/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringBeanProcessor.java
+++ b/jaxrs/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringBeanProcessor.java
@@ -425,7 +425,7 @@ public class SpringBeanProcessor implements BeanFactoryPostProcessor, SmartAppli
             }
          }
 
-         for (Method method : getBeanClass(factoryClassName).getMethods())
+         for (Method method : getBeanClass(factoryClassName).getDeclaredMethods())
          {
             if (method.getName().equals(factoryMethodName))
             {

--- a/jaxrs/resteasy-spring/src/test/java/org/jboss/resteasy/spring/beanprocessor/ResourceConfiguration.java
+++ b/jaxrs/resteasy-spring/src/test/java/org/jboss/resteasy/spring/beanprocessor/ResourceConfiguration.java
@@ -21,7 +21,7 @@ public class ResourceConfiguration
    }
 
    @Bean
-   public Counter singletonCounter()
+   Counter singletonCounter()
    {
       return new Counter();
    }


### PR DESCRIPTION
A @Bean-annotated method on a Spring @Configuration class does not
have to be public. Previously, when SpringBeanProcessor encountered
a non-public @Bean method it would fail to determine the bean's type
and throw an IllegalStateException.

This commit updates SpringBeanProcessor to use
Class.getDeclaredMethods() when looking for the @Bean method on a
@Configuration class, thereby allowing it to find non-public methods.
