### PR TITLE
RESTEASY-1251: 

### DIFF
--- a/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientResponse.java
+++ b/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientResponse.java
@@ -186,7 +186,7 @@ public abstract class ClientResponse extends BuiltResponse
             {
                try
                {
-                  close();
+            	   releaseConnection();
                }
                catch (Exception ignored)
                {

--- a/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/client/entity/TestGetEntity.java
+++ b/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/client/entity/TestGetEntity.java
@@ -1,0 +1,113 @@
+package org.jboss.resteasy.test.client.entity;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.core.Dispatcher;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+import org.jboss.resteasy.test.EmbeddedContainer;
+import org.jboss.resteasy.util.HttpResponseCodes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+/**
+ * Unit tests for RESTEASY-1251.
+ * 
+ *
+ * @author <a href="mailto:ron.sigal@jboss.com">Ron Sigal</a>
+ * @date January 16, 2016
+ */
+public class TestGetEntity
+{
+   protected static ResteasyDeployment deployment;
+   protected static Dispatcher dispatcher;
+   protected static final String ANSWER = "answer";
+
+   @Path("/")
+   public static class TestResource
+   {
+     @GET
+     @Path("test")
+     public String test()
+     {
+    	 return ANSWER;
+     }
+   }
+
+   @Before
+   public void before() throws Exception
+   {
+      deployment = EmbeddedContainer.start();
+      dispatcher = deployment.getDispatcher();
+      deployment.getRegistry().addPerRequestResource(TestResource.class);
+   }
+   
+   @After
+   public void after() throws Exception
+   {
+      EmbeddedContainer.stop();
+      dispatcher = null;
+      deployment = null;
+   }
+
+
+   @Test
+   public void testGetEntity()
+   {
+	   ResteasyClient client = new ResteasyClientBuilder().build();
+       WebTarget base = client.target("http://localhost:8081/test");
+       Response response = base.request().get();
+       Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+       Assert.assertEquals(ANSWER, response.readEntity(String.class));
+       Assert.assertTrue(response.hasEntity());
+       Assert.assertEquals(ANSWER, response.getEntity());
+       response.close();
+       try
+       {
+    	   response.readEntity(String.class);
+    	   Assert.fail("Expected Exception");
+       }
+       catch (IllegalStateException e)
+       {
+    	   // Good
+       }
+       catch (Exception e)
+       {
+    	   Assert.fail("Expected IllegalStateException");
+       }
+       try
+       {
+    	   response.getEntity();
+    	   Assert.fail("Expected Exception");
+       }
+       catch (IllegalStateException e)
+       {
+    	   // Good
+       }
+       catch (Exception e)
+       {
+    	   Assert.fail("Expected IllegalStateException");
+       }
+       try
+       {
+    	   response.hasEntity();
+    	   Assert.fail("Expected Exception");
+       }
+       catch (IllegalStateException e)
+       {
+    	   // Good
+       }
+       catch (Exception e)
+       {
+    	   Assert.fail("Expected IllegalStateException");
+       }
+       client.close();
+   }
+}


### PR DESCRIPTION
ClientResponse in resteasy-client module calls releaseConnection() instead of close() in readEntity().