### PR TITLE
Migrating RESTEASY-610 patch to new ProxyBuilder, ignore Java8 default methods

### DIFF
--- a/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
+++ b/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
@@ -18,20 +18,20 @@ import java.util.Set;
 
 public class ProxyBuilder<T>
 {
-   private final Class<T> iface;
-   private final ResteasyWebTarget webTarget;
-   private ClassLoader loader = Thread.currentThread().getContextClassLoader();
-   private MediaType serverConsumes;
-   private MediaType serverProduces;
+	private final Class<T> iface;
+	private final ResteasyWebTarget webTarget;
+	private ClassLoader loader = Thread.currentThread().getContextClassLoader();
+	private MediaType serverConsumes;
+	private MediaType serverProduces;
 
    public static <T> ProxyBuilder<T> builder(Class<T> iface, WebTarget webTarget)
    {
       return new ProxyBuilder<T>(iface, (ResteasyWebTarget)webTarget);
    }
 
-   @SuppressWarnings("unchecked")
-   public static <T> T proxy(final Class<T> iface, WebTarget base, final ProxyConfig config)
-   {
+	@SuppressWarnings("unchecked")
+	public static <T> T proxy(final Class<T> iface, WebTarget base, final ProxyConfig config)
+	{
       if (iface.isAnnotationPresent(Path.class))
       {
          Path path = iface.getAnnotation(Path.class);
@@ -40,38 +40,38 @@ public class ProxyBuilder<T>
             base = base.path(path.value());
          }
       }
-      HashMap<Method, MethodInvoker> methodMap = new HashMap<Method, MethodInvoker>();
-      for (Method method : iface.getMethods())
-      {
-         if (!("as".equals(method.getName())) && !method.isDefault())
-         {
-            MethodInvoker invoker;
-            Set<String> httpMethods = IsHttpMethod.getHttpMethods(method);
-            if ((httpMethods == null || httpMethods.size() == 0) && method.isAnnotationPresent(Path.class) && method.getReturnType().isInterface())
-            {
-               invoker = new SubResourceInvoker((ResteasyWebTarget) base, method, config);
-            }
-            else
-            {
-               invoker = createClientInvoker(iface, method, (ResteasyWebTarget) base, config);
-            }
-            methodMap.put(method, invoker);
-         }
-      }
+		HashMap<Method, MethodInvoker> methodMap = new HashMap<Method, MethodInvoker>();
+		for (Method method : iface.getMethods())
+		{
+			if (!("as".equals(method.getName())) && !method.isDefault())
+			{
+				MethodInvoker invoker;
+				Set<String> httpMethods = IsHttpMethod.getHttpMethods(method);
+				if ((httpMethods == null || httpMethods.size() == 0) && method.isAnnotationPresent(Path.class) && method.getReturnType().isInterface())
+				{
+					invoker = new SubResourceInvoker((ResteasyWebTarget)base, method, config);
+				}
+				else
+				{
+					invoker = createClientInvoker(iface, method, (ResteasyWebTarget)base, config);
+				}
+				methodMap.put(method, invoker);
+			}
+		}
 
-      Class<?>[] intfs =
-              {
-                      iface
-              };
+		Class<?>[] intfs =
+		{
+				iface
+		};
 
-      ClientProxy clientProxy = new ClientProxy(methodMap);
-      // this is done so that equals and hashCode work ok. Adding the proxy to a
-      // Collection will cause equals and hashCode to be invoked. The Spring
-      // infrastructure had some problems without this.
-      clientProxy.setClazz(iface);
+		ClientProxy clientProxy = new ClientProxy(methodMap);
+		// this is done so that equals and hashCode work ok. Adding the proxy to a
+		// Collection will cause equals and hashCode to be invoked. The Spring
+		// infrastructure had some problems without this.
+		clientProxy.setClazz(iface);
 
-      return (T) Proxy.newProxyInstance(config.getLoader(), intfs, clientProxy);
-   }
+		return (T) Proxy.newProxyInstance(config.getLoader(), intfs, clientProxy);
+	}
 
    private static <T> ClientInvoker createClientInvoker(Class<T> clazz, Method method, ResteasyWebTarget base, ProxyConfig config)
    {
@@ -92,22 +92,22 @@ public class ProxyBuilder<T>
    }
 
    public ProxyBuilder<T> classloader(ClassLoader cl)
