### PR TITLE
[Netty4] Correct handling for absolute URIs in HTTP request lines

### DIFF
--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyUtil.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyUtil.java
@@ -8,12 +8,10 @@ import org.jboss.resteasy.spi.ResteasyUriInfo;
 import org.jboss.resteasy.util.CookieParser;
 import org.jboss.resteasy.util.HttpHeaderNames;
 import org.jboss.resteasy.util.MediaTypeHelper;
-import org.jboss.resteasy.util.PathHelper;
 
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,9 +29,16 @@ public class NettyUtil
       String host = HttpHeaders.getHost(request, "unknown");
       String uri = request.getUri();
 
-      String uriString = protocol + "://" + host + uri;
+      String uriString;
+
+      // If we appear to have an absolute URL, don't try to recreate it from the host and request line.
+      if (uri.startsWith(protocol + "://")) {
+         uriString = uri;
+      } else {
+         uriString = protocol + "://" + host + uri;
+      }
+
       URI absoluteURI = URI.create(uriString);
-      URI noQuery = UriBuilder.fromUri(uriString).replaceQuery(null).build();
       return new ResteasyUriInfo(uriString, absoluteURI.getRawQuery(), contextPath);
    }
 


### PR DESCRIPTION
Correctly handle requests with an absolute URI in the request line, like:

```
GET http://www.example.com/testContent HTTP/1.1
Host: www.example.com
```

This is required per the spec: http://tools.ietf.org/html/rfc2616#section-5, specifically: 

> To allow for transition to absoluteURIs in all requests in future versions of HTTP, all HTTP/1.1 servers MUST accept the absoluteURI form in requests, even though HTTP/1.1 clients will only generate them in requests to proxies.

And:

> If Request-URI is an absoluteURI, the host is part of the Request-URI. Any Host header field value in the request MUST be ignored.

Issue: https://issues.jboss.org/browse/RESTEASY-1193