### PR TITLE
Add listener constructor

### DIFF
--- a/resteasy-spring/pom.xml
+++ b/resteasy-spring/pom.xml
@@ -59,19 +59,19 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>3.0.6.RELEASE</version>
+            <version>3.1.0.RELEASE</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>3.0.6.RELEASE</version>
+            <version>3.1.0.RELEASE</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>3.0.6.RELEASE</version>
+            <version>3.1.0.RELEASE</version>
             <scope>provided</scope>
         </dependency>
          <dependency>

--- a/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringContextLoaderListener.java
+++ b/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringContextLoaderListener.java
@@ -16,6 +16,13 @@ public class SpringContextLoaderListener extends ContextLoaderListener
 {
    private SpringContextLoaderSupport springContextLoaderSupport = new SpringContextLoaderSupport();
 
+   public SpringContextLoaderListener() {
+   }
+
+   public SpringContextLoaderListener(WebApplicationContext context) {
+      super(context);
+   }
+
    @Override
    public void contextInitialized(ServletContextEvent event)
    {

--- a/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringContextLoaderListener.java
+++ b/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringContextLoaderListener.java
@@ -40,7 +40,7 @@ public class SpringContextLoaderListener extends ContextLoaderListener
       {
          boolean tmp = Boolean.valueOf(scanAll.trim());
          scanProviders = tmp || scanProviders;
-         scanResources = tmp || scanResources;
+         scanResources = tmp;
       }
       String sResources = event.getServletContext().getInitParameter("resteasy.scan.resources");
       if (sResources != null)

--- a/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringContextLoaderListener.java
+++ b/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringContextLoaderListener.java
@@ -4,6 +4,7 @@ import org.jboss.resteasy.plugins.spring.i18n.Messages;
 import org.springframework.web.context.ConfigurableWebApplicationContext;
 import org.springframework.web.context.ContextLoader;
 import org.springframework.web.context.ContextLoaderListener;
+import org.springframework.web.context.WebApplicationContext;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;


### PR DESCRIPTION
This allows for code such as
```
Server server = new Server(8080);
ServletContextHandler contextHandler = new  ServletContextHandler(ServletContextHandler.SESSIONS);
AnnotationConfigWebApplicationContext rootContext = new AnnotationConfigWebApplicationContext();
rootContext.register(AppConfig.class);
contextHandler.addEventListener(new ResteasyBootstrap());
contextHandler.addEventListener(new SpringContextLoaderListener(rootContext));
contextHandler.addServlet(HttpServletDispatcher.class, "/*");
server.setHandler(contextHandler);
server.start();
server.join();
```

to be used inside of a servlet 3.0 container such as the Jetty server, without requiring `web.xml` and `applicationContext.xml` files.