### PR TITLE
Fixes for resteasy-links #833, #1271

### DIFF
--- a/jaxrs/resteasy-links/src/main/java/org/jboss/resteasy/links/RESTServiceDiscovery.java
+++ b/jaxrs/resteasy-links/src/main/java/org/jboss/resteasy/links/RESTServiceDiscovery.java
@@ -4,6 +4,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
+
 import java.net.URI;
 import java.util.ArrayList;
 
@@ -99,10 +100,43 @@ public class RESTServiceDiscovery extends ArrayList<RESTServiceDiscovery.AtomLin
 		public void setLength(String length) {
 			this.length = length;
 		}
+		
+		@Override
+		public int hashCode() {
+			int code = 17;
+			code = 31 * code + ((rel == null)?0:rel.hashCode());
+			code = 31 * code + ((href == null)?0:href.hashCode());
+			code = 31 * code + ((type == null)?0:type.hashCode());
+			code = 31 * code + ((hreflang == null)?0:hreflang.hashCode());
+			code = 31 * code + ((title == null)?0:title.hashCode());
+			code = 31 * code + ((length == null)?0:length.hashCode());
+			return code;
+		}
+		
+		@Override
+		public boolean equals(Object obj) {
+			if (obj == null || obj.getClass() != AtomLink.class) return false;
+			AtomLink l = (AtomLink)obj;
+			return equals(rel, l.rel) && equals(href, l.href) &&
+					equals(type, l.type) && equals(hreflang, l.hreflang) &&
+						equals(title, l.title) && equals(length, l.length);
+		}
+		
+		/**
+		 * Determines whether two strings are both null or equal.
+		 * 
+		 * @param a A string.
+		 * @param b Another string.
+		 * @return True if a and b are both null or if they are equal.
+		 */
+		private static boolean equals(String a, String b) {
+			return (a == null && b == null) || (a != null && a.equals(b));
+		}
 	}
 
 	public void addLink(URI uri, String rel) {
-		add(new AtomLink(uri.toString(), rel));
+		AtomLink link = new AtomLink(uri.toString(), rel);
+		if (!contains(link)) add(link);
 	}
 	
 	public AtomLink getLinkForRel(String rel){

--- a/jaxrs/resteasy-links/src/main/java/org/jboss/resteasy/links/i18n/Messages.java
+++ b/jaxrs/resteasy-links/src/main/java/org/jboss/resteasy/links/i18n/Messages.java
@@ -55,4 +55,7 @@ public interface Messages
    
    @Message(id = BASE + 60, value = "Not enough URI parameters: expecting {0} but only found {1}", format=Format.MESSAGE_FORMAT)
    String notEnoughtUriParameters(int expected, int actual);
+   
+   @Message(id = BASE + 65, value = "Failed to access links in %s")
+   String failedToAccessLinks(Object expression);
 }

--- a/jaxrs/resteasy-links/src/test/resources/i18n/Messages.i18n_en.properties
+++ b/jaxrs/resteasy-links/src/test/resources/i18n/Messages.i18n_en.properties
@@ -50,3 +50,7 @@ failedToReadPropertyFromMethod=Failed to read property from method %s
 # @param 1: expected - 
 # @param 2: actual - 
 notEnoughtUriParameters=Not enough URI parameters: expecting {0} but only found {1}
+# Id: 12065
+# Message: Failed to access links in %s
+# @param 1: expression - 
+failedToAccessLinks=Failed to access links in %s


### PR DESCRIPTION
#833
- In RESTUtils: Load existing value of injection field from entity to
  avoid overwriting manually specified links. 
- In RESTServiceDiscovery: Prevent insertion of duplicate links into
  injection field by performing duplicate check in addLinks. 
- In Messages: Add additional error message when injection field cannot
  be read which will result in overwritten manually specified links.
#1271
- In RESTUtils: Replace calls to Method.findAnnotation and
  Method.isAnnotationPresent with implementations that also look at
  inherited annotations.
