### PR TITLE
providers/multipart: RESTEASY-754 Support apache-mime4j 0.7.2

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -275,9 +275,14 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.james</groupId>
-                <artifactId>apache-mime4j</artifactId>
-                <version>0.6</version>
+                <artifactId>apache-mime4j-dom</artifactId>
+                <version>0.7.2</version>
              </dependency>
+             <dependency>
+                <groupId>org.apache.james</groupId>
+                <artifactId>apache-mime4j-storage</artifactId>
+                <version>0.7.2</version>
+            </dependency>
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>

--- a/jaxrs/providers/multipart/pom.xml
+++ b/jaxrs/providers/multipart/pom.xml
@@ -39,7 +39,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.james</groupId>
-            <artifactId>apache-mime4j</artifactId>
+            <artifactId>apache-mime4j-dom</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-mime4j-storage</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>

--- a/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/Mime4JWorkaround.java
+++ b/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/Mime4JWorkaround.java
@@ -1,0 +1,60 @@
+package org.jboss.resteasy.plugins.providers.multipart;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.james.mime4j.MimeException;
+import org.apache.james.mime4j.MimeIOException;
+import org.apache.james.mime4j.codec.DecodeMonitor;
+import org.apache.james.mime4j.dom.Message;
+import org.apache.james.mime4j.field.DefaultFieldParser;
+import org.apache.james.mime4j.field.LenientFieldParser;
+import org.apache.james.mime4j.message.BasicBodyFactory;
+import org.apache.james.mime4j.message.BodyFactory;
+import org.apache.james.mime4j.message.DefaultBodyDescriptorBuilder;
+import org.apache.james.mime4j.message.MessageImpl;
+import org.apache.james.mime4j.parser.MimeStreamParser;
+import org.apache.james.mime4j.stream.BodyDescriptorBuilder;
+import org.apache.james.mime4j.stream.MimeConfig;
+
+/**
+ * Copy code from org.apache.james.mime4j.message.DefaultMessageBuilder.parseMessage().
+ * Alter said code to use Mime4JWorkaroundBinaryEntityBuilder instead of EntityBuilder.
+ */
+public class Mime4JWorkaround
+{
+    /**
+     * This is a rough copy of DefaultMessageBuilder.parseMessage() modified to use a Mime4JWorkaround as the contentHandler instead
+     * of an EntityBuilder.
+     * <p>
+     * @see org.apache.james.mime4j.message.DefaultMessageBuilder#parseMessage(java.io.InputStream)
+     * @param is
+     * @return
+     * @throws IOException
+     * @throws MimeIOException
+     */
+    public static Message parseMessage(InputStream is) throws IOException, MimeIOException
+    {
+        try
+        {
+            MessageImpl message = new MessageImpl();
+            MimeConfig cfg = new MimeConfig();
+            boolean strict = cfg.isStrictParsing();
+            DecodeMonitor mon = strict ? DecodeMonitor.STRICT : DecodeMonitor.SILENT;
+            BodyDescriptorBuilder bdb = new DefaultBodyDescriptorBuilder(null, strict ? DefaultFieldParser.getParser() : LenientFieldParser.getParser(), mon);
+            BodyFactory bf = new BasicBodyFactory();
+            MimeStreamParser parser = new MimeStreamParser(cfg, mon, bdb);
+            // EntityBuilder expect the parser will send ParserFields for the well known fields
+            // It will throw exceptions, otherwise.
+            parser.setContentHandler(new Mime4jWorkaroundBinaryEntityBuilder(message, bf));
+            parser.setContentDecoding(false);
+            parser.setRecurse();
+
+            parser.parse(is);
+            return message;
+        }
+        catch (MimeException e)
+        {
+            throw new MimeIOException(e);
+        }
+    }
+}

