### PR TITLE
RESTEASY-1439: ETag not quoted in ResponseBuilder.tag(String tag)

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResponseBuilderImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResponseBuilderImpl.java
@@ -231,8 +231,7 @@ public class ResponseBuilderImpl extends Response.ResponseBuilder
          metadata.remove(HttpHeaderNames.ETAG);
          return this;
       }
-      metadata.putSingle(HttpHeaderNames.ETAG, tag);
-      return this;
+      return tag(new EntityTag(tag));
    }
 
    @Override

--- a/resteasy-jaxrs/src/test/java/org/jboss/resteasy/specimpl/ResponseBuilderImplTest.java
+++ b/resteasy-jaxrs/src/test/java/org/jboss/resteasy/specimpl/ResponseBuilderImplTest.java
@@ -1,0 +1,42 @@
+package org.jboss.resteasy.specimpl;
+
+import org.junit.Test;
+
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author <a href="dmitry.bedrin@gmail.com">Dmitry Bedrin</a>
+ */
+public class ResponseBuilderImplTest {
+
+    @Test
+    public void testObjectEntityTagValue() throws Exception {
+        Response response = Response.ok("entityValue").tag(new EntityTag("etagValue")).build();
+        assertEquals("\"etagValue\"", response.getHeaderString("ETag"));
+    }
+
+    /**
+     * test for RESTEASY-1439: ETag not quoted in ResponseBuilder.tag(String tag)
+     */
+    @Test
+    public void testStringEntityTagValue() throws Exception {
+        Response response = Response.ok("entityValue").tag("etagValue").build();
+        assertEquals("\"etagValue\"", response.getHeaderString("ETag"));
+    }
+
+    @Test
+    public void testNotModifiedWithObjectEntityTagValue() throws Exception {
+        Response response = Response.notModified(new EntityTag("etagValue")).build();
+        assertEquals("\"etagValue\"", response.getHeaderString("ETag"));
+    }
+
+    @Test
+    public void testNotModifiedWithStringEntityTagValue() throws Exception {
+        Response response = Response.notModified("etagValue").build();
+        assertEquals("\"etagValue\"", response.getHeaderString("ETag"));
+    }
+
+}


### PR DESCRIPTION
[RESTEASY-1439: ETag not quoted in ResponseBuilder.tag(String tag)](https://issues.jboss.org/browse/RESTEASY-1439)

`Response.status(412).entity(message).tag("123").build()` should generate `ETag: "123"` but instead does not quote the tag `ETag: 123.`
The [JAX-RS spec](http://docs.oracle.com/javaee/6/api/javax/ws/rs/core/Response.ResponseBuilder.html#tag(java.lang.String)) says:

> the ETag should be quoted by the runtime

Jersey adheres to the spec here, RESTEasy doesn't.
`ResponseBuilder.tag(EntityTag tag)` method works corrrectly but `ResponseBuilder.tag(String tag)` has this bug