### PR TITLE
My resteasy 1341

### DIFF
--- a/jaxrs/resteasy-client/src/test/java/org/jboss/resteasy/test/internal/ClientInvocationBuilderTest.java
+++ b/jaxrs/resteasy-client/src/test/java/org/jboss/resteasy/test/internal/ClientInvocationBuilderTest.java
@@ -1,0 +1,101 @@
+package org.jboss.resteasy.test.internal;
+
+import java.io.ByteArrayOutputStream;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
+import org.jboss.resteasy.core.Dispatcher;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+import org.jboss.resteasy.test.EmbeddedContainer;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ClientInvocationBuilderTest {
+
+	protected static ResteasyDeployment deployment;
+	protected static Dispatcher dispatcher;
+	protected static ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+	@Path("/")
+	public static class TestResource {
+		@POST
+		@Produces("text/plain")
+		public String post(String s) {
+			System.out.println("server entity: " + s);
+			return s;
+		}
+
+		@GET
+		@Produces("text/plain")
+		public String get() {
+			String s = "default";
+			System.out.println("server entity: " + s);
+			return s;
+		}
+	}
+
+	@BeforeClass
+	public static void before() throws Exception {
+		deployment = EmbeddedContainer.start();
+		dispatcher = deployment.getDispatcher();
+		deployment.getRegistry().addPerRequestResource(TestResource.class);
+	}
+
+	@AfterClass
+	public static void after() throws Exception {
+		EmbeddedContainer.stop();
+		dispatcher = null;
+		deployment = null;
+	}
+
+	@Test
+	public void test_build_method_return_new_instance() {
+		ResteasyClient client = new ResteasyClientBuilder().build();
+		try {
+			ResteasyWebTarget webTarget = client.target("http://localhost:8081");
+			Builder invocationBuilder = webTarget.request();
+
+			// GET invocation
+			ClientInvocation getInvocation = (ClientInvocation) invocationBuilder.accept(MediaType.TEXT_PLAIN_TYPE)
+					.build("GET");
+			Assert.assertEquals("default", getInvocation.invoke(String.class));
+
+			// Alter invocationBuilder
+			invocationBuilder.accept(MediaType.APPLICATION_XML_TYPE);
+			invocationBuilder.property("property1", "property1Value");
+			// Previously built getInvocation must not have been altered.(Those
+			// tests are not about immutability of
+			// getInvocation instance but about Builder pattern behavior).
+			Assert.assertFalse(getInvocation.getHeaders().getAcceptableMediaTypes()
+					.contains(MediaType.APPLICATION_XML_TYPE));
+			Assert.assertFalse(getInvocation.getConfiguration().getProperties().containsKey("property1"));
+
+			// POST invocation
+			ClientInvocation postInvocation = (ClientInvocation) invocationBuilder.accept(MediaType.TEXT_PLAIN_TYPE)
+					.build("POST", Entity.text("test"));
+			// Previous lines must build a new postInvocation instance and not
+			// modify previously built getInvocation instance.
+			// (It's all about Builder pattern behavior not immutability since
+			// Invocation is a mutable object.)
+			Assert.assertNotSame(getInvocation, postInvocation);
+			Assert.assertEquals("default", getInvocation.invoke(String.class));
+			Assert.assertTrue(postInvocation.getConfiguration().getProperties().containsKey("property1"));
+			Assert.assertEquals("test", postInvocation.invoke(String.class));
+		} finally {
+			client.close();
+		}
+	}
+
+}

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/AsynchronousInvoke.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/AsynchronousInvoke.java
@@ -24,191 +24,157 @@ public class AsynchronousInvoke implements AsyncInvoker
    @Override
    public Future<Response> get()
    {
-      invocation.setMethod(HttpMethod.GET);
-      return invocation.submit();
+      return method(HttpMethod.GET);
    }
 
    @Override
    public <T> Future<T> get(Class<T> responseType)
    {
-      invocation.setMethod(HttpMethod.GET);
-      return invocation.submit(responseType);
+      return method(HttpMethod.GET, responseType);
    }
 
    @Override
    public <T> Future<T> get(GenericType<T> responseType)
    {
-      invocation.setMethod(HttpMethod.GET);
-      return invocation.submit(responseType);
+      return method(HttpMethod.GET, responseType);
    }
 
    @Override
    public <T> Future<T> get(InvocationCallback<T> callback)
    {
-      invocation.setMethod(HttpMethod.GET);
-      return invocation.submit(callback);
+      return method(HttpMethod.GET, callback);
    }
 
    @Override
    public Future<Response> trace()
    {
-      invocation.setMethod("TRACE");
-      return invocation.submit();
+      return method("TRACE");
    }
 
    @Override
    public <T> Future<T> trace(Class<T> responseType)
    {
-      invocation.setMethod("TRACE");
-      return invocation.submit(responseType);
+      return method("TRACE", responseType);
    }
 
    @Override
    public <T> Future<T> trace(GenericType<T> responseType)
    {
-      invocation.setMethod("TRACE");
-      return invocation.submit(responseType);
+      return method("TRACE", responseType);
    }
 
    @Override
    public <T> Future<T> trace(InvocationCallback<T> callback)
    {
-      invocation.setMethod("TRACE");
-      return invocation.submit(callback);
+      return method("TRACE", callback);
    }
 
    @Override
    public Future<Response> put(Entity<?> entity)
    {
-      invocation.setMethod(HttpMethod.PUT);
-      invocation.setEntity(entity);
-      return invocation.submit();
+      return method(HttpMethod.PUT, entity);
    }
 
    @Override
    public <T> Future<T> put(Entity<?> entity, Class<T> responseType)
    {
-      invocation.setMethod(HttpMethod.PUT);
-      invocation.setEntity(entity);
-      return invocation.submit(responseType);
+      return method(HttpMethod.PUT, entity, responseType);
    }
 
    @Override
    public <T> Future<T> put(Entity<?> entity, GenericType<T> responseType)
    {
-      invocation.setMethod(HttpMethod.PUT);
-      invocation.setEntity(entity);
-      return invocation.submit(responseType);
+      return method(HttpMethod.PUT, entity, responseType);
    }
 
    @Override
    public <T> Future<T> put(Entity<?> entity, InvocationCallback<T> callback)
    {
-      invocation.setMethod(HttpMethod.PUT);
-      invocation.setEntity(entity);
-      return invocation.submit(callback);
+      return method(HttpMethod.PUT, entity, callback);
    }
 
    @Override
    public Future<Response> post(Entity<?> entity)
    {
-      invocation.setMethod(HttpMethod.POST);
-      invocation.setEntity(entity);
-      return invocation.submit();
+      return method(HttpMethod.POST, entity);
    }
 
    @Override
    public <T> Future<T> post(Entity<?> entity, Class<T> responseType)
    {
-      invocation.setMethod(HttpMethod.POST);
-      invocation.setEntity(entity);
-      return invocation.submit(responseType);
+      return method(HttpMethod.POST, entity, responseType);
    }
 
    @Override
    public <T> Future<T> post(Entity<?> entity, GenericType<T> responseType)
    {
-      invocation.setMethod(HttpMethod.POST);
-      invocation.setEntity(entity);
-      return invocation.submit(responseType);
+      return method(HttpMethod.POST, entity, responseType);
    }
 
    @Override
    public <T> Future<T> post(Entity<?> entity, InvocationCallback<T> callback)
    {
-      invocation.setMethod(HttpMethod.POST);
-      invocation.setEntity(entity);
-      return invocation.submit(callback);
+      return method(HttpMethod.POST, entity, callback);
    }
 
    @Override
    public Future<Response> delete()
    {
-      invocation.setMethod(HttpMethod.DELETE);
-      return invocation.submit();
+      return method(HttpMethod.DELETE);
    }
 
    @Override
    public <T> Future<T> delete(Class<T> responseType)
    {
-      invocation.setMethod(HttpMethod.DELETE);
-      return invocation.submit(responseType);
+      return method(HttpMethod.DELETE, responseType);
    }
 
    @Override
    public <T> Future<T> delete(GenericType<T> responseType)
    {
-      invocation.setMethod(HttpMethod.DELETE);
-      return invocation.submit(responseType);
+      return method(HttpMethod.DELETE, responseType);
    }
 
    @Override
    public <T> Future<T> delete(InvocationCallback<T> callback)
    {
-      invocation.setMethod(HttpMethod.DELETE);
-      return invocation.submit(callback);
+      return method(HttpMethod.DELETE, callback);
    }
 
    @Override
    public Future<Response> head()
    {
-      invocation.setMethod(HttpMethod.HEAD);
-      return invocation.submit();
+      return method(HttpMethod.HEAD);
    }
 
    @Override
    public Future<Response> head(InvocationCallback<Response> callback)
    {
-      invocation.setMethod(HttpMethod.HEAD);
-      return invocation.submit(callback);
+      return method(HttpMethod.HEAD,callback);
    }
 
    @Override
    public Future<Response> options()
    {
-      invocation.setMethod(HttpMethod.OPTIONS);
-      return invocation.submit();
+      return method(HttpMethod.OPTIONS);
    }
 
    @Override
    public <T> Future<T> options(Class<T> responseType)
    {
-      invocation.setMethod(HttpMethod.OPTIONS);
-      return invocation.submit(responseType);
+      return method(HttpMethod.OPTIONS, responseType);
    }
 
    @Override
    public <T> Future<T> options(GenericType<T> responseType)
    {
-      invocation.setMethod(HttpMethod.OPTIONS);
-      return invocation.submit(responseType);
+      return method(HttpMethod.OPTIONS, responseType);
    }
 
    @Override
    public <T> Future<T> options(InvocationCallback<T> callback)
    {
-      invocation.setMethod(HttpMethod.OPTIONS);
-      return invocation.submit(callback);
+      return method(HttpMethod.OPTIONS, callback);
    }
 
 
