### PR TITLE
Fix RESTEASY-1201

### DIFF
--- a/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/AbstractMultipartWriter.java
+++ b/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/AbstractMultipartWriter.java
@@ -8,6 +8,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Providers;
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Type;
@@ -30,7 +31,13 @@ public class AbstractMultipartWriter
       httpHeaders.putSingle(HttpHeaderNames.CONTENT_TYPE, mediaType.toString() + "; boundary=" + multipartOutput.getBoundary());
       byte[] boundaryBytes = ("--" + boundary).getBytes();
 
-      writeParts(multipartOutput, entityStream, boundaryBytes);
+      writeParts(multipartOutput, new FilterOutputStream(entityStream) {
+         @Override
+         public void close() throws IOException {
+            // no close
+            //super.close();
+         }
+      }, boundaryBytes);
       entityStream.write(boundaryBytes);
       entityStream.write("--".getBytes());
    }


### PR DESCRIPTION

resteasy-multipart-provider/AbstractMultipartWriter: Wrap entityStream into a no closable stream when writeParts()

The cause of the issue https://issues.jboss.org/browse/RESTEASY-1201 is like that, when write the content of parts, the JSON parts will use the org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider to write, and in https://github.com/resteasy/Resteasy/blob/master/jaxrs/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/ResteasyJackson2Provider.java#L209, the jq.close() closed the stream, that cause the entityStream closed unexpectly.

I'm not sure that jq.close() is really need to close the entityStream, but I am really sure that the implements of MessageBodyWriter shoud never close the entityStream as it mentioned in http://docs.jboss.org/resteasy/docs/3.0-rc-1/javadocs/javax/ws/rs/ext/MessageBodyWriter.html#writeTo%28T,%20java.lang.Class,%20java.lang.reflect.Type,%20java.lang.annotation.Annotation[],%20javax.ws.rs.core.MediaType,%20javax.ws.rs.core.MultivaluedMap,%20java.io.OutputStream%29 about the entityStream param