### PR TITLE
RESTEASY-1261 Use queryStringEncoding for the fragment

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/Encode.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/Encode.java
@@ -180,7 +180,7 @@ public class Encode
     */
    public static String encodeFragment(String value)
    {
-      return encodeValue(value, queryNameValueEncoding);
+      return encodeValue(value, queryStringEncoding);
    }
 
    /**

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/specimpl/ResteasyUriBuilderTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/specimpl/ResteasyUriBuilderTest.java
@@ -1,8 +1,11 @@
 package org.jboss.resteasy.specimpl;
 
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+
+import javax.ws.rs.core.UriBuilder;
 
 public class ResteasyUriBuilderTest {
 
@@ -18,5 +21,14 @@ public class ResteasyUriBuilderTest {
     assertSame(builder, builder.uri("foo:/bar"));
     builder = new ResteasyUriBuilder();
     assertSame(builder, builder.uri("foo:bar"));
+  }
+  
+  @Test
+  public void testUriWithFragment() {
+    UriBuilder builder = ResteasyUriBuilder.fromTemplate("http://domain.com/path#fragment=with/allowed/special-chars");
+    assertEquals("http://domain.com/path#fragment=with/allowed/special-chars", builder.build().toString());
+
+    builder = ResteasyUriBuilder.fromTemplate("http://domain.com/path#fragment%with[forbidden}special<chars");
+    assertEquals("http://domain.com/path#fragment%25with%5Bforbidden%7Dspecial%3Cchars", builder.build().toString());
   }
 }


### PR DESCRIPTION
Use queryStringEncoding instead of queryNameValueEncoding for encoding
the fragment part of a URI