### PR TITLE
resteasy-jaxrs: attempt to use ParamConverter on null input Strings

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/StringParameterInjector.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/StringParameterInjector.java
@@ -278,16 +278,33 @@ public class StringParameterInjector
    {
       if (strVal == null)
       {
-         if (defaultValue == null)
+         if (defaultValue != null)
          {
-            //System.out.println("NO DEFAULT VALUE");
-            if (!baseType.isPrimitive()) return null;
+            strVal = defaultValue;
+         }
+      }
+      if (paramConverter != null)
+      {
+         if (strVal == null)
+         {
+            try
+            {
+               return paramConverter.fromString(null);
+            }
+            catch (Exception e)
+            {
+               // fall through in this scenario to maintain old behavior that was not sending null
+               // strings to custom paramconverters
+            }
          }
          else
          {
-            strVal = defaultValue;
-            //System.out.println("DEFAULT VAULUE: " + strVal);
+            return paramConverter.fromString(strVal);
          }
+      }
+      if (strVal == null && !baseType.isPrimitive())
+      {
+         return null;
       }
       try
       {
@@ -296,10 +313,6 @@ public class StringParameterInjector
       catch (Exception e)
       {
          throwProcessingException("Unable to extract parameter from http request for " + getParamSignature() + " value is '" + strVal + "'" + " for " + target, e);
-      }
-      if (paramConverter != null)
-      {
-         return paramConverter.fromString(strVal);
       }
       if (converter != null)
       {


### PR DESCRIPTION
The jaxrs spec is unclear exactly what to do in regards to ParamExtractor
when the incoming value to fromString is null. They say it should return
an IllegalArgumentException. Resteasy appears to have taken that to mean
that they should not even call the converter with the null input.

This ends up being a limiting factor when you want to, for example, take
null in and convert that parameter to Optional.empty().

I came across this while trying to write something akin to
dropwizard-java8 for gwizard, which uses Resteasy.

Further, I am swallowing the NPE that this change possibly introduces because previous Resteasy users may depend on fromString not being called with null inputs. However, its still possible that a ParamConverter.fromString that returns an IllegalArgumentException will begin erroring after this push, so an argument could be made that that should be caught as well, or perhaps all 