### PR TITLE
Fixes RESTEASY-1544

### DIFF
--- a/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
+++ b/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
@@ -299,8 +299,8 @@ public class NettyJaxrsServer implements EmbeddedJaxrsServer
         ChannelPipeline channelPipeline = ch.pipeline();
         channelPipeline.addLast(channelHandlers.toArray(new ChannelHandler[channelHandlers.size()]));
         channelPipeline.addLast(new HttpRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize));
-        channelPipeline.addLast(new HttpObjectAggregator(maxRequestSize));
         channelPipeline.addLast(new HttpResponseEncoder());
+        channelPipeline.addLast(new HttpObjectAggregator(maxRequestSize));
         channelPipeline.addLast(httpChannelHandlers.toArray(new ChannelHandler[httpChannelHandlers.size()]));
         channelPipeline.addLast(new RestEasyHttpRequestDecoder(dispatcher.getDispatcher(), root, protocol));
         channelPipeline.addLast(new RestEasyHttpResponseEncoder());


### PR DESCRIPTION
Moves HttpObjectAggregator after HttpResponseEncoder as told here : https://issues.jboss.org/browse/RESTEASY-1544