@@ -216,6 +182,7 @@ public class AsynchronousInvoke implements AsyncInvoker
    public Future<Response> method(String name)
    {
       invocation.setMethod(name);
+      invocation.setEntity(null);
       return invocation.submit();
    }
 
@@ -223,6 +190,7 @@ public class AsynchronousInvoke implements AsyncInvoker
    public <T> Future<T> method(String name, Class<T> responseType)
    {
       invocation.setMethod(name);
+      invocation.setEntity(null);
       return invocation.submit(responseType);
    }
 
@@ -230,6 +198,7 @@ public class AsynchronousInvoke implements AsyncInvoker
    public <T> Future<T> method(String name, GenericType<T> responseType)
    {
       invocation.setMethod(name);
+      invocation.setEntity(null);
       return invocation.submit(responseType);
    }
 
@@ -237,6 +206,7 @@ public class AsynchronousInvoke implements AsyncInvoker
    public <T> Future<T> method(String name, InvocationCallback<T> callback)
    {
       invocation.setMethod(name);
+      invocation.setEntity(null);
       return invocation.submit(callback);
    }
 

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.client.jaxrs.internal;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.core.interception.AbstractWriterInterceptorContext;
 import org.jboss.resteasy.core.interception.ClientWriterInterceptorContext;
+import org.jboss.resteasy.specimpl.MultivaluedTreeMap;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.util.DelegatingOutputStream;
 import org.jboss.resteasy.util.Types;
