### PR TITLE
RESTEASY-1334 JUnit Assert.assertEquals(a,b) for floating point is deprecated

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -455,7 +454,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.3</version>
+                <version>4.12</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/finegrain/methodparams/QueryParamAsPrimitiveTest.java
+++ b/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/finegrain/methodparams/QueryParamAsPrimitiveTest.java
@@ -32,6 +32,8 @@ import static org.jboss.resteasy.util.HttpClient4xUtils.updateQuery;
  */
 public class QueryParamAsPrimitiveTest
 {
+   private static final float ASSERT_FLOAT_THRESHOLD = 0.000000001f;
+   private static final double ASSERT_DOUBLE_THRESHOLD = 0.000000000000001d;
 
    private static Dispatcher dispatcher;
 
@@ -141,7 +143,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@QueryParam("float") float v)
       {
-         Assert.assertEquals(3.14159265f, v);
+         Assert.assertEquals(3.14159265f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -149,7 +151,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@QueryParam("double") double v)
       {
-         Assert.assertEquals(3.14159265358979d, v);
+         Assert.assertEquals(3.14159265358979d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -201,7 +203,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@QueryParam("float") float v)
       {
-         Assert.assertEquals(0.0f, v);
+         Assert.assertEquals(0.0f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -209,7 +211,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@QueryParam("double") double v)
       {
-         Assert.assertEquals(0.0d, v);
+         Assert.assertEquals(0.0d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -261,7 +263,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@QueryParam("float") @DefaultValue("3.14159265") float v)
       {
-         Assert.assertEquals(3.14159265f, v);
+         Assert.assertEquals(3.14159265f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -269,7 +271,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@QueryParam("double") @DefaultValue("3.14159265358979") double v)
       {
-         Assert.assertEquals(3.14159265358979d, v);
+         Assert.assertEquals(3.14159265358979d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -321,7 +323,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@QueryParam("float") @DefaultValue("0.0") float v)
       {
-         Assert.assertEquals(3.14159265f, v);
+         Assert.assertEquals(3.14159265f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -329,7 +331,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@QueryParam("double") @DefaultValue("0.0") double v)
       {
-         Assert.assertEquals(3.14159265358979d, v);
+         Assert.assertEquals(3.14159265358979d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -381,7 +383,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@QueryParam("float") Float v)
       {
-         Assert.assertEquals(3.14159265f, v.floatValue());
+         Assert.assertEquals(3.14159265f, v.floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -389,7 +391,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@QueryParam("double") Double v)
       {
-         Assert.assertEquals(3.14159265358979d, v.doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -501,7 +503,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@QueryParam("float") @DefaultValue("3.14159265") Float v)
       {
-         Assert.assertEquals(3.14159265f, v.floatValue());
+         Assert.assertEquals(3.14159265f, v.floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -509,7 +511,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@QueryParam("double") @DefaultValue("3.14159265358979") Double v)
       {
-         Assert.assertEquals(3.14159265358979d, v.doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -561,7 +563,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@QueryParam("float") @DefaultValue("0.0") Float v)
       {
-         Assert.assertEquals(3.14159265f, v.floatValue());
+         Assert.assertEquals(3.14159265f, v.floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -569,7 +571,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@QueryParam("double") @DefaultValue("0.0") Double v)
       {
-         Assert.assertEquals(3.14159265358979d, v.doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -631,9 +633,9 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@QueryParam("float") List<Float> v)
       {
-         Assert.assertEquals(3.14159265f, v.get(0).floatValue());
-         Assert.assertEquals(3.14159265f, v.get(1).floatValue());
-         Assert.assertEquals(3.14159265f, v.get(2).floatValue());
+         Assert.assertEquals(3.14159265f, v.get(0).floatValue(), ASSERT_FLOAT_THRESHOLD);
+         Assert.assertEquals(3.14159265f, v.get(1).floatValue(), ASSERT_FLOAT_THRESHOLD);
+         Assert.assertEquals(3.14159265f, v.get(2).floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -641,9 +643,9 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@QueryParam("double") List<Double> v)
       {
-         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue());
-         Assert.assertEquals(3.14159265358979d, v.get(1).doubleValue());
-         Assert.assertEquals(3.14159265358979d, v.get(2).doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
+         Assert.assertEquals(3.14159265358979d, v.get(1).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
+         Assert.assertEquals(3.14159265358979d, v.get(2).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -755,7 +757,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@QueryParam("float") @DefaultValue("3.14159265") List<Float> v)
       {
-         Assert.assertEquals(3.14159265f, v.get(0).floatValue());
+         Assert.assertEquals(3.14159265f, v.get(0).floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -763,7 +765,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@QueryParam("double") @DefaultValue("3.14159265358979") List<Double> v)
       {
-         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -815,7 +817,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@QueryParam("float") @DefaultValue("0.0") List<Float> v)
       {
-         Assert.assertEquals(3.14159265f, v.get(0).floatValue());
+         Assert.assertEquals(3.14159265f, v.get(0).floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -823,7 +825,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@QueryParam("double") @DefaultValue("0.0") List<Double> v)
       {
-         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -885,9 +887,9 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@QueryParam("float") float[] v)
       {
-         Assert.assertEquals(3.14159265f, v[0]);
-         Assert.assertEquals(3.14159265f, v[1]);
-         Assert.assertEquals(3.14159265f, v[2]);
+         Assert.assertEquals(3.14159265f, v[0], ASSERT_FLOAT_THRESHOLD);
+         Assert.assertEquals(3.14159265f, v[1], ASSERT_FLOAT_THRESHOLD);
+         Assert.assertEquals(3.14159265f, v[2], ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -895,9 +897,9 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@QueryParam("double") double[] v)
       {
-         Assert.assertEquals(3.14159265358979d, v[0]);
-         Assert.assertEquals(3.14159265358979d, v[1]);
-         Assert.assertEquals(3.14159265358979d, v[2]);
+         Assert.assertEquals(3.14159265358979d, v[0], ASSERT_DOUBLE_THRESHOLD);
+         Assert.assertEquals(3.14159265358979d, v[1], ASSERT_DOUBLE_THRESHOLD);
+         Assert.assertEquals(3.14159265358979d, v[2], ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -1009,7 +1011,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@QueryParam("float") @DefaultValue("3.14159265") float[] v)
       {
-         Assert.assertEquals(3.14159265f, v[0]);
+         Assert.assertEquals(3.14159265f, v[0], ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -1017,7 +1019,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@QueryParam("double") @DefaultValue("3.14159265358979") double[] v)
       {
-         Assert.assertEquals(3.14159265358979d, v[0]);
+         Assert.assertEquals(3.14159265358979d, v[0], ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -1069,7 +1071,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@QueryParam("float") @DefaultValue("0.0") float[] v)
       {
-         Assert.assertEquals(3.14159265f, v[0]);
+         Assert.assertEquals(3.14159265f, v[0], ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -1077,7 +1079,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@QueryParam("double") @DefaultValue("0.0") double[] v)
       {
-         Assert.assertEquals(3.14159265358979d, v[0]);
+         Assert.assertEquals(3.14159265358979d, v[0], ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }

--- a/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/finegrain/methodparams/UriParamAsPrimitiveTest.java
+++ b/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/finegrain/methodparams/UriParamAsPrimitiveTest.java
@@ -28,6 +28,9 @@ import static org.jboss.resteasy.util.HttpClient4xUtils.updateQuery;
  */
 public class UriParamAsPrimitiveTest
 {
+   private static final float ASSERT_FLOAT_THRESHOLD = 0.000000001f;
+   private static final double ASSERT_DOUBLE_THRESHOLD = 0.000000000000001d;
+
    private static ResteasyDeployment deployment;
 
    private static IResourceUriBoolean resourceUriBoolean;
@@ -140,7 +143,7 @@ public class UriParamAsPrimitiveTest
       @GET
       public String doGet(@PathParam("arg") float v)
       {
-         Assert.assertEquals(3.14159265f, v);
+         Assert.assertEquals(3.14159265f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
    }
@@ -151,7 +154,7 @@ public class UriParamAsPrimitiveTest
       @GET
       public String doGet(@PathParam("arg") double v)
       {
-         Assert.assertEquals(3.14159265358979d, v);
+         Assert.assertEquals(3.14159265358979d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -217,7 +220,7 @@ public class UriParamAsPrimitiveTest
       @GET
       public String doGet(@PathParam("arg") Float v)
       {
-         Assert.assertEquals(3.14159265f, v.floatValue());
+         Assert.assertEquals(3.14159265f, v.floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
    }
@@ -228,7 +231,7 @@ public class UriParamAsPrimitiveTest
       @GET
       public String doGet(@PathParam("arg") Double v)
       {
-         Assert.assertEquals(3.14159265358979d, v.doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/TypeConverterTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/TypeConverterTest.java
@@ -57,8 +57,8 @@ public class TypeConverterTest
    @Test
    public void testDoubleTypes()
    {
-      assertEquals(20.15d, (double)TypeConverter.getType(double.class, "20.15"));
-      assertEquals(20.15d, (double)TypeConverter.getType(Double.class, "20.15"));
+      assertEquals(20.15d, (double)TypeConverter.getType(double.class, "20.15"), 0.00001d);
+      assertEquals(20.15d, (double)TypeConverter.getType(Double.class, "20.15"), 0.00001d);
    }
 
    /**
@@ -67,8 +67,8 @@ public class TypeConverterTest
    @Test
    public void testFloatTypes()
    {
-      assertEquals(23.44f, (float)TypeConverter.getType(float.class, "23.44"));
-      assertEquals(23.44f, (float)TypeConverter.getType(Float.class, "23.44"));
+      assertEquals(23.44f, (float)TypeConverter.getType(float.class, "23.44"), 0.00001f);
+      assertEquals(23.44f, (float)TypeConverter.getType(Float.class, "23.44"), 0.00001f);
    }
 
    /**

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/core/request/QualityValueTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/core/request/QualityValueTest.java
@@ -111,8 +111,8 @@ public class QualityValueTest
       QualityValue x = QualityValue.valueOf("0.08");
       assertEquals(80, x.intValue());
       assertEquals(80L, x.longValue());
-      assertEquals(0.08f, x.floatValue());
-      assertEquals(0.08d, x.doubleValue());
+      assertEquals(0.08f, x.floatValue(), 0.00001f);
+      assertEquals(0.08d, x.doubleValue(), 0.00001d);
    }
 
 }

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/methodparams/HeaderParamsAsPrimitivesTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/methodparams/HeaderParamsAsPrimitivesTest.java
@@ -35,6 +35,9 @@ import static org.junit.Assert.fail;
  */
 public class HeaderParamsAsPrimitivesTest
 {
+   private static final float ASSERT_FLOAT_THRESHOLD = 0.000000001f;
+   private static final double ASSERT_DOUBLE_THRESHOLD = 0.000000000000001d;
+
    private static Dispatcher dispatcher;
 
    private static IResourceHeaderPrimitives resourceHeaderPrimitives;
@@ -194,7 +197,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/float")
       public String doGet(@HeaderParam("float") float v)
       {
-         Assert.assertEquals(3.14159265f, v);
+         Assert.assertEquals(3.14159265f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -202,7 +205,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/double")
       public String doGet(@HeaderParam("double") double v)
       {
-         Assert.assertEquals(3.14159265358979d, v);
+         Assert.assertEquals(3.14159265358979d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -254,7 +257,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/float")
       public String doGet(@HeaderParam("float") float v)
       {
-         Assert.assertEquals(0.0f, v);
+         Assert.assertEquals(0.0f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -262,7 +265,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/double")
       public String doGet(@HeaderParam("double") double v)
       {
-         Assert.assertEquals(0.0d, v);
+         Assert.assertEquals(0.0d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -314,7 +317,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/float")
       public String doGet(@HeaderParam("float") @DefaultValue("3.14159265") float v)
       {
-         Assert.assertEquals(3.14159265f, v);
+         Assert.assertEquals(3.14159265f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -322,7 +325,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/double")
       public String doGet(@HeaderParam("double") @DefaultValue("3.14159265358979") double v)
       {
-         Assert.assertEquals(3.14159265358979d, v);
+         Assert.assertEquals(3.14159265358979d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -374,7 +377,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/float")
       public String doGet(@HeaderParam("float") @DefaultValue("0.0") float v)
       {
-         Assert.assertEquals(3.14159265f, v);
+         Assert.assertEquals(3.14159265f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -382,7 +385,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/double")
       public String doGet(@HeaderParam("double") @DefaultValue("0.0") double v)
       {
-         Assert.assertEquals(3.14159265358979d, v);
+         Assert.assertEquals(3.14159265358979d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -435,7 +438,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/float")
       public String doGet(@HeaderParam("float") Float v)
       {
-         Assert.assertEquals(3.14159265f, v.floatValue());
+         Assert.assertEquals(3.14159265f, v.floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -443,7 +446,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/double")
       public String doGet(@HeaderParam("double") Double v)
       {
-         Assert.assertEquals(3.14159265358979d, v.doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -556,7 +559,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/float")
       public String doGet(@HeaderParam("float") @DefaultValue("3.14159265") Float v)
       {
-         Assert.assertEquals(3.14159265f, v.floatValue());
+         Assert.assertEquals(3.14159265f, v.floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -564,7 +567,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/double")
       public String doGet(@HeaderParam("double") @DefaultValue("3.14159265358979") Double v)
       {
-         Assert.assertEquals(3.14159265358979d, v.doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -618,7 +621,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/float")
       public String doGet(@HeaderParam("float") @DefaultValue("0.0") Float v)
       {
-         Assert.assertEquals(3.14159265f, v.floatValue());
+         Assert.assertEquals(3.14159265f, v.floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -626,7 +629,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/double")
       public String doGet(@HeaderParam("double") @DefaultValue("0.0") Double v)
       {
-         Assert.assertEquals(3.14159265358979d, v.doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -688,9 +691,9 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/float")
       public String doGetFloat(@HeaderParam("float") List<Float> v)
       {
-         Assert.assertEquals(3.14159265f, v.get(0).floatValue());
-         Assert.assertEquals(3.14159265f, v.get(1).floatValue());
-         Assert.assertEquals(3.14159265f, v.get(2).floatValue());
+         Assert.assertEquals(3.14159265f, v.get(0).floatValue(), ASSERT_FLOAT_THRESHOLD);
+         Assert.assertEquals(3.14159265f, v.get(1).floatValue(), ASSERT_FLOAT_THRESHOLD);
+         Assert.assertEquals(3.14159265f, v.get(2).floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -698,9 +701,9 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/double")
       public String doGetDouble(@HeaderParam("double") List<Double> v)
       {
-         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue());
-         Assert.assertEquals(3.14159265358979d, v.get(1).doubleValue());
-         Assert.assertEquals(3.14159265358979d, v.get(2).doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
+         Assert.assertEquals(3.14159265358979d, v.get(1).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
+         Assert.assertEquals(3.14159265358979d, v.get(2).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -812,7 +815,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/float")
       public String doGetFloat(@HeaderParam("float") @DefaultValue("3.14159265") List<Float> v)
       {
-         Assert.assertEquals(3.14159265f, v.get(0).floatValue());
+         Assert.assertEquals(3.14159265f, v.get(0).floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -820,7 +823,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/double")
       public String doGetDouble(@HeaderParam("double") @DefaultValue("3.14159265358979") List<Double> v)
       {
-         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -874,7 +877,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/float")
       public String doGetFloat(@HeaderParam("float") @DefaultValue("0.0") List<Float> v)
       {
-         Assert.assertEquals(3.14159265f, v.get(0).floatValue());
+         Assert.assertEquals(3.14159265f, v.get(0).floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -882,7 +885,7 @@ public class HeaderParamsAsPrimitivesTest
       @Produces("application/double")
       public String doGetDouble(@HeaderParam("double") @DefaultValue("0.0") List<Double> v)
       {
-         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/methodparams/MatrixParamAsPrimitiveTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/methodparams/MatrixParamAsPrimitiveTest.java
@@ -27,6 +27,9 @@ import static org.jboss.resteasy.test.TestPortProvider.generateURL;
  */
 public class MatrixParamAsPrimitiveTest
 {
+   private static final float ASSERT_FLOAT_THRESHOLD = 0.000000001f;
+   private static final double ASSERT_DOUBLE_THRESHOLD = 0.000000000000001d;
+
    private static Dispatcher dispatcher;
 
    //private static IResourceUriBoolean resourceUriBoolean;
@@ -107,7 +110,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@MatrixParam("float") float v)
       {
-         Assert.assertEquals(3.14159265f, v);
+         Assert.assertEquals(3.14159265f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -115,7 +118,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@MatrixParam("double") double v)
       {
-         Assert.assertEquals(3.14159265358979d, v);
+         Assert.assertEquals(3.14159265358979d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -167,7 +170,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@MatrixParam("float") float v)
       {
-         Assert.assertEquals(0.0f, v);
+         Assert.assertEquals(0.0f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -175,7 +178,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@MatrixParam("double") double v)
       {
-         Assert.assertEquals(0.0d, v);
+         Assert.assertEquals(0.0d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -227,7 +230,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@MatrixParam("float") @DefaultValue("3.14159265") float v)
       {
-         Assert.assertEquals(3.14159265f, v);
+         Assert.assertEquals(3.14159265f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -235,7 +238,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@MatrixParam("double") @DefaultValue("3.14159265358979") double v)
       {
-         Assert.assertEquals(3.14159265358979d, v);
+         Assert.assertEquals(3.14159265358979d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -287,7 +290,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@MatrixParam("float") @DefaultValue("0.0") float v)
       {
-         Assert.assertEquals(3.14159265f, v);
+         Assert.assertEquals(3.14159265f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -295,7 +298,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@MatrixParam("double") @DefaultValue("0.0") double v)
       {
-         Assert.assertEquals(3.14159265358979d, v);
+         Assert.assertEquals(3.14159265358979d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -347,7 +350,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@MatrixParam("float") Float v)
       {
-         Assert.assertEquals(3.14159265f, v.floatValue());
+         Assert.assertEquals(3.14159265f, v.floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -355,7 +358,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@MatrixParam("double") Double v)
       {
-         Assert.assertEquals(3.14159265358979d, v.doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -467,7 +470,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@MatrixParam("float") @DefaultValue("3.14159265") Float v)
       {
-         Assert.assertEquals(3.14159265f, v.floatValue());
+         Assert.assertEquals(3.14159265f, v.floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -475,7 +478,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@MatrixParam("double") @DefaultValue("3.14159265358979") Double v)
       {
-         Assert.assertEquals(3.14159265358979d, v.doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -527,7 +530,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@MatrixParam("float") @DefaultValue("0.0") Float v)
       {
-         Assert.assertEquals(3.14159265f, v.floatValue());
+         Assert.assertEquals(3.14159265f, v.floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -535,7 +538,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@MatrixParam("double") @DefaultValue("0.0") Double v)
       {
-         Assert.assertEquals(3.14159265358979d, v.doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -597,9 +600,9 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@MatrixParam("float") List<Float> v)
       {
-         Assert.assertEquals(3.14159265f, v.get(0).floatValue());
-         Assert.assertEquals(3.14159265f, v.get(1).floatValue());
-         Assert.assertEquals(3.14159265f, v.get(2).floatValue());
+         Assert.assertEquals(3.14159265f, v.get(0).floatValue(), ASSERT_FLOAT_THRESHOLD);
+         Assert.assertEquals(3.14159265f, v.get(1).floatValue(), ASSERT_FLOAT_THRESHOLD);
+         Assert.assertEquals(3.14159265f, v.get(2).floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -607,9 +610,9 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@MatrixParam("double") List<Double> v)
       {
-         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue());
-         Assert.assertEquals(3.14159265358979d, v.get(1).doubleValue());
-         Assert.assertEquals(3.14159265358979d, v.get(2).doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
+         Assert.assertEquals(3.14159265358979d, v.get(1).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
+         Assert.assertEquals(3.14159265358979d, v.get(2).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -728,7 +731,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@MatrixParam("float") @DefaultValue("3.14159265") List<Float> v)
       {
-         Assert.assertEquals(3.14159265f, v.get(0).floatValue());
+         Assert.assertEquals(3.14159265f, v.get(0).floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -736,7 +739,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@MatrixParam("double") @DefaultValue("3.14159265358979") List<Double> v)
       {
-         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -788,7 +791,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@MatrixParam("float") @DefaultValue("0.0") List<Float> v)
       {
-         Assert.assertEquals(3.14159265f, v.get(0).floatValue());
+         Assert.assertEquals(3.14159265f, v.get(0).floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -796,7 +799,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@MatrixParam("double") @DefaultValue("0.0") List<Double> v)
       {
-         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -858,9 +861,9 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@MatrixParam("float") float[] v)
       {
-         Assert.assertEquals(3.14159265f, v[0]);
-         Assert.assertEquals(3.14159265f, v[1]);
-         Assert.assertEquals(3.14159265f, v[2]);
+         Assert.assertEquals(3.14159265f, v[0], ASSERT_FLOAT_THRESHOLD);
+         Assert.assertEquals(3.14159265f, v[1], ASSERT_FLOAT_THRESHOLD);
+         Assert.assertEquals(3.14159265f, v[2], ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -868,9 +871,9 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@MatrixParam("double") double[] v)
       {
-         Assert.assertEquals(3.14159265358979d, v[0]);
-         Assert.assertEquals(3.14159265358979d, v[1]);
-         Assert.assertEquals(3.14159265358979d, v[2]);
+         Assert.assertEquals(3.14159265358979d, v[0], ASSERT_DOUBLE_THRESHOLD);
+         Assert.assertEquals(3.14159265358979d, v[1], ASSERT_DOUBLE_THRESHOLD);
+         Assert.assertEquals(3.14159265358979d, v[2], ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -989,7 +992,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@MatrixParam("float") @DefaultValue("3.14159265") float[] v)
       {
-         Assert.assertEquals(3.14159265f, v[0]);
+         Assert.assertEquals(3.14159265f, v[0], ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -997,7 +1000,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@MatrixParam("double") @DefaultValue("3.14159265358979") double[] v)
       {
-         Assert.assertEquals(3.14159265358979d, v[0]);
+         Assert.assertEquals(3.14159265358979d, v[0], ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -1049,7 +1052,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@MatrixParam("float") @DefaultValue("0.0") float[] v)
       {
-         Assert.assertEquals(3.14159265f, v[0]);
+         Assert.assertEquals(3.14159265f, v[0], ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -1057,7 +1060,7 @@ public class MatrixParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@MatrixParam("double") @DefaultValue("0.0") double[] v)
       {
-         Assert.assertEquals(3.14159265358979d, v[0]);
+         Assert.assertEquals(3.14159265358979d, v[0], ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/methodparams/QueryParamAsPrimitiveTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/methodparams/QueryParamAsPrimitiveTest.java
@@ -31,6 +31,8 @@ import static org.jboss.resteasy.util.HttpClient4xUtils.updateQuery;
  */
 public class QueryParamAsPrimitiveTest
 {
+   private static final float ASSERT_FLOAT_THRESHOLD = 0.000000001f;
+   private static final double ASSERT_DOUBLE_THRESHOLD = 0.000000000000001d;
 
    private static Dispatcher dispatcher;
 
@@ -138,7 +140,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@QueryParam("float") float v)
       {
-         Assert.assertEquals(3.14159265f, v);
+         Assert.assertEquals(3.14159265f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -146,7 +148,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@QueryParam("double") double v)
       {
-         Assert.assertEquals(3.14159265358979d, v);
+         Assert.assertEquals(3.14159265358979d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -198,7 +200,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@QueryParam("float") float v)
       {
-         Assert.assertEquals(0.0f, v);
+         Assert.assertEquals(0.0f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -206,7 +208,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@QueryParam("double") double v)
       {
-         Assert.assertEquals(0.0d, v);
+         Assert.assertEquals(0.0d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -258,7 +260,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@QueryParam("float") @DefaultValue("3.14159265") float v)
       {
-         Assert.assertEquals(3.14159265f, v);
+         Assert.assertEquals(3.14159265f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -266,7 +268,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@QueryParam("double") @DefaultValue("3.14159265358979") double v)
       {
-         Assert.assertEquals(3.14159265358979d, v);
+         Assert.assertEquals(3.14159265358979d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -318,7 +320,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@QueryParam("float") @DefaultValue("0.0") float v)
       {
-         Assert.assertEquals(3.14159265f, v);
+         Assert.assertEquals(3.14159265f, v, ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -326,7 +328,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@QueryParam("double") @DefaultValue("0.0") double v)
       {
-         Assert.assertEquals(3.14159265358979d, v);
+         Assert.assertEquals(3.14159265358979d, v, ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -378,7 +380,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@QueryParam("float") Float v)
       {
-         Assert.assertEquals(3.14159265f, v.floatValue());
+         Assert.assertEquals(3.14159265f, v.floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -386,7 +388,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@QueryParam("double") Double v)
       {
-         Assert.assertEquals(3.14159265358979d, v.doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -498,7 +500,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@QueryParam("float") @DefaultValue("3.14159265") Float v)
       {
-         Assert.assertEquals(3.14159265f, v.floatValue());
+         Assert.assertEquals(3.14159265f, v.floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -506,7 +508,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@QueryParam("double") @DefaultValue("3.14159265358979") Double v)
       {
-         Assert.assertEquals(3.14159265358979d, v.doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -558,7 +560,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGet(@QueryParam("float") @DefaultValue("0.0") Float v)
       {
-         Assert.assertEquals(3.14159265f, v.floatValue());
+         Assert.assertEquals(3.14159265f, v.floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -566,7 +568,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGet(@QueryParam("double") @DefaultValue("0.0") Double v)
       {
-         Assert.assertEquals(3.14159265358979d, v.doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -628,9 +630,9 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@QueryParam("float") List<Float> v)
       {
-         Assert.assertEquals(3.14159265f, v.get(0).floatValue());
-         Assert.assertEquals(3.14159265f, v.get(1).floatValue());
-         Assert.assertEquals(3.14159265f, v.get(2).floatValue());
+         Assert.assertEquals(3.14159265f, v.get(0).floatValue(), ASSERT_FLOAT_THRESHOLD);
+         Assert.assertEquals(3.14159265f, v.get(1).floatValue(), ASSERT_FLOAT_THRESHOLD);
+         Assert.assertEquals(3.14159265f, v.get(2).floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -638,9 +640,9 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@QueryParam("double") List<Double> v)
       {
-         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue());
-         Assert.assertEquals(3.14159265358979d, v.get(1).doubleValue());
-         Assert.assertEquals(3.14159265358979d, v.get(2).doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
+         Assert.assertEquals(3.14159265358979d, v.get(1).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
+         Assert.assertEquals(3.14159265358979d, v.get(2).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -752,7 +754,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@QueryParam("float") @DefaultValue("3.14159265") List<Float> v)
       {
-         Assert.assertEquals(3.14159265f, v.get(0).floatValue());
+         Assert.assertEquals(3.14159265f, v.get(0).floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -760,7 +762,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@QueryParam("double") @DefaultValue("3.14159265358979") List<Double> v)
       {
-         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -812,7 +814,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@QueryParam("float") @DefaultValue("0.0") List<Float> v)
       {
-         Assert.assertEquals(3.14159265f, v.get(0).floatValue());
+         Assert.assertEquals(3.14159265f, v.get(0).floatValue(), ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -820,7 +822,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@QueryParam("double") @DefaultValue("0.0") List<Double> v)
       {
-         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.get(0).doubleValue(), ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -882,9 +884,9 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@QueryParam("float") float[] v)
       {
-         Assert.assertEquals(3.14159265f, v[0]);
-         Assert.assertEquals(3.14159265f, v[1]);
-         Assert.assertEquals(3.14159265f, v[2]);
+         Assert.assertEquals(3.14159265f, v[0], ASSERT_FLOAT_THRESHOLD);
+         Assert.assertEquals(3.14159265f, v[1], ASSERT_FLOAT_THRESHOLD);
+         Assert.assertEquals(3.14159265f, v[2], ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -892,9 +894,9 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@QueryParam("double") double[] v)
       {
-         Assert.assertEquals(3.14159265358979d, v[0]);
-         Assert.assertEquals(3.14159265358979d, v[1]);
-         Assert.assertEquals(3.14159265358979d, v[2]);
+         Assert.assertEquals(3.14159265358979d, v[0], ASSERT_DOUBLE_THRESHOLD);
+         Assert.assertEquals(3.14159265358979d, v[1], ASSERT_DOUBLE_THRESHOLD);
+         Assert.assertEquals(3.14159265358979d, v[2], ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -1006,7 +1008,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@QueryParam("float") @DefaultValue("3.14159265") float[] v)
       {
-         Assert.assertEquals(3.14159265f, v[0]);
+         Assert.assertEquals(3.14159265f, v[0], ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -1014,7 +1016,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@QueryParam("double") @DefaultValue("3.14159265358979") double[] v)
       {
-         Assert.assertEquals(3.14159265358979d, v[0]);
+         Assert.assertEquals(3.14159265358979d, v[0], ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }
@@ -1066,7 +1068,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/float")
       public String doGetFloat(@QueryParam("float") @DefaultValue("0.0") float[] v)
       {
-         Assert.assertEquals(3.14159265f, v[0]);
+         Assert.assertEquals(3.14159265f, v[0], ASSERT_FLOAT_THRESHOLD);
          return "content";
       }
 
@@ -1074,7 +1076,7 @@ public class QueryParamAsPrimitiveTest
       @Produces("application/double")
       public String doGetDouble(@QueryParam("double") @DefaultValue("0.0") double[] v)
       {
-         Assert.assertEquals(3.14159265358979d, v[0]);
+         Assert.assertEquals(3.14159265358979d, v[0], ASSERT_DOUBLE_THRESHOLD);
          return "content";
       }
    }

--- a/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/methodparams/UriParamAsPrimitiveTest.java
+++ b/jaxrs/resteasy-jaxrs/src/test/java/org/jboss/resteasy/test/finegrain/methodparams/UriParamAsPrimitiveTest.java
@@ -135,7 +135,7 @@ public class UriParamAsPrimitiveTest
       @GET
       public String doGet(@PathParam("arg") float v)
       {
-         Assert.assertEquals(3.14159265f, v);
+         Assert.assertEquals(3.14159265f, v, 0.0000000001f);
          return "content";
       }
    }
@@ -146,7 +146,7 @@ public class UriParamAsPrimitiveTest
       @GET
       public String doGet(@PathParam("arg") double v)
       {
-         Assert.assertEquals(3.14159265358979d, v);
+         Assert.assertEquals(3.14159265358979d, v, 0.0000000000000001d);
          return "content";
       }
    }
@@ -212,7 +212,7 @@ public class UriParamAsPrimitiveTest
       @GET
       public String doGet(@PathParam("arg") Float v)
       {
-         Assert.assertEquals(3.14159265f, v.floatValue());
+         Assert.assertEquals(3.14159265f, v.floatValue(), 0.0000000001f);
          return "content";
       }
    }
@@ -223,7 +223,7 @@ public class UriParamAsPrimitiveTest
       @GET
       public String doGet(@PathParam("arg") Double v)
       {
-         Assert.assertEquals(3.14159265358979d, v.doubleValue());
+         Assert.assertEquals(3.14159265358979d, v.doubleValue(), 0.0000000000000001d);
          return "content";
       }
    }

--- a/jaxrs/resteasy-spring/pom.xml
+++ b/jaxrs/resteasy-spring/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxrs/security/keystone/example/keystone-server/pom.xml
+++ b/jaxrs/security/keystone/example/keystone-server/pom.xml
@@ -27,7 +27,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxrs/security/keystone/example/some-app/pom.xml
+++ b/jaxrs/security/keystone/example/some-app/pom.xml
@@ -27,7 +27,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxrs/security/skeleton-key-idm/skeleton-key-idp-war/pom.xml
+++ b/jaxrs/security/skeleton-key-idm/skeleton-key-idp-war/pom.xml
@@ -27,7 +27,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxrs/server-adapters/resteasy-netty4-cdi/pom.xml
+++ b/jaxrs/server-adapters/resteasy-netty4-cdi/pom.xml
@@ -16,7 +16,6 @@
         <dep.weld.se.version>2.1.2.Final</dep.weld.se.version>
         <dep.arq.weld.se>1.0.0.CR8</dep.arq.weld.se>
         <dep.arq.version>1.1.3.Final</dep.arq.version>
-        <dep.junit>4.11</dep.junit>
     </properties>
     <dependencies>
         <dependency>
@@ -86,7 +85,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
-            <version>${dep.junit}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>


### PR DESCRIPTION
The [Assert.assertEquals(e,a)](http://junit.sourceforge.net/javadoc/org/junit/Assert.html#assertEquals(double, double)) for floating point variables is deprecated.  One must use the newer [Assert.assertEquals(e,a,d)](http://junit.sourceforge.net/javadoc/org/junit/Assert.html#assertEquals(double, double, double)).

In addition, the version of JUnit used throughout the project was inconsistent.  Some `pom.xml` was tweaked to make it more consistent and centralize the version at the parent pom.