### PR TITLE
remove use of System.out.println for logging

### DIFF
--- a/jaxrs/tjws/src/main/java/Acme/Serve/Serve.java
+++ b/jaxrs/tjws/src/main/java/Acme/Serve/Serve.java
@@ -312,7 +312,6 @@ public class Serve implements ServletContext, Serializable
       });
       setAccessLogged();
       keepAlive = arguments.get(ARG_KEEPALIVE) == null || ((Boolean) arguments.get(ARG_KEEPALIVE)).booleanValue();
-      System.out.println("KEEPALIVE!: " + keepAlive);
       int timeoutKeepAliveSec;
       try
       {
@@ -852,8 +851,6 @@ public class Serve implements ServletContext, Serializable
       }
       if (sessions == null)
          sessions = new HttpSessionContextImpl();
-      // TODO: display address as name and as ip
-      System.out.println("[" + new Date() + "] TJWS httpd " + hostName + " - " + acceptor + " is listening.");
    }
 
    /**


### PR DESCRIPTION
As a developer, I am not interested in the value of the "keepalive" variable. I also don't care if the "Servlet for path '/' already defined and no default will be used." Yet my IDE (and maven) tells me this for every integration test I run.

There are some other places as well where I get unwanted output.

If desired, a logging framework like JUL could be a suitable replacement.