### PR TITLE
https://issues.jboss.org/browse/RESTEASY-1356

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/FileProvider.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/FileProvider.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.plugins.providers;
 
+import org.jboss.resteasy.logging.Logger;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.util.NoContent;
 
@@ -37,6 +38,8 @@ import java.lang.reflect.Type;
 public class FileProvider implements MessageBodyReader<File>,
         MessageBodyWriter<File>
 {
+   private static final Logger LOG = Logger.getLogger(FileProvider.class);
+
    private static final String PREFIX = "pfx";
 
    private static final String SUFFIX = "sfx";
@@ -70,9 +73,7 @@ public class FileProvider implements MessageBodyReader<File>,
             // could make this configurable, so we fail on fault rather than
             // default.
 
-            System.err
-                    .println("Could not bind to specified download directory "
-                            + _downloadDirectory + " so will use temp dir.");
+            LOG.warn("Could not bind to specified download directory " + _downloadDirectory +" so will use temp dir.");
          }
       }
 

--- a/resteasy-wadl/src/main/java/org/jboss/resteasy/wadl/ResteasyWadlDefaultResource.java
+++ b/resteasy-wadl/src/main/java/org/jboss/resteasy/wadl/ResteasyWadlDefaultResource.java
@@ -1,5 +1,8 @@
 package org.jboss.resteasy.wadl;
 
+import org.jboss.resteasy.logging.Logger;
+import org.jboss.resteasy.wadl.i18n.Messages;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -16,6 +19,8 @@ public class ResteasyWadlDefaultResource {
     private final static ResteasyWadlWriter apiWriter = new ResteasyWadlServletWriter();
     private final static Map<String, ResteasyWadlServiceRegistry> services = new HashMap<>();
 
+    private final static Logger LOG = Logger.getLogger(ResteasyWadlDefaultResource.class);
+
     public static Map<String, ResteasyWadlServiceRegistry> getServices() {
         return services;
     }
@@ -26,7 +31,7 @@ public class ResteasyWadlDefaultResource {
         try {
             return this.apiWriter.getStringWriter("", services).toString();
         } catch (JAXBException e) {
-            e.printStackTrace();
+            LOG.error(Messages.MESSAGES.cantProcessWadl(), e);
         }
         return null;
     }

--- a/resteasy-wadl/src/main/java/org/jboss/resteasy/wadl/i18n/Messages.java
+++ b/resteasy-wadl/src/main/java/org/jboss/resteasy/wadl/i18n/Messages.java
@@ -41,5 +41,6 @@ public interface Messages
    @Message(id = BASE + 35, value = "Serving %s")
    String servingPathInfo(String pathInfo);
    
-   
+   @Message(id = BASE + 36, value = "Error while processing WADL")
+   String cantProcessWadl();
 }

--- a/security/skeleton-key-idm/skeleton-key-core/src/main/java/org/jboss/resteasy/skeleton/key/AbstractOAuthClient.java
+++ b/security/skeleton-key-idm/skeleton-key-core/src/main/java/org/jboss/resteasy/skeleton/key/AbstractOAuthClient.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.skeleton.key;
 
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.logging.Logger;
 import org.jboss.resteasy.skeleton.key.i18n.Messages;
 import org.jboss.resteasy.skeleton.key.representations.AccessTokenResponse;
 import org.jboss.resteasy.util.BasicAuthHelper;
