### PR TITLE
bump version

### DIFF
--- a/jaxrs/arquillian/RESTEASY-1008-AS7/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1008-AS7/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-1008-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1008-WF8/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-1054-AS7/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1054-AS7/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-1054-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1054-WF8/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-1056-jetty-bv10/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1056-jetty-bv10/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>RESTEASY-1056-jetty-bv10</artifactId>

--- a/jaxrs/arquillian/RESTEASY-1056-jetty-bv11/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1056-jetty-bv11/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>RESTEASY-1056-jetty-bv11</artifactId>

--- a/jaxrs/arquillian/RESTEASY-1058-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1058-WF8/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-1073-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1073-WF8/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-1082-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1082-WF8/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-736-as71/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-736-as71/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>RESTEASY-736-as71</artifactId>
@@ -13,7 +13,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <resteasy.version>3.0.12.Final</resteasy.version>
+    <resteasy.version>3.0.13.Final-SNAPSHOT</resteasy.version>
   </properties>
   
   <dependencyManagement>

--- a/jaxrs/arquillian/RESTEASY-736-jetty/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-736-jetty/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>RESTEASY-736-jetty</artifactId>
@@ -14,7 +14,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <jetty.version>8.1.1.v20120215</jetty.version>
-      <resteasy.version>3.0.12.Final</resteasy.version>
+      <resteasy.version>3.0.13.Final-SNAPSHOT</resteasy.version>
   </properties>
   
   <dependencyManagement>

--- a/jaxrs/arquillian/RESTEASY-760-jetty/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-760-jetty/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>RESTEASY-760-jetty</artifactId>
@@ -15,7 +15,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <!--jetty.version>7.0.2.v20100331</jetty.version-->
       <jetty.version>8.1.1.v20120215</jetty.version>
-      <resteasy.version>3.0.12.Final</resteasy.version>
+      <resteasy.version>3.0.13.Final-SNAPSHOT</resteasy.version>
   </properties>
   
   <dependencyManagement>

--- a/jaxrs/arquillian/RESTEASY-767-jetty/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-767-jetty/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>RESTEASY-767-jetty</artifactId>
@@ -15,7 +15,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <!--jetty.version>7.0.2.v20100331</jetty.version-->
       <jetty.version>8.1.1.v20120215</jetty.version>
-      <resteasy.version>3.0.12.Final</resteasy.version>
+      <resteasy.version>3.0.13.Final-SNAPSHOT</resteasy.version>
   </properties>
   
   <dependencyManagement>

--- a/jaxrs/arquillian/RESTEASY-800-AS71/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-800-AS71/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-903-AS7/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-903-AS7/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-903-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-903-WF8/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-923-AS7/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-923-AS7/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-923-EAP6/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-923-EAP6/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-923-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-923-WF8/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-945-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-945-WF8/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-TEST-EAP6/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-TEST-EAP6/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-TEST-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-TEST-WF8/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/RESTEASY-TEST-WF8/src/main/java/org/jboss/resteasy/resteasy1137/package-info.java
+++ b/jaxrs/arquillian/RESTEASY-TEST-WF8/src/main/java/org/jboss/resteasy/resteasy1137/package-info.java
@@ -2,7 +2,7 @@
  * This package (along with @see org.jboss.resteasy.test.resteasy1137) tests versioning compatibility
  * of the class org.jboss.resteasy.api.validation.ResteasyViolationException in module resteasy-validator-provider11.
  * 
- * As of release 3.0.12.Final, ResteasyViolationException was changed from a subclass of javax.validation.ValidationException
+ * As of release 3.0.13.Final-SNAPSHOT, ResteasyViolationException was changed from a subclass of javax.validation.ValidationException
  * to a subclass of javax.validation.ConstraintViolationException, which is a subclass of javax.validation.ValidationException.
  * 
  * The jar validation-versioning.jar in src/test/resources/1137 contains the class 

--- a/jaxrs/arquillian/ValidationTest-AS7/pom.xml
+++ b/jaxrs/arquillian/ValidationTest-AS7/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/ValidationTest-WF8/pom.xml
+++ b/jaxrs/arquillian/ValidationTest-WF8/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/ValidationTest/pom.xml
+++ b/jaxrs/arquillian/ValidationTest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jaxrs/arquillian/pom.xml
+++ b/jaxrs/arquillian/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Arquillian</name>

--- a/jaxrs/arquillian/resteasy-cdi-ejb-test/pom.xml
+++ b/jaxrs/arquillian/resteasy-cdi-ejb-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>resteasy-cdi-ejb-test</artifactId>

--- a/jaxrs/as7-integration-testing/cdi-test/pom.xml
+++ b/jaxrs/as7-integration-testing/cdi-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/as7-integration-testing/modules-test/pom.xml
+++ b/jaxrs/as7-integration-testing/modules-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/as7-integration-testing/pom.xml
+++ b/jaxrs/as7-integration-testing/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <name>Resteasy JBoss AS7 Integration Tests</name>
     <description/>

--- a/jaxrs/as8-integration-testing/application-test/pom.xml
+++ b/jaxrs/as8-integration-testing/application-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -15,7 +15,7 @@
     <url>http://maven.apache.org</url>
 
     <properties>
-        <jboss.dist.version>8.0.0m-alpha-20130417-resteasy-3.0.12.Final</jboss.dist.version>
+        <jboss.dist.version>8.0.0m-alpha-20130417-resteasy-3.0.13.Final-SNAPSHOT</jboss.dist.version>
     </properties>
     <dependencies>
         <dependency>

--- a/jaxrs/as8-integration-testing/cdilocator-test/pom.xml
+++ b/jaxrs/as8-integration-testing/cdilocator-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/as8-integration-testing/ejb-singleton-test/pom.xml
+++ b/jaxrs/as8-integration-testing/ejb-singleton-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/as8-integration-testing/pom.xml
+++ b/jaxrs/as8-integration-testing/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <name>Resteasy AS8 Tests</name>
     <description/>

--- a/jaxrs/as8-mavenized-distro/pom.xml
+++ b/jaxrs/as8-mavenized-distro/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.as</groupId>