-   {
-      this.loader = cl;
-      return this;
-   }
+	{
+		this.loader = cl;
+		return this;
+	}
 
-   public ProxyBuilder<T> defaultProduces(MediaType type)
-   {
-      this.serverProduces = type;
-      return this;
-   }
+	public ProxyBuilder<T> defaultProduces(MediaType type)
+	{
+		this.serverProduces = type;
+		return this;
+	}
 
-   public ProxyBuilder<T> defaultConsumes(MediaType type)
-   {
-      this.serverConsumes = type;
-      return this;
-   }
+	public ProxyBuilder<T> defaultConsumes(MediaType type)
+	{
+		this.serverConsumes = type;
+		return this;
+	}
 
    public ProxyBuilder<T> defaultProduces(String type)
    {
@@ -120,10 +120,10 @@ public class ProxyBuilder<T>
       this.serverConsumes = MediaType.valueOf(type);
       return this;
    }
-   public T build()
-   {
+	public T build()
+	{
       return proxy(iface, webTarget, new ProxyConfig(loader, serverConsumes, serverProduces));
-   }
+	}
 
 
 

--- a/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
+++ b/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
@@ -18,20 +18,20 @@ import java.util.Set;
 
 public class ProxyBuilder<T>
 {
-	private final Class<T> iface;
-	private final ResteasyWebTarget webTarget;
-	private ClassLoader loader = Thread.currentThread().getContextClassLoader();
-	private MediaType serverConsumes;
-	private MediaType serverProduces;
+   private final Class<T> iface;
+   private final ResteasyWebTarget webTarget;
+   private ClassLoader loader = Thread.currentThread().getContextClassLoader();
+   private MediaType serverConsumes;
+   private MediaType serverProduces;
 
    public static <T> ProxyBuilder<T> builder(Class<T> iface, WebTarget webTarget)
    {
       return new ProxyBuilder<T>(iface, (ResteasyWebTarget)webTarget);
    }
 
-	@SuppressWarnings("unchecked")
-	public static <T> T proxy(final Class<T> iface, WebTarget base, final ProxyConfig config)
-	{
+   @SuppressWarnings("unchecked")
+   public static <T> T proxy(final Class<T> iface, WebTarget base, final ProxyConfig config)
+   {
       if (iface.isAnnotationPresent(Path.class))
       {
          Path path = iface.getAnnotation(Path.class);
@@ -40,35 +40,38 @@ public class ProxyBuilder<T>
             base = base.path(path.value());
          }
       }
-		HashMap<Method, MethodInvoker> methodMap = new HashMap<Method, MethodInvoker>();
-		for (Method method : iface.getMethods())
-		{
-         MethodInvoker invoker;
-         Set<String> httpMethods = IsHttpMethod.getHttpMethods(method);
-         if ((httpMethods == null || httpMethods.size() == 0) && method.isAnnotationPresent(Path.class) && method.getReturnType().isInterface())
+      HashMap<Method, MethodInvoker> methodMap = new HashMap<Method, MethodInvoker>();
+      for (Method method : iface.getMethods())
+      {
+         if (!("as".equals(method.getName())) && !method.isDefault())
          {
-            invoker = new SubResourceInvoker((ResteasyWebTarget)base, method, config);
+            MethodInvoker invoker;
+            Set<String> httpMethods = IsHttpMethod.getHttpMethods(method);
+            if ((httpMethods == null || httpMethods.size() == 0) && method.isAnnotationPresent(Path.class) && method.getReturnType().isInterface())
+            {
+               invoker = new SubResourceInvoker((ResteasyWebTarget) base, method, config);
+            }
+            else
+            {
+               invoker = createClientInvoker(iface, method, (ResteasyWebTarget) base, config);
+            }
+            methodMap.put(method, invoker);
          }
-         else
-         {
-            invoker = createClientInvoker(iface, method, (ResteasyWebTarget)base, config);
-         }
-         methodMap.put(method, invoker);
-		}
+      }
 
-		Class<?>[] intfs =
-		{
-				iface
-		};
+      Class<?>[] intfs =
+              {
+                      iface
+              };
 
-		ClientProxy clientProxy = new ClientProxy(methodMap);
-		// this is done so that equals and hashCode work ok. Adding the proxy to a
-		// Collection will cause equals and hashCode to be invoked. The Spring
-		// infrastructure had some problems without this.
-		clientProxy.setClazz(iface);
+      ClientProxy clientProxy = new ClientProxy(methodMap);
+      // this is done so that equals and hashCode work ok. Adding the proxy to a
+      // Collection will cause equals and hashCode to be invoked. The Spring
+      // infrastructure had some problems without this.
+      clientProxy.setClazz(iface);
 
-		return (T) Proxy.newProxyInstance(config.getLoader(), intfs, clientProxy);
-	}
+      return (T) Proxy.newProxyInstance(config.getLoader(), intfs, clientProxy);
+   }
 
    private static <T> ClientInvoker createClientInvoker(Class<T> clazz, Method method, ResteasyWebTarget base, ProxyConfig config)
    {
@@ -89,22 +92,22 @@ public class ProxyBuilder<T>
    }
 
    public ProxyBuilder<T> classloader(ClassLoader cl)
