### PR TITLE
ProxyBuilder/ProxyClient: do not proxy default methods

### DIFF
--- a/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
+++ b/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
@@ -12,6 +12,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Set;
@@ -27,6 +28,11 @@ public class ProxyBuilder<T>
    public static <T> ProxyBuilder<T> builder(Class<T> iface, WebTarget webTarget)
    {
       return new ProxyBuilder<T>(iface, (ResteasyWebTarget)webTarget);
+   }
+
+   private static boolean isDefault(Method method) {
+      return ((method.getModifiers() & (Modifier.ABSTRACT | Modifier.PUBLIC | Modifier.STATIC)) ==
+         Modifier.PUBLIC) && method.getDeclaringClass().isInterface();
    }
 
 	@SuppressWarnings("unchecked")
@@ -45,7 +51,10 @@ public class ProxyBuilder<T>
 		{
          MethodInvoker invoker;
          Set<String> httpMethods = IsHttpMethod.getHttpMethods(method);
-         if ((httpMethods == null || httpMethods.size() == 0) && method.isAnnotationPresent(Path.class) && method.getReturnType().isInterface())
+         if (isDefault(method)) {
+            continue;
+         }
+         else if ((httpMethods == null || httpMethods.size() == 0) && method.isAnnotationPresent(Path.class) && method.getReturnType().isInterface())
          {
             invoker = new SubResourceInvoker((ResteasyWebTarget)base, method, config);
          }


### PR DESCRIPTION
I have been playing around with this for a while and wanted to see if other people might be interested in this and want to see this merged. This allows to use default methods in shared resource interfaces that can be used for a [HttpClient proxy](https://docs.jboss.org/resteasy/docs/3.0-beta-3/userguide/html/RESTEasy_Client_Framework.html#d4e2049). This allows you to create method aliases with default values set. Approach based on https://rmannibucau.wordpress.com/2014/03/27/java-8-default-interface-methods-and-jdk-dynamic-proxies/

Example usage:

``` java

@Consumes(MediaType.WILDCARD)
@Produces(MediaType.APPLICATION_JSON)
interface ExampleResource {

    default Response test() {
        return test("5");
    }

    @GET
    Response test(@QueryParam("lupa") @DefaultValue("5") String value);
}

```

And:

``` java
            Client client = ClientFactory.newClient();
            WebTarget target = client.target("http://example.com/base/uri");
            ResteasyWebTarget rtarget = (ResteasyWebTarget)target;

            ExampleResource simple = rtarget.proxy(ExampleResource.class);
            simple.test(); // instead of simple.test(5).
```

_Edit_ I just see that it does not completely match the code style. If there is interest in merging this I will correct the errors.