--- a/jaxrs/as8-resteasy/pom.xml
+++ b/jaxrs/as8-resteasy/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.as</groupId>
     <artifactId>jboss-as-dist</artifactId>
-    <version>8.0.0m-alpha-20130417-resteasy-3.0.12.Final</version>
+    <version>8.0.0m-alpha-20130417-resteasy-3.0.13.Final-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Custom AS8 Resteasy Distribution</name>
     <description/>

--- a/jaxrs/async-http-servlet-3.0/async-http-servlet-3.0-test/pom.xml
+++ b/jaxrs/async-http-servlet-3.0/async-http-servlet-3.0-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/async-http-servlet-3.0/async-http-servlet-3.0/pom.xml
+++ b/jaxrs/async-http-servlet-3.0/async-http-servlet-3.0/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>async-http-servlet-3.0</artifactId>

--- a/jaxrs/async-http-servlet-3.0/callback-test/pom.xml
+++ b/jaxrs/async-http-servlet-3.0/callback-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/async-http-servlet-3.0/pom.xml
+++ b/jaxrs/async-http-servlet-3.0/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <name>Async Http JBossWeb</name>
     <description/>

--- a/jaxrs/distribution/pom.xml
+++ b/jaxrs/distribution/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-jaxrs-dist</artifactId>

--- a/jaxrs/distribution/src-distribution/pom.xml
+++ b/jaxrs/distribution/src-distribution/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-jaxrs-src-dist</artifactId>

--- a/jaxrs/docbook/pom.xml
+++ b/jaxrs/docbook/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-reference-guide-${translation}</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <packaging>jdocbook</packaging>
     <name>RESTEasy Reference Guide (${translation})</name>
     <description/>

--- a/jaxrs/docbook/reference/en/en-US/master.xml
+++ b/jaxrs/docbook/reference/en/en-US/master.xml
@@ -63,7 +63,7 @@
    <bookinfo>
       <title>RESTEasy JAX-RS</title>
       <subtitle>RESTFul Web Services for Java</subtitle>
-      <releaseinfo>3.0.12.Final</releaseinfo>
+      <releaseinfo>3.0.13.Final-SNAPSHOT</releaseinfo>
    </bookinfo>
 
    <toc/>

--- a/jaxrs/docbook/reference/en/en-US/modules/Cache_NoCache_CacheControl.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/Cache_NoCache_CacheControl.xml
@@ -136,7 +136,7 @@ public static void main(String[] args) throws Exception
 <dependency>
    <groupId>org.jboss.resteasy</groupId>
    <artifactId>resteasy-cache-core</artifactId>
-   <version>3.0.12.Final</version>
+   <version>3.0.13.Final-SNAPSHOT</version>
 </dependency>
 ]]>
 </programlisting>

--- a/jaxrs/docbook/reference/en/en-US/modules/Installation_Configuration.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/Installation_Configuration.xml
@@ -14,7 +14,7 @@
         <title>Upgrading Resteasy Within JBoss AS 7</title>
         <para>
             Resteasy is bundled with JBoss AS 7.  You may have the need to upgrade Resteasy in AS7.  The Resteasy
-            distribution comes with a zip file called resteasy-jboss-modules-3.0.12.Final.zip.  Unzip this file while
+            distribution comes with a zip file called resteasy-jboss-modules-3.0.13.Final-SNAPSHOT.zip.  Unzip this file while
             with the modules/ directory of the JBoss AS7 distribution.  This will overwrite some of the existing files there.
         </para>
     </section>
@@ -22,7 +22,7 @@
         <title>Upgrading Resteasy Within JBoss EAP 6.1</title>
         <para>
             Resteasy is bundled with JBoss EAP 6.1.  You may have the need to upgrade Resteasy in JBoss EAP 6.1.  The Resteasy
-            distribution comes with a zip file called resteasy-jboss-modules-3.0.12.Final.zip.  Unzip this file while
+            distribution comes with a zip file called resteasy-jboss-modules-3.0.13.Final-SNAPSHOT.zip.  Unzip this file while
             with the modules/system/layers/base/ directory of the JBoss EAP 6.1 distribution.  This will overwrite some of the existing files there.
         </para>
         <warning>
@@ -36,7 +36,7 @@
         <title>Upgrading Resteasy Within Wildfly</title>
         <para>
             Resteasy is bundled with Wildfly.  You may have the need to upgrade Resteasy in Wildfly.  The Resteasy
-            distribution comes with a zip file called resteasy-jboss-modules-wf8-3.0.12.Final.zip.  Unzip this file while
+            distribution comes with a zip file called resteasy-jboss-modules-wf8-3.0.13.Final-SNAPSHOT.zip.  Unzip this file while
             with the modules/system/layers/base/ directory of the Wildfly distribution.  This will overwrite some of the existing files there.
         </para>
     </section>
@@ -264,7 +264,7 @@ public class MyApplication extends Application
 <dependency>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-servlet-initializer</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
 </dependency>]]></programlisting>
         <para>
             We strongly suggest that you

--- a/jaxrs/docbook/reference/en/en-US/modules/Json-p.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/Json-p.xml
@@ -9,7 +9,7 @@
 <dependency>
    <groupId>org.jboss.resteasy</groupId>
    <artifactId>resteasy-json-p-provider</artifactId>
-   <version>3.0.12.Final</version>
+   <version>3.0.13.Final-SNAPSHOT</version>
 </dependency>
 ]]></programlisting>
     <para>

--- a/jaxrs/docbook/reference/en/en-US/modules/Json.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/Json.xml
@@ -20,7 +20,7 @@
 <dependency>
    <groupId>org.jboss.resteasy</groupId>
    <artifactId>resteasy-jackson-provider</artifactId>
-   <version>3.0.12.Final</version>
+   <version>3.0.13.Final-SNAPSHOT</version>
 </dependency>
 ]]></programlisting>
     </sect1>
@@ -38,7 +38,7 @@
 <dependency>
    <groupId>org.jboss.resteasy</groupId>
    <artifactId>resteasy-jackson2-provider</artifactId>
