### PR TITLE
RESTEASY-1405: Support InputPart form parameters for @MultipartForm.

### DIFF
--- a/arquillian/RESTEASY-1405-WF8/pom.xml
+++ b/arquillian/RESTEASY-1405-WF8/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-jaxrs-all</artifactId>
+        <version>3.1.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>RESTEASY-1405-WF8</artifactId>
+    <name>RESTEASY-1405-WF8</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wildfly</groupId>
+                                    <artifactId>wildfly-dist</artifactId>
+                                    <version>${dep.arquillian-wildfly.version}</version>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack resteasy</id>
+                        <phase>process-test-classes</phase>
+                        <configuration>
+                            <target>
+                                <move todir="${project.build.directory}/wildfly">
+                                    <fileset dir="${project.build.directory}/wildfly-${dep.arquillian-wildfly.version}"/>
+                                </move>
+                                <unzip src="${project.basedir}/../../jboss-modules/target/resteasy-jboss-modules-wf8-${project.version}.zip"
+                                       dest="${project.build.directory}/wildfly/modules/system/layers/base"
+                                       overwrite="true"/>
+                                <delete dir="${project.build.directory}/dependency-maven-plugin-markers"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${dep.arquillian-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-arquillian-container-managed</artifactId>
+            <version>${dep.arquillian-wildfly.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-multipart-provider</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/arquillian/RESTEASY-1405-WF8/src/main/java/org/jboss/resteasy/resteasy1405/ByFieldForm.java
+++ b/arquillian/RESTEASY-1405-WF8/src/main/java/org/jboss/resteasy/resteasy1405/ByFieldForm.java
@@ -1,0 +1,30 @@
+package org.jboss.resteasy.resteasy1405;
+
+import javax.ws.rs.FormParam;
+import org.jboss.resteasy.plugins.providers.multipart.InputPart;
+
+public class ByFieldForm {
+
+    @FormParam("name")
+    private String name;
+
+    @FormParam("data")
+    private InputPart data;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public InputPart getData() {
+        return data;
+    }
+
+    public void setData(InputPart data) {
+        this.data = data;
+    }
+
+}

--- a/arquillian/RESTEASY-1405-WF8/src/main/java/org/jboss/resteasy/resteasy1405/BySetterForm.java
+++ b/arquillian/RESTEASY-1405-WF8/src/main/java/org/jboss/resteasy/resteasy1405/BySetterForm.java
@@ -1,0 +1,29 @@
+package org.jboss.resteasy.resteasy1405;
+
+import javax.ws.rs.FormParam;
+import org.jboss.resteasy.plugins.providers.multipart.InputPart;
+
+public class BySetterForm {
+
+    private String name;
+    private InputPart data;
+
+    public String getName() {
+        return name;
+    }
+
+    @FormParam("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public InputPart getData() {
+        return data;
+    }
+
+    @FormParam("data")
+    public void setData(InputPart data) {
+        this.data = data;
+    }
+
+}

--- a/arquillian/RESTEASY-1405-WF8/src/main/java/org/jboss/resteasy/resteasy1405/InputData.java
+++ b/arquillian/RESTEASY-1405-WF8/src/main/java/org/jboss/resteasy/resteasy1405/InputData.java
@@ -1,0 +1,23 @@
+package org.jboss.resteasy.resteasy1405;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class InputData {
+
+    private List<String> items;
+
+    @XmlElementWrapper(name = "items")
+    @XmlElement(name = "item")
+    public List<String> getItems() {
+        return items;
+    }
+
+    public void setItems(List<String> items) {
+        this.items = items;
+    }
+
+}

--- a/arquillian/RESTEASY-1405-WF8/src/main/java/org/jboss/resteasy/resteasy1405/MyApplication.java
+++ b/arquillian/RESTEASY-1405-WF8/src/main/java/org/jboss/resteasy/resteasy1405/MyApplication.java
@@ -1,0 +1,17 @@
+package org.jboss.resteasy.resteasy1405;
+
+import static java.util.Collections.unmodifiableSet;
+import java.util.HashSet;
+import javax.ws.rs.core.Application;
+import java.util.Set;
+
+public class MyApplication extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        Set<Class<?>> classes = new HashSet<>();
+        classes.add(MyResource.class);
+        return unmodifiableSet(classes);
+    }
+
+}

