### PR TITLE
Update Hibernate Validator in resteasy-validator-provider-11

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -23,7 +23,7 @@
         <dep.jaxb-impl.version>2.2.7</dep.jaxb-impl.version>
         <dep.jettison.version>1.3.2</dep.jettison.version>
         <dep.commons-io.version>2.1</dep.commons-io.version>
-        <dep.hibernate-validator.version>5.1.0.Final</dep.hibernate-validator.version>
+        <dep.hibernate-validator.version>5.1.3.Final</dep.hibernate-validator.version>
         <dep.javax.persistence.version>1.0.1.Final</dep.javax.persistence.version>
         <dep.javax.activation.version>1.1.1</dep.javax.activation.version>
         <dep.spring-webmvc.version>3.0.6.RELEASE</dep.spring-webmvc.version>

--- a/jaxrs/providers/resteasy-validator-provider-11/pom.xml
+++ b/jaxrs/providers/resteasy-validator-provider-11/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.0.1.Final</version>
+            <version>${dep.hibernate-validator.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
`resteasy-validator-provider-11` currently ships with Hibernate Validator 5.0.1 which is rather old and contains a memory leaks: [HV-838](https://hibernate.atlassian.net/browse/HV-838).

This pull request makes `resteasy-validator-provider-11` use the Hibernate Validator version defined in the main `pom.xml` and updates it to Hibernate Validator 5.1.3.

`dep.hibernate-validator.version` is not used anywhere else in the project in the moment. I suspect it got abandoned when `resteasy-hibernatevalidator-provider` got split.