-   <version>3.0.12.Final</version>
+   <version>3.0.13.Final-SNAPSHOT</version>
 </dependency>
 ]]></programlisting>
     </sect1>

--- a/jaxrs/docbook/reference/en/en-US/modules/Links.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/Links.xml
@@ -52,7 +52,7 @@
 					<tr>
 						<td>org.jboss.resteasy</td>
 						<td>resteasy-links</td>
-						<td>3.0.12.Final</td>
+						<td>3.0.13.Final-SNAPSHOT</td>
 					</tr>
 				</tbody>
 			</table>

--- a/jaxrs/docbook/reference/en/en-US/modules/Maven_and_RESTEasy.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/Maven_and_RESTEasy.xml
@@ -6,7 +6,7 @@ JBoss's Maven Repository is at:
    </para>
    <para>
 
-      Here's the pom.xml fragment to use. Resteasy is modularized into various components.  Mix and max as you see fit.  Please replace 3.0.12.Final with the current Resteasy version you want to use.
+      Here's the pom.xml fragment to use. Resteasy is modularized into various components.  Mix and max as you see fit.  Please replace 3.0.13.Final-SNAPSHOT with the current Resteasy version you want to use.
    </para>
 <programlisting>
 <![CDATA[
@@ -21,12 +21,12 @@ JBoss's Maven Repository is at:
    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxrs</artifactId>
-      <version>3.0.12.Final</version>
+      <version>3.0.13.Final-SNAPSHOT</version>
    </dependency>
    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
-      <version>3.0.12.Final</version>
+      <version>3.0.13.Final-SNAPSHOT</version>
    </dependency>
 
    <!-- optional modules -->
@@ -35,50 +35,50 @@ JBoss's Maven Repository is at:
    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxb-provider</artifactId>
-      <version>3.0.12.Final</version>
+      <version>3.0.13.Final-SNAPSHOT</version>
    </dependency>
    <!-- multipart/form-data and multipart/mixed support -->
    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-multipart-provider</artifactId>
-      <version>3.0.12.Final</version>
+      <version>3.0.13.Final-SNAPSHOT</version>
    </dependency>
    <!-- Resteasy Server Cache -->
    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-cache-core</artifactId>
-      <version>3.0.12.Final</version>
+      <version>3.0.13.Final-SNAPSHOT</version>
    </dependency>
    <!-- Ruby YAML support -->
    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-yaml-provider</artifactId>
-      <version>3.0.12.Final</version>
+      <version>3.0.13.Final-SNAPSHOT</version>
    </dependency>
    <!-- JAXB + Atom support -->
    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-atom-provider</artifactId>
-      <version>3.0.12.Final</version>
+      <version>3.0.13.Final-SNAPSHOT</version>
    </dependency>
    <!-- Spring integration -->
    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-spring</artifactId>
-      <version>3.0.12.Final</version>
+      <version>3.0.13.Final-SNAPSHOT</version>
    </dependency>
    <!-- Guice integration -->
    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-guice</artifactId>
-      <version>3.0.12.Final</version>
+      <version>3.0.13.Final-SNAPSHOT</version>
    </dependency>
 
    <!-- Asynchronous HTTP support with Servlet 3.0  -->
    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>async-http-servlet-3.0</artifactId>
-      <version>3.0.12.Final</version>
+      <version>3.0.13.Final-SNAPSHOT</version>
    </dependency>
 
 </dependencies>
@@ -94,7 +94,7 @@ JBoss's Maven Repository is at:
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-bom</artifactId>
-                <version>3.0.12.Final</version>
+                <version>3.0.13.Final-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/jaxrs/docbook/reference/en/en-US/modules/RESTEasy_Embedded_Container.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/RESTEasy_Embedded_Container.xml
@@ -138,7 +138,7 @@ public class UndertowTest
   <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jdk-http</artifactId>
-      <version>3.0.12.Final</version>
+      <version>3.0.13.Final-SNAPSHOT</version>
   </dependency>
 ]]></programlisting>
 
@@ -157,7 +157,7 @@ RESTeasy integrates with the TJWS Embeddable Servlet container.  It comes with t
   <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>tjws</artifactId>
-      <version>3.0.12.Final</version>
+      <version>3.0.13.Final-SNAPSHOT</version>
   </dependency>
 
   <dependency>
@@ -244,7 +244,7 @@ If you want to use Spring, see the SpringBeanProcessor.  Here's a pseudo-code ex
   <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-netty</artifactId>
-      <version>3.0.12.Final</version>
+      <version>3.0.13.Final-SNAPSHOT</version>
   </dependency>
 ]]></programlisting>
 

--- a/jaxrs/docbook/reference/en/en-US/modules/Yaml.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/Yaml.xml
@@ -3,7 +3,7 @@
 
    <para>
 
-      Since 3.0.12.Final  release, resteasy comes with built in support for YAML using the SnakeYAML library. To enable YAML support,
+      Since 3.0.13.Final-SNAPSHOT  release, resteasy comes with built in support for YAML using the SnakeYAML library. To enable YAML support,
       you need to drop in the SnakeYaml 1.8 jar and the resteasy-yaml-provider.jar (whatever the current version is) in RestEASY's classpath.
    </para>
    <para>

--- a/jaxrs/docbook/reference/en/en-US/modules/signature.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/signature.xml
@@ -172,7 +172,7 @@
     <para><programlisting>        &lt;dependency&gt;
             &lt;groupId&gt;org.jboss.resteasy&lt;/groupId&gt;
             &lt;artifactId&gt;resteasy-crypto&lt;/artifactId&gt;
-            &lt;version&gt;3.0.12.Final&lt;/version&gt;
+            &lt;version&gt;3.0.13.Final-SNAPSHOT&lt;/version&gt;
         &lt;/dependency&gt;
 
 </programlisting></para>

--- a/jaxrs/docbook/reference/en/en-US/modules/smime.xml
+++ b/jaxrs/docbook/reference/en/en-US/modules/smime.xml
@@ -21,7 +21,7 @@
     <para><programlisting>        &lt;dependency&gt;
             &lt;groupId&gt;org.jboss.resteasy&lt;/groupId&gt;
             &lt;artifactId&gt;resteasy-crypto&lt;/artifactId&gt;
