### PR TITLE
[RESTEASY-1470] Property to specify resteasy version for testsuite + update creaper version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <version.org.slf4j>1.7.7</version.org.slf4j>
         <version.org.springframework.spring-webmvc>3.0.6.RELEASE</version.org.springframework.spring-webmvc>
         <version.org.wildfly.core.wildfly-cli>2.1.0.Final</version.org.wildfly.core.wildfly-cli>
-        <version.org.wildfly.extras.creaper>0.9.4</version.org.wildfly.extras.creaper>
+        <version.org.wildfly.extras.creaper>1.4.0</version.org.wildfly.extras.creaper>
         <version.org.wildfly.wildfly-arquillian-container-managed>2.0.0.Final
         </version.org.wildfly.wildfly-arquillian-container-managed>
         <version.org.wildfly-security>10.0.0.Final</version.org.wildfly-security>

--- a/testsuite/arquillian-utils/pom.xml
+++ b/testsuite/arquillian-utils/pom.xml
@@ -64,19 +64,19 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
         
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-validator-provider-11</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/TestUtil.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/TestUtil.java
@@ -13,7 +13,6 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.wildfly.extras.creaper.core.ManagementClient;
-import org.wildfly.extras.creaper.core.ServerType;
 import org.wildfly.extras.creaper.core.online.ModelNodeResult;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.OnlineOptions;
@@ -171,7 +170,6 @@ public class TestUtil {
         OnlineOptions onlineOptions = OnlineOptions
                     .standalone()
                     .hostAndPort(PortProviderUtil.getHost(), 9990) // 9990 is default port for EAP 7
-                    .serverType(ServerType.WILDFLY)
                     .connectionTimeout(120000)
                     .build();
         return ManagementClient.online(onlineOptions);

--- a/testsuite/integration-tests-spring/deployment/pom.xml
+++ b/testsuite/integration-tests-spring/deployment/pom.xml
@@ -108,20 +108,6 @@
 
     </profiles>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-    </dependencies>
-
     <build>
         <testResources>
             <testResource>

--- a/testsuite/integration-tests-spring/inmodule/pom.xml
+++ b/testsuite/integration-tests-spring/inmodule/pom.xml
@@ -113,31 +113,6 @@
         </profile>
     </profiles>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <version>${version.org.springframework}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-    </dependencies>
-
     <build>
         <testResources>
             <testResource>

--- a/testsuite/integration-tests-spring/pom.xml
+++ b/testsuite/integration-tests-spring/pom.xml
@@ -51,7 +51,19 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>${version.resteasy.testsuite}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxb-provider</artifactId>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
@@ -63,7 +75,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-spring</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
@@ -76,6 +88,17 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <version>${version.org.springframework}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${version.org.springframework}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
         </dependency>
     </dependencies>
 

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -118,67 +118,67 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-multipart-provider</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson-provider</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson2-provider</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jettison-provider</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-p-provider</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-yaml-provider</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-atom-provider</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-cdi</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-crypto</artifactId>
-            <version>${project.version}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -20,6 +20,10 @@
     
     <artifactId>resteasy-testsuite</artifactId>
 
+    <properties>
+        <version.resteasy.testsuite>${project.version}</version.resteasy.testsuite>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -72,6 +76,18 @@
             </activation>
             <properties>
                 <server.version>10.0.0.Final</server.version>
+            </properties>
+        </profile>
+        <!-- If resteasy.version is specified, it will be used for tests instead of the project.version -->
+        <profile>
+            <id>custom-resteasy-version</id>
+            <activation>
+                <property>
+                    <name>version.resteasy.testsuite</name>
+                </property>
+            </activation>
+            <properties>
+                <version.resteasy.testsuite>${version.resteasy.testsuite}</version.resteasy.testsuite>
             </properties>
         </profile>
 

--- a/testsuite/unit-tests/pom.xml
+++ b/testsuite/unit-tests/pom.xml
@@ -14,25 +14,6 @@
     <artifactId>resteasy-unit-tests</artifactId>
     <name>RESTEasy testsuite: Unit tests</name>
 
-    <properties>
-            <resteasy.version.unit.tests>${project.version}</resteasy.version.unit.tests>
-    </properties>
-
-    <!-- If resteasy.version is specified, it will be used for unit tests instead of the project.version -->
-    <profiles>
-        <profile>
-            <id>custom-resteasy-version</id>
-            <activation>
-                <property>
-                    <name>resteasy.version</name>
-                </property>
-            </activation>
-            <properties>
-                <resteasy.version.unit.tests>${resteasy.version}</resteasy.version.unit.tests>
-            </properties>
-        </profile>
-    </profiles>
-
 
     <dependencies>
         <dependency>
@@ -44,49 +25,49 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>${resteasy.version.unit.tests}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>${resteasy.version.unit.tests}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-atom-provider</artifactId>
-            <version>${resteasy.version.unit.tests}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jettison-provider</artifactId>
-            <version>${resteasy.version.unit.tests}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-cdi</artifactId>
-            <version>${resteasy.version.unit.tests}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-crypto</artifactId>
-            <version>${resteasy.version.unit.tests}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jose-jwt</artifactId>
-            <version>${resteasy.version.unit.tests}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-validator-provider-11</artifactId>
-            <version>${resteasy.version.unit.tests}</version>
+            <version>${version.resteasy.testsuite}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Custom resteasy version is needed to be able to run testsuite with different resteasy version than the project version. 

If the property "version.resteasy.testsuite" is  it applies to whole testsuite module. Otherwise project.version for resteasy dependencies is used.