### PR TITLE
RESTEASY-1184: Cannot remove property from client configuration

### DIFF
--- a/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
+++ b/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
@@ -37,6 +37,23 @@ public class ClientBuilderTest
       client = ClientBuilder.newClient(config);
 
    }
+   
+   @Test
+   public void addAndRemovePropertyTest() throws Exception
+   {
+      String property = "prop";
+      Client client = ClientBuilder.newClient();
+      client.property(property, property);
+      Object p = client.getConfiguration().getProperty(property);
+      Assert.assertEquals("prop", (String)p);
+      try {
+         client.property(property, null);
+      } catch (NullPointerException e) {
+        Assert.fail("Couldn't remove property.");
+      }
+      p = client.getConfiguration().getProperty(property);
+      Assert.assertEquals(null, p);
+   }
 
    public static void inner() throws Exception
    {

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -2363,7 +2363,10 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
    @Override
    public ResteasyProviderFactory property(String name, Object value)
    {
-      properties.put(name, value);
+      if (value == null)
+         properties.remove(name);
+      else
+         properties.put(name, value);
       return this;
    }
 


### PR DESCRIPTION
client.property(some_property, null) should remove property from client configuration.