-            &lt;version&gt;3.0.12.Final&lt;/version&gt;
+            &lt;version&gt;3.0.13.Final-SNAPSHOT&lt;/version&gt;
         &lt;/dependency&gt;
 
 </programlisting></para>

--- a/jaxrs/eagledns/pom.xml
+++ b/jaxrs/eagledns/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
 
     <artifactId>eagledns-fork</artifactId>

--- a/jaxrs/examples/api-clients/pom.xml
+++ b/jaxrs/examples/api-clients/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>org.jboss.resteasy</groupId>
 		<artifactId>testable-examples-pom</artifactId>
-		<version>3.0.12.Final</version>
+		<version>3.0.13.Final-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jboss.resteasy.examples</groupId>
 	<artifactId>examples-api-clients</artifactId>
-	<version>3.0.12.Final</version>
+	<version>3.0.13.Final-SNAPSHOT</version>
     <description/>
 
 	<repositories>
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-jaxrs</artifactId>
-			<version>3.0.12.Final</version>
+			<version>3.0.13.Final-SNAPSHOT</version>
 			<!-- filter out unwanted jars -->
 			<exclusions>
 				<exclusion>
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-jaxb-provider</artifactId>
-			<version>3.0.12.Final</version>
+			<version>3.0.13.Final-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-httpclient</groupId>

--- a/jaxrs/examples/async-job-service/pom.xml
+++ b/jaxrs/examples/async-job-service/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy.examples</groupId>
     <artifactId>examples-async-job-service</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Example: Async Job Service</name>
     <description/>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/digital-signatures/no-dns/pom.xml
+++ b/jaxrs/examples/digital-signatures/no-dns/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 		<relativePath>../../../pom.xml</relativePath>	    
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/examples/digital-signatures/pom.xml
+++ b/jaxrs/examples/digital-signatures/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <name>Resteasy Examples</name>

--- a/jaxrs/examples/digital-signatures/use-dns/pom.xml
+++ b/jaxrs/examples/digital-signatures/use-dns/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/examples/ejb-integration/ear/pom.xml
+++ b/jaxrs/examples/ejb-integration/ear/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>ejb-integration-example</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ejb-integration-ear</artifactId>

--- a/jaxrs/examples/ejb-integration/ejb/pom.xml
+++ b/jaxrs/examples/ejb-integration/ejb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>ejb-integration-example</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ejb-integration</artifactId>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>javax.ejb</groupId>

--- a/jaxrs/examples/ejb-integration/pom.xml
+++ b/jaxrs/examples/ejb-integration/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.resteasy</groupId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <artifactId>ejb-integration-example</artifactId>
     <packaging>pom</packaging>
     <description/>

--- a/jaxrs/examples/ejb-integration/war/pom.xml
+++ b/jaxrs/examples/ejb-integration/war/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>ejb-integration-example</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ejb-integration-war</artifactId>

--- a/jaxrs/examples/examples-jsapi/pom.xml
+++ b/jaxrs/examples/examples-jsapi/pom.xml
@@ -4,14 +4,14 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>examples-jsapi</artifactId>
     <packaging>war</packaging>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <name>Example: JS-API</name>
     <description/>
 
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jsapi</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/jaxrs/examples/guice-hello/pom.xml
+++ b/jaxrs/examples/guice-hello/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy.examples</groupId>
     <artifactId>examples-guice-hello</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>guice hello example</name>
     <description>guice hello world example</description>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-guice</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/jaxb-json/pom.xml
+++ b/jaxrs/examples/jaxb-json/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>org.jboss.resteasy.examples</groupId>
     <artifactId>examples-jaxb-json</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Example: JAXB-JSON</name>
     <description/>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <!-- filter out unwanted jars -->
             <exclusions>
                 <exclusion>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jettison-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.xml.bind</groupId>

--- a/jaxrs/examples/jaxrs-2.0/server-async-http/pom.xml
+++ b/jaxrs/examples/jaxrs-2.0/server-async-http/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 		<relativePath>../../../pom.xml</relativePath>	    
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/examples/jaxrs-2.0/simple-client/pom.xml
+++ b/jaxrs/examples/jaxrs-2.0/simple-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 		<relativePath>../../../pom.xml</relativePath>	    
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/examples/jaxrs2-async-pubsub-example/pom.xml
+++ b/jaxrs/examples/jaxrs2-async-pubsub-example/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/examples/oauth1-examples/oauth-catalina-authenticator/authenticator/pom.xml
+++ b/jaxrs/examples/oauth1-examples/oauth-catalina-authenticator/authenticator/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy.examples</groupId>
     <artifactId>examples-oauth-authenticator</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Example: OAuth Authenticator</name>
     <description/>

--- a/jaxrs/examples/oauth1-examples/oauth-catalina-authenticator/oauth/pom.xml
+++ b/jaxrs/examples/oauth1-examples/oauth-catalina-authenticator/oauth/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy.examples</groupId>
     <artifactId>examples-oauth-no-filter</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Example: OAuth Without Servlet filters</name>
     <description/>

--- a/jaxrs/examples/oauth1-examples/oauth-catalina-authenticator/pom.xml
+++ b/jaxrs/examples/oauth1-examples/oauth-catalina-authenticator/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../../pom.xml</relativePath>
     </parent>
     <name>OAuth With Catalina Authenticator</name>

--- a/jaxrs/examples/oauth1-examples/oauth-provider/pom.xml
+++ b/jaxrs/examples/oauth1-examples/oauth-provider/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy.examples</groupId>
     <artifactId>examples-oauth-provider</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Example: OAuth Provider</name>
     <description/>

--- a/jaxrs/examples/oauth1-examples/oauth-push-messaging-openid/openid/pom.xml
+++ b/jaxrs/examples/oauth1-examples/oauth-push-messaging-openid/openid/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy.examples</groupId>
     <artifactId>examples-oauth-push-messaging-openid-provider</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Example: OAuth Push Messaging OpenId Provider</name>
     <description/>

