### PR TITLE
[RESTEASY-1190] Wrap JSONP response in try-catch block

### DIFF
--- a/jaxrs/docbook/reference/en/en-US/modules/Json.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/Json.xml
@@ -157,6 +157,13 @@ processStuffResponse(&lt;nomal JSON body&gt;)
         <para>
             You can change the name of the callback parameter by setting the callbackQueryParameter property.
         </para>
+        <para>
+            JacksonJsonpInterceptor can wrap the response into a try-catch block:
+<programlisting>
+try{processStuffResponse(&lt;nomal JSON body&gt;)}catch(e){}
+</programlisting>
+            You can enable this feture be setting the resteasy.jsonp.silent property to true
+        </para>
     </sect1>
     <sect1 id="Jackson_JSON_Decorator">
         <title>Jackson JSON Decorator</title>

--- a/jaxrs/docbook/reference/en/en-US/modules/Json.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/Json.xml
@@ -160,9 +160,9 @@ processStuffResponse(&lt;nomal JSON body&gt;)
         <para>
             JacksonJsonpInterceptor can wrap the response into a try-catch block:
 <programlisting>
-try{processStuffResponse(&lt;nomal JSON body&gt;)}catch(e){}
+try{processStuffResponse(&lt;normal JSON body&gt;)}catch(e){}
 </programlisting>
-            You can enable this feature be setting the resteasy.jsonp.silent property to true
+            You can enable this feature by setting the resteasy.jsonp.silent property to true
         </para>
     </sect1>
     <sect1 id="Jackson_JSON_Decorator">

--- a/jaxrs/docbook/reference/en/en-US/modules/Json.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/Json.xml
@@ -162,7 +162,7 @@ processStuffResponse(&lt;nomal JSON body&gt;)
 <programlisting>
 try{processStuffResponse(&lt;nomal JSON body&gt;)}catch(e){}
 </programlisting>
-            You can enable this feture be setting the resteasy.jsonp.silent property to true
+            You can enable this feature be setting the resteasy.jsonp.silent property to true
         </para>
     </sect1>
     <sect1 id="Jackson_JSON_Decorator">

--- a/jaxrs/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/Jackson2JsonpInterceptor.java
+++ b/jaxrs/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/Jackson2JsonpInterceptor.java
@@ -35,6 +35,19 @@ import org.jboss.resteasy.util.CommitHeaderOutputStream;
  *  parameter with the method name. The default name of this query parameter is "callback". So this interceptor is compatible with 
  *  <a href="http://api.jquery.com/jQuery.ajax/">jQuery</a>.
  * </p>
+ * <p>
+ *  It is possible to wrap the generated javascript function call in a try-catch block.
+ *  You can enable it either by setting the {@link #wrapInTryCatch} property of the provider instance to {@code true}
+ *  or by setting the {@code resteasy.jsonp.silent} context-param to true:
+ * </p>
+ * <pre>
+ *  {@code
+ *  <context-param>
+ *   <param-name>resteasy.jsonp.silent</param-name>
+ *   <param-value>true</param-value>
+ *  </context-param>
+ *  }
+ * </pre>
  *
  * @author <a href="mailto:holger.morch@nokia.com">Holger Morch</a>
  * @version $Revision: 1 $

--- a/jaxrs/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/Jackson2JsonpInterceptor.java
+++ b/jaxrs/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/Jackson2JsonpInterceptor.java
@@ -88,6 +88,8 @@ public class Jackson2JsonpInterceptor implements WriterInterceptor{
     
     private String callbackQueryParameter = DEFAULT_CALLBACK_QUERY_PARAMETER;
 
+    private boolean wrapInTryCatch = false;
+
     /**
      * The {@link ObjectMapper} used to create typing information. 
      */
@@ -124,6 +126,7 @@ public class Jackson2JsonpInterceptor implements WriterInterceptor{
 
             OutputStreamWriter writer = new OutputStreamWriter(context.getOutputStream());
 
+            if (wrapInTryCatch) writer.write("try{");
             writer.write(function + "(");
             writer.flush();
 
@@ -136,6 +139,7 @@ public class Jackson2JsonpInterceptor implements WriterInterceptor{
                 context.proceed();
                 wrappedOutputStream.flush();
                 writer.write(")");
+                if (wrapInTryCatch) writer.write("}catch(e){}");
                 writer.flush();
             } finally {
                 context.setOutputStream(old);
@@ -218,6 +222,24 @@ public class Jackson2JsonpInterceptor implements WriterInterceptor{
      */
     public void setCallbackQueryParameter(String callbackQueryParameter) {
         this.callbackQueryParameter = callbackQueryParameter;
+    }
+
+    /**
+     * Check is the JSONP callback will be wrapped with try-catch block
+     *
+     * @return true if try-catch block is generated; false otherwise
+     */
+    public boolean isWrapInTryCatch() {
+        return wrapInTryCatch;
+    }
+
+    /**
+     * Enables or disables wrapping the JSONP callback try try-catch block
+     *
+     * @param wrapInTryCatch true if you want to wrap the result with try-catch block; false otherwise
+     */
+    public void setWrapInTryCatch(boolean wrapInTryCatch) {
+        this.wrapInTryCatch = wrapInTryCatch;
     }
 
 }

--- a/jaxrs/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/Jackson2JsonpInterceptor.java
+++ b/jaxrs/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/Jackson2JsonpInterceptor.java
@@ -19,6 +19,8 @@ import javax.ws.rs.ext.WriterInterceptorContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.resteasy.core.MediaTypeMap;
+import org.jboss.resteasy.spi.ResteasyConfiguration;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.util.CommitHeaderOutputStream;
 
 /**
@@ -89,6 +91,13 @@ public class Jackson2JsonpInterceptor implements WriterInterceptor{
     private String callbackQueryParameter = DEFAULT_CALLBACK_QUERY_PARAMETER;
 
     private boolean wrapInTryCatch = false;
+
+    public Jackson2JsonpInterceptor() {
+        ResteasyConfiguration context = ResteasyProviderFactory.getContextData(ResteasyConfiguration.class);
+        if (context != null) {
+            wrapInTryCatch = Boolean.parseBoolean(context.getParameter("resteasy.jsonp.silent"));
+        }
+    }
 
     /**
      * The {@link ObjectMapper} used to create typing information. 


### PR DESCRIPTION
I suggest wrapping the JSONP callback in a try-catch block.
It will prevent some browsers like MSIE to shown an error window when the specified callback function doesn't exist
