### PR TITLE
Test case and fix for RESTEASY-222

### DIFF
--- a/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/client/ResponseTest.java
+++ b/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/client/ResponseTest.java
@@ -22,7 +22,7 @@ public class ResponseTest
    @Test
    public void getLastModifiedTest()
    {
-      Date date = Calendar.getInstance().getTime();
+      Date date = new Date(1455097347000L);
       Response response = Response.ok().lastModified(date).build();
       Date responseDate = response.getLastModified();
       System.out.println(date);

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResponseBuilderImpl.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResponseBuilderImpl.java
@@ -243,7 +243,7 @@ public class ResponseBuilderImpl extends Response.ResponseBuilder
          metadata.remove(HttpHeaderNames.LAST_MODIFIED);
          return this;
       }
-      metadata.putSingle(HttpHeaderNames.LAST_MODIFIED, lastModified);
+      metadata.putSingle(HttpHeaderNames.LAST_MODIFIED, getDateFormatRFC822().format(lastModified));
       return this;
    }
 

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/specimpl/ResponseBuilderImplTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/specimpl/ResponseBuilderImplTest.java
@@ -19,7 +19,7 @@ public class ResponseBuilderImplTest
    {
       ResponseBuilderImpl impl = new ResponseBuilderImpl();
 
-      Date date = new SimpleDateFormat("yyyy-MM-dd HH:mm").parse("2015-12-08 16:50:00");
+      Date date = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z").parse("2015-12-08 15:50:00 GMT");
       impl.lastModified(date);
       assertEquals(impl.build().getLastModified(), date);
       assertEquals(impl.build().getHeaderString("Last-Modified"), "Tue, 08 Dec 2015 15:50:00 GMT");

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/specimpl/ResponseBuilderImplTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/specimpl/ResponseBuilderImplTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * @author Michiel Meeuwissen
- * @since 3.0.14
+ * @since 3.0.15
  */
 public class ResponseBuilderImplTest
 {

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/specimpl/ResponseBuilderImplTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/specimpl/ResponseBuilderImplTest.java
@@ -1,0 +1,30 @@
+package org.jboss.resteasy.specimpl;
+
+import org.junit.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Michiel Meeuwissen
+ * @since 3.0.14
+ */
+public class ResponseBuilderImplTest
+{
+
+   @Test
+   public void testLastModified() throws Exception
+   {
+      ResponseBuilderImpl impl = new ResponseBuilderImpl();
+
+      Date date = new SimpleDateFormat("yyyy-MM-dd HH:mm").parse("2015-12-08 16:50:00");
+      impl.lastModified(date);
+      assertEquals(impl.build().getLastModified(), date);
+      assertEquals(impl.build().getHeaderString("Last-Modified"), "Tue, 08 Dec 2015 15:50:00 GMT");
+
+      // getHeaders is used to actually build the response, so date headers must be formatted correctly in that too
+      assertEquals(impl.build().getHeaders().getFirst("Last-Modified"), "Tue, 08 Dec 2015 15:50:00 GMT"); // FAILS in 3.0.13
+   }
+}


### PR DESCRIPTION
It seems that RESTEASY-222 should be reopened again, because when I use 'lastModified' the actual Last-Modified header is not correctly formatted. This is a fix, plus a test-case.