### PR TITLE
Build: dependency and import fixes

### DIFF
--- a/jaxrs/providers/resteasy-validator-provider-11/pom.xml
+++ b/jaxrs/providers/resteasy-validator-provider-11/pom.xml
@@ -68,7 +68,14 @@
             <groupId>org.jboss.spec.javax.servlet</groupId>
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
         </dependency>
-        
+
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>1.0</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>tjws</artifactId>

--- a/jaxrs/security/resteasy-oauth/src/main/java/org/jboss/resteasy/auth/oauth/OAuthUtils.java
+++ b/jaxrs/security/resteasy-oauth/src/main/java/org/jboss/resteasy/auth/oauth/OAuthUtils.java
@@ -17,10 +17,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 public class OAuthUtils {
 	


### PR DESCRIPTION
Added cdi-api dep to resteasy-validator-provider-11 since it use javax.enterprise.inject.spi.
Added import for ArrayList in org.jboss.resteasy.auth.oauth.OAuthUtils since it used in code.