--- a/jaxrs/examples/oauth1-examples/oauth-push-messaging-openid/pom.xml
+++ b/jaxrs/examples/oauth1-examples/oauth-push-messaging-openid/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../../pom.xml</relativePath>
     </parent>
     <name>Example: OAuth Push Messaging OpenId Modules</name>

--- a/jaxrs/examples/oauth1-examples/oauth-push-messaging-openid/push-messaging/pom.xml
+++ b/jaxrs/examples/oauth1-examples/oauth-push-messaging-openid/push-messaging/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy.examples</groupId>
     <artifactId>examples-oauth-push-messaging-sso</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Example: OAuth Push Messaging SSO</name>
     <description/>

--- a/jaxrs/examples/oauth1-examples/oauth-push-messaging/pom.xml
+++ b/jaxrs/examples/oauth1-examples/oauth-push-messaging/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy.examples</groupId>
     <artifactId>examples-oauth-push-messaging</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Example: OAuth Push Messaging</name>
     <description/>

--- a/jaxrs/examples/oauth1-examples/oauth/pom.xml
+++ b/jaxrs/examples/oauth1-examples/oauth/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy.examples</groupId>
     <artifactId>examples-oauth</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Example: OAuth</name>
     <description/>

--- a/jaxrs/examples/oauth1-examples/pom.xml
+++ b/jaxrs/examples/oauth1-examples/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <name>OAuth Examples</name>

--- a/jaxrs/examples/oauth2-as7-example/pom.xml
+++ b/jaxrs/examples/oauth2-as7-example/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <name>Resteasy Skeleton Key Examples POM</name>

--- a/jaxrs/examples/oauth2-as7-example/wars/auth-server/pom.xml
+++ b/jaxrs/examples/oauth2-as7-example/wars/auth-server/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/examples/oauth2-as7-example/wars/client-grant/pom.xml
+++ b/jaxrs/examples/oauth2-as7-example/wars/client-grant/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/examples/oauth2-as7-example/wars/customer-app/pom.xml
+++ b/jaxrs/examples/oauth2-as7-example/wars/customer-app/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/examples/oauth2-as7-example/wars/database-service/pom.xml
+++ b/jaxrs/examples/oauth2-as7-example/wars/database-service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/examples/oauth2-as7-example/wars/product-app/pom.xml
+++ b/jaxrs/examples/oauth2-as7-example/wars/product-app/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/examples/oauth2-as7-example/wars/third-party/pom.xml
+++ b/jaxrs/examples/oauth2-as7-example/wars/third-party/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex03_1/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex03_1/pom.xml
@@ -20,27 +20,27 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex04_1/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex04_1/pom.xml
@@ -20,27 +20,27 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex04_2/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex04_2/pom.xml
@@ -20,27 +20,27 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex04_3/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex04_3/pom.xml
@@ -20,27 +20,27 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex05_1/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex05_1/pom.xml
@@ -20,27 +20,27 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex05_2/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex05_2/pom.xml
@@ -20,27 +20,27 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex06_1/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex06_1/pom.xml
@@ -20,32 +20,32 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex06_2/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex06_2/pom.xml
@@ -20,27 +20,27 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex07_1/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex07_1/pom.xml
@@ -20,32 +20,32 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex09_1/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex09_1/pom.xml
@@ -20,37 +20,37 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson2-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex09_2/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex09_2/pom.xml
@@ -20,37 +20,37 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson2-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex10_1/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex10_1/pom.xml
@@ -20,32 +20,32 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex10_2/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex10_2/pom.xml
@@ -20,32 +20,32 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex11_1/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex11_1/pom.xml
@@ -20,32 +20,32 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex12_1/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex12_1/pom.xml
@@ -20,32 +20,32 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex12_2/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex12_2/pom.xml
@@ -20,32 +20,32 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex13_1/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex13_1/pom.xml
@@ -20,32 +20,32 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex14_1/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex14_1/pom.xml
@@ -17,13 +17,13 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex14_2/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex14_2/pom.xml
@@ -30,32 +30,32 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>javax.persistence</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex15_1/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex15_1/pom.xml
@@ -20,32 +20,32 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex15_2/pom.xml
+++ b/jaxrs/examples/oreilly-jaxrs-2.0-workbook/ex15_2/pom.xml
@@ -20,37 +20,37 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>async-http-servlet-3.0</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jose-jwt</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-workbook-as7/ex03_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook-as7/ex03_1/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook-as7/ex04_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook-as7/ex04_1/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook-as7/ex04_2/pom.xml
+++ b/jaxrs/examples/oreilly-workbook-as7/ex04_2/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook-as7/ex04_3/pom.xml
+++ b/jaxrs/examples/oreilly-workbook-as7/ex04_3/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook-as7/ex05_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook-as7/ex05_1/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook-as7/ex05_2/pom.xml
+++ b/jaxrs/examples/oreilly-workbook-as7/ex05_2/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook-as7/ex06_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook-as7/ex06_1/pom.xml
@@ -20,13 +20,13 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook-as7/ex06_2/pom.xml
+++ b/jaxrs/examples/oreilly-workbook-as7/ex06_2/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook-as7/ex07_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook-as7/ex07_1/pom.xml
@@ -20,13 +20,13 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook-as7/ex08_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook-as7/ex08_1/pom.xml
@@ -20,13 +20,13 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jettison-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook-as7/ex08_2/pom.xml
+++ b/jaxrs/examples/oreilly-workbook-as7/ex08_2/pom.xml
@@ -20,13 +20,13 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook-as7/ex09_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook-as7/ex09_1/pom.xml
@@ -20,13 +20,13 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook-as7/ex09_2/pom.xml
+++ b/jaxrs/examples/oreilly-workbook-as7/ex09_2/pom.xml
@@ -20,13 +20,13 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook-as7/ex10_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook-as7/ex10_1/pom.xml
@@ -20,13 +20,13 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook-as7/ex11_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook-as7/ex11_1/pom.xml
@@ -17,13 +17,13 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook/ex03_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex03_1/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-workbook/ex04_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex04_1/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-workbook/ex04_2/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex04_2/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-workbook/ex04_3/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex04_3/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-workbook/ex05_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex05_1/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-workbook/ex05_2/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex05_2/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-workbook/ex06_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex06_1/pom.xml
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-workbook/ex06_2/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex06_2/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-workbook/ex07_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex07_1/pom.xml
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-workbook/ex08_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex08_1/pom.xml
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jettison-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-workbook/ex08_2/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex08_2/pom.xml
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-workbook/ex09_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex09_1/pom.xml
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-workbook/ex09_2/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex09_2/pom.xml
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-workbook/ex10_1/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex10_1/pom.xml
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/examples/oreilly-workbook/ex11_1/ejb/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex11_1/ejb/pom.xml
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>javax.ejb</groupId>