--- a/arquillian/RESTEASY-1405-WF8/src/main/java/org/jboss/resteasy/resteasy1405/MyResource.java
+++ b/arquillian/RESTEASY-1405-WF8/src/main/java/org/jboss/resteasy/resteasy1405/MyResource.java
@@ -1,0 +1,94 @@
+package org.jboss.resteasy.resteasy1405;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.transform.stream.StreamSource;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
+import org.jboss.resteasy.plugins.providers.multipart.InputPart;
+
+@Path("/")
+public class MyResource {
+    private static final Log LOG = LogFactory.getLog(MyResource.class);
+
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("/field")
+    @POST
+    public Response byField(@MultipartForm ByFieldForm form) {
+        LOG.info("Entered byField");
+
+        try {
+            LOG.info("Name: " + form.getName());
+
+            InputData input = parse(form.getData());
+            LOG.info("Items: " + input.getItems() + " (" + form.getData().getMediaType() + ')');
+
+            OutputData output = new OutputData()
+                .withName(form.getName())
+                .withContentType(form.getData().getMediaType())
+                .withItems(input.getItems());
+
+            return Response.ok()
+                .entity(output)
+                .build();
+        } catch (IOException | JAXBException e) {
+            return Response.serverError()
+                .entity(e.getMessage())
+                .build();
+        }
+    }
+
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("/setter")
+    @POST
+    public Response bySetter(@MultipartForm BySetterForm form) {
+        LOG.info("Entered bySetter");
+
+        try {
+            LOG.info("Name: " + form.getName());
+
+            InputData input = parse(form.getData());
+            LOG.info("Items: " + input.getItems() + " (" + form.getData().getMediaType() + ')');
+
+            OutputData output = new OutputData()
+                .withName(form.getName())
+                .withContentType(form.getData().getMediaType())
+                .withItems(input.getItems());
+
+            return Response.ok()
+                .entity(output)
+                .build();
+        } catch (IOException | JAXBException e) {
+            return Response.serverError()
+                .entity(e.getMessage())
+                .build();
+        }
+    }
+
+    private InputData parse(InputPart part) throws JAXBException, IOException {
+        JAXBContext jaxbc = JAXBContext.newInstance(InputData.class);
+        Unmarshaller unmarshaller = jaxbc.createUnmarshaller();
+
+        try (InputStream stream = part.getBody(InputStream.class, null)) {
+            StreamSource source = new StreamSource(stream);
+            return unmarshaller.unmarshal(source, InputData.class).getValue();
+        } finally {
+            if (unmarshaller instanceof Closeable) {
+                ((Closeable) unmarshaller).close();
+            }
+        }
+    }
+}

--- a/arquillian/RESTEASY-1405-WF8/src/main/java/org/jboss/resteasy/resteasy1405/OutputData.java
+++ b/arquillian/RESTEASY-1405-WF8/src/main/java/org/jboss/resteasy/resteasy1405/OutputData.java
@@ -1,0 +1,52 @@
+package org.jboss.resteasy.resteasy1405;
+
+import java.util.Iterator;
+import java.util.List;
+import javax.ws.rs.core.MediaType;
+
+public class OutputData {
+
+    private String name;
+    private MediaType contentType;
+    private List<String> items;
+
+    public OutputData withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public OutputData withContentType(MediaType contentType) {
+        this.contentType = contentType;
+        return this;
+    }
+
+    public OutputData withItems(List<String> items) {
+        this.items = items;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("OutputData[")
+            .append("name='").append(name)
+            .append("', contentType='").append(contentType)
+            .append("', items={").append(join(items, ','))
+            .append("}]")
+            .toString();
+    }
+
+    private static StringBuilder join(List<String> items, char separator) {
+        StringBuilder builder = new StringBuilder();
+        if (items != null) {
+            Iterator<String> iter = items.iterator();
+            if (iter.hasNext()) {
+                builder.append(iter.next());
+
+                while (iter.hasNext()) {
+                    builder.append(separator).append(iter.next());
+                }
+            }
+        }
+        return builder;
+    }
+}

