### PR TITLE
[RESTEASY-1365] resteasy-netty: HEAD requests always return Content-Length: 0

### DIFF
--- a/arquillian/RESTEASY-TEST-WF10/src/main/java/org/jboss/resteasy/resteasy1365/HeadContentLengthApplication.java
+++ b/arquillian/RESTEASY-TEST-WF10/src/main/java/org/jboss/resteasy/resteasy1365/HeadContentLengthApplication.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.resteasy.resteasy1365;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * @author Ivo Studensky
+ */
+@ApplicationPath("/headcontentlength")
+public class HeadContentLengthApplication extends Application {
+}

--- a/arquillian/RESTEASY-TEST-WF10/src/main/java/org/jboss/resteasy/resteasy1365/SimpleResource.java
+++ b/arquillian/RESTEASY-TEST-WF10/src/main/java/org/jboss/resteasy/resteasy1365/SimpleResource.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.resteasy.resteasy1365;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+/**
+ * @author Ivo Studensky
+ */
+@Path("/simpleresource")
+public class SimpleResource {
+
+    @GET
+    @Produces("text/plain")
+    public String get() {
+        return "hello";
+    }
+}

--- a/arquillian/RESTEASY-TEST-WF10/src/test/java/org/jboss/resteasy/test/resteasy1365/HeadContentLengthTest.java
+++ b/arquillian/RESTEASY-TEST-WF10/src/test/java/org/jboss/resteasy/test/resteasy1365/HeadContentLengthTest.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.resteasy.test.resteasy1365;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.resteasy1365.HeadContentLengthApplication;
+import org.jboss.resteasy.resteasy1365.SimpleResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+
+/**
+ * RESTEASY-1365
+ *
+ * @author Ivo Studensky
+ */
+@RunWith(Arquillian.class)
+public class HeadContentLengthTest {
+
+	private static final String WAR_FILE_NAME = HeadContentLengthTest.class.getSimpleName() + ".war";
+
+	@Deployment(testable=false)
+	public static Archive<?> createTestArchive() {
+		return ShrinkWrap.create( WebArchive.class, WAR_FILE_NAME )
+				.addClasses( HeadContentLengthApplication.class )
+				.addClasses( SimpleResource.class )
+				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" );
+	}
+
+	@Test
+	public void testHeadContentLength() {
+		Client client = ClientBuilder.newClient();
+		Builder builder = client.target("http://localhost:8080:/HeadContentLengthTest/headcontentlength/simpleresource").request();
+		builder.accept(MediaType.TEXT_PLAIN_TYPE);
+
+		Response getResponse = builder.get();
+		String responseBody = getResponse.readEntity(String.class);
+		Assert.assertEquals("hello", responseBody);
+		int getResponseLength = getResponse.getLength();
+		Assert.assertEquals(5, getResponseLength);
+
+		Response headResponse = builder.head();
+		int headResponseLength = headResponse.getLength();
+		Assert.assertEquals(getResponseLength, headResponseLength);
+	}
+
+}

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ServerResponseWriter.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ServerResponseWriter.java
@@ -47,7 +47,7 @@ public class ServerResponseWriter
 
       executeFilters(jaxrsResponse, request, response, providerFactory, method);
 
-      if (jaxrsResponse.getEntity() == null || request.getHttpMethod().equalsIgnoreCase("HEAD"))
+      if (jaxrsResponse.getEntity() == null)
       {
          response.setStatus(jaxrsResponse.getStatus());
          commitHeaders(jaxrsResponse, response);

--- a/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpResponse.java
+++ b/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpResponse.java
@@ -7,6 +7,7 @@ import org.jboss.netty.channel.Channel;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpHeaders.Names;
 import org.jboss.netty.handler.codec.http.HttpHeaders.Values;
+import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.resteasy.plugins.server.netty.i18n.Messages;
 import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
@@ -34,13 +35,20 @@ public class NettyHttpResponse implements HttpResponse
    private final Channel channel;
    private boolean committed;
    private boolean keepAlive;
-   
+   private HttpMethod method;
+
    public NettyHttpResponse(Channel channel, boolean keepAlive)
+   {
+      this(channel, keepAlive, null);
+   }
+
+   public NettyHttpResponse(Channel channel, boolean keepAlive, HttpMethod method)
    {
       outputHeaders = new MultivaluedMapImpl<String, Object>();
       os = underlyingOutputStream = new ChannelBufferOutputStream(ChannelBuffers.dynamicBuffer());
       this.channel = channel;
       this.keepAlive = keepAlive;
+      this.method = method;
    }
 
    @Override
@@ -139,4 +147,9 @@ public class NettyHttpResponse implements HttpResponse
    public boolean isKeepAlive() {
        return keepAlive;
    }
+
+   public HttpMethod getMethod() {
+      return method;
+   }
+
 }

