### PR TITLE
FIX FOR: ClassCastException when using Collection with generic element t...

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/StringParameterInjector.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/StringParameterInjector.java
@@ -5,6 +5,7 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.spi.StringConverter;
 import org.jboss.resteasy.spi.StringParameterUnmarshaller;
 import org.jboss.resteasy.util.StringToPrimitive;
+import org.jboss.resteasy.util.Types;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.HeaderParam;
@@ -97,7 +98,7 @@ public class StringParameterInjector
          if (genericType != null && genericType instanceof ParameterizedType)
          {
             ParameterizedType zType = (ParameterizedType) genericType;
-            baseType = (Class) zType.getActualTypeArguments()[0];
+            baseType = Types.getRawType(zType.getActualTypeArguments()[0]);
             baseGenericType = zType.getActualTypeArguments()[0];
          }
          else

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/StringParameterInjectorTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/StringParameterInjectorTest.java
@@ -11,7 +11,10 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.List;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 
 public class StringParameterInjectorTest
@@ -75,4 +78,30 @@ public class StringParameterInjectorTest
    public static @interface SpecialString
    {
    }
+   
+   // ***************************************************************************
+   
+   @Test
+   public void instantiation() throws Exception
+   {
+      final Type type = GenericType.class.getDeclaredMethod("returnSomething").getGenericReturnType();
+      final StringParameterInjector injector = new StringParameterInjector(
+               List.class, type, "ignored", String.class, null, null,
+               new Annotation[0], new ResteasyProviderFactory());
+      final Object result = injector.extractValue("");
+      assertNotNull(result);
+   }
+   
+   public static class GenericType<T>
+   {
+      public GenericType(String ignore)
+      {
+      }
+
+      public List<GenericType<T>> returnSomething()
+      {
+         return null;
+      }
+   }
 }
+


### PR DESCRIPTION
ClassCastException when using Collection with generic element type as parameter

My code looks like
public MyResultClass doSomething(@QueryParam("param") List<MyGenericType<? extends MyParamClass>> params)

However invoking it through REST results in ClassCastException:
Unknown exception while executing POST ...: java.lang.ClassCastException: org.jboss.resteasy.util.Types$1 cannot be cast to java.lang.Class
	at org.jboss.resteasy.core.StringParameterInjector.initialize(StringParameterInjector.java:100) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.core.StringParameterInjector.<init>(StringParameterInjector.java:61) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.core.QueryParamInjector.<init>(QueryParamInjector.java:28) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.core.InjectorFactoryImpl.createParameterExtractor(InjectorFactoryImpl.java:85) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.core.MethodInjectorImpl.<init>(MethodInjectorImpl.java:42) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.core.InjectorFactoryImpl.createMethodInjector(InjectorFactoryImpl.java:76) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.core.ResourceMethodInvoker.<init>(ResourceMethodInvoker.java:100) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.core.LocatorRegistry.processMethod(LocatorRegistry.java:63) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.core.LocatorRegistry.register(LocatorRegistry.java:48) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.core.LocatorRegistry.<init>(LocatorRegistry.java:40) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.core.ResourceLocatorInvoker.invokeOnTargetObject(ResourceLocatorInvoker.java:128) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.core.ResourceLocatorInvoker.invoke(ResourceLocatorInvoker.java:103) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:356) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:179) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:220) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:56) [resteasy-jaxrs-3.0.10.Final.jar:]
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51) [resteasy-jaxrs-3.0.10.Final.jar:]

The problem seems to be in StringParameterInjector.initialize(...), which assumes Collection type parameter always being a Class
(but in this case it is ParameterizedType).