### PR TITLE
Support for not defined Matrix Parameter

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/StringParameterInjector.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/StringParameterInjector.java
@@ -277,7 +277,7 @@ public class StringParameterInjector
 
    public Object extractValue(String strVal)
    {
-      if (strVal == null || strVal.isEmpty())
+      if (strVal == null)
       {
          if (defaultValue == null)
          {

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/StringParameterInjector.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/StringParameterInjector.java
@@ -277,7 +277,7 @@ public class StringParameterInjector
 
    public Object extractValue(String strVal)
    {
-      if (strVal == null)
+      if (strVal == null || strVal.isEmpty())
       {
          if (defaultValue == null)
          {

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/PathSegmentImpl.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/PathSegmentImpl.java
@@ -42,12 +42,12 @@ public class PathSegmentImpl implements PathSegment
             {
                String name = namevalue[0];
                if (decode) name = Encode.decodePath(name);
-               String value = "";
+               String value = null;
                if (namevalue.length > 1)
                {
                   value = namevalue[1];
                }
-               if (decode) value = Encode.decodePath(value);
+               if (decode && value != null) value = Encode.decodePath(value);
                matrixParameters.add(name, value);
             }
          }


### PR DESCRIPTION
When sending matrixParams that are not defined (like ;a;b=1;c=2, where a is not defined) a 404 Not found will be returned. Instead it should just ignore the value and fullfill the reuqest, therefor a check for an empty String is necessary.