### PR TITLE
Resteasy 1248 - Fix cache expired time and prevent for NullPointerException

### DIFF
--- a/jaxrs/resteasy-cache/resteasy-cache-core/src/main/java/org/jboss/resteasy/plugins/cache/server/InfinispanCache.java
+++ b/jaxrs/resteasy-cache/resteasy-cache-core/src/main/java/org/jboss/resteasy/plugins/cache/server/InfinispanCache.java
@@ -44,7 +44,7 @@ public class InfinispanCache implements ServerCache
 
       public boolean isExpired()
       {
-         return System.currentTimeMillis() - timestamp >= expires * 1000;
+         return System.currentTimeMillis() - timestamp >= expires * 1000L;
       }
 
       public String getEtag()

--- a/jaxrs/resteasy-cache/resteasy-cache-core/src/main/java/org/jboss/resteasy/plugins/cache/server/SimpleServerCache.java
+++ b/jaxrs/resteasy-cache/resteasy-cache-core/src/main/java/org/jboss/resteasy/plugins/cache/server/SimpleServerCache.java
@@ -39,7 +39,7 @@ public class SimpleServerCache implements ServerCache
 
       public boolean isExpired()
       {
-         return System.currentTimeMillis() - timestamp >= expires * 1000;
+         return System.currentTimeMillis() - timestamp >= expires * 1000L;
       }
 
       public String getEtag()

--- a/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/cache/CacheEntry.java
+++ b/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/cache/CacheEntry.java
@@ -63,7 +63,7 @@ public class CacheEntry implements Entry, Serializable
 
    public boolean expired()
    {
-      return System.currentTimeMillis() - timestamp >= expires * 1000;
+      return System.currentTimeMillis() - timestamp >= expires * 1000L;
    }
 
    public Header[] getValidationHeaders()

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/cache/CacheEntry.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/cache/CacheEntry.java
@@ -71,7 +71,7 @@ public class CacheEntry implements Entry, Serializable
 
    public boolean expired()
    {
-      return System.currentTimeMillis() - timestamp >= expires * 1000;
+      return System.currentTimeMillis() - timestamp >= expires * 1000L;
    }
 
    public Header[] getValidationHeaders()

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/cache/MapCache.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/cache/MapCache.java
@@ -60,7 +60,7 @@ public class MapCache implements BrowserCache
    {
       Map<String, Entry> data = cache.get(key);
       if (data == null) return null;
-      Entry removed = data.remove(type);
+      Entry removed = data.remove(type.toString());
       if (data.isEmpty())
       {
          cache.remove(key);

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResteasyUriBuilder.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResteasyUriBuilder.java
@@ -937,8 +937,6 @@ public class ResteasyUriBuilder extends UriBuilder
       }
       // don't set values if values is null
       if (values == null) return this;
-      // don't set values if values is null
-      if (values == null) return this;
       return queryParam(name, values);
    }
 

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/WeightedMediaType.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/WeightedMediaType.java
@@ -71,13 +71,13 @@ public class WeightedMediaType extends MediaType implements Comparable<WeightedM
       boolean result;
       if (other == null)
          result = false;
-      if (getType().equals(MEDIA_TYPE_WILDCARD) || other.getType().equals(MEDIA_TYPE_WILDCARD))
+      if (getType().equals(MEDIA_TYPE_WILDCARD) || (other != null && other.getType().equals(MEDIA_TYPE_WILDCARD)))
          result = true;
-      else if (getType().equalsIgnoreCase(other.getType()) && (getSubtype().equals(MEDIA_TYPE_WILDCARD) || other.getSubtype().equals(MEDIA_TYPE_WILDCARD)))
+      else if (other != null && getType().equalsIgnoreCase(other.getType()) && (getSubtype().equals(MEDIA_TYPE_WILDCARD) || (other != null && other.getSubtype().equals(MEDIA_TYPE_WILDCARD))))
          result = true;
       else
       {
-         if (getType().equalsIgnoreCase(other.getType())
+         if (other!= null && getType().equalsIgnoreCase(other.getType())
                  && this.getSubtype().equalsIgnoreCase(other.getSubtype()))
          {
             if (getParameters() == null || getParameters().size() == 0)

--- a/jaxrs/security/resteasy-crypto/src/main/java/org/jboss/resteasy/security/doseta/DosetaKeyRepository.java
+++ b/jaxrs/security/resteasy-crypto/src/main/java/org/jboss/resteasy/security/doseta/DosetaKeyRepository.java
@@ -202,7 +202,7 @@ public class DosetaKeyRepository implements KeyRepository
       if (entry == null) return null;
       if (entry.isStale())
       {
-         privateCache.remove(entry, entry);
+         privateCache.remove(alias, entry);
          return null;
       }
       return entry.key;
@@ -214,7 +214,7 @@ public class DosetaKeyRepository implements KeyRepository
       if (entry == null) return null;
       if (entry.isStale())
       {
-         publicCache.remove(entry, entry);
+         publicCache.remove(alias, entry);
          return null;
       }
       return entry.key;


### PR DESCRIPTION
* Use long type in time comparision in cache classes:
    * InfinispanCache.java
    * SimpleServerCache.java
    * CacheEntry.java
* Use correct key during cache cleanup
* Add prevention for NullPointerException in WeightedMediaType.java
* Remove duplicite code in ResteasyUriBuilder