### PR TITLE
RESTEASY-1176

### DIFF
--- a/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/security/PasswordColonTest.java
+++ b/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/security/PasswordColonTest.java
@@ -1,0 +1,26 @@
+package org.jboss.resteasy.test.nextgen.security;
+
+import org.jboss.resteasy.util.BasicAuthHelper;
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+/**
+ * RESTEASY-1176
+ * 
+ * @author <a href="mailto:ron.sigal@jboss.com">Ron Sigal</a>
+ * @date May 7, 2016
+ */
+public class PasswordColonTest
+{
+   @Test
+   public void testPasswordWithColon()
+   {
+      String header = BasicAuthHelper.createHeader("user", "pass:word");
+      String[] credentials = BasicAuthHelper.parseHeader(header);
+      System.out.println("user: " + credentials[0]);
+      System.out.println("password: " + credentials[1]);
+      Assert.assertEquals("user", credentials[0]);
+      Assert.assertEquals("pass:word", credentials[1]);
+   }
+}

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -1728,11 +1728,6 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
 
    public void registerProviderInstance(Object provider, Map<Class<?>, Integer> contracts, Integer priorityOverride, boolean builtIn)
    {
-      if (getClasses().contains(provider.getClass()))
-      {
-         LogMessages.LOGGER.providerClassAlreadyRegistered(provider.getClass().getName());
-         return;
-      }
       for (Object registered : getInstances())
       {
          if (registered == provider)
@@ -1740,6 +1735,11 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
             LogMessages.LOGGER.providerInstanceAlreadyRegistered(provider.getClass().getName());
             return;
          }
+      }
+      if (getClasses().contains(provider.getClass()))
+      {
+         LogMessages.LOGGER.providerClassAlreadyRegistered(provider.getClass().getName());
+         return;
       }
       Map<Class<?>, Integer> newContracts = new HashMap<Class<?>, Integer>();
       if (isA(provider, ParamConverterProvider.class, contracts))

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/BasicAuthHelper.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/BasicAuthHelper.java
@@ -30,8 +30,10 @@ public class BasicAuthHelper
       if (!type.equalsIgnoreCase("Basic")) return null;
       String val = header.substring(6);
       val = new String(org.apache.commons.codec.binary.Base64.decodeBase64(val.getBytes()));
-      String[] split = val.split(":");
-      if (split.length != 2) return null;
+      int pos = val.indexOf(':');
+      String[] split = new String[2];
+      split[0] = val.substring(0, pos);
+      split[1] = val.substring(pos + 1);
       return split;
    }
 }

--- a/jaxrs/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/RESTEASY1323Test.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/RESTEASY1323Test.java
@@ -27,7 +27,7 @@ public class RESTEASY1323Test
 {
    static String BASE_URI = generateURL("");
 
-   static final int REQUEST_TIMEOUT = 1000;
+   static final int REQUEST_TIMEOUT = 2000;
 
    @BeforeClass
    public static void setupSuite() throws Exception

--- a/jaxrs/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/RESTEASY1323Test.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/RESTEASY1323Test.java
@@ -27,7 +27,7 @@ public class RESTEASY1323Test
 {
    static String BASE_URI = generateURL("");
 
-   static final int REQUEST_TIMEOUT = 2000;
+   static final int REQUEST_TIMEOUT = 4000;
 
    @BeforeClass
    public static void setupSuite() throws Exception

--- a/jaxrs/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/RESTEASY1325Test.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/RESTEASY1325Test.java
@@ -23,7 +23,7 @@ public class RESTEASY1325Test
 {
    static String BASE_URI = generateURL("");
 
-   static final int IDLE_TIMEOUT = 3;
+   static final int IDLE_TIMEOUT = 5;
 
    @BeforeClass
    public static void setupSuite() throws Exception

--- a/jaxrs/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/RESTEASY1325Test.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/RESTEASY1325Test.java
@@ -23,7 +23,7 @@ public class RESTEASY1325Test
 {
    static String BASE_URI = generateURL("");
 
-   static final int IDLE_TIMEOUT = 5;
+   static final int IDLE_TIMEOUT = 10;
 
    @BeforeClass
    public static void setupSuite() throws Exception


### PR DESCRIPTION
* Allow ':' in Basic Authentication password.
* Also, rearrange duplicate registration test in ResteasyProviderFactory for RESTEASY-1284.

https://issues.jboss.org/browse/RESTEASY-1176