### PR TITLE
RESTEASY-1333 Upgraded Javassist to latest version.

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -317,9 +317,9 @@
             </dependency>
 
             <dependency>
-                <groupId>javassist</groupId>
+                <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
-                <version>3.8.0.GA</version>
+                <version>3.20.0-GA</version>
             </dependency>
 
             <dependency>

--- a/jaxrs/resteasy-jaxrs/pom.xml
+++ b/jaxrs/resteasy-jaxrs/pom.xml
@@ -51,7 +51,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javassist</groupId>
+            <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Note that the `groupId` changed from `javassist` to `org.javassist`.