@@ -34,6 +35,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Variant;
 import javax.ws.rs.ext.Providers;
 import javax.ws.rs.ext.WriterInterceptor;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -41,7 +43,10 @@ import java.io.Reader;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
@@ -81,7 +86,7 @@ public class ClientInvocation implements Invocation
       this.client = clientInvocation.client;
       this.configuration = new ClientConfiguration(clientInvocation.configuration);
       this.headers =  new ClientRequestHeaders(this.configuration);
-      this.headers.setHeaders(clientInvocation.headers.getHeaders());
+      MultivaluedTreeMap.copy(clientInvocation.headers.getHeaders(), this.headers.headers);
       this.method = clientInvocation.method;
       this.entity = clientInvocation.entity;
       this.entityGenericType = clientInvocation.entityGenericType;

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
@@ -75,6 +75,20 @@ public class ClientInvocation implements Invocation
       this.configuration = new ClientConfiguration(parent);
       this.headers = headers;
    }
+   
+   ClientInvocation(ClientInvocation clientInvocation)
+   {
+      this.client = clientInvocation.client;
+      this.configuration = new ClientConfiguration(clientInvocation.configuration);
+      this.headers =  new ClientRequestHeaders(this.configuration);
+      this.headers.setHeaders(clientInvocation.headers.getHeaders());
+      this.method = clientInvocation.method;
+      this.entity = clientInvocation.entity;
+      this.entityGenericType = clientInvocation.entityGenericType;
+      this.entityClass = clientInvocation.entityClass;
+      this.entityAnnotations = clientInvocation.entityAnnotations;
+      this.uri = clientInvocation.uri;
+   }
 
    /**
     * Extracts result from response throwing an appropriate exception if not a successful response.

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocationBuilder.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocationBuilder.java
@@ -21,16 +21,11 @@ import java.util.Locale;
  */
 public class ClientInvocationBuilder implements Invocation.Builder
 {
-   protected ClientInvocation invocation;
+   private final ClientInvocation invocation;
 
    public ClientInvocationBuilder(ResteasyClient client, URI uri, ClientConfiguration configuration)
    {
       invocation = new ClientInvocation(client, uri, new ClientRequestHeaders(configuration), configuration);
-   }
-
-   public ClientInvocation getInvocation()
-   {
-      return invocation;
    }
 
    public ClientRequestHeaders getHeaders()

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocationBuilder.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocationBuilder.java
@@ -111,8 +111,8 @@ public class ClientInvocationBuilder implements Invocation.Builder
    @Override
    public Invocation build(String method)
    {
-      invocation.setMethod(method);
-      return invocation;
+	  invocation.setMethod(method);
+      return new ClientInvocation(this.invocation);
    }
 
    @Override
@@ -120,7 +120,7 @@ public class ClientInvocationBuilder implements Invocation.Builder
    {
       invocation.setMethod(method);
       invocation.setEntity(entity);
-      return invocation;
+      return new ClientInvocation(this.invocation);
    }
 
    @Override
@@ -150,7 +150,7 @@ public class ClientInvocationBuilder implements Invocation.Builder
    @Override
    public AsyncInvoker async()
    {
-      return new AsynchronousInvoke(invocation);
+      return new AsynchronousInvoke(new ClientInvocation(this.invocation));
    }
 
    @Override

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocationBuilder.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocationBuilder.java
@@ -111,8 +111,7 @@ public class ClientInvocationBuilder implements Invocation.Builder
    @Override
    public Invocation build(String method)
    {
-	  invocation.setMethod(method);
-      return new ClientInvocation(this.invocation);
+      return build(method, null);
    }
 
    @Override

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientWebTarget.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientWebTarget.java
@@ -86,7 +86,7 @@ public class ClientWebTarget implements ResteasyWebTarget
    public URI getUri()
    {
       client.abortIfClosed();
-      return uriBuilder.clone().build();
+      return uriBuilder.build();
    }
 
    @Override
@@ -137,7 +137,7 @@ public class ClientWebTarget implements ResteasyWebTarget
       if (name == null) throw new NullPointerException(Messages.MESSAGES.nameWasNull());
       if (value == null) throw new NullPointerException(Messages.MESSAGES.valueWasNull());
       String val = configuration.toString(value);
-      UriBuilder copy = uriBuilder.resolveTemplate(name, val);
+      UriBuilder copy = uriBuilder.clone().resolveTemplate(name, val);
       ClientWebTarget target = new ClientWebTarget(client, copy, configuration);
       return target;
    }
