### PR TITLE
Update readme. Remove github issues that are no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To read the documentation you can [read it online](http://resteasy.jboss.org/doc
 A wiki exists. You can find it [here](http://wiki.jboss.org/wiki/RESTeasyJAXRS)
 
 ## Issues
-Issues are kept both as a [JIRA](http://jira.jboss.org/jira/browse/RESTEASY) and on [Github](https://github.com/resteasy/Resteasy/issues)
+Issues are kept in [JIRA](http://jira.jboss.org/jira/browse/RESTEASY)
 
 ## Build
 After pulling down a clone of the Resteasy repository run


### PR DESCRIPTION
It looks like the issues section on github is no longer used.

Remove the reference to those from the readme.