### PR TITLE
[RESTEASY-1420]

### DIFF
--- a/jaxrs/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/JAXBContextWrapper.java
+++ b/jaxrs/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/JAXBContextWrapper.java
@@ -242,6 +242,7 @@ public class JAXBContextWrapper extends JAXBContext
     * @see javax.xml.bind.JAXBContext#createValidator()
     * @deprecated See javax.xml.bind.JAXBContext#createValidator().
     */
+   @Deprecated
    public Validator createValidator() throws JAXBException
    {
       return wrappedContext.createValidator();

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/ClientResponseType.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/ClientResponseType.java
@@ -27,8 +27,13 @@ import java.lang.annotation.Target;
  *
  * @author <a href="mailto:sduskis@gmail.com">Solomon Duskis</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ * 
+ * @see javax.ws.rs.core.Response
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
-
+@Deprecated
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @SuppressWarnings("unchecked")

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/ClientInterceptor.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/ClientInterceptor.java
@@ -10,7 +10,13 @@ import java.lang.annotation.Target;
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy interceptor facility introduced in release 2.x
+ * is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ClientInterceptor

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/DecoderPrecedence.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/DecoderPrecedence.java
@@ -10,7 +10,13 @@ import java.lang.annotation.Target;
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy interceptor facility introduced in release 2.x
+ * is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Precedence("DECODER")

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/EncoderPrecedence.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/EncoderPrecedence.java
@@ -10,7 +10,13 @@ import java.lang.annotation.Target;
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy interceptor facility introduced in release 2.x
+ * is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Precedence("ENCODER")

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/HeaderDecoratorPrecedence.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/HeaderDecoratorPrecedence.java
@@ -11,7 +11,13 @@ import java.lang.annotation.Target;
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy interceptor facility introduced in release 2.x
+ * is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Precedence("HEADER_DECORATOR")

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/Precedence.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/Precedence.java
@@ -8,7 +8,13 @@ import java.lang.annotation.Target;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy interceptor facility introduced in release 2.x
+ * is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 @Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Precedence

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/RedirectPrecedence.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/RedirectPrecedence.java
@@ -12,7 +12,13 @@ import java.lang.annotation.Target;
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy interceptor facility introduced in release 2.x
+ * is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Precedence("REDIRECT")

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/SecurityPrecedence.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/SecurityPrecedence.java
@@ -13,7 +13,13 @@ import java.lang.annotation.Target;
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy interceptor facility introduced in release 2.x
+ * is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Precedence("SECURITY")

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/ServerInterceptor.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/interception/ServerInterceptor.java
@@ -10,7 +10,13 @@ import java.lang.annotation.Target;
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy interceptor facility introduced in release 2.x
+ * is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ServerInterceptor

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/BaseClientResponse.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/BaseClientResponse.java
@@ -48,7 +48,13 @@ import static java.lang.String.format;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ * 
+ * @see javax.ws.rs.core.Response
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 @SuppressWarnings("unchecked")
 public class BaseClientResponse<T> extends ClientResponse<T>
 {

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/ClientErrorInterceptor.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/ClientErrorInterceptor.java
@@ -14,7 +14,16 @@ import javax.ws.rs.core.Response;
  * encountered exception.
  *
  * @author <a href="mailto:lincoln@ocpsoft.com">Lincoln Baxter, III</a>
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy interceptor facility introduced in release 2.x
+ *             is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public interface ClientErrorInterceptor
 {
    /**

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/ClientInterceptorRepository.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/ClientInterceptorRepository.java
@@ -9,7 +9,16 @@ import java.util.LinkedList;
 /**
  * @author <a href="mailto:sduskis@gmail.com">Solomon Duskis</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy interceptor facility introduced in release 2.x
+ *             is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public interface ClientInterceptorRepository
 {
 

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/ClientInterceptorRepositoryImpl.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/ClientInterceptorRepositoryImpl.java
@@ -18,6 +18,17 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
 
+/**
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy interceptor facility introduced in release 2.x
+ *             is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
+ */
+@Deprecated
 @SuppressWarnings("unchecked")
 public class ClientInterceptorRepositoryImpl implements ClientInterceptorRepository
 {

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/ClientInvoker.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/ClientInvoker.java
@@ -29,7 +29,17 @@ import java.util.Map;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *
+ * @see org.jboss.resteasy.client.jaxrs.internal.proxy.ClientInvoker
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 @SuppressWarnings("unchecked")
 public class ClientInvoker extends ClientInterceptorRepositoryImpl implements MethodInvoker
 {

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/ClientInvokerInterceptorFactory.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/ClientInvokerInterceptorFactory.java
@@ -4,6 +4,17 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 import java.lang.reflect.Method;
 
+/**
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy interceptor facility introduced in release 2.x
+ *             is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
+ */
+@Deprecated
 @SuppressWarnings("unchecked")
 public class ClientInvokerInterceptorFactory
 {

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/ClientInvokerModifier.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/ClientInvokerModifier.java
@@ -6,7 +6,16 @@ package org.jboss.resteasy.client.core;
  *
  * @author <a href="mailto:sduskis@gmail.com">Solomon Duskis</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *             
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public interface ClientInvokerModifier
 {
    void modify(ClientInvoker invoker);

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/ClientProxy.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/ClientProxy.java
@@ -12,7 +12,16 @@ import java.util.Map;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *  
+ *  @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public class ClientProxy implements InvocationHandler
 {
 	private Map<Method, MethodInvoker> methodMap;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/MethodInvoker.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/MethodInvoker.java
@@ -1,5 +1,16 @@
 package org.jboss.resteasy.client.core;
 
+/**
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *             
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
+ */
+@Deprecated
 public interface MethodInvoker
 {
 	Object invoke(Object[] args);

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/SelfExpandingBufferredInputStream.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/SelfExpandingBufferredInputStream.java
@@ -13,7 +13,13 @@ import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
  * stream.
  *
  * @author ul8b
+ * 
+ * @deprecated Replaced by org.jboss.resteasy.client.jaxrs.engines.SelfExpandingBufferredInputStream
+ *             in resteasy-client module
+ *             
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public class SelfExpandingBufferredInputStream extends BufferedInputStream
 {
    private static int defaultBufferSize = 8192;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/SubResourceInvoker.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/SubResourceInvoker.java
@@ -10,6 +10,18 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.net.URI;
 
+/**
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *             
+ *             
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
+ */
+@Deprecated
 public class SubResourceInvoker implements MethodInvoker
 {
 	final ProxyConfig config;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/VoidEntityTypeFactory.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/VoidEntityTypeFactory.java
@@ -4,6 +4,13 @@ import org.jboss.resteasy.client.EntityTypeFactory;
 
 import javax.ws.rs.core.MultivaluedMap;
 
+/**
+* 
+* @deprecated The Resteasy client framework in resteasy-jaxrs is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+* 
+* @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
+*/
+@Deprecated
 public class VoidEntityTypeFactory implements EntityTypeFactory
 {
 

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/executors/ApacheHttpClient4Executor.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/executors/ApacheHttpClient4Executor.java
@@ -49,7 +49,11 @@ import java.util.Map;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated Replaced by org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine and
+ *             org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient43Engine in resteasy-client module
  */
+@Deprecated
 public class ApacheHttpClient4Executor implements ClientExecutor
 {
    public static final String BYTE_MEMORY_UNIT = "BY";

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/executors/InMemoryClientExecutor.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/executors/InMemoryClientExecutor.java
@@ -33,7 +33,10 @@ import java.util.Map.Entry;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated 
  */
+@Deprecated
 @SuppressWarnings("unchecked")
 public class InMemoryClientExecutor implements ClientExecutor
 {

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/executors/URLConnectionClientExecutor.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/executors/URLConnectionClientExecutor.java
@@ -21,6 +21,13 @@ import java.util.Map.Entry;
 
 import static org.jboss.resteasy.util.HttpHeaderNames.*;
 
+/**
+ * 
+ * @deprecated Replaced by org.jboss.resteasy.client.jaxrs.engines.URLConnectionEngine
+ *             in resteasy-client module
+ * 
+ */
+@Deprecated
 public class URLConnectionClientExecutor implements ClientExecutor
 {
 

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/BodyEntityExtractor.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/BodyEntityExtractor.java
@@ -20,7 +20,18 @@ import java.lang.reflect.Method;
  * @version $Revision: 1 $
  * @see EntityExtractorFactory
  * @see MessageBodyReader
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs is replaced by
+ *             the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ * 
+ * @see org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.BodyEntityExtractor
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
+ * 
  */
+@Deprecated
 @SuppressWarnings("unchecked")
 public class BodyEntityExtractor implements EntityExtractor
 {

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/ClientErrorHandler.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/ClientErrorHandler.java
@@ -11,10 +11,18 @@ import java.util.List;
  * This class handles client errors (of course...).
  *
  * @author Solomon.Duskis
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs is replaced by
+ *             the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *             
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
 
 // TODO: expand this class for more robust, complicated error handling
-
+@Deprecated
 public class ClientErrorHandler
 {
    private List<ClientErrorInterceptor> interceptors;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/ClientRequestContext.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/ClientRequestContext.java
@@ -5,6 +5,17 @@ import org.jboss.resteasy.client.core.BaseClientResponse;
 
 import java.net.URI;
 
+/**
+ * @deprecated The Resteasy client framework in resteasy-jaxrs is replaced by
+ *             the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ * 
+ * @see org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ClientContext
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
+ */
+@Deprecated
 public class ClientRequestContext
 {
    private ClientRequest request;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/ClientResponseProxy.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/ClientResponseProxy.java
@@ -16,7 +16,17 @@ import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
  * @see EntityExtractor
  * @see EntityExtractorFactory
  * @see ResponseObjectEntityExtractorFactory
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs is replaced by
+ *             the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ * 
+ * @see org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ClientResponseProxy
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 @SuppressWarnings("unchecked")
 public class ClientResponseProxy implements InvocationHandler
 {

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/DefaultEntityExtractorFactory.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/DefaultEntityExtractorFactory.java
@@ -17,7 +17,16 @@ import java.lang.reflect.Type;
 
 /**
  * @author Solomon.Duskis
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs is replaced by
+ *             the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ * 
+ * @see org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.DefaultEntityExtractorFactory
  */
+@Deprecated
 @SuppressWarnings("unchecked")
 public class DefaultEntityExtractorFactory implements EntityExtractorFactory
 {

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/EntityExtractor.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/EntityExtractor.java
@@ -9,7 +9,16 @@ package org.jboss.resteasy.client.core.extractors;
  * @author <a href="mailto:sduskis@gmail.com">Solomon Duskis</a>
  * @version $Revision: 1 $
  * @see EntityExtractorFactory
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs is replaced by
+ *             the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ * 
+ * @see org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.EntityExtractor
  */
+@Deprecated
 public interface EntityExtractor<T>
 {
    T extractEntity(ClientRequestContext context, Object... args);

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/EntityExtractorFactory.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/EntityExtractorFactory.java
@@ -11,7 +11,16 @@ import java.lang.reflect.Method;
  * @version $Revision: 1 $
  * @see EntityExtractor, DefaultObjectEntityExtractor,
  *      ResponseObjectEntityExtractor
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs is replaced by
+ *             the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ * 
+ * @see org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.EntityExtractorFactory
  */
+@Deprecated
 public interface EntityExtractorFactory
 {
    @SuppressWarnings("unchecked")

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/ResponseObjectEntityExtractorFactory.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/ResponseObjectEntityExtractorFactory.java
@@ -30,7 +30,16 @@ import java.util.Set;
  * @author <a href="mailto:sduskis@gmail.com">Solomon Duskis</a>
  * @version $Revision: 1 $
  * @see EntityExtractor, ResponseObjectEntityExtractor
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs is replaced by
+ *             the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ * 
+ * @see org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.EntityExtractorResponseObjectEntityExtractorFactoryFactory
  */
+@Deprecated
 public class ResponseObjectEntityExtractorFactory extends DefaultEntityExtractorFactory
 {
 

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/ResponseObjectProxy.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/extractors/ResponseObjectProxy.java
@@ -12,8 +12,16 @@ import java.util.HashMap;
  * @author <a href="mailto:sduskis@gmail.com">Solomon Duskis</a>
  * @version $Revision: 1 $
  * @see EntityExtractor, ResponseObjectEntityExtractorFactory
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs is replaced by
+ *             the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ * 
+ * @see org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ResponseObjectProxy
  */
-
+@Deprecated
 @SuppressWarnings("unchecked")
 public class ResponseObjectProxy<T> implements EntityExtractor
 {

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/ClientMarshallerFactory.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/ClientMarshallerFactory.java
@@ -24,6 +24,19 @@ import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
+/**
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *  
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.webtarget
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
+ */
+@Deprecated
 public class ClientMarshallerFactory
 {
 

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/CookieParamMarshaller.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/CookieParamMarshaller.java
@@ -7,7 +7,19 @@ import javax.ws.rs.core.Cookie;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *  
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.webtarget
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public class CookieParamMarshaller implements Marshaller
 {
    private String cookieName;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/FormMarshaller.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/FormMarshaller.java
@@ -22,7 +22,19 @@ import java.util.Map;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *  
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.webtarget
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public class FormMarshaller implements Marshaller
 {
    protected HashMap<Field, Marshaller> fieldMap = new HashMap<Field, Marshaller>();

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/FormParamMarshaller.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/FormParamMarshaller.java
@@ -7,7 +7,19 @@ import java.util.Collection;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *  
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.webtarget
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public class FormParamMarshaller implements Marshaller
 {
    private String paramName;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/HeaderParamMarshaller.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/HeaderParamMarshaller.java
@@ -7,7 +7,19 @@ import java.util.Collection;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *  
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.webtarget
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public class HeaderParamMarshaller implements Marshaller
 {
    private String paramName;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/Marshaller.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/Marshaller.java
@@ -5,7 +5,19 @@ import org.jboss.resteasy.client.ClientRequest;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *  
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.webtarget
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public interface Marshaller
 {
    void build(ClientRequest request, Object target);

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/MatrixParamMarshaller.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/MatrixParamMarshaller.java
@@ -8,7 +8,19 @@ import org.jboss.resteasy.client.ClientRequest;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *  
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.webtarget
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public class MatrixParamMarshaller implements Marshaller
 {
    private String paramName;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/MessageBodyParameterMarshaller.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/MessageBodyParameterMarshaller.java
@@ -9,7 +9,19 @@ import java.lang.reflect.Type;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *  
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.webtarget
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public class MessageBodyParameterMarshaller implements Marshaller
 {
    private Class type;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/NOOPMarshaller.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/NOOPMarshaller.java
@@ -6,7 +6,19 @@ import org.jboss.resteasy.client.ClientRequest;
  * Marshaller that doesn't do anything with the target. Useful for @Context parameters which are server-generated.
  *
  * @author Stephane Epardaud
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *  
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.webtarget
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public class NOOPMarshaller implements Marshaller
 {
 

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/PathParamMarshaller.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/PathParamMarshaller.java
@@ -6,7 +6,19 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *  
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.webtarget
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public class PathParamMarshaller implements Marshaller
 {
    private String paramName;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/QueryParamMarshaller.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/QueryParamMarshaller.java
@@ -7,7 +7,19 @@ import java.util.Collection;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *  
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.webtarget
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public class QueryParamMarshaller implements Marshaller
 {
    private String paramName;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/ResteasyClientProxy.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/ResteasyClientProxy.java
@@ -12,6 +12,17 @@ import java.util.Collection;
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *  
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.webtarget
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
 @Deprecated
 public interface ResteasyClientProxy

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/URIParamMarshaller.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/core/marshallers/URIParamMarshaller.java
@@ -11,7 +11,19 @@ import java.net.URL;
  *
  * @author <a href="mailto:sduskis@gmail.com">Solomon Duskis</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy client framework in resteasy-jaxrs
+ *             is replaced by the JAX-RS 2.0 compliant resteasy-client module.
+ *             
+ *             The Resteasy client proxy framework is replaced by the client proxy
+ *             framework in resteasy-client module.
+ *  
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation
+ * @see package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.webtarget
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 public class URIParamMarshaller implements Marshaller
 {
    public void build(ClientRequest request, Object target)

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyAuthChallengeException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyAuthChallengeException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyAuthChallengeException extends ResteasyAuthenticationException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyAuthenticationException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyAuthenticationException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyAuthenticationException extends ResteasyProtocolException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyCircularRedirectException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyCircularRedirectException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyCircularRedirectException extends ResteasyRedirectException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyClientException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyClientException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyClientException extends RuntimeException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyClientProtocolException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyClientProtocolException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyClientProtocolException extends ResteasyIOException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyConnectTimeoutException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyConnectTimeoutException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyConnectTimeoutException extends ResteasyIOException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyConnectionClosedException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyConnectionClosedException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyConnectionClosedException extends ResteasyIOException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyConnectionPoolTimeoutException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyConnectionPoolTimeoutException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyConnectionPoolTimeoutException extends ResteasyConnectTimeoutException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyCookieRestrictionViolationException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyCookieRestrictionViolationException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyCookieRestrictionViolationException extends ResteasyMalformedCookieException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyCredentialsNotAvailableException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyCredentialsNotAvailableException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyCredentialsNotAvailableException extends ResteasyAuthenticationException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyHttpContentTooLargeException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyHttpContentTooLargeException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyHttpContentTooLargeException extends ResteasyHttpException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyHttpException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyHttpException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyHttpException extends ResteasyClientException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyHttpHostConnectException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyHttpHostConnectException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyHttpHostConnectException extends ResteasyIOException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyHttpRecoverableException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyHttpRecoverableException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyHttpRecoverableException extends ResteasyHttpException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyIOException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyIOException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyIOException extends ResteasyClientException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyInvalidCredentialsException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyInvalidCredentialsException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyInvalidCredentialsException extends ResteasyAuthenticationException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyInvalidRedirectLocationException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyInvalidRedirectLocationException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyInvalidRedirectLocationException extends ResteasyRedirectException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyMalformedChallengeException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyMalformedChallengeException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyMalformedChallengeException extends ResteasyProtocolException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyMalformedChunkCodingException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyMalformedChunkCodingException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyMalformedChunkCodingException extends ResteasyIOException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyMalformedCookieException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyMalformedCookieException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyMalformedCookieException extends ResteasyProtocolException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyMethodNotSupportedException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyMethodNotSupportedException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyMethodNotSupportedException extends ResteasyHttpException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyNTLMEngineException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyNTLMEngineException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyNTLMEngineException extends ResteasyAuthenticationException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyNoHttpResponseException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyNoHttpResponseException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyNoHttpResponseException extends ResteasyIOException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyNonRepeatableRequestException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyNonRepeatableRequestException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyNonRepeatableRequestException extends ResteasyProtocolException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyProtocolException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyProtocolException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyProtocolException extends ResteasyHttpException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyRedirectException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyRedirectException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyRedirectException extends ResteasyNonRepeatableRequestException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyTunnelRefusedException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyTunnelRefusedException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyTunnelRefusedException extends ResteasyProtocolException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyURIException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyURIException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyURIException extends ResteasyHttpException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyUnsupportedHttpVersionException.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/ResteasyUnsupportedHttpVersionException.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public class ResteasyUnsupportedHttpVersionException extends ResteasyProtocolException
 {
 	private static final long serialVersionUID = -5711578608757689465L;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/mapper/ApacheHttpClient4ExceptionMapper.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/mapper/ApacheHttpClient4ExceptionMapper.java
@@ -54,7 +54,11 @@ import java.io.IOException;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 @Provider
 public class ApacheHttpClient4ExceptionMapper implements ClientExceptionMapper<Exception>
 {

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/mapper/ClientExceptionMapper.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/exception/mapper/ClientExceptionMapper.java
@@ -5,7 +5,11 @@ package org.jboss.resteasy.client.exception.mapper;
  * @version $Revision: 1.1 $
  *
  * Copyright Jul 28, 2012
+ * 
+ * @deprecated The JAX-RS 2.0 client proxy framework in resteasy-client module
+ *             does not use org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper. 
  */
+@Deprecated
 public interface ClientExceptionMapper<E extends Throwable>
 {
       RuntimeException toException(E exception);

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResteasyHttpServletRequestWrapper.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResteasyHttpServletRequestWrapper.java
@@ -196,6 +196,7 @@ public class ResteasyHttpServletRequestWrapper extends ServletRequestWrapper imp
    *
    */
    @Override
+   @Deprecated
    public boolean isRequestedSessionIdFromUrl()
    {
       return proxy.isRequestedSessionIdFromUrl();

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResteasyHttpServletResponseWrapper.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResteasyHttpServletResponseWrapper.java
@@ -164,6 +164,7 @@ public class ResteasyHttpServletResponseWrapper extends ServletResponseWrapper i
     * @return    the encoded URL if encoding is needed; 
     *         the unchanged URL otherwise.
     */
+   @Deprecated
    @Override
    public String encodeUrl(String url)
    {
@@ -178,6 +179,7 @@ public class ResteasyHttpServletResponseWrapper extends ServletResponseWrapper i
     * @return    the encoded URL if encoding is needed; 
     *         the unchanged URL otherwise.
     */
+   @Deprecated
    @Override
    public String encodeRedirectUrl(String url)
    {
@@ -255,6 +257,7 @@ public class ResteasyHttpServletResponseWrapper extends ServletResponseWrapper i
     * @param  sc the status code
     * @param  sm the status message
     */
+   @Deprecated
    @Override
    public void setStatus(int sc, String sm)
    {

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/LegacyPrecedence.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/LegacyPrecedence.java
@@ -15,7 +15,14 @@ import java.util.Map;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy interceptor facility introduced in release 2.x
+ * is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
+ * 
  */
+@Deprecated
 public class LegacyPrecedence
 {
    private static final int DEFAULTS_ORDER = 100000;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/logging/Logger.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/logging/Logger.java
@@ -10,7 +10,11 @@ import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy logger is no longer used. Resteasy now uses the JBoss logging framework.
+ * 
  */
+@Deprecated
 public abstract class Logger
 {
    public static enum LoggerType

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/logging/impl/JULLogger.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/logging/impl/JULLogger.java
@@ -5,7 +5,10 @@ import org.jboss.resteasy.logging.Logger;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy logger is no longer used. Resteasy now uses the JBoss logging framework.
  */
+@Deprecated
 public class JULLogger extends Logger
 {
    private transient java.util.logging.Logger delegate;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/logging/impl/Log4jLogger.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/logging/impl/Log4jLogger.java
@@ -7,7 +7,10 @@ import java.text.MessageFormat;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy logger is no longer used. Resteasy now uses the JBoss logging framework.
  */
+@Deprecated
 public class Log4jLogger extends org.jboss.resteasy.logging.Logger
 {
    private transient Logger delegate;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/logging/impl/Slf4jLogger.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/logging/impl/Slf4jLogger.java
@@ -8,7 +8,10 @@ import java.text.MessageFormat;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy logger is no longer used. Resteasy now uses the JBoss logging framework.
  */
+@Deprecated
 public class Slf4jLogger extends org.jboss.resteasy.logging.Logger
 {
    private transient Logger delegate;

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/delegates/ServerCookie.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/delegates/ServerCookie.java
@@ -77,6 +77,7 @@ public class ServerCookie implements Serializable
    /**
     * @deprecated Not used: Deprecated in the orginal org.apache.tomcat.util.http.ServerCookie class.
     */
+   @Deprecated
    public static boolean checkName(String name)
    {
       if (!isToken(name)

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/interceptors/encoding/AcceptEncodingGZIPInterceptor.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/interceptors/encoding/AcceptEncodingGZIPInterceptor.java
@@ -16,7 +16,14 @@ import javax.ws.rs.ext.Provider;
  *
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy interceptor facility introduced in release 2.x
+ * is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
+ * 
  */
+@Deprecated
 @Provider
 @ClientInterceptor
 @HeaderDecoratorPrecedence

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/test/TestPortProvider.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/test/TestPortProvider.java
@@ -28,7 +28,11 @@ import java.net.URL;
  *
  * @author <a href="justin@justinedelson.com">Justin Edelson</a>
  * @version $Revision$
+ * 
+ * @deprecated Replaced by org.jboss.resteasy.test.TestPortProvider in resteasy-client module.
+ * 
  */
+@Deprecated
 public class TestPortProvider
 {
    private static final int DEFAULT_PORT = 8081;

--- a/jaxrs/security/resteasy-crypto/src/main/java/org/jboss/resteasy/security/doseta/DigitalSigningHeaderDecoratorClientExecutionInterceptor.java
+++ b/jaxrs/security/resteasy-crypto/src/main/java/org/jboss/resteasy/security/doseta/DigitalSigningHeaderDecoratorClientExecutionInterceptor.java
@@ -14,7 +14,13 @@ import java.lang.reflect.Method;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy interceptor facility introduced in release 2.x
+ * is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 @Provider
 @HeaderDecoratorPrecedence
 public class DigitalSigningHeaderDecoratorClientExecutionInterceptor extends AbstractDigitalSigningHeaderDecorator implements ClientExecutionInterceptor, AcceptedByMethod

--- a/jaxrs/security/resteasy-crypto/src/main/java/org/jboss/resteasy/security/doseta/DigitalVerificationHeaderDecoratorClientExecutionInterceptor.java
+++ b/jaxrs/security/resteasy-crypto/src/main/java/org/jboss/resteasy/security/doseta/DigitalVerificationHeaderDecoratorClientExecutionInterceptor.java
@@ -14,7 +14,13 @@ import java.lang.reflect.Method;
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
+ * 
+ * @deprecated The Resteasy interceptor facility introduced in release 2.x
+ * is replaced by the JAX-RS 2.0 compliant interceptor facility in release 3.0.x.
+ * 
+ * @see jaxrs-api (https://jcp.org/en/jsr/detail?id=339)
  */
+@Deprecated
 @Provider
 @HeaderDecoratorPrecedence
 public class DigitalVerificationHeaderDecoratorClientExecutionInterceptor extends AbstractDigitalVerificationHeaderDecorator implements ClientExecutionInterceptor, AcceptedByMethod

--- a/jaxrs/tjws/src/main/java/Acme/Serve/Serve.java
+++ b/jaxrs/tjws/src/main/java/Acme/Serve/Serve.java
@@ -5200,6 +5200,7 @@ public class Serve implements ServletContext, Serializable
        * this method is deprecated and has no replacement.
        * It will be removed in a future version of the Java Servlet API.
        */
+      @Deprecated
       public HttpSessionContext getSessionContext()
       {
          return sessionContext;


### PR DESCRIPTION
Deprecated various classes:

 * old client framework
 * old client executors
 * client exception mapping
 * old proxy framework
 * old interceptor framework
 * old cache facility
 * Resteasy logger
 * Resteasy Link
 * Resteasy GenericType
 * Resteasy asynchronous facility