### PR TITLE
Forward Compatibility profile excludes legacy integration tests

### DIFF
--- a/testsuite/integration-tests-spring/deployment/pom.xml
+++ b/testsuite/integration-tests-spring/deployment/pom.xml
@@ -15,27 +15,6 @@
     <name>RESTEasy Main testsuite: Spring integration tests - Deployment</name>
 
     <profiles>
-        <!-- Forward compatibility: use EAP 7.0.0.GA and newer Client from CP stream (e.g. client from RESTEasy delivered by EAP 7.0.2 -->
-        <profile>
-            <id>forward.compatibility</id>
-            <activation>
-                <property>
-                    <name>forward.compatibility</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludedGroups>org.jboss.resteasy.category.NotForForwardCompatibility</excludedGroups>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <!--
         Name:  download
         Descr: Download WildFly

--- a/testsuite/integration-tests-spring/inmodule/pom.xml
+++ b/testsuite/integration-tests-spring/inmodule/pom.xml
@@ -21,27 +21,6 @@
     </properties>
 
     <profiles>
-        <!-- Forward compatibility: use EAP 7.0.0.GA and newer Client from CP stream (e.g. client from RESTEasy delivered by EAP 7.0.2 -->
-        <profile>
-            <id>forward.compatibility</id>
-            <activation>
-                <property>
-                    <name>forward.compatibility</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludedGroups>org.jboss.resteasy.category.NotForForwardCompatibility</excludedGroups>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <!--
         Name:  download
         Descr: Download WildFly

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -15,27 +15,6 @@
     <name>RESTEasy Main testsuite: Integration tests</name>
 
     <profiles>
-        <!-- Forward compatibility: use EAP 7.0.0.GA and newer Client from CP stream (e.g. client from RESTEasy delivered by EAP 7.0.2 -->
-        <profile>
-            <id>forward.compatibility</id>
-            <activation>
-                <property>
-                    <name>forward.compatibility</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludedGroups>org.jboss.resteasy.category.NotForForwardCompatibility</excludedGroups>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <!--
         Name:  download
         Descr: Download WildFly

--- a/testsuite/legacy-integration-tests/pom.xml
+++ b/testsuite/legacy-integration-tests/pom.xml
@@ -15,27 +15,6 @@
     <name>RESTEasy Main testsuite: Legacy integration tests</name>
 
     <profiles>
-        <!-- Forward compatibility: use EAP 7.0.0.GA and newer Client from CP stream (e.g. client from RESTEasy delivered by EAP 7.0.2 -->
-        <profile>
-            <id>forward.compatibility</id>
-            <activation>
-                <property>
-                    <name>forward.compatibility</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludedGroups>org.jboss.resteasy.category.NotForForwardCompatibility</excludedGroups>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <!--
         Name:  download
         Descr: Download WildFly

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -10,14 +10,6 @@
     <description/>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
-
-    <modules>
-        <module>arquillian-utils</module>
-        <module>unit-tests</module>
-        <module>legacy-integration-tests</module>
-        <module>integration-tests</module>
-        <module>integration-tests-spring</module>
-    </modules>
     
     <artifactId>resteasy-testsuite</artifactId>
 
@@ -60,6 +52,41 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <property>
+                    <name>!forward.compatibility</name>
+                </property>
+            </activation>
+            <modules>
+                <module>arquillian-utils</module>
+                <module>unit-tests</module>
+                <module>legacy-integration-tests</module>
+                <module>integration-tests</module>
+                <module>integration-tests-spring</module>
+            </modules>
+        </profile>
+        <!-- Forward compatibility: use EAP 7.0.0.GA and newer Client from CP stream (e.g. client from RESTEasy delivered by EAP 7.0.2 -->
+        <profile>
+            <id>forward.compatibility</id>
+            <activation>
+                <property>
+                    <name>forward.compatibility</name>
+                </property>
+            </activation>
+            <modules>
+                <module>arquillian-utils</module>
+                <module>unit-tests</module>
+                <!-- Uncomment module below when EAP/Widlfly with Resteasy 3.1 is released -->
+                <!-- <module>legacy-integration-tests</module>-->
+                <module>integration-tests</module>
+                <module>integration-tests-spring</module>
+            </modules>
+            <properties>
+                <additional.surefire.excluded.groups>org.jboss.resteasy.category.NotForForwardCompatibility</additional.surefire.excluded.groups>
+            </properties>
+        </profile>
         <profile>
             <id>home</id>
             <activation>


### PR DESCRIPTION
* moves forward compatibility profile to the main testsuite pom
* excludes legacy integration tests module from the profile (that will be needed to added later When Wildfly/EAP with the resteasy 3.1 is released).