### PR TITLE
OAuthUtils readMessage removes duplicate Parameter values

### DIFF
--- a/jaxrs/security/resteasy-oauth/src/main/java/org/jboss/resteasy/auth/oauth/OAuthUtils.java
+++ b/jaxrs/security/resteasy-oauth/src/main/java/org/jboss/resteasy/auth/oauth/OAuthUtils.java
@@ -90,7 +90,7 @@ public class OAuthUtils {
 	 */
 	public static OAuthMessage readMessage(HttpServletRequest req) {
 		String authorizationHeader = req.getHeader(AUTHORIZATION_HEADER);
-		Set<OAuth.Parameter> parameters = new HashSet<OAuth.Parameter>();
+		List<OAuth.Parameter> parameters = new ArrayList<OAuth.Parameter>();
 		
 		// first read the Authorization header
 		if(authorizationHeader != null){


### PR DESCRIPTION
OAuthFilter filters uses OAuth.readMessage() to create a OAuthMessage and use it to validate the OAuth request. 
Please do not use a HashSet, it does not allow for duplicate parameters while HTTP and OAUTH do. (eg ?a=1&a=1....). This causes the signature check to fail.

HTTP Request: http://localhost:8080/rest/v1/a/2/event&kind=1&kind=1

16:13:30,916 TRACE [nl.topicus.cobra.rest.security.oauth.RestOAuthAuthenticationFilter](default task-35) Handling failed: net.oauth.OAuthProblemException: signature_invalid
oauth_signature: ...
oauth_signature_base_string: GET%26http%3A%2F%2Flocalhost%3A8080%2Frest%2Fv1%2Fa%2F2%2Fevent%26kind%3D1%26oauth_consumer_key%3Da10e722c-1200-4021-b0aa-eccb6783a6f3%26oauth_nonce%3D1459824376%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1415286810%26oauth_token%3Da2649ea4-d8ee-4ed8-a93b-5cdc943008b1%26oauth_version%3D1.0
oauth_problem: signature_invalid
oauth_signature_method: HMAC-SHA1
    at net.oauth.signature.OAuthSignatureMethod.validate(OAuthSignatureMethod.java:69) [oauth-20100527.jar:]
    at net.oauth.SimpleOAuthValidator.validateSignature(SimpleOAuthValidator.java:254) [oauth-provider-20100527.jar:]
    at org.jboss.resteasy.auth.oauth.OAuthValidator.validateMessage(OAuthValidator.java:45) [resteasy-oauth-3.0.10.Final.jar:]
    at org.jboss.resteasy.auth.oauth.OAuthUtils.validateRequestWithAccessToken(OAuthUtils.java:208) [resteasy-oauth-3.0.10.Final.jar:]
    at org.jboss.resteasy.auth.oauth.OAuthFilter:71) [:]
