### PR TITLE
RESTEASY-1311: ResteasyProviderFactory.registerProviderInstance does not always take priority into account

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -1856,8 +1856,8 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
          {
             containerRequestFilterRegistry = parent.getContainerRequestFilterRegistry().clone(this);
          }
-         containerRequestFilterRegistry.registerSingleton((ContainerRequestFilter) provider);
          int priority = getPriority(priorityOverride, contracts, ContainerRequestFilter.class, provider.getClass());
+         containerRequestFilterRegistry.registerSingleton((ContainerRequestFilter) provider, priority);
          newContracts.put(ContainerRequestFilter.class, priority);
       }
       if (isA(provider, PostProcessInterceptor.class, contracts))
@@ -1875,8 +1875,8 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
          {
             containerResponseFilterRegistry = parent.getContainerResponseFilterRegistry().clone(this);
          }
-         containerResponseFilterRegistry.registerSingleton((ContainerResponseFilter) provider);
          int priority = getPriority(priorityOverride, contracts, ContainerResponseFilter.class, provider.getClass());
+         containerResponseFilterRegistry.registerSingleton((ContainerResponseFilter) provider, priority);
          newContracts.put(ContainerResponseFilter.class, priority);
       }
       if (isA(provider, ReaderInterceptor.class, contracts))

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/regression/ResteasyProviderFactoryTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/regression/ResteasyProviderFactoryTest.java
@@ -1,14 +1,24 @@
 package org.jboss.resteasy.test.regression;
 
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.jboss.resteasy.spi.StringParameterUnmarshaller;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
 import java.sql.Date;
+import java.util.List;
 
-import static org.junit.Assert.assertNotNull;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+
+import org.jboss.resteasy.core.interception.JaxrsInterceptorRegistry.InterceptorFactory;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.StringParameterUnmarshaller;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 /**
  * resteasy-584
  *
@@ -43,5 +53,49 @@ public class ResteasyProviderFactoryTest
 			return null;
 		}
 
+	}
+	
+	/**
+	 * Test case for bug RESTEASY-1311.
+	 * Test whether the priority is supplied to the container request filter registry.
+	 */
+	@Test
+	public void testRegisterProviderInstancePriorityContainerRequestFilter() throws Exception {
+		ContainerRequestFilter requestFilter = new ContainerRequestFilter() {
+			public void filter(ContainerRequestContext requestContext) {}
+		};
+		this.testRegisterProviderInstancePriority(requestFilter, factory.getContainerRequestFilterRegistry());
+	}
+	
+	/**
+	 * Test case for bug RESTEASY-1311.
+	 * Test whether the priority is supplied to the container response filter registry.
+	 */
+	@Test
+	public void testRegisterProviderInstancePriorityContainerResponseFilter() throws Exception {
+		ContainerResponseFilter responseFilter = new ContainerResponseFilter() {
+			public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {}
+		};
+		this.testRegisterProviderInstancePriority(responseFilter, factory.getContainerResponseFilterRegistry());
+	}
+	
+	/**
+	 * Generic helper method for RESTEASY-1311 cases, because the test logic is the same.
+	 * Unfortunately, there seems to be no public accessors for the properties we need,
+	 * so we have to resort to using reflection to check the right priority setting.
+	 */
+	private void testRegisterProviderInstancePriority(Object filter, Object registry) throws Exception {
+		int priorityOverride = Priorities.USER + 1;
+		factory.registerProviderInstance(filter, null, priorityOverride, false);
+		
+		Field interceptorsField = registry.getClass().getSuperclass().getDeclaredField("interceptors");
+		interceptorsField.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		List<InterceptorFactory> interceptors = (List<InterceptorFactory>) interceptorsField.get(registry);
+		
+		Field orderField = interceptors.get(0).getClass().getSuperclass().getDeclaredField("order");
+		orderField.setAccessible(true);
+		int order = (Integer) orderField.get(interceptors.get(0));
+		Assert.assertEquals(priorityOverride, order);
 	}
 }


### PR DESCRIPTION
At 2 points in the code, the priority was not provided to the registerSingleton method. This caused a bug for me when I tried to get one ContainerResponseFilter to run before another, but the priority was not picked up.