--- a/jaxrs/examples/oreilly-workbook/ex11_1/war/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex11_1/war/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jaxrs/examples/oreilly-workbook/ex11_2/pom.xml
+++ b/jaxrs/examples/oreilly-workbook/ex11_2/pom.xml
@@ -24,12 +24,12 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>javax.persistence</groupId>

--- a/jaxrs/examples/pom.xml
+++ b/jaxrs/examples/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <name>Resteasy Examples</name>
     <description/>

--- a/jaxrs/examples/resteasy-springMVC/pom.xml
+++ b/jaxrs/examples/resteasy-springMVC/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.jboss.resteasy.examples</groupId>
     <artifactId>examples-resteasy-springMVC</artifactId>
     <packaging>war</packaging>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <name>Spring MVC RestContact Maven Webapp</name>
     <description/>
     <url>http://maven.apache.org</url>
@@ -13,17 +13,17 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-spring</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>tjws</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jaxrs/examples/smime/pom.xml
+++ b/jaxrs/examples/smime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/examples/spring-hibernate-contacts/core/pom.xml
+++ b/jaxrs/examples/spring-hibernate-contacts/core/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>org.jboss.resteasy.examples</groupId>
         <artifactId>examples-spring-hibernate-contacts</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy.examples</groupId>
     <artifactId>examples-spring-hibernate-contacts-core</artifactId>
     <name>Example: Spring + Hibernate Contacts - Core</name>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <description/>
 
     <dependencies>

--- a/jaxrs/examples/spring-hibernate-contacts/persistence/pom.xml
+++ b/jaxrs/examples/spring-hibernate-contacts/persistence/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>org.jboss.resteasy.examples</groupId>
         <artifactId>examples-spring-hibernate-contacts</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy.examples</groupId>
     <artifactId>examples-spring-hibernate-contacts-persistence</artifactId>
     <name>Example: Spring + Hibernate Contacts - Persistence</name>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <description/>
 
     <dependencies>

--- a/jaxrs/examples/spring-hibernate-contacts/pom.xml
+++ b/jaxrs/examples/spring-hibernate-contacts/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.jboss.resteasy.examples</groupId>
     <artifactId>examples-spring-hibernate-contacts</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <name>Example: RestContact Maven Webapp</name>
     <url>http://maven.apache.org</url>
     <repositories>
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-bom</artifactId>
-                <version>3.0.12.Final</version>
+                <version>3.0.13.Final-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/jaxrs/examples/spring-hibernate-contacts/services/pom.xml
+++ b/jaxrs/examples/spring-hibernate-contacts/services/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>org.jboss.resteasy.examples</groupId>
         <artifactId>examples-spring-hibernate-contacts</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy.examples</groupId>
     <artifactId>examples-spring-hibernate-contacts-services</artifactId>
     <packaging>war</packaging>
     <name>Example: Spring + Hibernate Contacts - Services</name>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <description/>
 
     <build>

--- a/jaxrs/jaxrs-api/pom.xml
+++ b/jaxrs/jaxrs-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jaxrs/jboss-integration-testing/application-config-test/pom.xml
+++ b/jaxrs/jboss-integration-testing/application-config-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-jboss-integration-testing</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy</groupId>

--- a/jaxrs/jboss-integration-testing/basic-integration-test/pom.xml
+++ b/jaxrs/jboss-integration-testing/basic-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-jboss-integration-testing</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>basic-integration-test</artifactId>

--- a/jaxrs/jboss-integration-testing/ejb-test/ear/pom.xml
+++ b/jaxrs/jboss-integration-testing/ejb-test/ear/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>ejb-integration-test</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ejb-test-ear</artifactId>

--- a/jaxrs/jboss-integration-testing/ejb-test/ejb/pom.xml
+++ b/jaxrs/jboss-integration-testing/ejb-test/ejb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>ejb-integration-test</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ejb-test</artifactId>

--- a/jaxrs/jboss-integration-testing/ejb-test/pom.xml
+++ b/jaxrs/jboss-integration-testing/ejb-test/pom.xml
@@ -2,13 +2,13 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-jboss-integration-testing</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <name>Resteasy JAX-RS EJB Test</name>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jboss.resteasy</groupId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <artifactId>ejb-integration-test</artifactId>
     <packaging>pom</packaging>
 

--- a/jaxrs/jboss-integration-testing/ejb-test/war/pom.xml
+++ b/jaxrs/jboss-integration-testing/ejb-test/war/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>ejb-integration-test</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ejb-test-war</artifactId>

--- a/jaxrs/jboss-integration-testing/pom.xml
+++ b/jaxrs/jboss-integration-testing/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <name>Resteasy JAX-RS JBoss Integration Testing</name>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/jboss-integration-testing/scanning-test/pom.xml
+++ b/jaxrs/jboss-integration-testing/scanning-test/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-jboss-integration-testing</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     
     <name>Resteasy Scanning Tests</name>
@@ -11,7 +11,7 @@
     <groupId>org.jboss.resteasy.test</groupId>
     <artifactId>scanning-test</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
 
     <modules>
         <module>scanning-test-jar</module>

