### PR TITLE
RESTEASY-1176

### DIFF
--- a/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/security/PasswordColonTest.java
+++ b/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/security/PasswordColonTest.java
@@ -1,0 +1,26 @@
+package org.jboss.resteasy.test.nextgen.security;
+
+import org.jboss.resteasy.util.BasicAuthHelper;
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+/**
+ * RESTEASY-1176
+ * 
+ * @author <a href="mailto:ron.sigal@jboss.com">Ron Sigal</a>
+ * @date May 7, 2016
+ */
+public class PasswordColonTest
+{
+   @Test
+   public void testPasswordWithColon()
+   {
+      String header = BasicAuthHelper.createHeader("user", "pass:word");
+      String[] credentials = BasicAuthHelper.parseHeader(header);
+      System.out.println("user: " + credentials[0]);
+      System.out.println("password: " + credentials[1]);
+      Assert.assertEquals("user", credentials[0]);
+      Assert.assertEquals("pass:word", credentials[1]);
+   }
+}

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -1728,11 +1728,6 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
 
    public void registerProviderInstance(Object provider, Map<Class<?>, Integer> contracts, Integer priorityOverride, boolean builtIn)
    {
-      if (getClasses().contains(provider.getClass()))
-      {
-         LogMessages.LOGGER.providerClassAlreadyRegistered(provider.getClass().getName());
-         return;
-      }
       for (Object registered : getInstances())
       {
          if (registered == provider)
@@ -1740,6 +1735,11 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
             LogMessages.LOGGER.providerInstanceAlreadyRegistered(provider.getClass().getName());
             return;
          }
+      }
+      if (getClasses().contains(provider.getClass()))
+      {
+         LogMessages.LOGGER.providerClassAlreadyRegistered(provider.getClass().getName());
+         return;
       }
       Map<Class<?>, Integer> newContracts = new HashMap<Class<?>, Integer>();
       if (isA(provider, ParamConverterProvider.class, contracts))

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/BasicAuthHelper.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/BasicAuthHelper.java
@@ -30,8 +30,10 @@ public class BasicAuthHelper
       if (!type.equalsIgnoreCase("Basic")) return null;
       String val = header.substring(6);
       val = new String(org.apache.commons.codec.binary.Base64.decodeBase64(val.getBytes()));
-      String[] split = val.split(":");
-      if (split.length != 2) return null;
+      int pos = val.indexOf(':');
+      String[] split = new String[2];
+      split[0] = val.substring(0, pos);
+      split[1] = val.substring(pos + 1);
       return split;
    }
 }


### PR DESCRIPTION
Allow ':' in Basic Auth passwords.

https://issues.jboss.org/browse/RESTEASY-1176

Also, reversing a test in ResteasyProviderFactory for RESTEASY-1284.