### PR TITLE
Allow setting of 'cleanupExecutor' property for custom executors on client builder

### DIFF
--- a/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ResteasyClientBuilder.java
+++ b/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ResteasyClientBuilder.java
@@ -72,6 +72,7 @@ public class ResteasyClientBuilder extends ClientBuilder
    protected HostnameVerificationPolicy policy = HostnameVerificationPolicy.WILDCARD;
    protected ResteasyProviderFactory providerFactory;
    protected ExecutorService asyncExecutor;
+   protected boolean cleanupExecutor;
    protected SSLContext sslContext;
    protected Map<String, Object> properties = new HashMap<String, Object>();
    protected ClientHttpEngine httpEngine;
@@ -108,7 +109,20 @@ public class ResteasyClientBuilder extends ClientBuilder
     */
    public ResteasyClientBuilder asyncExecutor(ExecutorService asyncExecutor)
    {
+      return asyncExecutor(asyncExecutor, false);
+   }
+
+   /**
+    * Executor to use to run AsyncInvoker invocations
+    *
+    * @param asyncExecutor
+    * @param cleanupExecutor true if the Client should close the executor when it is closed
+    * @return
+    */
+   public ResteasyClientBuilder asyncExecutor(ExecutorService asyncExecutor, boolean cleanupExecutor)
+   {
       this.asyncExecutor = asyncExecutor;
+      this.cleanupExecutor = cleanupExecutor;
       return this;
    }
 
@@ -336,7 +350,6 @@ public class ResteasyClientBuilder extends ClientBuilder
 
       ExecutorService executor = asyncExecutor;
 
-      boolean cleanupExecutor = false;
       if (executor == null)
       {
          cleanupExecutor = true;

--- a/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
+++ b/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
@@ -1,7 +1,9 @@
 package org.jboss.resteasy.test.client;
 
 import junit.framework.Assert;
+
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.junit.Test;
 
 import javax.ws.rs.client.Client;
@@ -12,6 +14,8 @@ import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Modifier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.logging.*;
 
 /**
@@ -162,4 +166,14 @@ public class ClientBuilderTest
       client.close();
 
    }
+
+   @Test
+   public void testExecutorClose()
+   {
+      ExecutorService exec = Executors.newSingleThreadExecutor();
+      Client client = ((ResteasyClientBuilder)ClientBuilder.newBuilder()).asyncExecutor(exec, true).build();
+      client.close();
+      Assert.assertTrue(exec.isShutdown());
+   }
+
 }


### PR DESCRIPTION
If you are creating your own thread pool and giving it to the client for exclusive use,
you probably want the executor cleaned up when the client is closed.