@@ -24,6 +25,8 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class AbstractOAuthClient
 {
+   private static final Logger LOG = Logger.getLogger(AbstractOAuthClient.class);
+
    protected String clientId;
    protected String password;
    protected KeyStore truststore;
@@ -154,7 +157,7 @@ public class AbstractOAuthClient
 
    protected String stripOauthParametersFromRedirect(String uri)
    {
-      System.out.println(Messages.MESSAGES.redirectUri(uri));
+      LOG.info(Messages.MESSAGES.redirectUri(uri));
       UriBuilder builder = UriBuilder.fromUri(uri)
               .replaceQueryParam("code", null)
               .replaceQueryParam("state", null);

--- a/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
+++ b/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
@@ -11,6 +11,7 @@ import org.jboss.netty.handler.codec.frame.TooLongFrameException;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.resteasy.logging.Logger;
 import org.jboss.resteasy.plugins.server.netty.i18n.LogMessages;
 import org.jboss.resteasy.plugins.server.netty.i18n.Messages;
 import org.jboss.resteasy.spi.Failure;
@@ -32,6 +33,8 @@ import static org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 @Sharable
 public class RequestHandler extends SimpleChannelUpstreamHandler
 {
+   private static final Logger LOG = Logger.getLogger(RequestHandler.class);
+
    protected final RequestDispatcher dispatcher;
 
    public RequestHandler(RequestDispatcher dispatcher)
@@ -100,7 +103,7 @@ public class RequestHandler extends SimpleChannelUpstreamHandler
       }
       else
       {
-          e.getCause().printStackTrace();
+          LOG.info("Exception caught by handler", e);
           e.getChannel().close();
       }
 

--- a/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
+++ b/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
@@ -9,6 +9,7 @@ import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpResponse;
 
 import io.netty.handler.timeout.IdleStateEvent;
+import org.jboss.resteasy.logging.Logger;
 import org.jboss.resteasy.plugins.server.netty.i18n.LogMessages;
 import org.jboss.resteasy.plugins.server.netty.i18n.Messages;
 import org.jboss.resteasy.spi.Failure;
@@ -31,6 +32,8 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 @Sharable
 public class RequestHandler extends SimpleChannelInboundHandler
 {
+   private static final Logger LOG = Logger.getLogger(RequestHandler.class);
+
    protected final RequestDispatcher dispatcher;
 
    public RequestHandler(RequestDispatcher dispatcher)
@@ -90,7 +93,7 @@ public class RequestHandler extends SimpleChannelInboundHandler
       }
       else
       {
-          e.getCause().printStackTrace();
+          LOG.info("Exception caught by handler", e);
           ctx.close();
       }
    }

--- a/tjws/src/main/java/Acme/Serve/SSLAcceptor.java
+++ b/tjws/src/main/java/Acme/Serve/SSLAcceptor.java
@@ -43,9 +43,13 @@ import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
 import java.security.Security;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class SSLAcceptor implements Acceptor
 {
+   private static final Logger LOG = Logger.getLogger(SSLAcceptor.class.getName());
+
    public static final String ARG_ALGORITHM = "algorithm"; // SUNX509
 
    public static final String ARG_CLIENTAUTH = "clientAuth"; // false
@@ -163,8 +167,7 @@ public class SSLAcceptor implements Acceptor
       }
       catch (Exception e)
       {
-         System.err.println("initKeyStore:  " + e);
-         e.printStackTrace();
+         LOG.log(Level.SEVERE, "initKeyStore: " + e, e);
          throw new IOException(e.toString());
       }
       finally
@@ -195,7 +198,7 @@ public class SSLAcceptor implements Acceptor
             }
             catch (Throwable t)
             {
-               t.printStackTrace();
+               LOG.log(Level.SEVERE, t.getMessage(), t);
                throw new IOException(t.toString());
             }
 
@@ -220,8 +223,7 @@ public class SSLAcceptor implements Acceptor
       }
       catch (Exception e)
       {
-         System.err.println("SSLsocket creation:  " + e);
-         e.printStackTrace();
+         LOG.log(Level.SEVERE, "SSLsocket creation:  " + e, e);
          throw new IOException(e.toString());
       }
 

--- a/tjws/src/main/java/Acme/Serve/Serve.java
+++ b/tjws/src/main/java/Acme/Serve/Serve.java
@@ -109,6 +109,10 @@ import java.util.TreeSet;
 import java.util.Vector;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
 
 /// Minimal Java servlet container class.
 // <P>
@@ -242,7 +246,7 @@ public class Serve implements ServletContext, Serializable
 
    protected String hostName;
 
-   private transient PrintStream logStream;
+   private transient Logger log;
 
    private boolean useAccLog;
 
@@ -289,11 +293,23 @@ public class Serve implements ServletContext, Serializable
 
    protected List<ServeConnection> connections = new ArrayList<ServeConnection>();
 
