### PR TITLE
Make multipart/form-data more compatible

### DIFF
--- a/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/AbstractMultipartWriter.java
+++ b/jaxrs/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/AbstractMultipartWriter.java
@@ -33,6 +33,7 @@ public class AbstractMultipartWriter
       writeParts(multipartOutput, entityStream, boundaryBytes);
       entityStream.write(boundaryBytes);
       entityStream.write("--".getBytes());
+      entityStream.write("\r\n".getBytes());
    }
 
    protected void writeParts(MultipartOutput multipartOutput, OutputStream entityStream, byte[] boundaryBytes)


### PR DESCRIPTION
resteasy-multipart-provider/AbstractMultipartWriter: Make multipart/form-data more compatible

As some web server not compatibe with this writer but working well with curl, I diffed the package that write by AbstractMultipartWriter and curl, I found AbstractMultipartWriter did not write a trialling CRLF but the curl did. and when there is no trailling CRLF some server may miss the whole body.