--- a/jaxrs/jboss-integration-testing/scanning-test/scanning-test-jar/pom.xml
+++ b/jaxrs/jboss-integration-testing/scanning-test/scanning-test-jar/pom.xml
@@ -3,21 +3,21 @@
 	<parent>
         <groupId>org.jboss.resteasy.test</groupId>
         <artifactId>scanning-test</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy.test</groupId>
     <artifactId>scanning-test-jar</artifactId>
     <packaging>jar</packaging>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <name>Scanning Test Jar</name>
     <url>http://maven.apache.org</url>
     <dependencies>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/jaxrs/jboss-integration-testing/scanning-test/scanning-test-war/pom.xml
+++ b/jaxrs/jboss-integration-testing/scanning-test/scanning-test-war/pom.xml
@@ -4,14 +4,14 @@
 	<parent>
         <groupId>org.jboss.resteasy.test</groupId>
         <artifactId>scanning-test</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy.test</groupId>
     <artifactId>scanning-test-war</artifactId>
     <packaging>war</packaging>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <name>encoding-test</name>
     <url>http://maven.apache.org</url>
 
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.jboss.resteasy.test</groupId>
             <artifactId>scanning-test-jar</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
 
     </dependencies>

--- a/jaxrs/jboss-integration-testing/servlet-mapping-test/pom.xml
+++ b/jaxrs/jboss-integration-testing/servlet-mapping-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-jboss-integration-testing</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>servlet-mapping-test</artifactId>

--- a/jaxrs/jboss-integration-testing/spring-integration-test/pom.xml
+++ b/jaxrs/jboss-integration-testing/spring-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-jboss-integration-testing</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spring-integration-test</artifactId>

--- a/jaxrs/jboss-modules/pom.xml
+++ b/jaxrs/jboss-modules/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-jboss-modules</artifactId>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -8,7 +8,7 @@
     </description>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/jaxrs/profiling-tests/pom.xml
+++ b/jaxrs/profiling-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <artifactId>profiling-tests</artifactId>
     <packaging>jar</packaging>

--- a/jaxrs/providers/abdera-atom/pom.xml
+++ b/jaxrs/providers/abdera-atom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>abdera-atom-provider</artifactId>

--- a/jaxrs/providers/fastinfoset/pom.xml
+++ b/jaxrs/providers/fastinfoset/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-fastinfoset-provider</artifactId>

--- a/jaxrs/providers/jackson/pom.xml
+++ b/jaxrs/providers/jackson/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-jackson-provider</artifactId>

--- a/jaxrs/providers/jackson2/pom.xml
+++ b/jaxrs/providers/jackson2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-jackson2-provider</artifactId>

--- a/jaxrs/providers/jaxb/pom.xml
+++ b/jaxrs/providers/jaxb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-jaxb-provider</artifactId>

--- a/jaxrs/providers/jettison/pom.xml
+++ b/jaxrs/providers/jettison/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-jettison-provider</artifactId>

--- a/jaxrs/providers/json-p-ee7/pom.xml
+++ b/jaxrs/providers/json-p-ee7/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-json-p-provider</artifactId>

--- a/jaxrs/providers/multipart/pom.xml
+++ b/jaxrs/providers/multipart/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-multipart-provider</artifactId>

--- a/jaxrs/providers/pom.xml
+++ b/jaxrs/providers/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <name>Resteasy Providers</name>
     <description/>

--- a/jaxrs/providers/resteasy-atom/pom.xml
+++ b/jaxrs/providers/resteasy-atom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-atom-provider</artifactId>

--- a/jaxrs/providers/resteasy-hibernatevalidator-provider/pom.xml
+++ b/jaxrs/providers/resteasy-hibernatevalidator-provider/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
   <groupId>org.jboss.resteasy</groupId>

--- a/jaxrs/providers/resteasy-html/pom.xml
+++ b/jaxrs/providers/resteasy-html/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-html</artifactId>

--- a/jaxrs/providers/resteasy-validator-provider-11/pom.xml
+++ b/jaxrs/providers/resteasy-validator-provider-11/pom.xml
@@ -4,7 +4,7 @@
 <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 <relativePath>../../pom.xml</relativePath>
     </parent>
   <groupId>org.jboss.resteasy</groupId>

--- a/jaxrs/providers/test-all-jaxb/pom.xml
+++ b/jaxrs/providers/test-all-jaxb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>test-all-jaxb</artifactId>

--- a/jaxrs/providers/test-jackson-jaxb-coexistence/pom.xml
+++ b/jaxrs/providers/test-jackson-jaxb-coexistence/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>test-jackson-jaxb-coexistence</artifactId>

--- a/jaxrs/providers/test-resteasy-html/pom.xml
+++ b/jaxrs/providers/test-resteasy-html/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>test-resteasy-html</artifactId>

--- a/jaxrs/providers/yaml/pom.xml
+++ b/jaxrs/providers/yaml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-yaml-provider</artifactId>

--- a/jaxrs/resteasy-bom/pom.xml
+++ b/jaxrs/resteasy-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
 
     <name>RESTEasy Maven Import</name>

--- a/jaxrs/resteasy-cache/pom.xml
+++ b/jaxrs/resteasy-cache/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <name>RESTEasy Cache</name>
     <description/>

--- a/jaxrs/resteasy-cache/resteasy-cache-core/pom.xml
+++ b/jaxrs/resteasy-cache/resteasy-cache-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.jboss.resteasy</groupId>

--- a/jaxrs/resteasy-cdi/pom.xml
+++ b/jaxrs/resteasy-cdi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <artifactId>resteasy-cdi</artifactId>
     <name>RESTEasy CDI integration module</name>

--- a/jaxrs/resteasy-client/pom.xml
+++ b/jaxrs/resteasy-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-client</artifactId>

--- a/jaxrs/resteasy-guice/pom.xml
+++ b/jaxrs/resteasy-guice/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <artifactId>resteasy-guice</artifactId>
     <name>Resteasy Guice</name>

--- a/jaxrs/resteasy-jaxrs-testsuite/pom.xml
+++ b/jaxrs/resteasy-jaxrs-testsuite/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-jaxrs-testsuite</artifactId>

