### PR TITLE
Update DocumentProvider

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/DocumentProvider.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/DocumentProvider.java
@@ -37,7 +37,7 @@ import java.lang.reflect.Type;
 @Consumes({"text/*+xml", "application/*+xml"})
 public class DocumentProvider extends AbstractEntityProvider<Document>
 {
-   private static final Logger logger = Logger.getLogger(DocumentProvider.class);
+   private static final Logger logger = Logger.getLogger(DocumentProvider.class.getName());
    
    private final TransformerFactory transformerFactory;
    private final DocumentBuilderFactory documentBuilder;


### PR DESCRIPTION
Logger.getLogger(DocumentProvider.class) should be Logger.getLogger(DocumentProvider.class.getName()) else JBoss give : 
ERROR [stderr] (ServerService Thread Pool -- 63) log4j:WARN No appenders could be found for logger (org.jboss.resteasy.plugins.providers.DocumentProvider).