### PR TITLE
[RESTEASY-1550] Allow to change redirectTestOutputToFile from console

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
 
     <properties>
         <jboss.home/>
+        <!-- print logs to file by default -->
+        <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     </properties>
 
     <url>http://rest-easy.org</url>
@@ -292,7 +294,6 @@
                     <configuration>
                         <forkMode>once</forkMode>
                         <argLine>-Xms512m -Xmx512m</argLine>
-                        <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
See https://issues.jboss.org/browse/RESTEASY-1550

Default behaviour keeps same, test output is printed to file. But if something like this is used, test output is printed to console:
mvn install -Dmaven.test.redirectTestOutputToFile=false