--- a/arquillian/RESTEASY-1405-WF8/src/test/java/org/jboss/resteasy/resteasy1405/TestResteasy1405.java
+++ b/arquillian/RESTEASY-1405-WF8/src/test/java/org/jboss/resteasy/resteasy1405/TestResteasy1405.java
@@ -1,0 +1,115 @@
+package org.jboss.resteasy.resteasy1405;
+
+import java.io.StringWriter;
+import static java.util.Arrays.asList;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericEntity;
+import static javax.ws.rs.core.MediaType.*;
+import javax.ws.rs.core.Response;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class TestResteasy1405 {
+
+    @Deployment(testable = false)
+    public static Archive<?> createTestArchive() {
+        return ShrinkWrap.create(WebArchive.class, "resteasy1405.war")
+            .addClasses(
+                MyApplication.class,
+                MyResource.class,
+                ByFieldForm.class,
+                BySetterForm.class,
+                InputData.class,
+                OutputData.class
+            )
+            .setWebXML("web.xml");
+    }
+
+    private static final String TEST_URI = "http://localhost:8080/resteasy1405";
+
+    private JAXBContext jaxbc;
+    private Client client;
+
+    @Before
+    public void setup() throws JAXBException {
+        jaxbc = JAXBContext.newInstance(InputData.class);
+        client = ClientBuilder.newClient();
+    }
+
+    @After
+    public void done() {
+        client.close();
+    }
+
+    @Test
+    public void testInputPartByField() throws Exception {
+        WebTarget post = client.target(TEST_URI + "/field");
+
+        InputData data = new InputData();
+        data.setItems(asList("value1", "value2"));
+
+        MultipartFormDataOutput multipart = new MultipartFormDataOutput();
+        multipart.addFormData("name", "Test by field", TEXT_PLAIN_TYPE);
+        multipart.addFormData("data", asXml(data), APPLICATION_XML_TYPE);
+        GenericEntity<MultipartFormDataOutput> entity = new GenericEntity<MultipartFormDataOutput>(multipart) {};
+
+        Response response = post.request().post(Entity.entity(entity, MULTIPART_FORM_DATA_TYPE));
+        try {
+            assertEquals(200, response.getStatus());
+            assertEquals("OutputData[name='Test by field', contentType='application/xml', items={value1,value2}]",
+                         response.readEntity(String.class));
+        } finally {
+            response.close();
+        }
+    }
+
+    @Test
+    public void testInputPartBySetter() throws Exception {
+        WebTarget post = client.target(TEST_URI + "/setter");
+
+        InputData data = new InputData();
+        data.setItems(asList("value1", "value2"));
+
+        MultipartFormDataOutput multipart = new MultipartFormDataOutput();
+        multipart.addFormData("name", "Test by setter", TEXT_PLAIN_TYPE);
+        multipart.addFormData("data", asXml(data), APPLICATION_XML_TYPE);
+        GenericEntity<MultipartFormDataOutput> entity = new GenericEntity<MultipartFormDataOutput>(multipart) {};
+
+        Response response = post.request().post(Entity.entity(entity, MULTIPART_FORM_DATA_TYPE));
+        try {
+            assertEquals(200, response.getStatus());
+            assertEquals("OutputData[name='Test by setter', contentType='application/xml', items={value1,value2}]",
+                          response.readEntity(String.class));
+        } finally {
+            response.close();
+        }
+    }
+
+    private String asXml(Object obj) throws JAXBException {
+        Marshaller m = jaxbc.createMarshaller();
+        m.setProperty(Marshaller.JAXB_ENCODING, "UTF-8");
+
+        StringWriter writer = new StringWriter();
+        m.marshal(obj, writer);
+        return writer.toString();
+    }
+}