@@ -155,7 +155,7 @@ public class ClientWebTarget implements ResteasyWebTarget
          String val = configuration.toString(entry.getValue());
          vals.put(entry.getKey(), val);
       }
-      UriBuilder copy = uriBuilder.resolveTemplates(vals);
+      UriBuilder copy = uriBuilder.clone().resolveTemplates(vals);
       ClientWebTarget target = new ClientWebTarget(client, copy, configuration);
       return target;
    }
@@ -167,7 +167,7 @@ public class ClientWebTarget implements ResteasyWebTarget
       if (name == null) throw new NullPointerException(Messages.MESSAGES.nameWasNull());
       if (value == null) throw new NullPointerException(Messages.MESSAGES.valueWasNull());
       String val = configuration.toString(value);
-      UriBuilder copy = uriBuilder.resolveTemplate(name, val, encodeSlashInPath);
+      UriBuilder copy = uriBuilder.clone().resolveTemplate(name, val, encodeSlashInPath);
       ClientWebTarget target = new ClientWebTarget(client, copy, configuration);
       return target;
    }
@@ -179,7 +179,7 @@ public class ClientWebTarget implements ResteasyWebTarget
       if (name == null) throw new NullPointerException(Messages.MESSAGES.nameWasNull());
       if (value == null) throw new NullPointerException(Messages.MESSAGES.valueWasNull());
       String val = configuration.toString(value);
-      UriBuilder copy = uriBuilder.resolveTemplateFromEncoded(name, val);
+      UriBuilder copy = uriBuilder.clone().resolveTemplateFromEncoded(name, val);
       ClientWebTarget target = new ClientWebTarget(client, copy, configuration);
       return target;
    }
@@ -197,7 +197,7 @@ public class ClientWebTarget implements ResteasyWebTarget
          String val = configuration.toString(entry.getValue());
          vals.put(entry.getKey(), val);
       }
-      UriBuilder copy = uriBuilder.resolveTemplatesFromEncoded(vals) ;
+      UriBuilder copy = uriBuilder.clone().resolveTemplatesFromEncoded(vals) ;
       ClientWebTarget target = new ClientWebTarget(client, copy, configuration);
       return target;
    }
@@ -215,7 +215,7 @@ public class ClientWebTarget implements ResteasyWebTarget
          String val = configuration.toString(entry.getValue());
          vals.put(entry.getKey(), val);
       }
-      UriBuilder copy = uriBuilder.resolveTemplates(vals, encodeSlashInPath) ;
+      UriBuilder copy = uriBuilder.clone().resolveTemplates(vals, encodeSlashInPath) ;
       ClientWebTarget target = new ClientWebTarget(client, copy, configuration);
       return target;
    }
@@ -233,7 +233,7 @@ public class ClientWebTarget implements ResteasyWebTarget
       else
       {
          String[] stringValues = toStringValues(values);
-         copy = uriBuilder.clone().matrixParam(name, stringValues);
+         copy.matrixParam(name, stringValues);
       }
       return new ClientWebTarget(client, copy, configuration);
    }
@@ -261,7 +261,7 @@ public class ClientWebTarget implements ResteasyWebTarget
       else
       {
          String[] stringValues = toStringValues(values);
-         copy = uriBuilder.clone().queryParam(name, stringValues);
+         copy.queryParam(name, stringValues);
       }
       return new ClientWebTarget(client, copy, configuration);
    }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/FormProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/FormProcessor.java
@@ -1,7 +1,7 @@
 package org.jboss.resteasy.client.jaxrs.internal.proxy.processors;
 
 import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
-import org.jboss.resteasy.client.jaxrs.internal.ClientInvocationBuilder;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 import org.jboss.resteasy.spi.LoggableFailure;
 
 import javax.ws.rs.client.WebTarget;
