### PR TITLE
Added deprecation info for the resteasy.scan

### DIFF
--- a/docbook/reference/en/en-US/modules/Installation_Configuration.xml
+++ b/docbook/reference/en/en-US/modules/Installation_Configuration.xml
@@ -352,7 +352,9 @@ public class MyApplication extends Application
                             </entry>
                             <entry>
                                 Automatically scan WEB-INF/lib jars and WEB-INF/classes directory for both @Provider and
-                                JAX-RS resource classes (@Path, @GET, @POST etc..) and register them
+                                JAX-RS resource classes (@Path, @GET, @POST etc..) and register them. 
+                                This property is pretty much deprecated--you should use a Servlet 3.0 container or higher
+                                and the ResteasyServletInitializer instead.
                             </entry>
                         </row>
                         <row>


### PR DESCRIPTION
I wasn't able to see that resteasy.scan is deprecated until I prepared logging. I feel this should be mentioned in the documentation.