--- a/arquillian/RESTEASY-1405-WF8/src/test/resources/arquillian.xml
+++ b/arquillian/RESTEASY-1405-WF8/src/test/resources/arquillian.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="
+        http://jboss.org/schema/arquillian
+        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
+    <defaultProtocol type="Servlet 3.0" />
+
+    <engine>
+        <property name="deploymentExportPath">target/deployments</property>
+    </engine>
+
+    <container qualifier="jbossas-managed" default="true">
+        <configuration>
+            <property name="jbossHome">target/wildfly</property>
+            <property name="serverConfig">standalone-full.xml</property>
+            <!-- Uncomment next line to run server in debug mode.  -->
+            <!--property name="javaVmArguments">-Xmx512m -XX:MaxPermSize=128m -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</property-->
+        </configuration>
+    </container>
+</arquillian>

--- a/arquillian/RESTEASY-1405-WF8/src/test/resources/web.xml
+++ b/arquillian/RESTEASY-1405-WF8/src/test/resources/web.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+
+    <display-name>RESTEASY-1405</display-name>
+
+    <servlet>
+        <servlet-name>Resteasy</servlet-name>
+
+        <servlet-class>
+            org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher
+        </servlet-class>
+        <init-param>
+            <param-name>javax.ws.rs.Application</param-name>
+            <param-value>org.jboss.resteasy.resteasy1405.MyApplication</param-value>
+        </init-param>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>Resteasy</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/arquillian/pom.xml
+++ b/arquillian/pom.xml
@@ -31,6 +31,7 @@
         <module>RESTEASY-1141-WF8</module>
         <module>RESTEASY-1141-jetty</module>
         <module>RESTEASY-1223-WF8</module>
+        <module>RESTEASY-1405-WF8</module>
         <module>RESTEASY-TEST-WF10</module>
     </modules>
     

--- a/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartFormAnnotationReader.java
+++ b/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartFormAnnotationReader.java
@@ -37,6 +37,7 @@ public class MultipartFormAnnotationReader implements MessageBodyReader<Object>
    @Context
    Providers workers;
 
+   @Override
    public boolean isReadable(Class<?> type, Type genericType,
                              Annotation[] annotations, MediaType mediaType)
    {
@@ -44,6 +45,7 @@ public class MultipartFormAnnotationReader implements MessageBodyReader<Object>
               || type.isAnnotationPresent(MultipartForm.class);
    }
 
+   @Override
    public Object readFrom(Class<Object> type, Type genericType,
                           Annotation[] annotations, MediaType mediaType,
                           MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
@@ -100,12 +102,20 @@ public class MultipartFormAnnotationReader implements MessageBodyReader<Object>
             if (part == null)
                continue;
             Class<?> type1 = method.getParameterTypes()[0];
-            if (InputStream.class.equals(type1))
-            {
-               hasInputStream = true;
+            Object data;
+            if (InputPart.class.equals(type1)) {
+                hasInputStream = true;
+                data = part;
             }
-            Object data = part.getBody(type1,
-                    method.getGenericParameterTypes()[0]);
+            else
+            {
+                if (InputStream.class.equals(type1))
+                {
+                   hasInputStream = true;
+                }
+                data = part.getBody(type1,
+                        method.getGenericParameterTypes()[0]);
+            }
             try
             {
                method.invoke(obj, data);
@@ -147,12 +157,20 @@ public class MultipartFormAnnotationReader implements MessageBodyReader<Object>
             // param.value());
             if (part == null)
                continue;
-            if (InputStream.class.equals(field.getType()))
-            {
-               hasInputStream = true;
+            Object data;
+            if (InputPart.class.equals(field.getType())) {
+                hasInputStream = true;
+                data = part;
             }
-            Object data = part.getBody(field.getType(), field
-                    .getGenericType());
+            else
+            {
+                if (InputStream.class.equals(field.getType()))
+                {
+                    hasInputStream = true;
+                }
+                data = part.getBody(field.getType(), field
+                        .getGenericType());
+            }
             try
             {
                field.set(obj, data);


### PR DESCRIPTION
Allow Resteasy to inject InputPart as well as InputStream, so that we also have access to the part's Content-Type header.
See https://issues.jboss.org/browse/RESTEASY-1405