### PR TITLE
[RESTEASY-1156] Installation instructions for EAP 6 should not recommend...

### DIFF
--- a/jaxrs/docbook/reference/en/en-US/modules/Installation_Configuration.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/Installation_Configuration.xml
@@ -13,7 +13,7 @@
     <section id="upgrading-as7">
         <title>Upgrading Resteasy Within JBoss AS 7</title>
         <para>
-            Resteasy is bundled with JBoss AS 7.  You will likely have the need to upgrade Resteasy in AS7.  The Resteasy
+            Resteasy is bundled with JBoss AS 7.  You may have the need to upgrade Resteasy in AS7.  The Resteasy
             distribution comes with a zip file called resteasy-jboss-modules-3.0.11.Final-SNAPSHOT.zip.  Unzip this file while
             with the modules/ directory of the JBoss AS7 distribution.  This will overwrite some of the existing files there.
         </para>
@@ -21,15 +21,21 @@
     <section id="upgrading-eap61">
         <title>Upgrading Resteasy Within JBoss EAP 6.1</title>
         <para>
-            Resteasy is bundled with JBoss EAP 6.1.  You will likely have the need to upgrade Resteasy in JBoss EAP 6.1.  The Resteasy
+            Resteasy is bundled with JBoss EAP 6.1.  You may have the need to upgrade Resteasy in JBoss EAP 6.1.  The Resteasy
             distribution comes with a zip file called resteasy-jboss-modules-3.0.11.Final-SNAPSHOT.zip.  Unzip this file while
             with the modules/system/layers/base/ directory of the JBoss EAP 6.1 distribution.  This will overwrite some of the existing files there.
         </para>
+        <warning>
+            <para>
+                Overwriting Resteasy modules in EAP 6 will place your installation in a less supportable state because Red Hat does not provide 
+                direct support for Resteasy 3.x or JAX-RS 2.x in EAP 6; this will only be supported by the community.
+            </para>
+        </warning>
     </section>
     <section id="upgrading-wildfly">
         <title>Upgrading Resteasy Within Wildfly</title>
         <para>
-            Resteasy is bundled with Wildfly.  You will likely have the need to upgrade Resteasy in Wildfly.  The Resteasy
+            Resteasy is bundled with Wildfly.  You may have the need to upgrade Resteasy in Wildfly.  The Resteasy
             distribution comes with a zip file called resteasy-jboss-modules-wf8-3.0.11.Final-SNAPSHOT.zip.  Unzip this file while
             with the modules/system/layers/base/ directory of the Wildfly distribution.  This will overwrite some of the existing files there.
         </para>


### PR DESCRIPTION
... overwriting supported components

https://issues.jboss.org/browse/RESTEASY-1156

I actually left the recommendation in there, but I softened the wording a bit and adding a warning box explaining the reduced supportability.