### PR TITLE
Add META-INF service for RestEASY ClientBuilder

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
+++ b/jaxrs/resteasy-jaxrs/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
@@ -1,0 +1,1 @@
+org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder


### PR DESCRIPTION
Needed to make service lookup for RestEASY work correctly. Otherwise it
will fallback to org.glassfish.jersey.client.JerseyClientBuilder.

Signed-off-by: Andreas Häber <andreas.haber@intele.com>