@@ -209,13 +209,13 @@ public class FormProcessor implements InvocationProcessor, WebTargetProcessor
    }
 
    @Override
-   public void process(ClientInvocationBuilder invocation, Object param)
+   public void process(ClientInvocation invocation, Object param)
    {
       process(new Process()  {
          @Override
          public Object process(Object target, Object value, Object processor)
          {
-            processParam((ClientInvocationBuilder)target, value, processor);
+            processParam((ClientInvocation)target, value, processor);
             return target;
          }
       }, invocation, param);
@@ -271,7 +271,7 @@ public class FormProcessor implements InvocationProcessor, WebTargetProcessor
       return target;
    }
 
-   private void processParam(ClientInvocationBuilder invocation, Object val, Object proc)
+   private void processParam(ClientInvocation invocation, Object val, Object proc)
    {
       if (proc instanceof InvocationProcessor)
       {

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/InvocationProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/InvocationProcessor.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.client.jaxrs.internal.proxy.processors;
 
-import org.jboss.resteasy.client.jaxrs.internal.ClientInvocationBuilder;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -8,5 +8,5 @@ import org.jboss.resteasy.client.jaxrs.internal.ClientInvocationBuilder;
  */
 public interface InvocationProcessor
 {
-   void process(ClientInvocationBuilder invocation, Object param);
+   void process(ClientInvocation invocation, Object param);
 }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/AbstractInvocationCollectionProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/AbstractInvocationCollectionProcessor.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation;
 
-import org.jboss.resteasy.client.jaxrs.internal.ClientInvocationBuilder;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 import org.jboss.resteasy.client.jaxrs.internal.proxy.processors.AbstractCollectionProcessor;
 import org.jboss.resteasy.client.jaxrs.internal.proxy.processors.InvocationProcessor;
 
@@ -8,7 +8,7 @@ import org.jboss.resteasy.client.jaxrs.internal.proxy.processors.InvocationProce
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public abstract class AbstractInvocationCollectionProcessor extends AbstractCollectionProcessor<ClientInvocationBuilder> implements InvocationProcessor
+public abstract class AbstractInvocationCollectionProcessor extends AbstractCollectionProcessor<ClientInvocation> implements InvocationProcessor
 {
    public AbstractInvocationCollectionProcessor(String paramName)
    {
@@ -16,7 +16,7 @@ public abstract class AbstractInvocationCollectionProcessor extends AbstractColl
    }
 
    @Override
-   public void process(ClientInvocationBuilder invocation, Object param)
+   public void process(ClientInvocation invocation, Object param)
    {
       buildIt(invocation, param);
    }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/CookieParamProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/CookieParamProcessor.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation;
 
-import org.jboss.resteasy.client.jaxrs.internal.ClientInvocationBuilder;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 import org.jboss.resteasy.client.jaxrs.internal.proxy.processors.InvocationProcessor;
 
 import javax.ws.rs.core.Cookie;
@@ -24,17 +24,17 @@ public class CookieParamProcessor implements InvocationProcessor
    }
 
    @Override
-   public void process(ClientInvocationBuilder request, Object object)
+   public void process(ClientInvocation invocation, Object object)
    {
       if (object == null) return;  // don't set a null value
       if (object instanceof Cookie)
       {
          Cookie cookie = (Cookie) object;
-         request.cookie(cookie);
+         invocation.getHeaders().cookie(cookie);
       }
       else
       {
-         request.cookie(new Cookie(cookieName, request.getInvocation().getClientConfiguration().toString(object)));
+    	  invocation.getHeaders().cookie(new Cookie(cookieName, invocation.getClientConfiguration().toString(object)));
       }
    }
 }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/FormParamProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/FormParamProcessor.java
@@ -1,7 +1,7 @@
 package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation;
 
 import org.jboss.resteasy.client.jaxrs.i18n.Messages;
-import org.jboss.resteasy.client.jaxrs.internal.ClientInvocationBuilder;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Form;
@@ -19,10 +19,10 @@ public class FormParamProcessor extends AbstractInvocationCollectionProcessor
    }
 
    @Override
-   protected ClientInvocationBuilder apply(ClientInvocationBuilder target, Object object)
+   protected ClientInvocation apply(ClientInvocation invocation, Object object)
    {
       Form form = null;
-      Object entity = target.getInvocation().getEntity();
+      Object entity = invocation.getEntity();
       if (entity != null)
       {
          if (entity instanceof Form)
@@ -37,11 +37,11 @@ public class FormParamProcessor extends AbstractInvocationCollectionProcessor
       else
       {
          form = new Form();
-         target.getInvocation().setEntity(Entity.form(form));
+         invocation.setEntity(Entity.form(form));
       }
-      String value = target.getInvocation().getClientConfiguration().toString(object);
+      String value = invocation.getClientConfiguration().toString(object);
       form.param(paramName, value);
-      return target;
+      return invocation;
    }
 
 }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/HeaderParamProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/HeaderParamProcessor.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation;
 
