### PR TITLE
Added ability to control slash encoding for ParamParam

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/ProcessorFactory.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/ProcessorFactory.java
@@ -104,7 +104,7 @@ public class ProcessorFactory
       else if ((uriParam = FindAnnotation.findAnnotation(annotations,
               PathParam.class)) != null)
       {
-         processor = new PathParamProcessor(uriParam.value());
+         processor = new PathParamProcessor(uriParam.value(), !isEncoded);
       }
       else if ((matrix = FindAnnotation.findAnnotation(annotations,
               MatrixParam.class)) != null)

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/webtarget/PathParamProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/webtarget/PathParamProcessor.java
@@ -11,15 +11,23 @@ import javax.ws.rs.client.WebTarget;
 public class PathParamProcessor implements WebTargetProcessor
 {
    private final String paramName;
+   private final Boolean encodeSlashInPath;
 
    public PathParamProcessor(String paramName)
    {
       this.paramName = paramName;
+      this.encodeSlashInPath = true;
+   }
+
+   public PathParamProcessor(String paramName, Boolean encodeSlashInPath)
+   {
+      this.paramName = paramName;
+      this.encodeSlashInPath = encodeSlashInPath;
    }
 
    @Override
    public WebTarget build(WebTarget target, Object param)
    {
-      return target.resolveTemplate(paramName, param);
+      return target.resolveTemplate(paramName, param, encodeSlashInPath);
    }
 }


### PR DESCRIPTION
If a client uses @PathParam which contains a slash, its currently encoded which then causes the call to fail. With this change, the user can decide to not encode the slashes by adding @Encoded