### PR TITLE
resteasy-jackson2: switch to non-deprecated jackson2 methods

### DIFF
--- a/jaxrs/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/ResteasyJackson2Provider.java
+++ b/jaxrs/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/ResteasyJackson2Provider.java
@@ -65,7 +65,7 @@ public class ResteasyJackson2Provider extends JacksonJaxbJsonProvider
 
       private ClassAnnotationKey(Class<?> clazz, Annotation[] annotations)
       {
-         this.annotations = new AnnotationBundleKey(annotations);
+         this.annotations = new AnnotationBundleKey(annotations, AnnotationBundleKey.class);
          this.classKey = new ClassKey(clazz);
          hash = this.annotations.hashCode();
          hash = 31 * hash + classKey.hashCode();
@@ -105,7 +105,7 @@ public class ResteasyJackson2Provider extends JacksonJaxbJsonProvider
       // not yet resolved (or not cached any more)? Resolve!
       if (endpoint == null) {
          ObjectMapper mapper = locateMapper(type, mediaType);
-         endpoint = _configForReading(mapper, annotations);
+         endpoint = _configForReading(mapper, annotations, type);
          _readers.put(key, endpoint);
       }
       ObjectReader reader = endpoint.getReader();
@@ -143,7 +143,7 @@ public class ResteasyJackson2Provider extends JacksonJaxbJsonProvider
       // not yet resolved (or not cached any more)? Resolve!
       if (endpoint == null) {
           ObjectMapper mapper = locateMapper(type, mediaType);
-          endpoint = _configForWriting(mapper, annotations);
+          endpoint = _configForWriting(mapper, annotations, type);
 
           // and cache for future reuse
          _writers.put(key, endpoint);


### PR DESCRIPTION
resteasy-jackson2 is incompatible with jackson 2.6 because it uses methods that were deprecated in 2.2 and 2.3 and have been removed. 