### PR TITLE
[RESTEASY-1548] Add tests for jackson-datatype-jsr310 and jackson-datatype-jdk8 modules

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/JacksonDatatypeTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/JacksonDatatypeTest.java
@@ -1,0 +1,187 @@
+package org.jboss.resteasy.test.providers.jackson2;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.ExpectedFailing;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.test.core.basic.resource.ApplicationTestScannedApplication;
+import org.jboss.resteasy.test.providers.jackson2.resource.JacksonDatatypeEndPoint;
+import org.jboss.resteasy.test.providers.jackson2.resource.JacksonDatatypeJacksonProducer;
+import org.jboss.resteasy.util.HttpResponseCodes;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.StringContains.containsString;
+
+/**
+ * @tpSubChapter Jackson2 provider
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Test for WFLY-5916. Integration tests for jackson-datatype-jsr310 and jackson-datatype-jdk8 modules
+ * @tpSince RESTEasy 3.1.0.CR3
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+// This test passes with WildFly master branch, but don't pass with WildFly 10.1
+// Next annotation needs to be removed after new version of WildFly would be used - FIXME
+@Category({ExpectedFailing.class})
+public class JacksonDatatypeTest {
+    private static final String DEFAULT_DEPLOYMENT = String.format("%sDefault",
+            JacksonDatatypeTest.class.getSimpleName());
+    private static final String DEPLOYMENT_WITH_DATATYPE = String.format("%sWithDatatypeSupport",
+            JacksonDatatypeTest.class.getSimpleName());
+
+    static ResteasyClient client;
+    protected static final Logger logger = Logger.getLogger(JacksonDatatypeTest.class.getName());
+
+    @BeforeClass
+    public static void init() {
+        client = new ResteasyClientBuilder().build();
+    }
+
+    @AfterClass
+    public static void close() {
+        client.close();
+    }
+
+    @Deployment(name = "default")
+    public static Archive<?> deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DEFAULT_DEPLOYMENT + ".war");
+        war.addClasses(ApplicationTestScannedApplication.class, JacksonDatatypeEndPoint.class);
+        return war;
+    }
+
+    @Deployment(name = "withDatatype")
+    public static Archive<?> deployJettison() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_WITH_DATATYPE + ".war");
+        war.addClasses(JacksonDatatypeEndPoint.class,
+                JacksonDatatypeJacksonProducer.class, ApplicationTestScannedApplication.class);
+        return war;
+    }
+
+    private String requestHelper(String endPath, String deployment) {
+        String url = PortProviderUtil.generateURL(String.format("/scanned/%s", endPath), deployment);
+        WebTarget base = client.target(url);
+        Response response = base.request().get();
+        Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        String strResponse = response.readEntity(String.class);
+        logger.info(String.format("Url: %s", url));
+        logger.info(String.format("Response: %s", strResponse));
+        return strResponse;
+    }
+
+    /**
+     * @tpTestDetails Check string type without datatype supported
+     * @tpSince RESTEasy 3.1.0.CR3
+     */
+    @Test
+    public void testDatatypeNotSupportedString() throws Exception {
+        String strResponse = requestHelper("string", DEFAULT_DEPLOYMENT);
+        Assert.assertThat("Wrong conversion of String", strResponse, containsString("someString"));
+    }
+
+    /**
+     * @tpTestDetails Check date type without datatype supported
+     * @tpSince RESTEasy 3.1.0.CR3
+     */
+    @Test
+    public void testDatatypeNotSupportedDate() throws Exception {
+        String strResponse = requestHelper("date", DEFAULT_DEPLOYMENT);
+        Assert.assertThat("Wrong conversion of Date", strResponse.matches("^[0-9]*$"), is(true));
+    }
+
+    /**
+     * @tpTestDetails Check duration type without datatype supported
+     * @tpSince RESTEasy 3.1.0.CR3
+     */
+    @Test
+    public void testDatatypeNotSupportedDuration() throws Exception {
+        String strResponse = requestHelper("duration", DEFAULT_DEPLOYMENT);
+        Assert.assertThat("Wrong conversion of Duration", strResponse, not(containsString("PT5.000000006S")));
+    }
+
+    /**
+     * @tpTestDetails Check null optional type without datatype supported
+     * @tpSince RESTEasy 3.1.0.CR3
+     */
+    @Test
+    public void testDatatypeNotSupportedOptionalNull() throws Exception {
+        String strResponse = requestHelper("optional/true", DEFAULT_DEPLOYMENT);
+        Assert.assertThat("Wrong conversion of Optional (null)", strResponse, not(containsString("null")));
+    }
+
+    /**
+     * @tpTestDetails Check not null optional type without datatype supported
+     * @tpSince RESTEasy 3.1.0.CR3
+     */
+    @Test
+    public void testDatatypeNotSupportedOptionalNotNull() throws Exception {
+        String strResponse = requestHelper("optional/false", DEFAULT_DEPLOYMENT);
+        Assert.assertThat("Wrong conversion of Optional (not null)", strResponse, not(containsString("info@example.com")));
+    }
+
+    /**
+     * @tpTestDetails Check string type with datatype supported
+     * @tpSince RESTEasy 3.1.0.CR3
+     */
+    @Test
+    public void testDatatypeSupportedString() throws Exception {
+        String strResponse = requestHelper("string", DEPLOYMENT_WITH_DATATYPE);
+        Assert.assertThat("Wrong conversion of String", strResponse, containsString("someString"));
+    }
+
+    /**
+     * @tpTestDetails Check date type with datatype supported
+     * @tpSince RESTEasy 3.1.0.CR3
+     */
+    @Test
+    public void testDatatypeSupportedDate() throws Exception {
+        String strResponse = requestHelper("date", DEPLOYMENT_WITH_DATATYPE);
+        Assert.assertThat("Wrong conversion of Date", strResponse.matches("^[0-9]*$"), is(false));
+    }
+
+    /**
+     * @tpTestDetails Check duration type with datatype supported
+     * @tpSince RESTEasy 3.1.0.CR3
+     */
+    @Test
+    public void testDatatypeSupportedDuration() throws Exception {
+        String strResponse = requestHelper("duration", DEPLOYMENT_WITH_DATATYPE);
+        Assert.assertThat("Wrong conversion of Duration", strResponse, containsString("PT5.000000006S"));
+    }
+
+    /**
+     * @tpTestDetails Check null optional type with datatype supported
+     * @tpSince RESTEasy 3.1.0.CR3
+     */
+    @Test
+    public void testDatatypeSupportedOptionalNull() throws Exception {
+        String strResponse = requestHelper("optional/true", DEPLOYMENT_WITH_DATATYPE);
+        Assert.assertThat("Wrong conversion of Optional (null)", strResponse, containsString("null"));
+    }
+
+    /**
+     * @tpTestDetails Check not null optional type with datatype supported
+     * @tpSince RESTEasy 3.1.0.CR3
+     */
+    @Test
+    public void testDatatypeSupportedOptionalNotNull() throws Exception {
+        String strResponse = requestHelper("optional/false", DEPLOYMENT_WITH_DATATYPE);
+        Assert.assertThat("Wrong conversion of Optional (not null)", strResponse, containsString("info@example.com"));
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/resource/JacksonDatatypeEndPoint.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/resource/JacksonDatatypeEndPoint.java
@@ -1,0 +1,42 @@
+package org.jboss.resteasy.test.providers.jackson2.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.time.Duration;
+import java.util.Date;
+import java.util.Optional;
+
+@Path("/")
+public class JacksonDatatypeEndPoint {
+
+    @GET
+    @Path("/string")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String getString() {
+        return "someString";
+    }
+
+    @GET
+    @Path("/date")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Date getDate() {
+        return new Date();
+    }
+
+    @GET
+    @Path("/duration")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Duration getDuration() {
+        return Duration.ofSeconds(5, 6);
+    }
+
+    @GET
+    @Path("/optional/{nullParam}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Optional<String> getOptional(@PathParam("nullParam") boolean nullParameter) {
+        return nullParameter ? Optional.<String>empty() : Optional.of("info@example.com");
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/resource/JacksonDatatypeJacksonProducer.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/resource/JacksonDatatypeJacksonProducer.java
@@ -1,0 +1,30 @@
+package org.jboss.resteasy.test.providers.jackson2.resource;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+public class JacksonDatatypeJacksonProducer implements ContextResolver<ObjectMapper> {
+
+    private final ObjectMapper json;
+
+    public JacksonDatatypeJacksonProducer() throws Exception {
+        this.json = new ObjectMapper()
+                .findAndRegisterModules()
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    @Override
+    public ObjectMapper getContext(Class<?> objectType) {
+        return json;
+    }
+
+}


### PR DESCRIPTION
Basic integration test for jackson-datatype-jsr310 and jackson-datatype-jdk8 modules.

This test fails with WildFly 10.1, because this old WildFly doesn't contains jackson-datatype-jsr310 and jackson-datatype-jdk8 modules. So I add @Category({ExpectedFailing.class}) to new test now. And this annotation will be removed once new WildFly will be used in RESTEasy for testing.