### PR TITLE
[RESTEASY-1499] @GZIP annotation on client proxy doesn't set content-type gzip to the request header

### DIFF
--- a/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
+++ b/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
@@ -1,9 +1,9 @@
 package org.jboss.resteasy.client.jaxrs.internal;
 
+import org.jboss.resteasy.annotations.ContentEncoding;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.core.interception.AbstractWriterInterceptorContext;
 import org.jboss.resteasy.core.interception.ClientWriterInterceptorContext;
-import org.jboss.resteasy.spi.ResteasyConfiguration;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.util.DelegatingOutputStream;
 import org.jboss.resteasy.util.Types;
@@ -32,7 +32,6 @@ import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Variant;
-import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Providers;
 import javax.ws.rs.ext.WriterInterceptor;
 import java.io.IOException;
@@ -44,10 +43,7 @@ import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -327,7 +323,17 @@ public class ClientInvocation implements Invocation
          Variant v = entity.getVariant();
          headers.setMediaType(v.getMediaType());
          headers.setLanguage(v.getLanguage());
-         headers.header("Content-Encoding", v.getEncoding());
+
+         headers.header("Content-Encoding", null);
+
+         if(v.getEncoding() == null) {
+            for(Annotation annotation : this.entityAnnotations) {
+                ContentEncoding contentEncoding = annotation.annotationType().getAnnotation(ContentEncoding.class);
+               if(contentEncoding != null) {
+                  headers.header("Content-Encoding", contentEncoding.value());
+               }
+            }
+         }
       }
 
    }

--- a/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/interceptors/resource/GzipProxy.java
+++ b/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/interceptors/resource/GzipProxy.java
@@ -1,0 +1,18 @@
+package org.jboss.resteasy.test.nextgen.interceptors.resource;
+
+import org.jboss.resteasy.annotations.GZIP;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/gzippost")
+public interface GzipProxy {
+
+    @Consumes(MediaType.TEXT_PLAIN)
+    @POST
+    @GZIP
+    public Response post(@GZIP Pair pair);
+}

--- a/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/interceptors/resource/Pair.java
+++ b/jaxrs/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/nextgen/interceptors/resource/Pair.java
@@ -1,0 +1,26 @@
+package org.jboss.resteasy.test.nextgen.interceptors.resource;
+
+import java.io.Serializable;
+
+public class Pair implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private String P1;
+    private String P2;
+
+    public String getP1() {
+        return this.P1;
+    }
+
+    public String getP2() {
+        return this.P2;
+    }
+
+    public void setP1(String p1) {
+        this.P1 = p1;
+    }
+
+    public void setP2(String p2) {
+        this.P2 = p2;
+    }
+}


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/RESTEASY-1499