### PR TITLE
RESTEASY-1339 Arquillian Consistency and Upgrade

### DIFF
--- a/jaxrs/arquillian/RESTEASY-1008-AS7/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1008-AS7/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-bom</artifactId>
-            <version>1.0.3.Final</version>
+            <version>${dep.arquillian-bom.version}</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/jaxrs/arquillian/RESTEASY-1008-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1008-WF8/pom.xml
@@ -105,7 +105,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.0.3.Final</version>
+                <version>${dep.arquillian-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>8.0.0.CR1</version>
+            <version>${dep.arquillian-wildfly.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxrs/arquillian/RESTEASY-1054-AS7/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1054-AS7/pom.xml
@@ -89,7 +89,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.0.3.Final</version>
+                <version>${dep.arquillian-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/jaxrs/arquillian/RESTEASY-1054-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1054-WF8/pom.xml
@@ -107,7 +107,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.0.3.Final</version>
+                <version>${dep.arquillian-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/jaxrs/arquillian/RESTEASY-1056-jetty-bv10/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1056-jetty-bv10/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-bom</artifactId>
-            <version>1.0.0.Final</version>
+            <version>${dep.arquillian-bom.version}</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/jaxrs/arquillian/RESTEASY-1056-jetty-bv11/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1056-jetty-bv11/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-bom</artifactId>
-            <version>1.0.0.Final</version>
+            <version>${dep.arquillian-bom.version}</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/jaxrs/arquillian/RESTEASY-1058-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1058-WF8/pom.xml
@@ -92,7 +92,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.0.3.Final</version>
+                <version>${dep.arquillian-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>8.0.0.CR1</version>
+            <version>${dep.arquillian-wildfly.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxrs/arquillian/RESTEASY-1073-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1073-WF8/pom.xml
@@ -107,7 +107,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.0.3.Final</version>
+                <version>${dep.arquillian-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>8.0.0.Alpha1</version>
+            <version>${dep.arquillian-wildfly.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxrs/arquillian/RESTEASY-1082-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1082-WF8/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-bom</artifactId>
-            <version>1.0.3.Final</version>
+            <version>${dep.arquillian-bom.version}</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>
@@ -144,7 +144,7 @@
     <dependency>
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-arquillian-container-managed</artifactId>
-        <version>8.0.0.Final</version>
+        <version>${dep.arquillian-wildfly.version}</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/jaxrs/arquillian/RESTEASY-1141-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-1141-WF8/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>8.0.0.Alpha1</version>
+            <version>${dep.arquillian-wildfly.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxrs/arquillian/RESTEASY-736-as71/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-736-as71/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-bom</artifactId>
-            <version>1.0.0.Final</version>
+            <version>${dep.arquillian-bom.version}</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/jaxrs/arquillian/RESTEASY-736-jetty/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-736-jetty/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-bom</artifactId>
-            <version>1.0.0.Final</version>
+            <version>${dep.arquillian-bom.version}</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/jaxrs/arquillian/RESTEASY-760-jetty/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-760-jetty/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-bom</artifactId>
-            <version>1.0.0.Final</version>
+            <version>${dep.arquillian-bom.version}</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/jaxrs/arquillian/RESTEASY-767-jetty/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-767-jetty/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-bom</artifactId>
-            <version>1.0.0.Final</version>
+            <version>${dep.arquillian-bom.version}</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/jaxrs/arquillian/RESTEASY-800-AS71/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-800-AS71/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-bom</artifactId>
-            <version>1.0.3.Final</version>
+            <version>${dep.arquillian-bom.version}</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/jaxrs/arquillian/RESTEASY-903-AS7/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-903-AS7/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-bom</artifactId>
-            <version>1.0.3.Final</version>
+            <version>${dep.arquillian-bom.version}</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/jaxrs/arquillian/RESTEASY-903-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-903-WF8/pom.xml
@@ -105,7 +105,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.0.3.Final</version>
+                <version>${dep.arquillian-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>8.0.0.CR1</version>
+            <version>${dep.arquillian-wildfly.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxrs/arquillian/RESTEASY-923-AS7/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-923-AS7/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-bom</artifactId>
-            <version>1.0.3.Final</version>
+            <version>${dep.arquillian-bom.version}</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/jaxrs/arquillian/RESTEASY-923-EAP6/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-923-EAP6/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-bom</artifactId>
-            <version>1.0.3.Final</version>
+            <version>${dep.arquillian-bom.version}</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/jaxrs/arquillian/RESTEASY-923-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-923-WF8/pom.xml
@@ -105,7 +105,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.0.3.Final</version>
+                <version>${dep.arquillian-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>8.0.0.CR1</version>
+            <version>${dep.arquillian-wildfly.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxrs/arquillian/RESTEASY-945-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-945-WF8/pom.xml
@@ -96,7 +96,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.0.3.Final</version>
+                <version>${dep.arquillian-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>8.0.0.CR1</version>
+            <version>${dep.arquillian-wildfly.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxrs/arquillian/RESTEASY-TEST-EAP6/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-TEST-EAP6/pom.xml
@@ -93,7 +93,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.0.3.Final</version>
+                <version>${dep.arquillian-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/jaxrs/arquillian/RESTEASY-TEST-EAP7/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-TEST-EAP7/pom.xml
@@ -126,7 +126,7 @@
     <dependency>
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-arquillian-container-managed</artifactId>
-        <version>8.0.0.Final</version>
+        <version>${dep.arquillian-wildfly.version}</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/jaxrs/arquillian/RESTEASY-TEST-WF10/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-TEST-WF10/pom.xml
@@ -92,7 +92,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.0.3.Final</version>
+                <version>${dep.arquillian-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/jaxrs/arquillian/RESTEASY-TEST-WF8/pom.xml
+++ b/jaxrs/arquillian/RESTEASY-TEST-WF8/pom.xml
@@ -92,7 +92,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.0.3.Final</version>
+                <version>${dep.arquillian-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/jaxrs/arquillian/ValidationTest-WF8/pom.xml
+++ b/jaxrs/arquillian/ValidationTest-WF8/pom.xml
@@ -92,7 +92,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.0.3.Final</version>
+                <version>${dep.arquillian-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>8.0.0.Alpha1</version>
+            <version>${dep.arquillian-wildfly.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jaxrs/arquillian/ValidationTest/pom.xml
+++ b/jaxrs/arquillian/ValidationTest/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-bom</artifactId>
-            <version>1.0.3.Final</version>
+            <version>${dep.arquillian-bom.version}</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>
@@ -138,7 +138,7 @@
         <!--artifactId>jboss-as-arquillian-container-managed</artifactId-->
         <artifactId>wildfly-arquillian-container-managed</artifactId>
         <!--version>7.1.1.Final</version-->
-        <version>8.2.0.Final</version>
+        <version>${dep.arquillian-wildfly.version}</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/jaxrs/arquillian/resteasy-cdi-ejb-test/pom.xml
+++ b/jaxrs/arquillian/resteasy-cdi-ejb-test/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-bom</artifactId>
-            <version>1.0.0.Final</version>
+            <version>${dep.arquillian-bom.version}</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -44,8 +44,8 @@
         <dep.slf4j.version>1.7.5</dep.slf4j.version>
         <dep.bc.version>1.52</dep.bc.version>
         <dep.com.sun.mail.version>1.5.5</dep.com.sun.mail.version>
-        <dep.arquillian-bom.version>1.0.3.Final</dep.arquillian-bom.version>
-        <dep.arquillian-wildfly.version>8.1.0.Final</dep.arquillian-wildfly.version>
+        <dep.arquillian-bom.version>1.1.11.Final</dep.arquillian-bom.version>
+        <dep.arquillian-wildfly.version>8.2.1.Final</dep.arquillian-wildfly.version>
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.0.Final
         </version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final


### PR DESCRIPTION
Consistent versions for `arquillian-bom` and `wildfly-arquillian-container-managed`, then upgraded to:
* `arquillian-bom-1.1.11.Final`
* `wildfly-arquillian-container-managed-8.2.1.Final`