### PR TITLE
RESTEASY-1402: Let user override the cache by defining a ContextResolver<JAXBContext

### DIFF
--- a/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/AbstractJAXBContextFinder.java
+++ b/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/AbstractJAXBContextFinder.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.plugins.providers.jaxb;
 
+import java.util.Collections;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.ContextResolver;
@@ -9,6 +10,7 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.annotation.XmlRegistry;
 import javax.xml.bind.annotation.XmlType;
 import java.lang.annotation.Annotation;
+import java.util.Set;
 import java.util.HashSet;
 
 /**
@@ -136,19 +138,24 @@ public abstract class AbstractJAXBContextFinder implements JAXBContextFinder
       return createContextObject(parameterAnnotations, contextPath.toString());
    }
 
-   public JAXBContext createContext(Annotation[] parameterAnnotations, Class... classes) throws JAXBException
-   {
-      HashSet<Class> classes1 = new HashSet<Class>();
-      for (Class type : classes)
-      {
-         if (type == null) continue;
-         classes1.add(type);
-         Class factory = findDefaultObjectFactoryClass(type);
-         if (factory != null) classes1.add(factory);
-      }
-      Class[] classArray = classes1.toArray(new Class[classes1.size()]);
-      return createContextObject(parameterAnnotations, classArray);
-   }
+	@Override
+	public JAXBContext createContext(Annotation[] parameterAnnotations, Class... classes) throws JAXBException
+ {
+		Set<Class<?>> classes1 = Collections.emptySet();
+		if (classes != null && classes.length != 0) {
+			classes1 = new HashSet<Class<?>>();
+			for (Class<?> type : classes) {
+				if (type == null)
+					continue;
+				classes1.add(type);
+				Class<?> factory = findDefaultObjectFactoryClass(type);
+				if (factory != null)
+					classes1.add(factory);
+			}
+		}
+		Class<?>[] classArray = classes1.toArray(new Class[classes1.size()]);
+		return createContextObject(parameterAnnotations, classArray);
+	}
 
    public JAXBContextFinder getContext(Class<?> type)
    {

--- a/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/XmlJAXBContextFinder.java
+++ b/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/XmlJAXBContextFinder.java
@@ -12,6 +12,7 @@ import javax.xml.bind.JAXBException;
 import java.lang.annotation.Annotation;
 import java.util.concurrent.ConcurrentHashMap;
 
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
@@ -25,29 +26,23 @@ public class XmlJAXBContextFinder extends AbstractJAXBContextFinder implements C
    private ConcurrentHashMap<CacheKey, JAXBContext> xmlTypeCollectionCache = new ConcurrentHashMap<CacheKey, JAXBContext>();
 
 
+	@Override
    public JAXBContext findCachedContext(Class type, MediaType mediaType, Annotation[] parameterAnnotations) throws JAXBException
    {
-      JAXBContext result;
-
-      JAXBContext jaxb = null;
-      if (type != null)
+		JAXBContext jaxb = findProvidedJAXBContext(type, mediaType);
+		if (jaxb != null)
       {
-         jaxb = cache.get((Class<?>) type);
-         if (jaxb != null)
-         {
-            return jaxb;
-         }
+			return jaxb;
       }
-      jaxb = findProvidedJAXBContext((Class<?>) type, mediaType);
-      if (jaxb != null)
+		jaxb = type != null ? cache.get(type) : null;
+		if (jaxb == null)
       {
-         cache.putIfAbsent((Class<?>) type, jaxb);
-         return jaxb;
+			jaxb = createContext(parameterAnnotations, type);
+			if (jaxb != null && type != null) {
+				cache.putIfAbsent(type, jaxb);
+			}
       }
-      jaxb = createContext(parameterAnnotations, type);
-      if (jaxb != null && type != null) cache.putIfAbsent((Class<?>) type, jaxb);
-      result = jaxb;
-      return result;
+		return jaxb;
    }
 
    protected JAXBContext createContextObject(Annotation[] parameterAnnotations, Class... classes) throws JAXBException

--- a/providers/jaxb/src/test/java/org/jboss/resteasy/test/providers/jaxb/XmlJAXBContextFinderTest.java
+++ b/providers/jaxb/src/test/java/org/jboss/resteasy/test/providers/jaxb/XmlJAXBContextFinderTest.java
@@ -1,0 +1,207 @@
+package org.jboss.resteasy.test.providers.jaxb;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ContextResolver;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.jboss.resteasy.core.Dispatcher;
+import org.jboss.resteasy.spi.Registry;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+import org.jboss.resteasy.test.EmbeddedContainer;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class XmlJAXBContextFinderTest {
+
+	@XmlRootElement
+	@XmlAccessorType(XmlAccessType.FIELD)
+	private static final class BeanWrapper {
+
+		@XmlAnyElement(lax = true)
+		private Object bean;
+
+		public Object getBean() {
+			return this.bean;
+		}
+
+		public void setBean(Object bean) {
+			this.bean = bean;
+		}
+
+	}
+
+	@XmlRootElement
+	@XmlAccessorType(XmlAccessType.FIELD)
+	private static final class FirstBean {
+
+		private String data;
+
+		public String getData() {
+			return this.data;
+		}
+
+		public void setData(String data) {
+			this.data = data;
+		}
+
+	}
+
+	@XmlRootElement
+	@XmlAccessorType(XmlAccessType.FIELD)
+	private static final class SecondBean {
+
+		private String data;
+
+		public String getData() {
+			return this.data;
+		}
+
+		public void setData(String data) {
+			this.data = data;
+		}
+
+	}
+
+	@Path("/firstTestResource")
+	@Produces(MediaType.APPLICATION_XML)
+	public static final class FirstTestResource {
+
+		@GET
+		public Response get() {
+			FirstBean firstBean = new FirstBean();
+			firstBean.setData("firstTestResource");
+			BeanWrapper beanWrapper = new BeanWrapper();
+			beanWrapper.setBean(firstBean);
+			return Response.ok(beanWrapper).build();
+		}
+
+	}
+
+	@Path("/secondTestResource")
+	@Produces(MediaType.APPLICATION_XML)
+	public static final class SecondTestResource {
+
+		@GET
+		public Response get() {
+			SecondBean secondBean = new SecondBean();
+			secondBean.setData("secondTestResource");
+			BeanWrapper beanWrapper = new BeanWrapper();
+			beanWrapper.setBean(secondBean);
+			return Response.ok(beanWrapper).build();
+		}
+
+	}
+
+	private static ResteasyDeployment deployment;
+	private static Dispatcher dispatcher;
+
+	@BeforeClass
+	public static void before() throws Exception {
+		deployment = EmbeddedContainer.start();
+		ContextResolver<JAXBContext> jaxbContextResolver = new ContextResolver<JAXBContext>() {
+
+			private JAXBContext jaxbContext;
+
+			@Override
+			public JAXBContext getContext(Class<?> type) {
+				if (this.jaxbContext == null) {
+					try {
+						this.jaxbContext = JAXBContext
+								.newInstance(BeanWrapper.class, FirstBean.class, SecondBean.class);
+					} catch (JAXBException e) {
+					}
+				}
+				return this.jaxbContext;
+			}
+
+		};
+		deployment.getProviderFactory().register(jaxbContextResolver);
+		dispatcher = deployment.getDispatcher();
+		Registry registry = deployment.getRegistry();
+		registry.addPerRequestResource(FirstTestResource.class);
+		registry.addPerRequestResource(SecondTestResource.class);
+	}
+
+	@AfterClass
+	public static void after() throws Exception {
+		EmbeddedContainer.stop();
+		dispatcher = null;
+		deployment = null;
+	}
+
+	// In the following test both firstWebTarget and secondWebTarget will share
+	// the same XmlJAXBContextFinder inherited from their shared
+	// parent configuration.
+	// We define and register a ContextResolver<JAXBContext> for each webTarget
+	// so that firstWebTarget and secondWebTarget have its own (respectively
+	// firstJaxbContextResolver and secondJaxbContextResolver).
+	@Test
+	public void test() {
+		Client client = ClientBuilder.newClient();
+		try {
+			// Fist webTarget
+			WebTarget firstWebTarget = client.target("http://localhost:8081/firstTestResource");
+			ContextResolver<JAXBContext> firstJaxbContextResolver = new ContextResolver<JAXBContext>() {
+
+				private JAXBContext jaxbContext;
+
+				@Override
+				public JAXBContext getContext(Class<?> type) {
+					if (this.jaxbContext == null) {
+						try {
+							this.jaxbContext = JAXBContext.newInstance(BeanWrapper.class, FirstBean.class);
+						} catch (JAXBException e) {
+						}
+					}
+					return this.jaxbContext;
+				}
+
+			};
+			Response firstResponse = firstWebTarget.register(firstJaxbContextResolver)
+					.request(MediaType.APPLICATION_XML_TYPE).get();
+			BeanWrapper firstBeanWrapper = firstResponse.readEntity(BeanWrapper.class);
+			Assert.assertTrue(FirstBean.class.isAssignableFrom(firstBeanWrapper.getBean().getClass()));
+
+			// Second webTarget
+			WebTarget secondWebTarget = client.target("http://localhost:8081/secondTestResource");
+			// Will never be called
+			ContextResolver<JAXBContext> secondJaxbContextResolver = new ContextResolver<JAXBContext>() {
+
+				private JAXBContext jaxbContext;
+
+				@Override
+				public JAXBContext getContext(Class<?> type) {
+					if (this.jaxbContext == null) {
+						try {
+							this.jaxbContext = JAXBContext.newInstance(BeanWrapper.class, SecondBean.class);
+						} catch (JAXBException e) {
+						}
+					}
+					return this.jaxbContext;
+				}
+
+			};
+			Response secondResponse = secondWebTarget.register(secondJaxbContextResolver)
+					.request(MediaType.APPLICATION_XML_TYPE).get();
+			BeanWrapper secondBeanWrapper = secondResponse.readEntity(BeanWrapper.class);
+			Assert.assertTrue(SecondBean.class.isAssignableFrom(secondBeanWrapper.getBean().getClass()));
+		} finally {
+			client.close();
+		}
+	}
+
+}


### PR DESCRIPTION
The goal of this pull request is to review XmlJAXBContextFinder so that `JAXBContext findCachedContext(Class type, MediaType mediaType, Annotation[] parameterAnnotations)` method works as it is supposed to work according to its documentation and the way ContextResolver should be used in JaxRS.