### PR TITLE
RESTEASY-1237

### DIFF
--- a/jaxrs/jboss-modules/src/main/resources/modules/org/jboss/resteasy/resteasy-jaxrs-wf8/main/module.xml
+++ b/jaxrs/jboss-modules/src/main/resources/modules/org/jboss/resteasy/resteasy-jaxrs-wf8/main/module.xml
@@ -42,7 +42,7 @@
         <module name="org.hibernate.validator"/>
 
         <!-- exported -->
-        <module name="org.apache.httpcomponents" export="true"/>
+        <module name="org.apache.httpcomponents"/>
         <module name="org.apache.commons.io"/>
         <module name="org.jboss.resteasy.resteasy-validator-provider-11" services="export" export="true"/>
         <module name="org.jboss.logging"/>


### PR DESCRIPTION
resteasy-jaxrs-wf8 doesn't export httpcomponents in jboss-modules.