### PR TITLE
RESTEASY-1321: Support non-path-parameters in LinkResource

### DIFF
--- a/jaxrs/resteasy-links/src/main/java/org/jboss/resteasy/links/LinkResource.java
+++ b/jaxrs/resteasy-links/src/main/java/org/jboss/resteasy/links/LinkResource.java
@@ -69,6 +69,20 @@ public @interface LinkResource {
 	
 	/**
 	 * <p>
+	 * List of query parameters which should be attached to the link.
+	 * </p>
+	 */
+	ParamBinding[] queryParameters() default {};
+	
+	/**
+	 * <p>
+	 * List of matrix parameters which should be attached to the link.
+	 * </p>
+	 */
+	ParamBinding[] matrixParameters() default {};
+	
+	/**
+	 * <p>
 	 * EL expression that should return a boolean indicating whether or not this service link should be used.
 	 * This is useful for security constraints limiting access to resources. Defaults to using the
 	 * {@link javax.annotation.security.RolesAllowed @RolesAllowed} annotation using the current 

--- a/jaxrs/resteasy-links/src/main/java/org/jboss/resteasy/links/ParamBinding.java
+++ b/jaxrs/resteasy-links/src/main/java/org/jboss/resteasy/links/ParamBinding.java
@@ -1,0 +1,28 @@
+package org.jboss.resteasy.links;
+
+/**
+ * Defines a single URI template parameter binding. 
+ * 
+ * @author Alexander Rashed <alexander.rashed@gmail.com>
+ */
+public @interface ParamBinding {
+
+	/**
+	 * Name of the URI template parameter.
+	 */
+	String name();
+
+	/**
+	 * <p>
+	 * Expression language expression specifying the value of the parameter.
+	 * These can be normal constant string values or EL expressions (${foo.bar})
+	 * that will resolve using either the default EL context, or the context
+	 * specified by a {@link LinkELProvider @LinkELProvider} annotation. The
+	 * default context resolves any non-qualified variable to properties of the
+	 * response entity for whom we're discovering links, and has an extra
+	 * binding for the "this" variable which is the response entity as well.
+	 * </p>
+	 */
+	String value();
+	
+}

--- a/jaxrs/resteasy-links/src/main/java/org/jboss/resteasy/links/impl/RESTUtils.java
+++ b/jaxrs/resteasy-links/src/main/java/org/jboss/resteasy/links/impl/RESTUtils.java
@@ -8,6 +8,7 @@ import org.jboss.resteasy.links.ELProvider;
 import org.jboss.resteasy.links.LinkELProvider;
 import org.jboss.resteasy.links.LinkResource;
 import org.jboss.resteasy.links.LinkResources;
+import org.jboss.resteasy.links.ParamBinding;
 import org.jboss.resteasy.links.RESTServiceDiscovery;
 import org.jboss.resteasy.links.ResourceFacade;
 import org.jboss.resteasy.links.i18n.LogMessages;
@@ -240,7 +241,13 @@ public class RESTUtils {
 
 	private static URI buildURI(UriBuilder uriBuilder, LinkResource service,
 			Object entity, Method m) {
-		// see if we need parameters
+		for (ParamBinding binding : service.queryParameters()) {
+			uriBuilder.queryParam(binding.name(), evaluateEL(m, getELContext(m, entity), entity, binding.value()));
+		}
+		for (ParamBinding binding : service.matrixParameters()) {
+			uriBuilder.matrixParam(binding.name(), evaluateEL(m, getELContext(m, entity), entity, binding.value()));
+		}
+		
 		String[] uriTemplates = service.pathParameters();
 		if (uriTemplates.length > 0) {
 			Object[] values = new Object[uriTemplates.length];

--- a/jaxrs/resteasy-links/src/test/java/org/jboss/resteasy/links/test/BookStore.java
+++ b/jaxrs/resteasy-links/src/test/java/org/jboss/resteasy/links/test/BookStore.java
@@ -1,21 +1,25 @@
 package org.jboss.resteasy.links.test;
 
-import org.jboss.resteasy.links.AddLinks;
-import org.jboss.resteasy.links.LinkResource;
-import org.jboss.resteasy.links.LinkResources;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import javax.ws.rs.QueryParam;
+
+import org.jboss.resteasy.links.AddLinks;
+import org.jboss.resteasy.links.LinkResource;
+import org.jboss.resteasy.links.LinkResources;
+import org.jboss.resteasy.links.ParamBinding;
 
 @Path("/")
 public class BookStore {
@@ -88,13 +92,23 @@ public class BookStore {
 	@AddLinks
 	@LinkResources({
 		@LinkResource(value = Book.class, rel="comment-collection"),
-		@LinkResource(value = Comment.class, rel="collection")
+		@LinkResource(value = Comment.class, rel="collection"),
+		@LinkResource(value = ScrollableCollection.class, rel = "prev", constraint = "${this.start - this.limit >= 0}", queryParameters = {
+				@ParamBinding(name = "start", value = "${this.start - this.limit}"),
+				@ParamBinding(name = "limit", value = "${this.limit}") }),
+		@LinkResource(value = ScrollableCollection.class, rel = "next", constraint = "${this.start + this.limit < this.totalRecords}", queryParameters = {
+				@ParamBinding(name = "start", value = "${this.start + this.limit}"),
+				@ParamBinding(name = "limit", value = "${this.limit}")
+		})
 	})
 	@GET
 	@Path("book/{id}/comment-collection")
-	public ScrollableCollection getScrollableComments(@PathParam("id") String id){
+	public ScrollableCollection getScrollableComments(@PathParam("id") String id, @QueryParam("start") int start, @QueryParam("limit") @DefaultValue("1") int limit){
 		List<Comment> comments = books.get(id).getComments();
-		return new ScrollableCollection(id, 0, comments.size(), comments);
+		start = start < 0 ? 0 : start;
+		limit = limit < 1 ? 1 : limit;
+		limit = (start + limit) > comments.size() ? comments.size() - start : limit;
+		return new ScrollableCollection(id, start, limit, comments.size(), comments.subList(start, start + limit));
 	}
 
 	@Produces({"application/xml", "application/json"})

--- a/jaxrs/resteasy-links/src/test/java/org/jboss/resteasy/links/test/BookStoreMinimal.java
+++ b/jaxrs/resteasy-links/src/test/java/org/jboss/resteasy/links/test/BookStoreMinimal.java
@@ -9,6 +9,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.MatrixParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -16,6 +17,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -99,16 +101,21 @@ public class BookStoreMinimal {
 		@LinkResource(value = ScrollableCollection.class, rel = "next", constraint = "${this.start + this.limit < this.totalRecords}", queryParameters = {
 				@ParamBinding(name = "start", value = "${this.start + this.limit}"),
 				@ParamBinding(name = "limit", value = "${this.limit}")
-		})
+		}, matrixParameters = {@ParamBinding(name = "query", value = "${this.query}")})
 	})
 	@GET
 	@Path("book/{id}/comment-collection")
-	public ScrollableCollection getScrollableComments(@PathParam("id") String id, @QueryParam("start") int start, @QueryParam("limit") @DefaultValue("1") int limit){
-		List<Comment> comments = books.get(id).getComments();
+	public ScrollableCollection getScrollableComments(@PathParam("id") String id, @QueryParam("start") int start, @QueryParam("limit") @DefaultValue("1") int limit, @MatrixParam("query") String query){
+		List<Comment> comments = new ArrayList<Comment>();
+		for (Comment comment : books.get(id).getComments()) {
+			if (comment.getText().contains(query)) {
+				comments.add(comment);
+			}
+		}
 		start = start < 0 ? 0 : start;
 		limit = limit < 1 ? 1 : limit;
 		limit = (start + limit) > comments.size() ? comments.size() - start : limit;
-		return new ScrollableCollection(id, start, limit, comments.size(), comments.subList(start, start + limit));
+		return new ScrollableCollection(id, start, limit, comments.size(), comments.subList(start, start + limit), query);
 	}
 
 	@Produces({"application/xml", "application/json"})

--- a/jaxrs/resteasy-links/src/test/java/org/jboss/resteasy/links/test/BookStoreService.java
+++ b/jaxrs/resteasy-links/src/test/java/org/jboss/resteasy/links/test/BookStoreService.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.links.test;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.MatrixParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -32,11 +33,11 @@ public interface BookStoreService {
 	@Produces({"application/xml"})
 	@GET
 	@Path("book/{id}/comment-collection")
-	public ScrollableCollection getScrollableCommentsXML(@PathParam("id") String id);
+	public ScrollableCollection getScrollableCommentsXML(@PathParam("id") String id, @MatrixParam("query") String query);
 
 	@Produces({"application/json"})
 	@GET
 	@Path("book/{id}/comment-collection")
-	public ScrollableCollection getScrollableCommentsJSON(@PathParam("id") String id);
+	public ScrollableCollection getScrollableCommentsJSON(@PathParam("id") String id, @MatrixParam("query") String query);
 
 }

--- a/jaxrs/resteasy-links/src/test/java/org/jboss/resteasy/links/test/ScrollableCollection.java
+++ b/jaxrs/resteasy-links/src/test/java/org/jboss/resteasy/links/test/ScrollableCollection.java
@@ -9,6 +9,8 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -25,6 +27,8 @@ public class ScrollableCollection implements ResourceFacade<Comment> {
 	private int limit;
 	@XmlAttribute
 	private int totalRecords;
+	@XmlTransient
+	private String query;
 	@XmlElement
 	private List<Comment> comments = new ArrayList<Comment>();
 	@XmlElement
@@ -33,12 +37,13 @@ public class ScrollableCollection implements ResourceFacade<Comment> {
 	public ScrollableCollection() {}
 	
 	public ScrollableCollection(String id, int start, int limit, int totalRecords,
-			List<Comment> comments) {
+			List<Comment> comments, String query) {
 		this.id = id;
 		this.start = start;
 		this.limit = limit;
 		this.totalRecords = totalRecords;
 		this.comments.addAll(comments);
+		this.setQuery(query);
 	}
 
 	public Class<Comment> facadeFor() {
@@ -89,6 +94,14 @@ public class ScrollableCollection implements ResourceFacade<Comment> {
 
 	public void setComments(List<Comment> comments) {
 		this.comments = comments;
+	}
+
+	public String getQuery() {
+		return query;
+	}
+
+	public void setQuery(String query) {
+		this.query = query;
 	}
 
 }

--- a/jaxrs/resteasy-links/src/test/java/org/jboss/resteasy/links/test/ScrollableCollection.java
+++ b/jaxrs/resteasy-links/src/test/java/org/jboss/resteasy/links/test/ScrollableCollection.java
@@ -2,6 +2,7 @@ package org.jboss.resteasy.links.test;
 
 import org.jboss.resteasy.links.RESTServiceDiscovery;
 import org.jboss.resteasy.links.ResourceFacade;
+import org.jboss.resteasy.links.ResourceID;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -16,10 +17,12 @@ import java.util.Map;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.NONE)
 public class ScrollableCollection implements ResourceFacade<Comment> {
-
+	@ResourceID
 	private String id;
 	@XmlAttribute
 	private int start;
+	@XmlAttribute
+	private int limit;
 	@XmlAttribute
 	private int totalRecords;
 	@XmlElement
@@ -29,10 +32,11 @@ public class ScrollableCollection implements ResourceFacade<Comment> {
 
 	public ScrollableCollection() {}
 	
-	public ScrollableCollection(String id, int start, int totalRecords,
+	public ScrollableCollection(String id, int start, int limit, int totalRecords,
 			List<Comment> comments) {
 		this.id = id;
 		this.start = start;
+		this.limit = limit;
 		this.totalRecords = totalRecords;
 		this.comments.addAll(comments);
 	}
@@ -53,6 +57,14 @@ public class ScrollableCollection implements ResourceFacade<Comment> {
 
 	public void setStart(int start) {
 		this.start = start;
+	}
+
+	public int getLimit() {
+		return limit;
+	}
+
+	public void setLimit(int limit) {
+		this.limit = limit;
 	}
 
 	public int getTotalRecords() {

--- a/jaxrs/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestFacadeLinks.java
+++ b/jaxrs/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestFacadeLinks.java
@@ -1,5 +1,11 @@
 package org.jboss.resteasy.links.test;
 
+import static org.jboss.resteasy.test.TestPortProvider.generateBaseUrl;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.jboss.resteasy.client.ProxyFactory;
@@ -18,12 +24,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import static org.jboss.resteasy.test.TestPortProvider.generateBaseUrl;
 
 @RunWith(Parameterized.class)
 public class TestFacadeLinks
@@ -89,7 +89,7 @@ public class TestFacadeLinks
 		Assert.assertNotNull(comments);
 		RESTServiceDiscovery links = comments.getRest();
 		Assert.assertNotNull(links);
-		Assert.assertEquals(3, links.size());
+		Assert.assertEquals(4, links.size());
 		// list
 		AtomLink atomLink = links.getLinkForRel("list");
 		Assert.assertNotNull(atomLink);
@@ -102,6 +102,10 @@ public class TestFacadeLinks
 		atomLink = links.getLinkForRel("collection");
 		Assert.assertNotNull(atomLink);
 		Assert.assertEquals(url+"/book/foo/comment-collection", atomLink.getHref());
+		// next
+		atomLink = links.getLinkForRel("next");
+		Assert.assertNotNull(atomLink);
+		Assert.assertEquals(url+"/book/foo/comment-collection?start=1&limit=1", atomLink.getHref());
 	}
 
 	private void checkCommentLinks(String url, Comment comment) {

--- a/jaxrs/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestFacadeLinks.java
+++ b/jaxrs/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestFacadeLinks.java
@@ -79,9 +79,9 @@ public class TestFacadeLinks
 	@Test
 	public void testLinks() throws Exception
 	{
-		ScrollableCollection comments = client.getScrollableCommentsXML("foo");
+		ScrollableCollection comments = client.getScrollableCommentsXML("foo", "book");
 		checkCommentsLinks(url, comments);
-		comments = client.getScrollableCommentsJSON("foo");
+		comments = client.getScrollableCommentsJSON("foo", "book");
 		checkCommentsLinks(url, comments);
 	}
 
@@ -105,7 +105,7 @@ public class TestFacadeLinks
 		// next
 		atomLink = links.getLinkForRel("next");
 		Assert.assertNotNull(atomLink);
-		Assert.assertEquals(url+"/book/foo/comment-collection?start=1&limit=1", atomLink.getHref());
+		Assert.assertEquals(url+"/book/foo/comment-collection;query=book?start=1&limit=1", atomLink.getHref());
 	}
 
 	private void checkCommentLinks(String url, Comment comment) {


### PR DESCRIPTION
Implementation of feature request [RESTEASY-1321](https://issues.jboss.org/browse/RESTEASY-1321).

Currently the LinkResource annotation only supports path parameters for the atom link definition. This is enough when only adding default atom links (self, list, CRUD). But in order to add more advanced customized links (f.e. for paging) it is necessary to support the other types of parameters (query and matrix).

Therefore I added a new annotation called ParamBinding. Typically I would add the type as an enum in the ParamBinding, but just added two more members to the annotation (queryParameters, matrixParameters) in order not to break the API (this would remove / rename LinkResource#pathParameters).