--- a/jaxrs/resteasy-jaxrs/pom.xml
+++ b/jaxrs/resteasy-jaxrs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <artifactId>resteasy-jaxrs</artifactId>
     <name>RESTEasy JAX-RS Implementation</name>

--- a/jaxrs/resteasy-jsapi-testing/pom.xml
+++ b/jaxrs/resteasy-jsapi-testing/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jaxrs/resteasy-jsapi/pom.xml
+++ b/jaxrs/resteasy-jsapi/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-jsapi</artifactId>

--- a/jaxrs/resteasy-links/pom.xml
+++ b/jaxrs/resteasy-links/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-links</artifactId>

--- a/jaxrs/resteasy-servlet-initializer/pom.xml
+++ b/jaxrs/resteasy-servlet-initializer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-servlet-initializer</artifactId>

--- a/jaxrs/resteasy-spring/pom.xml
+++ b/jaxrs/resteasy-spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-spring</artifactId>

--- a/jaxrs/resteasy-test-data/pom.xml
+++ b/jaxrs/resteasy-test-data/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <artifactId>resteasy-test-data</artifactId>
     <name>RESTEasy JAX-RS Test Data</name>

--- a/jaxrs/security/jose-jwt/pom.xml
+++ b/jaxrs/security/jose-jwt/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/security/keystone/example/keystone-server/pom.xml
+++ b/jaxrs/security/keystone/example/keystone-server/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/security/keystone/example/some-app/pom.xml
+++ b/jaxrs/security/keystone/example/some-app/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/security/keystone/keystone-as7-modules/pom.xml
+++ b/jaxrs/security/keystone/keystone-as7-modules/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/jaxrs/security/keystone/keystone-as7/pom.xml
+++ b/jaxrs/security/keystone/keystone-as7/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/security/keystone/keystone-core/pom.xml
+++ b/jaxrs/security/keystone/keystone-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/security/login-module-authenticator/pom.xml
+++ b/jaxrs/security/login-module-authenticator/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/security/pom.xml
+++ b/jaxrs/security/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Resteasy Security</name>

--- a/jaxrs/security/resteasy-crypto/pom.xml
+++ b/jaxrs/security/resteasy-crypto/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/security/resteasy-oauth/pom.xml
+++ b/jaxrs/security/resteasy-oauth/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jaxrs/security/skeleton-key-idm/pom.xml
+++ b/jaxrs/security/skeleton-key-idm/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <name>Resteasy Skeleton Key POM</name>

--- a/jaxrs/security/skeleton-key-idm/skeleton-key-as7/pom.xml
+++ b/jaxrs/security/skeleton-key-idm/skeleton-key-as7/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/security/skeleton-key-idm/skeleton-key-core/pom.xml
+++ b/jaxrs/security/skeleton-key-idm/skeleton-key-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/security/skeleton-key-idm/skeleton-key-idp-war/pom.xml
+++ b/jaxrs/security/skeleton-key-idm/skeleton-key-idp-war/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/security/skeleton-key-idm/skeleton-key-idp/pom.xml
+++ b/jaxrs/security/skeleton-key-idm/skeleton-key-idp/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/security/skeleton-key-idm/skeleton-key-undertow/pom.xml
+++ b/jaxrs/security/skeleton-key-idm/skeleton-key-undertow/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/server-adapters/pom.xml
+++ b/jaxrs/server-adapters/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <name>Resteasy Http Adapter Plugins</name>
     <description/>

--- a/jaxrs/server-adapters/resteasy-jdk-http/pom.xml
+++ b/jaxrs/server-adapters/resteasy-jdk-http/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/server-adapters/resteasy-netty/pom.xml
+++ b/jaxrs/server-adapters/resteasy-netty/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/server-adapters/resteasy-netty4-cdi/pom.xml
+++ b/jaxrs/server-adapters/resteasy-netty4-cdi/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/server-adapters/resteasy-netty4/pom.xml
+++ b/jaxrs/server-adapters/resteasy-netty4/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/server-adapters/resteasy-undertow/pom.xml
+++ b/jaxrs/server-adapters/resteasy-undertow/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/tjws/pom.xml
+++ b/jaxrs/tjws/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
 
     <artifactId>tjws</artifactId>

--- a/jaxrs/war-tests/application-test/pom.xml
+++ b/jaxrs/war-tests/application-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/war-tests/client-typevar-test/pom.xml
+++ b/jaxrs/war-tests/client-typevar-test/pom.xml
@@ -2,7 +2,7 @@
   <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/war-tests/context-test/pom.xml
+++ b/jaxrs/war-tests/context-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/war-tests/encoding-test/pom.xml
+++ b/jaxrs/war-tests/encoding-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/war-tests/filter-test/pom.xml
+++ b/jaxrs/war-tests/filter-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/war-tests/jsapi-servlet-test/pom.xml
+++ b/jaxrs/war-tests/jsapi-servlet-test/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.jboss.resteasy.test</groupId>
     <artifactId>test-jsapi-servlet-war</artifactId>
     <packaging>war</packaging>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <name>jsapi-servlet-test</name>
     <description/>
     <url>http://maven.apache.org</url>
@@ -22,22 +22,22 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson2-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jsapi</artifactId>
-            <version>3.0.12.Final</version>
+            <version>3.0.13.Final-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jaxrs/war-tests/oauth-servlet-test/pom.xml
+++ b/jaxrs/war-tests/oauth-servlet-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
 	    <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jaxrs/war-tests/pom.xml
+++ b/jaxrs/war-tests/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.0.12.Final</version>
+        <version>3.0.13.Final-SNAPSHOT</version>
     </parent>
     <name>Resteasy WAR Tests</name>
     <description/>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>RESTEasy</name>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-pom</artifactId>
-    <version>3.0.12.Final</version>
+    <version>3.0.13.Final-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <url>http://rest-easy.org</url>


### PR DESCRIPTION
@ronsigal We have tagged 3.0.12.Final: https://github.com/resteasy/Resteasy/releases/tag/3.0.12.Final

So let's move upstream master to 3.0.13.Final-SNAPSHOT, do you agree?