### PR TITLE
Guice fix: Register generic @Providers

### DIFF
--- a/jaxrs/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/ModuleProcessor.java
+++ b/jaxrs/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/ModuleProcessor.java
@@ -33,7 +33,7 @@ public class ModuleProcessor
       List<Binding<?>> rootResourceBindings = new ArrayList<Binding<?>>();
       for (final Binding<?> binding : injector.getBindings().values())
       {
-         final Type type = binding.getKey().getTypeLiteral().getType();
+         final Type type = binding.getKey().getTypeLiteral().getRawType();
          if (type instanceof Class)
          {
             final Class<?> beanClass = (Class) type;


### PR DESCRIPTION
For guice, if you want to bind() a generic type you have to use the
TypeLiteral class. The type however is not of Class and the registration of class's annotated with
@Provider were being ommited.

see: https://github.com/google/guice/wiki/FrequentlyAskedQuestions#how-to-inject-class-with-generic-type