### PR TITLE
[RESTEASY-1443]: Fix partial registration of application properties

### DIFF
--- a/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/properties/GetPropertiesTest.java
+++ b/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/properties/GetPropertiesTest.java
@@ -1,24 +1,24 @@
 package org.jboss.resteasy.test.nextgen.properties;
 
-import com.sun.net.httpserver.HttpContext;
-import com.sun.net.httpserver.HttpServer;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+import org.jboss.resteasy.plugins.server.sun.http.HttpContextBuilder;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.net.InetSocketAddress;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.Feature;
-import javax.ws.rs.core.FeatureContext;
-import org.jboss.resteasy.plugins.server.sun.http.HttpContextBuilder;
-
-
-import static org.jboss.resteasy.test.TestPortProvider.generateURL;
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpServer;
 
 /**
  * Simple smoke test
@@ -34,10 +34,13 @@ public class GetPropertiesTest {
     public static void before() throws Exception {
         server = HttpServer.create(new InetSocketAddress(8081), 1);
         contextBuilder = new HttpContextBuilder();
+		final Map<String, Object> applicationProperties = new HashMap<>();
+		applicationProperties.put("Prop1", "Value1");
+		applicationProperties.put("Prop2", "Value2");
         Application application = new Application() {
             @Override
             public Map<String, Object> getProperties() {
-                return Collections.<String, Object>singletonMap("Prop1","Value1");
+				return applicationProperties;
             }
 
             @Override
@@ -52,9 +55,8 @@ public class GetPropertiesTest {
 
                     @Override
                     public boolean configure(FeatureContext featureContext) {
-                        propertyOk = featureContext.getConfiguration().getProperties().containsKey("Prop1");
-                        return featureContext.getConfiguration()
-                                .getProperties().containsKey("Prop1");
+						propertyOk = applicationProperties.equals(featureContext.getConfiguration().getProperties());
+						return propertyOk;
                     }
                 });
             }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyDeployment.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyDeployment.java
@@ -537,22 +537,22 @@ public class ResteasyDeployment
             }
          }
       }
-      if (config.getProperties() != null)
+      final Map<String, Object> properties = config.getProperties();
+      if (properties != null && !properties.isEmpty())
       {
-         for (Map.Entry<String,Object> property : config.getProperties().entrySet())
-         {
-            final Map.Entry<String,Object> prop = property;
-            Object obj = new Feature() {
-
-                    @Override
-                    public boolean configure(FeatureContext featureContext) {
-                        featureContext = featureContext.property(prop.getKey(), prop.getValue());
-                        return featureContext.getConfiguration()
-                                .getProperties().containsKey(featureContext.getConfiguration().getProperties().containsKey(prop.getKey()));
-                    }
-                };
-            providers.add(0,obj);
-         }
+    	  Feature appliationPropertiesRegistrationfeature = new Feature() 
+    	  {
+			 @Override
+			 public boolean configure(FeatureContext featureContext)
+			 {
+				for (Map.Entry<String, Object> property : properties.entrySet())
+				{
+				   featureContext = featureContext.property(property.getKey(), property.getValue());
+				}
+				return true;
+			 }
+    	  };
+	      this.providers.add(0, appliationPropertiesRegistrationfeature);
       }
       return registered;
    }


### PR DESCRIPTION
This pull request is a fix proposition so that all the application properties can be retrieved using `featureContext.getConfiguration().getProperties()`.