-import org.jboss.resteasy.client.jaxrs.internal.ClientInvocationBuilder;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -15,9 +15,10 @@ public class HeaderParamProcessor extends AbstractInvocationCollectionProcessor
    }
 
    @Override
-   protected ClientInvocationBuilder apply(ClientInvocationBuilder target, Object object)
+   protected ClientInvocation apply(ClientInvocation invocation, Object object)
    {
-      return (ClientInvocationBuilder)target.header(paramName, object);
+       invocation.getHeaders().header(paramName, object);
+       return invocation;
    }
 
 }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/MessageBodyParameterProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/MessageBodyParameterProcessor.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation;
 
-import org.jboss.resteasy.client.jaxrs.internal.ClientInvocationBuilder;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 import org.jboss.resteasy.client.jaxrs.internal.proxy.processors.InvocationProcessor;
 
 import javax.ws.rs.client.Entity;
@@ -30,9 +30,9 @@ public class MessageBodyParameterProcessor implements InvocationProcessor
 
    @SuppressWarnings("unchecked")
    @Override
-   public void process(ClientInvocationBuilder invocation, Object param)
+   public void process(ClientInvocation invocation, Object param)
    {
-      invocation.getInvocation().setEntity(Entity.entity(new GenericEntity<Object>(param, genericType), mediaType, annotations));
+      invocation.setEntity(Entity.entity(new GenericEntity<Object>(param, genericType), mediaType, annotations));
    }
 
    public Class<?> getType()

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/URIParamProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/URIParamProcessor.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.invocation;
 
-import org.jboss.resteasy.client.jaxrs.internal.ClientInvocationBuilder;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 import org.jboss.resteasy.client.jaxrs.internal.proxy.processors.InvocationProcessor;
 
 import java.net.URI;
@@ -17,13 +17,13 @@ public class URIParamProcessor implements InvocationProcessor
 {
 
    @Override
-   public void process(ClientInvocationBuilder invocation, Object param)
+   public void process(ClientInvocation invocation, Object param)
    {
       URI uri = getUri(param);
 
       if (uri != null)
       {
-         invocation.getInvocation().setUri(uri);
+         invocation.setUri(uri);
       }
    }
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/LinkBuilderImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/LinkBuilderImpl.java
@@ -8,6 +8,8 @@ import javax.ws.rs.core.UriBuilderException;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -15,16 +17,19 @@ import java.net.URI;
  */
 public class LinkBuilderImpl implements Link.Builder
 {
-   protected LinkImpl link = new LinkImpl();
+   /**
+    * A map for all the link parameters such as "rel", "type", etc.	
+    */
+   protected final Map<String, String> map = new HashMap<String, String>();
    protected UriBuilder uriBuilder;
-   protected URI baseUri = null;
+   protected URI baseUri;
 
    @Override
    public Link.Builder link(Link link)
    {
       uriBuilder = UriBuilder.fromUri(link.getUri());
-      this.link.map.clear();
-      this.link.map.putAll(link.getParams());
+      this.map.clear();
+      this.map.putAll(link.getParams());
       return this;
    }
 
@@ -59,7 +64,7 @@ public class LinkBuilderImpl implements Link.Builder
    @Override
    public Link.Builder rel(String rel) {
       if (rel == null) throw new IllegalArgumentException(Messages.MESSAGES.relParamNull());
-      final String rels = link.map.get(Link.REL);
+      final String rels = this.map.get(Link.REL);
       param(Link.REL, rels == null ? rel : rels + " " + rel);
       return this;
    }
@@ -83,7 +88,7 @@ public class LinkBuilderImpl implements Link.Builder
    public Link.Builder param(String name, String value) throws IllegalArgumentException {
       if (name == null) throw new IllegalArgumentException(Messages.MESSAGES.nameParamWasNull());
       if (value == null) throw new IllegalArgumentException(Messages.MESSAGES.valueParamWasNull());
-      link.map.put(name, value);
+      this.map.put(name, value);
       return this;
    }
 
@@ -91,8 +96,7 @@ public class LinkBuilderImpl implements Link.Builder
    public Link build(Object... values) throws UriBuilderException
    {
       if (values == null) throw new IllegalArgumentException(Messages.MESSAGES.valuesParamWasNull());
-      link.uri = uriBuilder.build(values);
-      return link;
+      return new LinkImpl(this.uriBuilder.build(values), this.map);
    }
 
    @Override
@@ -103,8 +107,7 @@ public class LinkBuilderImpl implements Link.Builder
       URI built = uriBuilder.build(values);
       URI with = built;
       if (baseUri != null) with = baseUri.resolve(built);
-      link.uri = uri.relativize(with);
-      return link;
+      return new LinkImpl(uri.relativize(with), this.map);
    }
 
    @Override

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/LinkImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/LinkImpl.java
@@ -16,12 +16,12 @@ import java.util.Map;
  */
 public class LinkImpl extends Link
 {
-   protected URI uri;
+   protected final URI uri;
 
    /**
     * A map for all the link parameters such as "rel", "type", etc.
     */
-   protected Map<String, String> map = new HashMap<String, String>();
+   protected final Map<String, String> map;
 
    protected static final RuntimeDelegate.HeaderDelegate<Link> delegate =
            RuntimeDelegate.getInstance().createHeaderDelegate(Link.class);
@@ -30,6 +30,13 @@ public class LinkImpl extends Link
    {
       return delegate.fromString(value);
    }
+   
+   LinkImpl(URI uri, Map<String, String> map) 
+   {
+	  this.uri = uri;
+	  this.map = map.isEmpty() ? Collections.<String, String> emptyMap() : Collections
+		.unmodifiableMap(new HashMap<String, String>(map));
+	}
 
    @Override
    public URI getUri() {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/LinkImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/LinkImpl.java
@@ -71,7 +71,7 @@ public class LinkImpl extends Link
 
    @Override
    public Map<String, String> getParams() {
-      return new HashMap<String, String>(map);
+      return map;
    }
 
    @Override

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResteasyUriBuilder.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResteasyUriBuilder.java
@@ -1083,7 +1083,7 @@ public class ResteasyUriBuilder extends UriBuilder
       if (templateValues == null) throw new IllegalArgumentException(Messages.MESSAGES.templateValuesParamNull());
       if (templateValues.containsKey(null)) throw new IllegalArgumentException(Messages.MESSAGES.mapKeyNull());
       String str = buildString(templateValues, false, true, true);
-      return fromTemplate(str);
+      return uriTemplate(str);
    }
 
    @Override
@@ -1094,7 +1094,7 @@ public class ResteasyUriBuilder extends UriBuilder
       HashMap<String, Object> vals = new HashMap<String, Object>();
       vals.put(name, value);
       String str = buildString(vals, false, true, encodeSlashInPath);
-      return fromTemplate(str);
+      return uriTemplate(str);
    }
 
    @Override
@@ -1105,7 +1105,7 @@ public class ResteasyUriBuilder extends UriBuilder
       HashMap<String, Object> vals = new HashMap<String, Object>();
       vals.put(name, value);
       String str = buildString(vals, true, true, true);
-      return fromTemplate(str);
+      return uriTemplate(str);
    }
 
    @Override