-	{
-		this.loader = cl;
-		return this;
-	}
+   {
+      this.loader = cl;
+      return this;
+   }
 
-	public ProxyBuilder<T> defaultProduces(MediaType type)
-	{
-		this.serverProduces = type;
-		return this;
-	}
+   public ProxyBuilder<T> defaultProduces(MediaType type)
+   {
+      this.serverProduces = type;
+      return this;
+   }
 
-	public ProxyBuilder<T> defaultConsumes(MediaType type)
-	{
-		this.serverConsumes = type;
-		return this;
-	}
+   public ProxyBuilder<T> defaultConsumes(MediaType type)
+   {
+      this.serverConsumes = type;
+      return this;
+   }
 
    public ProxyBuilder<T> defaultProduces(String type)
    {
@@ -117,10 +120,10 @@ public class ProxyBuilder<T>
       this.serverConsumes = MediaType.valueOf(type);
       return this;
    }
-	public T build()
-	{
+   public T build()
+   {
       return proxy(iface, webTarget, new ProxyConfig(loader, serverConsumes, serverProduces));
-	}
+   }
 
 
 

--- a/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
+++ b/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
@@ -43,7 +43,8 @@ public class ProxyBuilder<T>
 		HashMap<Method, MethodInvoker> methodMap = new HashMap<Method, MethodInvoker>();
 		for (Method method : iface.getMethods())
 		{
-			if (!("as".equals(method.getName())) && !method.isDefault())
+			// ignore the as method to allow declaration in client interfaces
+			if (!("as".equals(method.getName())))
 			{
 				MethodInvoker invoker;
 				Set<String> httpMethods = IsHttpMethod.getHttpMethods(method);


### PR DESCRIPTION
A patch was submitted to ProxyBuilder for RestEasy 2.3.4.  The original ProxyBuilder has now been deprecated and the new one did not include similar patch code.  That was copied that over.

https://issues.jboss.org/browse/RESTEASY-610

Also, we found that Java 8 generates default methods which don't include the original annotations causing RestEasy to fail.  This patch ignores those.

http://stackoverflow.com/questions/31962433/classgetdeclaredmethods-returns-inherited-methods
http://stackoverflow.com/questions/27013542/getdeclaredmethods-behaving-differently-in-java-7-vs-java-8
http://stackoverflow.com/questions/1961350/problem-in-the-getdeclaredmethods-java
http://stackoverflow.com/questions/6204339/java-class-getmethods-behavior-on-overridden-methods