-   // / Constructor.
-   public Serve(Map arguments, PrintStream logStream)
+   // / Constructor kept for API compatibility
+   public Serve(Map arguments, PrintStream logStream) {
+      this(arguments, newLoggerForPrintStream(logStream));
+   }
+
+   /**
+    * Default constructor to create TJWS as a bean
+    */
+   public Serve()
+   {
+      this(new HashMap(), Logger.getLogger(Serve.class.getName()));
+   }
+
+   private Serve(Map arguments, Logger log)
    {
       this.arguments = arguments;
-      this.logStream = logStream;
+      this.log = log;
       registry = new PathTreeDictionary();
       realms = new PathTreeDictionary();
       attributes = new Hashtable();
@@ -350,12 +366,11 @@ public class Serve implements ServletContext, Serializable
       initMime();
    }
 
-   /**
-    * Default constructor to create TJWS as a bean
-    */
-   public Serve()
-   {
-      this(new HashMap(), System.err);
+   private static Logger newLoggerForPrintStream(PrintStream printStream) {
+      Logger result = Logger.getLogger(Serve.class.getName());
+      result.setUseParentHandlers(false);
+      result.addHandler(new StreamHandler(printStream, new SimpleFormatter()));
+      return result;
    }
 
    protected void setAccessLogged()
@@ -1082,21 +1097,12 @@ public class Serve implements ServletContext, Serializable
    // @param message the message to log
    public void log(String message)
    {
-      Date date = new Date(System.currentTimeMillis());
-      logStream.println("[" + date.toString() + "] " + message);
+      log.log(Level.INFO, message);
    }
 
    public void log(String message, Throwable throwable)
    {
-      if (throwable != null)
-      {
-         StringWriter sw;
-         PrintWriter pw = new PrintWriter(sw = new StringWriter());
-         throwable.printStackTrace(pw);
-         // printCauses(throwable, pw);
-         message = message + '\n' + sw;
-      }
-      log(message);
+      log.log(Level.SEVERE, message, throwable);
    }
 
    // protected void printCauses(Throwable throwable, PrintWriter printWriter) {
@@ -2069,7 +2075,7 @@ public class Serve implements ServletContext, Serializable
                   logPlaceholders[9] = new Integer(socket.getLocalPort());
                   logPlaceholders[10] = serve.isShowReferer() ? getHeader("Referer") : "-";
                   logPlaceholders[11] = serve.isShowUserAgent() ? getHeader("User-Agent") : "-";
-                  serve.logStream.println(accessFmt.format(logPlaceholders));
+                  serve.log.finer(accessFmt.format(logPlaceholders));
                }
                lastRun = 0;
                timesRequested++;