@@ -1114,7 +1114,7 @@ public class ResteasyUriBuilder extends UriBuilder
       if (templateValues == null) throw new IllegalArgumentException(Messages.MESSAGES.templateValuesParamNull());
       if (templateValues.containsKey(null)) throw new IllegalArgumentException(Messages.MESSAGES.mapKeyNull());
       String str = buildString(templateValues, false, true, encodeSlashInPath);
-      return fromTemplate(str);
+      return uriTemplate(str);
    }
 
    @Override
@@ -1123,6 +1123,6 @@ public class ResteasyUriBuilder extends UriBuilder
       if (templateValues == null) throw new IllegalArgumentException(Messages.MESSAGES.templateValuesParamNull());
       if (templateValues.containsKey(null)) throw new IllegalArgumentException(Messages.MESSAGES.mapKeyNull());
       String str = buildString(templateValues, true, true, true);
-      return fromTemplate(str);
+      return uriTemplate(str);
    }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientInvocationBuilderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientInvocationBuilderTest.java
@@ -1,0 +1,135 @@
+package org.jboss.resteasy.test.client;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.AsyncInvoker;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ClientInvocationBuilderTest {
+
+	@Path("/")
+	public static class ClientInvocationBuilderResource {
+		@POST
+		@Produces("text/plain")
+		public String post(String s) {
+			System.out.println("server entity: " + s);
+			return s;
+		}
+
+		@GET
+		@Produces("text/plain")
+		public String get() {
+			String s = "default";
+			System.out.println("server entity: " + s);
+			return s;
+		}
+	}
+
+	@Deployment
+	public static Archive<?> deploy() {
+		WebArchive war = TestUtil.prepareArchive(ClientInvocationBuilderTest.class.getSimpleName());
+		war.addClass(ClientInvocationBuilderTest.class);
+		return TestUtil.finishContainerPrepare(war, null, ClientInvocationBuilderResource.class);
+	}
+
+	@Test
+	public void test_build_method_return_new_instance() {
+		ResteasyClient client = new ResteasyClientBuilder().build();
+		try {
+			ResteasyWebTarget webTarget = client.target(generateURL());
+			Builder invocationBuilder = webTarget.request();
+
+			// GET invocation
+			ClientInvocation getInvocation = (ClientInvocation) invocationBuilder.accept(MediaType.TEXT_PLAIN_TYPE)
+					.build("GET");
+			Assert.assertEquals("default", getInvocation.invoke(String.class));
+
+			// Alter invocationBuilder
+			invocationBuilder.accept(MediaType.APPLICATION_XML_TYPE);
+			invocationBuilder.property("property1", "property1Value");
+			// Previously built getInvocation must not have been altered.(Those
+			// tests are not about immutability of
+			// getInvocation instance but about Builder pattern behavior).
+			Assert.assertFalse(getInvocation.getHeaders().getAcceptableMediaTypes()
+					.contains(MediaType.APPLICATION_XML_TYPE));
+			Assert.assertFalse(getInvocation.getConfiguration().getProperties().containsKey("property1"));
+
+			// POST invocation
+			ClientInvocation postInvocation = (ClientInvocation) invocationBuilder.accept(MediaType.TEXT_PLAIN_TYPE)
+					.build("POST", Entity.text("test"));
+			// Previous lines must build a new postInvocation instance and not
+			// modify previously built getInvocation instance.
+			// (It's all about Builder pattern behavior not immutability since
+			// Invocation is a mutable object.)
+			Assert.assertNotSame(getInvocation, postInvocation);
+			Assert.assertEquals("default", getInvocation.invoke(String.class));
+			Assert.assertTrue(postInvocation.getConfiguration().getProperties().containsKey("property1"));
+			Assert.assertEquals("test", postInvocation.invoke(String.class));
+		} finally {
+			client.close();
+		}
+	}
+
+	@Test
+	public void test_build_method_reset_entity() throws InterruptedException, ExecutionException {
+		ResteasyClient client = new ResteasyClientBuilder().build();
+		try {
+			ResteasyWebTarget webTarget = client.target(generateURL());
+			Builder invocationBuilder = webTarget.request().accept(MediaType.TEXT_PLAIN_TYPE);
+
+			// POST invocation
+			ClientInvocation postInvocation = (ClientInvocation) invocationBuilder.build("POST", Entity.text("test"));
+			Assert.assertEquals("test", postInvocation.invoke(String.class));
+
+			// GET invocation
+			ClientInvocation getInvocation = (ClientInvocation) invocationBuilder.build("GET");
+			// In order the request to be OK, invocation instance built from
+			// invocationBuilder must not contain the previous entity used for
+			// post request.
+			Assert.assertNull(getInvocation.getEntity());
+			Assert.assertEquals("default", getInvocation.invoke(String.class));
+
+			// Same test for async request
+			AsyncInvoker async = invocationBuilder.async();
+
+			// POST invocation
+			Future<String> postFuture = async.post(Entity.text("test"), String.class);
+			Assert.assertEquals("test", postFuture.get());
+
+			// GET invocation
+			Future<String> getFuture = async.get(String.class);
+			Assert.assertEquals("default", getFuture.get());
+		} finally {
+			client.close();
+		}
+	}
+
+	private String generateURL() {
+		return PortProviderUtil.generateBaseUrl(ClientInvocationBuilderTest.class.getSimpleName());
+	}
+
+}


