### PR TITLE
RESTEASY-1185 - Missing warning 2nd registration of the *class* provider

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -1379,7 +1379,7 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
    {
       if (getClasses().contains(provider))
       {
-         //logger.warn("Provider class " + provider.getName() + " is already registered.  2nd registration is being ignored.");
+         logger.warn("Provider class " + provider.getName() + " is already registered.  2nd registration is being ignored.");
          return;
       }
       Map<Class<?>, Integer> newContracts = new HashMap<Class<?>, Integer>();


### PR DESCRIPTION
The user warning when the 2nd registration of the *class* provider is attempted.
This is documented as user should get warning in the javax.ws.rs.core.Configurable interface.
The 2nd registration of the *instance* provider gives the warning.