### PR TITLE
RESTEASY-1202 bump Jackson to 2.6.1

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -43,7 +43,7 @@
         <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec>
         <version.org.glassfish.javax.el>3.0.0</version.org.glassfish.javax.el>
         <version.io.undertow>1.2.8.Final</version.io.undertow>
-        <version.com.fasterxml.jackson>2.4.1</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.6.1</version.com.fasterxml.jackson>
         <version.org.apache.httpcomponents>4.3.6</version.org.apache.httpcomponents>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jaxrs/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/ResteasyJackson2Provider.java
+++ b/jaxrs/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/ResteasyJackson2Provider.java
@@ -65,7 +65,7 @@ public class ResteasyJackson2Provider extends JacksonJaxbJsonProvider
 
       private ClassAnnotationKey(Class<?> clazz, Annotation[] annotations)
       {
-         this.annotations = new AnnotationBundleKey(annotations);
+         this.annotations = new AnnotationBundleKey(annotations, clazz);
          this.classKey = new ClassKey(clazz);
          hash = this.annotations.hashCode();
          hash = 31 * hash + classKey.hashCode();
@@ -105,7 +105,7 @@ public class ResteasyJackson2Provider extends JacksonJaxbJsonProvider
       // not yet resolved (or not cached any more)? Resolve!
       if (endpoint == null) {
          ObjectMapper mapper = locateMapper(type, mediaType);
-         endpoint = _configForReading(mapper, annotations);
+         endpoint = _configForReading(mapper, annotations, type);
          _readers.put(key, endpoint);
       }
       ObjectReader reader = endpoint.getReader();
@@ -143,7 +143,7 @@ public class ResteasyJackson2Provider extends JacksonJaxbJsonProvider
       // not yet resolved (or not cached any more)? Resolve!
       if (endpoint == null) {
           ObjectMapper mapper = locateMapper(type, mediaType);
-          endpoint = _configForWriting(mapper, annotations);
+          endpoint = _configForWriting(mapper, annotations, type);
 
           // and cache for future reuse
          _writers.put(key, endpoint);


### PR DESCRIPTION
Fix Resteasy compatibility with 2.6.1 https://issues.jboss.org/browse/RESTEASY-1202
not to be confused with https://github.com/resteasy/Resteasy/pull/649