### PR TITLE
Resteasy 1325

### DIFF
--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
@@ -25,8 +25,6 @@ import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.channel.ChannelDuplexHandler;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.EventExecutor;
 import org.jboss.resteasy.core.SynchronousDispatcher;
 import org.jboss.resteasy.plugins.server.embedded.EmbeddedJaxrsServer;

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
@@ -281,10 +281,10 @@ public class NettyJaxrsServer implements EmbeddedJaxrsServer
         channelPipeline.addLast(httpChannelHandlers.toArray(new ChannelHandler[httpChannelHandlers.size()]));
         channelPipeline.addLast(new RestEasyHttpRequestDecoder(dispatcher.getDispatcher(), root, protocol));
         channelPipeline.addLast(new RestEasyHttpResponseEncoder());
-        channelPipeline.addLast(eventExecutor, new RequestHandler(dispatcher));
         if (idleTimeout > 0) {
             channelPipeline.addLast("idleStateHandler", new IdleStateHandler(0, 0, idleTimeout));
         }
+        channelPipeline.addLast(eventExecutor, new RequestHandler(dispatcher));
     }
 
    @Override

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
@@ -8,6 +8,7 @@ import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpResponse;
 
+import io.netty.handler.timeout.IdleStateEvent;
 import org.jboss.resteasy.plugins.server.netty.i18n.LogMessages;
 import org.jboss.resteasy.plugins.server.netty.i18n.Messages;
 import org.jboss.resteasy.spi.Failure;
@@ -93,4 +94,11 @@ public class RequestHandler extends SimpleChannelInboundHandler
           ctx.close();
       }
    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt instanceof IdleStateEvent) {
+            ctx.close();
+        }
+    }
 }

--- a/jaxrs/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/RESTEASY1325Test.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/RESTEASY1325Test.java
@@ -1,0 +1,123 @@
+package org.jboss.resteasy.test;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.*;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http.*;
+import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+import org.jboss.resteasy.util.HttpHeaderNames;
+import org.junit.*;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.jboss.resteasy.test.TestPortProvider.generateURL;
+
+public class RESTEASY1325Test
+{
+   static String BASE_URI = generateURL("");
+
+   static final int IDLE_TIMEOUT = 3;
+
+   @BeforeClass
+   public static void setupSuite() throws Exception
+   {
+   }
+
+   @AfterClass
+   public static void tearDownSuite() throws Exception
+   {
+   }
+
+   @Before
+   public void setupTest() throws Exception
+   {
+   }
+
+   @After
+   public void tearDownTest() throws Exception
+   {
+   }
+
+   @Test(timeout= IDLE_TIMEOUT * 1000 + 1000)
+   public void testIdleCloseConnection() throws Exception
+   {
+      NettyJaxrsServer netty = new NettyJaxrsServer();
+      ResteasyDeployment deployment = new ResteasyDeployment();
+      netty.setDeployment(deployment);
+      netty.setPort(TestPortProvider.getPort());
+      netty.setRootResourcePath("");
+      netty.setSecurityDomain(null);
+      netty.setIdleTimeout(IDLE_TIMEOUT);
+      netty.start();
+      deployment.getRegistry().addSingletonResource(new Resource());
+      callAndIdle();
+      netty.stop();
+
+   }
+
+    /**
+     * Test case
+     * @throws InterruptedException
+     * @throws MalformedURLException
+     */
+   private void callAndIdle() throws InterruptedException, MalformedURLException {
+
+         EventLoopGroup group = new NioEventLoopGroup();
+         try {
+            Bootstrap b = new Bootstrap();
+            b.group(group)
+                    .channel(NioSocketChannel.class)
+                    .handler(new ChannelInitializer<Channel>() {
+                       @Override
+                       protected void initChannel(Channel ch) throws Exception {
+                          ch.pipeline().addLast(new HttpClientCodec());
+                          ch.pipeline().addLast(new HttpObjectAggregator(4096));
+                          ch.pipeline().addLast(new SimpleChannelInboundHandler<FullHttpResponse>() {
+                             @Override
+                             protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) {
+                                System.out.println("HTTP response from resteasy: "+msg);
+                                 Assert.assertEquals(HttpResponseStatus.OK, msg.getStatus());
+                             }
+                          });
+                       }
+                    });
+
+            // first request;
+            URL url = new URL(BASE_URI+"/test");
+            // Make the connection attempt.
+            final Channel ch = b.connect(url.getHost(), url.getPort()).sync().channel();
+
+            // Prepare the HTTP request.
+            HttpRequest request = new DefaultFullHttpRequest(
+                    HttpVersion.HTTP_1_1, HttpMethod.GET, url.getFile());
+            request.headers().set(HttpHeaderNames.HOST, url.getHost());
+            request.headers().set(HttpHeaderNames.CONNECTION, "keep-alive");
+
+            // Send the HTTP request.
+            ch.writeAndFlush(request);
+
+            // waiting for server close connection after idle.
+            ch.closeFuture().await();
+         } finally {
+            // Shut down executor threads to exit.
+            group.shutdownGracefully();
+         }
+   }
+
+    @Path("/")
+    public static class Resource {
+        @GET
+        @Path("/test")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String get() {
+            return "hello world";
+        }
+    }
+}

--- a/jaxrs/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/RESTEASY1325Test.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/RESTEASY1325Test.java
@@ -99,7 +99,6 @@ public class RESTEASY1325Test
                     HttpVersion.HTTP_1_1, HttpMethod.GET, url.getFile());
             request.headers().set(HttpHeaderNames.HOST, url.getHost());
             request.headers().set(HttpHeaderNames.CONNECTION, "keep-alive");
-
             // Send the HTTP request.
             ch.writeAndFlush(request);
 


### PR DESCRIPTION
RETEASY-1325: Netty server should close idle connections.
Even NettyJaxrsServer has SO_KEEPALIVE socket option, I would like to add idle timeout option to cleanup idle TCP clients.
By defaul, this feature doesn't turn on, so it's identical to previous versions.
If call to setIdleTimeout with number of seconds, Http client connection will be closed after specific idle time.

Description of this JIRA from https://issues.jboss.org/browse/RESTEASY-1325

"
Netty server adapter should handle client idle when there is no traffic within a certain amount of time.
Currently, if client open connection without sending any message. The connection will keep open.
If there is no Connection: close header, the connection will keep open.
Unless there is "Connection: close" header, they always require client to close.
For Jetty, the default idleTimeOut for Connector is 30 seconds.
Even I can add an IdleHandler to NettyJaxrsServer.addChannelHandlers, it's better to build in NettyJaxrsServer and add setter and attribute for idleTimeOut.
"