--- a/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpRequestDecoder.java
+++ b/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpRequestDecoder.java
@@ -62,7 +62,7 @@ public class RestEasyHttpRequestDecoder extends OneToOneDecoder
         org.jboss.netty.handler.codec.http.HttpRequest request = (org.jboss.netty.handler.codec.http.HttpRequest) msg;
         boolean keepAlive = org.jboss.netty.handler.codec.http.HttpHeaders.isKeepAlive(request) & isKeepAlive;
 
-        NettyHttpResponse response = new NettyHttpResponse(channel, keepAlive);
+        NettyHttpResponse response = new NettyHttpResponse(channel, keepAlive, request.getMethod());
 
         ResteasyHttpHeaders headers = null;
         ResteasyUriInfo uriInfo = null;

--- a/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpResponseEncoder.java
+++ b/jaxrs/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpResponseEncoder.java
@@ -1,11 +1,13 @@
 package org.jboss.resteasy.plugins.server.netty;
 
+import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandler.Sharable;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpHeaders.Names;
 import org.jboss.netty.handler.codec.http.HttpHeaders.Values;
+import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.oneone.OneToOneEncoder;
@@ -66,12 +68,16 @@ public class RestEasyHttpResponseEncoder extends OneToOneEncoder
             }
 
             nettyResponse.getOutputStream().flush();
-            response.setContent(nettyResponse.getBuffer());
+            final ChannelBuffer buffer = nettyResponse.getBuffer();
+
+            if (nettyResponse.getMethod() == null || nettyResponse.getMethod() != HttpMethod.HEAD) {
+                response.setContent(buffer);
+            }
 
             if (nettyResponse.isKeepAlive()) 
             {
                 // Add content length and connection header if needed
-                response.setHeader(Names.CONTENT_LENGTH, response.getContent().readableBytes());
+                response.setHeader(Names.CONTENT_LENGTH, buffer.readableBytes());
                 response.setHeader(Names.CONNECTION, Values.KEEP_ALIVE);
             }
             return response;

--- a/jaxrs/server-adapters/resteasy-netty/src/test/java/org/jboss/resteasy/test/NettyTest.java
+++ b/jaxrs/server-adapters/resteasy-netty/src/test/java/org/jboss/resteasy/test/NettyTest.java
@@ -4,15 +4,18 @@ import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 
 import static org.jboss.resteasy.test.TestPortProvider.generateURL;
@@ -68,6 +71,18 @@ public class NettyTest
       ResteasyWebTarget target = client.target(generateURL("/test"));
       String val = target.request().get(String.class);
       Assert.assertEquals("hello world", val);
+   }
+
+   @Test
+   public void testHeadContentLength() throws Exception
+   {
+      ResteasyClient client = new ResteasyClientBuilder().build();
+      ResteasyWebTarget target = client.target(generateURL("/test"));
+      Response getResponse = target.request().buildGet().invoke();
+      String val = ClientInvocation.extractResult(new GenericType<String>(String.class), getResponse, null);
+      Assert.assertEquals("hello world", val);
+      Response headResponse = target.request().build(HttpMethod.HEAD).invoke();
+      Assert.assertEquals("HEAD method should return the same Content-Length as the GET method", getResponse.getLength(), headResponse.getLength());
    }
 
    @Test


### PR DESCRIPTION
Backport of https://issues.jboss.org/browse/RESTEASY-1365 to 3.0.x.

EAP 7.x Jira (still waiting for acks):
https://issues.jboss.org/browse/JBEAP-4671

Upstream:
https://github.com/resteasy/Resteasy/pull/842   (already merged)