### PR TITLE
RESTEASY-1163: use RestEasy's own UriBuilder and clone on resolveTemplate()

### DIFF
--- a/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientWebTarget.java
+++ b/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientWebTarget.java
@@ -35,19 +35,19 @@ public class ClientWebTarget implements ResteasyWebTarget
    public ClientWebTarget(ResteasyClient client, String uri, ClientConfiguration configuration) throws IllegalArgumentException, NullPointerException
    {
       this(client, configuration);
-      uriBuilder = UriBuilder.fromUri(uri);
+      this.uriBuilder = configuration.getProviderFactory().createUriBuilder().uri(uri);
    }
 
    public ClientWebTarget(ResteasyClient client, URI uri, ClientConfiguration configuration) throws NullPointerException
    {
       this(client, configuration);
-      uriBuilder = UriBuilder.fromUri(uri);
+      this.uriBuilder = configuration.getProviderFactory().createUriBuilder().uri( uri );
    }
 
    public ClientWebTarget(ResteasyClient client, UriBuilder uriBuilder, ClientConfiguration configuration) throws NullPointerException
    {
       this(client, configuration);
-      this.uriBuilder = uriBuilder.clone();
+      this.uriBuilder = configuration.getProviderFactory().createUriBuilder().uri(uriBuilder.toTemplate());
    }
 
    @Override
@@ -135,7 +135,7 @@ public class ClientWebTarget implements ResteasyWebTarget
       if (name == null) throw new NullPointerException("name was null");
       if (value == null) throw new NullPointerException("value was null");
       String val = configuration.toString(value);
-      UriBuilder copy = uriBuilder.resolveTemplate(name, val);
+      UriBuilder copy = uriBuilder.clone().resolveTemplate(name, val);
       ClientWebTarget target = new ClientWebTarget(client, copy, configuration);
       return target;
    }
@@ -153,7 +153,7 @@ public class ClientWebTarget implements ResteasyWebTarget
          String val = configuration.toString(entry.getValue());
          vals.put(entry.getKey(), val);
       }
-      UriBuilder copy = uriBuilder.resolveTemplates(vals);
+      UriBuilder copy = uriBuilder.clone().resolveTemplates(vals);
       ClientWebTarget target = new ClientWebTarget(client, copy, configuration);
       return target;
    }
@@ -165,7 +165,7 @@ public class ClientWebTarget implements ResteasyWebTarget
       if (name == null) throw new NullPointerException("name was null");
       if (value == null) throw new NullPointerException("value was null");
       String val = configuration.toString(value);
-      UriBuilder copy = uriBuilder.resolveTemplate(name, val, encodeSlashInPath);
+      UriBuilder copy = uriBuilder.clone().resolveTemplate(name, val, encodeSlashInPath);
       ClientWebTarget target = new ClientWebTarget(client, copy, configuration);
       return target;
    }
@@ -177,7 +177,7 @@ public class ClientWebTarget implements ResteasyWebTarget
       if (name == null) throw new NullPointerException("name was null");
       if (value == null) throw new NullPointerException("value was null");
       String val = configuration.toString(value);
-      UriBuilder copy = uriBuilder.resolveTemplateFromEncoded(name, val);
+      UriBuilder copy = uriBuilder.clone().resolveTemplateFromEncoded(name, val);
       ClientWebTarget target = new ClientWebTarget(client, copy, configuration);
       return target;
    }
@@ -195,7 +195,7 @@ public class ClientWebTarget implements ResteasyWebTarget
          String val = configuration.toString(entry.getValue());
          vals.put(entry.getKey(), val);
       }
-      UriBuilder copy = uriBuilder.resolveTemplatesFromEncoded(vals) ;
+      UriBuilder copy = uriBuilder.clone().resolveTemplatesFromEncoded(vals) ;
       ClientWebTarget target = new ClientWebTarget(client, copy, configuration);
       return target;
    }
@@ -213,7 +213,7 @@ public class ClientWebTarget implements ResteasyWebTarget
          String val = configuration.toString(entry.getValue());
          vals.put(entry.getKey(), val);
       }
-      UriBuilder copy = uriBuilder.resolveTemplates(vals, encodeSlashInPath) ;
+      UriBuilder copy = uriBuilder.clone().resolveTemplates(vals, encodeSlashInPath) ;
       ClientWebTarget target = new ClientWebTarget(client, copy, configuration);
       return target;
    }

--- a/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
+++ b/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
@@ -1,6 +1,13 @@
 package org.jboss.resteasy.test.client;
 
 import junit.framework.Assert;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
+import org.jboss.resteasy.client.jaxrs.internal.ClientWebTarget;
+import org.jboss.resteasy.specimpl.LinkImpl;
+import org.jboss.resteasy.specimpl.ResteasyUriBuilder;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.junit.Test;
 
 import javax.ws.rs.client.Client;