### PR DESCRIPTION
New pull request replacing https://github.com/resteasy/Resteasy/pull/906.

The goal of this pull request is to make few resteasy builders compliant with the Builder pattern (http://www.javaworld.com/article/2074938/core-java/too-many-parameters-in-java-methods-part-3-builder-pattern.html) and add consistency in the way Builder pattern is implemented in the project.
Actually almost all resteasy builders strictly follow the Builder pattern such as org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder but few others don't for unknown reason.

According to the pattern for a given builder instance, all "setters" methods (those which return a  builder) must return the updated builder instance not a new one:

>  public static class PersonBuilder
{
	....
	public PersonBuilder lastName(String newLastName)
	{
		this.nestedLastName = newLastName;
		**return this;**
	}
	public PersonBuilder firstName(String newFirstName)
	{
		this.nestedFirstName = newFirstName;
		**return this;**
	}
	...
}

And all "build()" methods (the one which return a built instance) must return a fresh new instance:

> public static class PersonBuilder
{
	....
	public Person createPerson()
	{
		 return **new Person**(
			nestedLastName, nestedFirstName, nestedMiddleName,
			nestedSalutation, nestedSuffix,
			nestedStreetAddress, nestedCity, nestedState,
			nestedIsFemale, nestedIsEmployed, nestedIsHomeOwner);
	}
}

I think it's the way we expect this pattern to work. It's not about immutability it can work whatever the type to build is mutable or not, it's clearly not my point. My point is about being consistent in how we implement the builders with respect to the Builder pattern. Once the object has been built from its builder, this object must not be altered by any builder method. If the built object is mutable it will be modified through its own methods (see ResteasyClient for example).

This pull request focuses on: 

- ClientInvocationBuilder
- LinkBuilderImpl
- ResteasyUriBuilder

This pull request allows to raise and fix another issue revealed by ClientInvocationBuilderTest.test_build_method_reset_entity().