--- a/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/Mime4jWorkaroundBinaryEntityBuilder.java
+++ b/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/Mime4jWorkaroundBinaryEntityBuilder.java
@@ -1,0 +1,249 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.jboss.resteasy.plugins.providers.multipart;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Stack;
+
+import org.apache.james.mime4j.MimeException;
+import org.apache.james.mime4j.dom.Body;
+import org.apache.james.mime4j.dom.Entity;
+import org.apache.james.mime4j.dom.Header;
+import org.apache.james.mime4j.dom.Message;
+import org.apache.james.mime4j.dom.Multipart;
+import org.apache.james.mime4j.parser.ContentHandler;
+import org.apache.james.mime4j.stream.BodyDescriptor;
+import org.apache.james.mime4j.stream.Field;
+import org.apache.james.mime4j.stream.RawField;
+import org.apache.james.mime4j.util.ByteArrayBuffer;
+import org.apache.james.mime4j.util.ByteSequence;
+
+// Imports added due to repackaging
+import org.apache.james.mime4j.message.BodyFactory;
+import org.apache.james.mime4j.message.BodyPart;
+import org.apache.james.mime4j.message.HeaderImpl;
+import org.apache.james.mime4j.message.MessageImpl;
+import org.apache.james.mime4j.message.MultipartImpl;
+
+
+/**
+ * A <code>ContentHandler</code> for building an <code>Entity</code> to be
+ * used in conjunction with a {@link org.apache.james.mime4j.parser.MimeStreamParser}.
+ * 
+ * This class was copied nearly verbatim from org.apache.james.mime4j.message.EntityBuilder
+ * It was duplicated because multipart-providers always wants a BinaryBody and never a TextBody.
+ * Unfortunately, there's no easy to get this in apache-mime4j. Further, the
+ * logical place to extend and override, "EntityBuilder", is a package-private class.
+ * <p>
+ * Therefore we duplicate EntityBuilder here.
+ * All code is identical except:
+ * <ul>
+ * <li>package changed</li>
+ * <li>class renamed</li>
+ * <li>constructor renamed</li>
+ * <li>additional imports added due to repackaging of the class</li>
+ * <li>body(BodyDescriptor bd, final InputStream is) - Method which unilaterally returns a BinaryBody.</li>
+ * </ul>
+ * <p>
+ * This file may not follow RESTEasy formatting standards. This is to make it easier to diff against the original EntityBuilder in the future when mime4j is updated again.
+ */
+class Mime4jWorkaroundBinaryEntityBuilder implements ContentHandler {
+
+    private final Entity entity;
+    private final BodyFactory bodyFactory;
+    private final Stack<Object> stack;
+
+    Mime4jWorkaroundBinaryEntityBuilder(
+            final Entity entity,
+            final BodyFactory bodyFactory) {
+        this.entity = entity;
+        this.bodyFactory = bodyFactory;
+        this.stack = new Stack<Object>();
+    }
+
+    private void expect(Class<?> c) {
+        if (!c.isInstance(stack.peek())) {
+            throw new IllegalStateException("Internal stack error: "
+                    + "Expected '" + c.getName() + "' found '"
+                    + stack.peek().getClass().getName() + "'");
+        }
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#startMessage()
+     */
+    public void startMessage() throws MimeException {
+        if (stack.isEmpty()) {
+            stack.push(this.entity);
+        } else {
+            expect(Entity.class);
+            Message m = new MessageImpl();
+            ((Entity) stack.peek()).setBody(m);
+            stack.push(m);
+        }
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#endMessage()
+     */
+    public void endMessage() throws MimeException {
+        expect(Message.class);
+        stack.pop();
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#startHeader()
+     */
+    public void startHeader() throws MimeException {
+        stack.push(new HeaderImpl());
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#field(RawField)
+     */
+    public void field(Field field) throws MimeException {
+        expect(Header.class);
+        ((Header) stack.peek()).addField(field);
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#endHeader()
+     */
+    public void endHeader() throws MimeException {
+        expect(Header.class);
+        Header h = (Header) stack.pop();
+        expect(Entity.class);
+        ((Entity) stack.peek()).setHeader(h);
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#startMultipart(org.apache.james.mime4j.stream.BodyDescriptor)
+     */
+    public void startMultipart(final BodyDescriptor bd) throws MimeException {
+        expect(Entity.class);
+
+        final Entity e = (Entity) stack.peek();
+        final String subType = bd.getSubType();
+        final Multipart multiPart = new MultipartImpl(subType);
+        e.setBody(multiPart);
+        stack.push(multiPart);
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#body(org.apache.james.mime4j.stream.BodyDescriptor, java.io.InputStream)
+     */
+    public void body(BodyDescriptor bd, final InputStream is) throws MimeException, IOException {
+        expect(Entity.class);
+
+        // NO NEED TO MANUALLY RUN DECODING.
+        // The parser has a "setContentDecoding" method. We should
+        // simply instantiate the MimeStreamParser with that method.
+
+        // final String enc = bd.getTransferEncoding();
+
+        final Body body;
+
+        /*
+        final InputStream decodedStream;
+        if (MimeUtil.ENC_BASE64.equals(enc)) {
+            decodedStream = new Base64InputStream(is);
+        } else if (MimeUtil.ENC_QUOTED_PRINTABLE.equals(enc)) {
+            decodedStream = new QuotedPrintableInputStream(is);
+        } else {
+            decodedStream = is;
+        }
+        */
+
+        //Code change here to unilaterally use binaryBody
+        //Code left commented out here to make diffs easy in the future when apache-mime4j updates.
+        //if (bd.getMimeType().startsWith("text/")) {
+        //    body = bodyFactory.textBody(is, bd.getCharset());
+        //} else {
+            body = bodyFactory.binaryBody(is);
+        //}
+
+        Entity entity = ((Entity) stack.peek());
+        entity.setBody(body);
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#endMultipart()
+     */
+    public void endMultipart() throws MimeException {
+        stack.pop();
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#startBodyPart()
+     */
+    public void startBodyPart() throws MimeException {
+        expect(Multipart.class);
+
+        BodyPart bodyPart = new BodyPart();
+        ((Multipart) stack.peek()).addBodyPart(bodyPart);
+        stack.push(bodyPart);
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#endBodyPart()
+     */
+    public void endBodyPart() throws MimeException {
+        expect(BodyPart.class);
+        stack.pop();
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#epilogue(java.io.InputStream)
+     */
+    public void epilogue(InputStream is) throws MimeException, IOException {
+        expect(MultipartImpl.class);
+        ByteSequence bytes = loadStream(is);
+        ((MultipartImpl) stack.peek()).setEpilogueRaw(bytes);
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#preamble(java.io.InputStream)
+     */
+    public void preamble(InputStream is) throws MimeException, IOException {
+        expect(MultipartImpl.class);
+        ByteSequence bytes = loadStream(is);
+        ((MultipartImpl) stack.peek()).setPreambleRaw(bytes);
+    }
+
+    /**
+     * Unsupported.
+     * @see org.apache.james.mime4j.parser.ContentHandler#raw(java.io.InputStream)
+     */
+    public void raw(InputStream is) throws MimeException, IOException {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    private static ByteSequence loadStream(InputStream in) throws IOException {
+        ByteArrayBuffer bab = new ByteArrayBuffer(64);
+
+        int b;
+        while ((b = in.read()) != -1) {
+            bab.append(b);
+        }
+
+        return bab;
+    }
+
+}

--- a/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartFormDataInputImpl.java
+++ b/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartFormDataInputImpl.java
@@ -1,9 +1,9 @@
 package org.jboss.resteasy.plugins.providers.multipart;
 
-import org.apache.james.mime4j.field.ContentDispositionField;
-import org.apache.james.mime4j.field.FieldName;
+import org.apache.james.mime4j.dom.field.ContentDispositionField;
+import org.apache.james.mime4j.dom.field.FieldName;
 import org.apache.james.mime4j.message.BodyPart;
-import org.apache.james.mime4j.parser.Field;
+import org.apache.james.mime4j.stream.Field;
 import org.jboss.resteasy.util.GenericType;
 
 import javax.ws.rs.core.MediaType;

--- a/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartInputImpl.java
+++ b/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartInputImpl.java
@@ -1,26 +1,13 @@
 package org.jboss.resteasy.plugins.providers.multipart;
 
-import org.apache.james.mime4j.MimeException;
-import org.apache.james.mime4j.MimeIOException;
-import org.apache.james.mime4j.codec.Base64InputStream;
-import org.apache.james.mime4j.codec.QuotedPrintableInputStream;
-import org.apache.james.mime4j.descriptor.BodyDescriptor;
-import org.apache.james.mime4j.field.ContentTypeField;
-import org.apache.james.mime4j.message.BinaryBody;
-import org.apache.james.mime4j.message.Body;
-import org.apache.james.mime4j.message.BodyFactory;
+import org.apache.james.mime4j.dom.field.ContentTypeField;
+import org.apache.james.mime4j.dom.BinaryBody;
+import org.apache.james.mime4j.dom.Body;
 import org.apache.james.mime4j.message.BodyPart;
-import org.apache.james.mime4j.message.Entity;
-import org.apache.james.mime4j.message.Message;
-import org.apache.james.mime4j.message.MessageBuilder;
-import org.apache.james.mime4j.message.Multipart;
-import org.apache.james.mime4j.message.TextBody;
-import org.apache.james.mime4j.parser.Field;
-import org.apache.james.mime4j.parser.MimeStreamParser;
-import org.apache.james.mime4j.storage.DefaultStorageProvider;
-import org.apache.james.mime4j.storage.StorageProvider;
-import org.apache.james.mime4j.util.CharsetUtil;
-import org.apache.james.mime4j.util.MimeUtil;
+import org.apache.james.mime4j.dom.Message;
+import org.apache.james.mime4j.dom.Multipart;
+import org.apache.james.mime4j.dom.TextBody;
+import org.apache.james.mime4j.stream.Field;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.util.CaseInsensitiveMap;
@@ -34,21 +21,16 @@ import javax.ws.rs.ext.Providers;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.io.SequenceInputStream;
-import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
+import org.apache.james.mime4j.dom.Entity;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -63,100 +45,6 @@ public class MultipartInputImpl implements MultipartInput
    protected static final Annotation[] empty = {};
    protected MediaType defaultPartContentType = MultipartConstants.TEXT_PLAIN_WITH_CHARSET_US_ASCII_TYPE;
    protected String defaultPartCharset = null;
-
-   // We hack MIME4j so that it always returns a BinaryBody so we don't have to deal with Readers and their charset conversions
-   private static class BinaryOnlyMessageBuilder extends MessageBuilder
-   {
-      private Method expectMethod;
-      private java.lang.reflect.Field bodyFactoryField;
-      private java.lang.reflect.Field stackField;
-
-      private void init()
-      {
-         try
-         {
-            expectMethod = MessageBuilder.class.getDeclaredMethod("expect", Class.class);
-            expectMethod.setAccessible(true);
-            bodyFactoryField = MessageBuilder.class.getDeclaredField("bodyFactory");
-            bodyFactoryField.setAccessible(true);
-            stackField = MessageBuilder.class.getDeclaredField("stack");
-            stackField.setAccessible(true);
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(e);
-         }
-      }
-
-      private BinaryOnlyMessageBuilder(Entity entity)
-      {
-         super(entity);
-         init();
-      }
-
-      private BinaryOnlyMessageBuilder(Entity entity, StorageProvider storageProvider)
-      {
-         super(entity, storageProvider);
-         init();
-      }
-
-      @Override
-      public void body(BodyDescriptor bd, InputStream is) throws MimeException, IOException
-      {
-         // the only thing different from the superclass is that we just return a BinaryBody no matter what
-         try
-         {
-            expectMethod.invoke(this, Entity.class);
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(e);
-         }
-
-         final String enc = bd.getTransferEncoding();
-
-         final Body body;
-
-         final InputStream decodedStream;
-         if (MimeUtil.ENC_BASE64.equals(enc)) {
-            decodedStream = new Base64InputStream(is);
-         } else if (MimeUtil.ENC_QUOTED_PRINTABLE.equals(enc)) {
-            decodedStream = new QuotedPrintableInputStream(is);
-         } else {
-            decodedStream = is;
-         }
-
-         try
-         {
-            BodyFactory factory = (BodyFactory)bodyFactoryField.get(this);
-            body = factory.binaryBody(decodedStream);
-
-            Stack<Object> st = (Stack<Object>)stackField.get(this);
-            Entity entity = ((Entity) st.peek());
-            entity.setBody(body);
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(e);
-         }
-
-      }
-   }
-
-   private static class BinaryMessage extends Message
-   {
-      private BinaryMessage(InputStream is) throws IOException, MimeIOException
-      {
-         try {
-            MimeStreamParser parser = new MimeStreamParser(null);
-            parser.setContentHandler(new BinaryOnlyMessageBuilder(this, DefaultStorageProvider.getInstance()));
-            parser.parse(is);
-         } catch (MimeException e) {
-            throw new MimeIOException(e);
-         }
-
-      }
-   }
 
    public MultipartInputImpl(MediaType contentType, Providers workers)
    {
@@ -194,7 +82,7 @@ public class MultipartInputImpl implements MultipartInput
 
    public void parse(InputStream is) throws IOException
    {
-      mimeMessage = new BinaryMessage(addHeaderToHeadlessStream(is));
+      mimeMessage = Mime4JWorkaround.parseMessage(addHeaderToHeadlessStream(is));
       extractParts();
    }
 
@@ -225,8 +113,11 @@ public class MultipartInputImpl implements MultipartInput
    protected void extractParts() throws IOException
    {
       Multipart multipart = (Multipart) mimeMessage.getBody();
-      for (BodyPart bodyPart : multipart.getBodyParts())
-         parts.add(extractPart(bodyPart));
+      for (Entity entity : multipart.getBodyParts())
+          if (entity instanceof BodyPart)
+          {
+            parts.add(extractPart((BodyPart)entity));
+          }
    }
 
    protected InputPart extractPart(BodyPart bodyPart) throws IOException

--- a/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartRelatedInputImpl.java
+++ b/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartRelatedInputImpl.java
@@ -1,7 +1,7 @@
 package org.jboss.resteasy.plugins.providers.multipart;
 
-import org.apache.james.mime4j.field.ContentTypeField;
-import org.apache.james.mime4j.field.FieldName;
+import org.apache.james.mime4j.dom.field.ContentTypeField;
+import org.apache.james.mime4j.dom.field.FieldName;
 import org.apache.james.mime4j.message.BodyPart;
 
 import javax.ws.rs.core.MediaType;

--- a/jaxrs/security/resteasy-crypto/pom.xml
+++ b/jaxrs/security/resteasy-crypto/pom.xml
@@ -64,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.james</groupId>
-            <artifactId>apache-mime4j</artifactId>
+            <artifactId>apache-mime4j-dom</artifactId>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Apache mime4j 0.7.2 has been out for a while now. Update the
multipart provider to support it.

The multipart provider had extended some classes from 0.6 that are
nolonger available in 0.7.2. Therefore a new approach was taken of
copying a few bits of code from mime4j and rewrite small parts.

See Mime4JWorkaround.java, and Mime4jWorkaroundBinaryEntityBuilder
for all such code.
