### PR TITLE
RESTEASY-1503 Netty4 server adapter exception handling NPE and cause memory leak.

### DIFF
--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpRequest.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpRequest.java
@@ -343,7 +343,9 @@ public class NettyHttpRequest extends BaseHttpRequest
               }
               finally
               {
-                 ctx.close();
+                  if (!isKeepAlive()) {
+                      ctx.close();
+                  }
               }
            }
 

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
@@ -89,8 +89,9 @@ public class RequestHandler extends SimpleChannelInboundHandler
       }
       else
       {
-          e.getCause().printStackTrace();
+          // make sure context close always call.
           ctx.close();
+          e.printStackTrace();
       }
    }
 }


### PR DESCRIPTION
e.getCause() is null. 
