### PR TITLE
[RESTEASY-1205] RestEasy-Netty4: ByteBuf leak in ResteasyHttpRequestDecoder

### DIFF
--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RequestHandler.java
@@ -9,6 +9,7 @@ import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpResponse;
 
 import io.netty.handler.timeout.IdleStateEvent;
+import org.apache.commons.io.IOUtils;
 import org.jboss.resteasy.plugins.server.netty.i18n.LogMessages;
 import org.jboss.resteasy.plugins.server.netty.i18n.Messages;
 import org.jboss.resteasy.spi.Failure;
@@ -29,7 +30,7 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
  * @version $Rev: 2368 $, $Date: 2010-10-18 17:19:03 +0900 (Mon, 18 Oct 2010) $
  */
 @Sharable
-public class RequestHandler extends SimpleChannelInboundHandler
+public class RequestHandler extends SimpleChannelInboundHandler<NettyHttpRequest>
 {
    protected final RequestDispatcher dispatcher;
 
@@ -39,11 +40,9 @@ public class RequestHandler extends SimpleChannelInboundHandler
    }
 
    @Override
-   protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception
+   protected void channelRead0(ChannelHandlerContext ctx, NettyHttpRequest request) throws Exception
    {
-      if (msg instanceof NettyHttpRequest) {
-          NettyHttpRequest request = (NettyHttpRequest) msg;
-
+      try {
           if (request.is100ContinueExpected())
           {
              send100Continue(ctx);
@@ -69,6 +68,8 @@ public class RequestHandler extends SimpleChannelInboundHandler
           if (!request.getAsyncContext().isSuspended()) {
              response.finish();
           }
+      } finally {
+         IOUtils.closeQuietly(request.getInputStream());
       }
    }
 

--- a/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpRequestDecoder.java
+++ b/jaxrs/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpRequestDecoder.java
@@ -1,14 +1,13 @@
 package org.jboss.resteasy.plugins.server.netty;
 
 import static io.netty.handler.codec.http.HttpHeaders.is100ContinueExpected;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufInputStream;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
 
+import java.io.ByteArrayInputStream;
 import java.util.List;
 
 import org.jboss.resteasy.core.SynchronousDispatcher;
@@ -72,9 +71,10 @@ public class RestEasyHttpRequestDecoder extends MessageToMessageDecoder<io.netty
                
                // Does the request contain a body that will need to be retained
                if(content.content().readableBytes() > 0) {
-                 ByteBuf buf = content.content().retain();
-                 ByteBufInputStream in = new ByteBufInputStream(buf);
-                 nettyRequest.setInputStream(in);
+                   byte[] buf = new byte[content.content().readableBytes()];
+                   content.content().readBytes(buf);
+                   ByteArrayInputStream in = new ByteArrayInputStream(buf);
+                   nettyRequest.setInputStream(in);
                }
                
                out.add(nettyRequest); 


### PR DESCRIPTION
content.content().retain() increases reference count without release.
resolve: convert ByteBuf to byte[], and use ByteArrayInputStream instead

[leak.txt](https://github.com/resteasy/Resteasy/files/594477/leak.txt)