@@ -9,7 +16,16 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.ext.RuntimeDelegate;
+
+import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -17,6 +33,110 @@ import java.lang.reflect.Modifier;
  */
 public class ClientBuilderTest
 {
+   @Test
+   public void RESTEASY_1163_resteasyclient_should_use_ProviderFactory_to_create_UriBuilder_instances() throws Exception {
+      class MustNotBeUsedRuntimeDelegate extends ResteasyProviderFactory {
+         @Override
+         public UriBuilder createUriBuilder() {
+            throw new AssertionError("shouldn't call global RuntimeDelegate to obtain UriBuilder instance");
+         }
+      }
+      final Link TESTLINK = Link.fromUri("http://dummy.local/someparam/myname").build();
+
+      RuntimeDelegate original = RuntimeDelegate.getInstance();
+      try {
+         RuntimeDelegate.setInstance(new MustNotBeUsedRuntimeDelegate());
+
+         final Client client = new ResteasyClientBuilder().build();
+
+         // ctor 1
+         client.target("http://dummy.local/{someparam}/{myname}/");
+         // ctor 2
+         client.target(new URI("http://dummy.local/someparam/myname/"));
+         // ctor 3
+         client.target(new ResteasyUriBuilder().uri("http://dummy.local/{someparam}/{myname}/"));
+         // ctor 4
+         client.target(TESTLINK);
+      } finally {
+         RuntimeDelegate.setInstance(original);
+      }
+   }
+
+   @Test
+   public void RESTEASY_1163_resteasyclient_should_clone_uriBuilder_on_resolveTemplate() throws Exception {
+      Field fldUriBuilder = ClientWebTarget.class.getDeclaredField("uriBuilder");
+      fldUriBuilder.setAccessible(true);
+
+      /**
+       * Emulate a UriBuilder implementation that doesn't return copies on resolveTemplate(), like Jersey's UriBuilder
+       */
+      class MisbehavingUriBuilder extends ResteasyUriBuilder {
+         @Override
+         public UriBuilder resolveTemplate(String name, Object value) throws IllegalArgumentException {
+            this.uri("changed");
+            return this;
+         }
+
+         @Override
+         public UriBuilder resolveTemplates(Map<String, Object> templateValues) throws IllegalArgumentException {
+            this.uri("changed");
+            return this;
+         }
+
+         @Override
+         public UriBuilder resolveTemplate(String name, Object value, boolean encodeSlashInPath) throws IllegalArgumentException {
+            this.uri("changed");
+            return this;
+         }
+
+         @Override
+         public UriBuilder resolveTemplateFromEncoded(String name, Object value) throws IllegalArgumentException {
+            this.uri("changed");
+            return this;
+         }
+
+         @Override
+         public UriBuilder resolveTemplates(Map<String, Object> templateValues, boolean encodeSlashInPath) throws IllegalArgumentException {
+            this.uri("changed");
+            return this;
+         }
+
+         @Override
+         public UriBuilder resolveTemplatesFromEncoded(Map<String, Object> templateValues) throws IllegalArgumentException {
+            this.uri("changed");
+            return this;
+         }
+      }
+
+      final WebTarget webTarget = new ResteasyClientBuilder().build().target("http://dummy.local/{someparam}/");
+      fldUriBuilder.set(webTarget, new MisbehavingUriBuilder().uri("http://dummy.local/{someparam}/"));
+
+      WebTarget resolvedWebTarget;
+
+      resolvedWebTarget = webTarget.resolveTemplate("someparam", "someval");
+      Assert.assertEquals("http://dummy.local/{someparam}/", webTarget.getUriBuilder().toTemplate());
+
+      resolvedWebTarget = webTarget.resolveTemplate("someparam", "someval", true);
+      Assert.assertEquals("http://dummy.local/{someparam}/", webTarget.getUriBuilder().toTemplate());
+
+      resolvedWebTarget = webTarget.resolveTemplateFromEncoded("someparam", "someval");
+      Assert.assertEquals("http://dummy.local/{someparam}/", webTarget.getUriBuilder().toTemplate());
+
+      resolvedWebTarget = webTarget.resolveTemplates(new HashMap<String, Object>() {{
+         put("someparam", "someval");
+      }});
+      Assert.assertEquals("http://dummy.local/{someparam}/", webTarget.getUriBuilder().toTemplate());
+
+      resolvedWebTarget = webTarget.resolveTemplates(new HashMap<String, Object>() {{
+         put("someparam", "someval");
+      }}, true);
+      Assert.assertEquals("http://dummy.local/{someparam}/", webTarget.getUriBuilder().toTemplate());
+
+      resolvedWebTarget = webTarget.resolveTemplatesFromEncoded(new HashMap<String, Object>() {{
+         put("someparam", "someval");
+      }});
+      Assert.assertEquals("http://dummy.local/{someparam}/", webTarget.getUriBuilder().toTemplate());
+   }
 
    @Test
    public void entityStringThrowsExceptionWhenUnparsableTest() throws Exception {


### PR DESCRIPTION
ensure to use RestEasy's own UriBuilder and proper cloning uriBuilder instances on resolveTemplateXXXX()

see https://issues.jboss.org/browse/RESTEASY-1163