@@ -4349,7 +4355,9 @@ public class Serve implements ServletContext, Serializable
 
    public static class ServeInputStream extends ServletInputStream
    {
-      private final static boolean STREAM_DEBUG = false;
+      private final static Logger LOG = Logger.getLogger(ServeInputStream.class.getName());
+
+      private final static boolean DEBUG_ON = LOG.isLoggable(Level.FINER);
 
       /**
        * The actual input stream (buffered).
@@ -4488,8 +4496,8 @@ public class Serve implements ServletContext, Serializable
                i++;
             }
          }
-         if (STREAM_DEBUG)
-            System.err.println(buf);
+         if (DEBUG_ON)
+            LOG.finer(String.valueOf(buf));
          if (c == -1 && buf.length() == 0)
             return null;
 
@@ -4534,8 +4542,7 @@ public class Serve implements ServletContext, Serializable
                   len = Math.min(len, (int) (contentLength - readCount));
                if (len <= 0)
                {
-                  if (STREAM_DEBUG)
-                     System.err.print("EOF");
+                  LOG.finer("EOF");
                   return -1;
                }
                len = in.read(b, off, len);
@@ -4546,8 +4553,8 @@ public class Serve implements ServletContext, Serializable
                // to avoid extra if
                len = in.read(b, off, len);
          }
-         if (STREAM_DEBUG && len > 0)
-            System.err.print(new String(b, off, len));
+         if (DEBUG_ON && len > 0)
+            LOG.finer(new String(b, off, len));
 
          return len;
       }
@@ -4555,8 +4562,7 @@ public class Serve implements ServletContext, Serializable
       /* ------------------------------------------------------------ */
       public long skip(long len) throws IOException
       {
-         if (STREAM_DEBUG)
-            System.err.println("instream.skip() :" + len);
+         LOG.finer("instream.skip() :" + len);
          if (closed)
             throw new IOException("The stream is already closed");
          if (chunking)
@@ -4590,8 +4596,7 @@ public class Serve implements ServletContext, Serializable
        */
       public int available() throws IOException
       {
-         if (STREAM_DEBUG)
-            System.err.println("instream.available()");
+         LOG.finer("instream.available()");
          if (closed)
             throw new IOException("The stream is already closed");
          if (chunking)
@@ -4618,8 +4623,7 @@ public class Serve implements ServletContext, Serializable
       {
          // keep alive, will be closed by socket
          // in.close();
-         if (STREAM_DEBUG)
-            System.err.println("instream.close() " + closed);
+         LOG.finer("instream.close() " + closed);
          if (closed)
             return; //throw new IOException("The stream is already closed");
          // read until end of chunks or content length
@@ -4662,8 +4666,7 @@ public class Serve implements ServletContext, Serializable
          // no buffering, so not possible
          if (closed)
             throw new IOException("The stream is already closed");
-         if (STREAM_DEBUG)
-            System.err.println("instream.reset()");
+         LOG.finer("instream.reset()");
          in.reset();
       }
 
@@ -4676,8 +4679,7 @@ public class Serve implements ServletContext, Serializable
       public void mark(int readlimit)
       {
          // not supported
-         if (STREAM_DEBUG)
-            System.err.println("instream.mark(" + readlimit + ")");
+         LOG.finer("instream.mark(" + readlimit + ")");
       }
 
       /* ------------------------------------------------------------ */
@@ -4747,7 +4749,9 @@ public class Serve implements ServletContext, Serializable
    public static class ServeOutputStream extends ServletOutputStream
    {
 
-      private static final boolean STREAM_DEBUG = false;
+      private static final Logger LOG = Logger.getLogger(ServeOutputStream.class.getName());
+
+      private final static boolean DEBUG_ON = LOG.isLoggable(Level.FINER);
 
       private boolean chunked;
 
@@ -4832,10 +4836,10 @@ public class Serve implements ServletContext, Serializable
 
       public void write(byte[] b, int off, int len) throws IOException
       {
-         if (closed)
-         {
-            if (STREAM_DEBUG)
-               System.err.println((b == null ? "null" : new String(b, off, len)) + "\n won't be written, stream closed.");
+         if (closed) {
+            if (DEBUG_ON) {
+               LOG.finer((b == null ? "null" : new String(b, off, len)) + "\n won't be written, stream closed.");
+            }
             throw new IOException("An attempt of writing " + len + " bytes to a closed out.");
          }
 
@@ -4864,13 +4868,12 @@ public class Serve implements ServletContext, Serializable
             lbytes += len;
          }
 
-         if (STREAM_DEBUG)
-         {
+         if (DEBUG_ON) {
             if (chunked)
-               System.err.println(Integer.toHexString(len));
-            System.err.print(new String(b, off, len));
+               LOG.finer(Integer.toHexString(len));
+            LOG.finer(new String(b, off, len));
             if (chunked)
-               System.err.println();
+               LOG.finer("end of chunk");
          }
       }
 
@@ -4892,20 +4895,17 @@ public class Serve implements ServletContext, Serializable
                lbytes += b.length;
                out.write("\r\n".getBytes());
                lbytes += 2;
-               if (STREAM_DEBUG)
-               {
-                  System.err.println(hexl);
-                  System.err.print(new String(b));
-                  System.err.println();
+               if (DEBUG_ON) {
+                  LOG.finer(hexl);
+                  LOG.finer(new String(b));
                }
             }
             else
             {
                out.write(b);
                lbytes += b.length;
-               if (STREAM_DEBUG)
-               {
-                  System.err.print(new String(b));
+               if (DEBUG_ON) {
+                  LOG.finer(new String(b));
                }
             }
          }
@@ -4927,8 +4927,7 @@ public class Serve implements ServletContext, Serializable
                {
                   out.write("0\r\n\r\n".getBytes());
                   lbytes += 5;
-                  if (STREAM_DEBUG)
-                     System.err.print("0\r\n\r\n");
+                  LOG.finer("0\r\n\r\n");
                   // TODO: here is possible to write trailer headers
                   out.flush();
                }


### PR DESCRIPTION
https://issues.jboss.org/browse/RESTEASY-1356
RESTEasy don't use correct logging on many places

Existing logging classes are used now instead of System.out/System.err. Logging in test code and main methods is left untouched.