### PR TITLE
Fix scaning rest path annotated classes-exclude interfaces

### DIFF
--- a/jaxrs/resteasy-servlet-initializer/src/main/java/org/jboss/resteasy/plugins/servlet/ResteasyServletInitializer.java
+++ b/jaxrs/resteasy-servlet-initializer/src/main/java/org/jboss/resteasy/plugins/servlet/ResteasyServletInitializer.java
@@ -53,7 +53,7 @@ public class ResteasyServletInitializer implements ServletContainerInitializer
       for (Class<?> clazz : classes)
       {
          if (ignoredPackages.contains(clazz.getPackage().getName())) continue;
-         if (clazz.isAnnotationPresent(Path.class))
+         if (!clazz.isInterface() && clazz.isAnnotationPresent(Path.class))
          {
             resources.add(clazz);
          }


### PR DESCRIPTION
My problem was that when I wanted to use in same application rest easy client proxy and rest controllers then I got exception that there is absent no-args public constructor. This fix solved my issue.