### PR TITLE
Update to ResteasyHttpHeaders.java

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResteasyHttpHeaders.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResteasyHttpHeaders.java
@@ -144,15 +144,18 @@ public class ResteasyHttpHeaders implements HttpHeaders
    public List<MediaType> getAcceptableMediaTypes()
    {
       String accepts = getHeaderString(ACCEPT);
-      if (accepts == null) return Collections.emptyList();
       List<MediaType> list = new ArrayList<MediaType>();
-      StringTokenizer tokenizer = new StringTokenizer(accepts, ",");
-      while (tokenizer.hasMoreElements())
-      {
-         String item = tokenizer.nextToken().trim();
-         list.add(MediaType.valueOf(item));
+      if (accepts == null){
+          list.add(MediaType.WILDCARD_TYPE);
+      }else{
+          StringTokenizer tokenizer = new StringTokenizer(accepts, ",");
+          while (tokenizer.hasMoreElements())
+          {
+            String item = tokenizer.nextToken().trim();
+            list.add(MediaType.valueOf(item));
+          }
+          MediaTypeHelper.sortByWeight(list);
       }
-      MediaTypeHelper.sortByWeight(list);
       return Collections.unmodifiableList(list);
    }
 


### PR DESCRIPTION
Details:

Fix for RESTEASY-1113: HttpHeaders.getAcceptableMediaTypes() doesn't comply with JAX-RS 2.0 spec
https://issues.jboss.org/browse/RESTEASY-1113

Updated getAcceptableMediaTypes() to return Wildcard media type in case no acceptable media types are specified