### PR TITLE
Character encoding problem when reading the services file

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/RegisterBuiltin.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/RegisterBuiltin.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.plugins.providers;
 
+import org.apache.commons.io.Charsets;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
@@ -48,7 +49,7 @@ public class RegisterBuiltin
          InputStream is = url.openStream();
          try
          {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(is, Charsets.UTF_8));
             String line;
             while ((line = reader.readLine()) != null)
             {


### PR DESCRIPTION
If I run Resteasy in Tomcat with "-Dfile.encoding=UTF-16" I get the following exception:

```
482  WARN   [ localhost-startStop-1   ] org.jboss.resteasy.plugins.providers.RegisterBuiltin   -  ClassNotFoundException :  Unable  to  load  builtin  provider : org.jboss.resteasy.plugins.providers.jackson.ResteasyJacksonProvider ²
483  WARN   [ localhost-startStop-1   ] org.jboss.resteasy.plugins.providers.RegisterBuiltin   -  ClassNotFoundException :  Unable  to  load  builtin  provider : org.jboss.resteasy.plugins.providers.DataSourceProvider
rg.jboss.resteasy.plugins.providers.DocumentProvider
rg.jboss.resteasy.plugins.providers.DefaultTextPlain
rg.jboss.resteasy.plugins.providers.StringTextStar
rg.jboss.resteasy.plugins.providers.SourceProvider
rg.jboss.resteasy.plugins.providers.InputStreamProvider
rg.jboss.resteasy.plugins.providers.ReaderProvider
rg.jboss.resteasy.plugins.providers.ByteArrayProvider
rg.jboss.resteasy.plugins.providers.FormUrlEncodedProvider
rg.jboss.resteasy.plugins.providers.JaxrsFormProvider
rg.jboss.resteasy.plugins.providers.FileProvider
rg.jboss.resteasy.plugins.providers.FileRangeWriter
rg.jboss.resteasy.plugins.providers.StreamingOutputProvider
rg.jboss.resteasy.plugins.providers.IIOImageProvider
rg.jboss.resteasy.plugins.providers.SerializableProvider
rg.jboss.resteasy.plugins.interceptors.CacheControlFeature
rg.jboss.resteasy.plugins.interceptors.encoding.AcceptEncodingGZIPInterceptor
rg.jboss.resteasy.plugins.interceptors.encoding.AcceptEncodingGZIPFilter
rg.jboss.resteasy.plugins.interceptors.encoding.ClientContentEncodingAnnotationFeature
rg.jboss.resteasy.plugins.interceptors.encoding.GZIPDecodingInterceptor
rg.jboss.resteasy.plugins.interceptors.encoding.GZIPEncodingInterceptor
rg.jboss.resteasy.plugins.interceptors.encoding.ServerContentEncodingAnnotationFeature



544  WARN   [  localhost-startStop-1   ]  org.jboss.resteasy.plugins.providers.RegisterBuiltin   -  ClassNotFoundException :  Unable  to  load  builtin  provider : org.jboss.resteasy.plugins.providers.multipart.MultipartReader
rg.jboss.resteasy.plugins.providers.multipart.ListMultipartReader
rg.jboss.resteasy.plugins.providers.multipart.MultipartFormDataReader
rg.jboss.resteasy.plugins.providers.multipart.MultipartRelatedReader
rg.jboss.resteasy.plugins.providers.multipart.MapMultipartFormDataReader
rg.jboss.resteasy.plugins.providers.multipart.MultipartWriter
rg.jboss.resteasy.plugins.providers.multipart.MultipartFormDataWriter
rg.jboss.resteasy.plugins.providers.multipart.MultipartRelatedWriter
rg.jboss.resteasy.plugins.providers.multipart.ListMultipartWriter
rg.jboss.resteasy.plugins.providers.multipart.MapMultipartFormDataWriter
rg.jboss.resteasy.plugins.providers.multipart.MultipartFormAnnotationReader
rg.jboss.resteasy.plugins.providers.multipart.MultipartFormAnnotationWriter
rg.jboss.resteasy.plugins.providers.multipart.MimeMultipartProvider
rg.jboss.resteasy.plugins.providers.multipart.XopWithMultipartRelatedReader
rg.jboss.resteasy.plugins.providers.multipart.XopWithMultipartRelatedWriter ²
```

I created the patch to fix this exception.