### PR TITLE
[RESTEASY-1305] RESTEasy Spring Boot starter integration

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SynchronousDispatcher.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SynchronousDispatcher.java
@@ -66,7 +66,8 @@ public class SynchronousDispatcher implements Dispatcher
       defaultContextObjects.put(InternalDispatcher.class, InternalDispatcher.getInstance());
    }
 
-   public SynchronousDispatcher(ResteasyProviderFactory providerFactory, ResourceMethodRegistry registry) {
+   public SynchronousDispatcher(ResteasyProviderFactory providerFactory, ResourceMethodRegistry registry)
+   {
       this(providerFactory);
       this.registry = registry;
       defaultContextObjects.put(Registry.class, registry);

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SynchronousDispatcher.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SynchronousDispatcher.java
@@ -66,6 +66,12 @@ public class SynchronousDispatcher implements Dispatcher
       defaultContextObjects.put(InternalDispatcher.class, InternalDispatcher.getInstance());
    }
 
+   public SynchronousDispatcher(ResteasyProviderFactory providerFactory, ResourceMethodRegistry registry) {
+      this(providerFactory);
+      this.registry = registry;
+      defaultContextObjects.put(Registry.class, registry);
+   }
+
    public ResteasyProviderFactory getProviderFactory()
    {
       return providerFactory;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyDeployment.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyDeployment.java
@@ -118,6 +118,9 @@ public class ResteasyDeployment
       }
       else
       {
+         // If dispatcher is NOT null, that means it has already been set
+         // previously, so we don' want to do it again, otherwise the original
+         // one will be replaced
          if(dispatcher == null) {
             SynchronousDispatcher dis = new SynchronousDispatcher(providerFactory);
             dis.getUnwrappedExceptions().addAll(unwrappedExceptions);

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyDeployment.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyDeployment.java
@@ -118,9 +118,11 @@ public class ResteasyDeployment
       }
       else
       {
-         SynchronousDispatcher dis = new SynchronousDispatcher(providerFactory);
-         dis.getUnwrappedExceptions().addAll(unwrappedExceptions);
-         dispatcher = dis;
+         if(dispatcher == null) {
+            SynchronousDispatcher dis = new SynchronousDispatcher(providerFactory);
+            dis.getUnwrappedExceptions().addAll(unwrappedExceptions);
+            dispatcher = dis;
+         }
       }
       registry = dispatcher.getRegistry();
       if (widerRequestMatching)


### PR DESCRIPTION
Allowing ResteasyDeployment to use previously set dispatcher
Also adding an extra constructor to SynchronousDispatcher with pre-set ResourceMethodRegistry object
This is necessary for RESTEasy Spring Boot starter
See https://issues.jboss.org/browse/RESTEASY-1305
See https://github.com/paypal/resteasy-spring-boot