### PR TITLE
Add NotForForwardCompatibility annotation into tests

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsynchCounterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsynchCounterTest.java
@@ -12,6 +12,7 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.test.asynch.resource.AsynchCounterResource;
 import org.jboss.resteasy.utils.PortProviderUtil;
 import org.jboss.resteasy.utils.TestUtil;
@@ -21,16 +22,18 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
  * @tpSubChapter Asynchronous RESTEasy
  * @tpChapter Integration tests
- * @tpTestCaseDetails Tests use of SecureRandom to generate location job ids
+ * @tpTestCaseDetails Tests use of SecureRandom to generate location job ids, RESTEASY-1483
  * @tpSince RESTEasy 3.1.0.Final
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({NotForForwardCompatibility.class})
 public class AsynchCounterTest {
 
     static Client client;
@@ -60,6 +63,7 @@ public class AsynchCounterTest {
 
     /**
      * @tpTestDetails Test that job ids are no longer consecutive
+     * @tpInfo RESTEASY-1483
      * @tpSince RESTEasy 3.1.0.Final
      */
     @Test

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/validation/ValidationWithCDITest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/validation/ValidationWithCDITest.java
@@ -1,7 +1,5 @@
 package org.jboss.resteasy.test.cdi.validation;
 
-import java.util.Iterator;
-
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -12,9 +10,9 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.resteasy.api.validation.ResteasyConstraintViolation;
 import org.jboss.resteasy.api.validation.Validation;
 import org.jboss.resteasy.api.validation.ViolationReport;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.test.cdi.validation.resource.AbstractAsyncRootResource;
 import org.jboss.resteasy.test.cdi.validation.resource.AsyncRootResource;
 import org.jboss.resteasy.test.cdi.validation.resource.AsyncRootResourceImpl;
@@ -36,6 +34,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -43,13 +42,13 @@ import org.junit.runner.RunWith;
  * @tpChapter Integration tests
  * @tpTestCaseDetails Tests RESTEASY-1186, which reports issues with validation in
  *                    the presence of CDI.
- * @tpSince RESTEasy 3.0.18.Final
+ * @tpSince RESTEasy 3.1.0
  */
 @RunWith(Arquillian.class)
 @RunAsClient
 public class ValidationWithCDITest
 {
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> createTestArchive()
    {
       WebArchive war = TestUtil.prepareArchive(ValidationWithCDITest.class.getSimpleName());
@@ -61,9 +60,8 @@ public class ValidationWithCDITest
          .addClasses(AsyncRootResource.class, AsyncRootResourceImpl.class)
          .addClasses(AsyncSubResource.class, AsyncSubResourceImpl.class)
          .addClasses(AsyncValidResource.class)
-         .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+              .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
          .addAsWebInfResource(ValidationWithCDITest.class.getPackage(), "web.xml", "/web.xml");
-         ;
       System.out.println(war.toString(true));
       return TestUtil.finishContainerPrepare(war, null, (Class<?>[]) null);
    }
@@ -72,6 +70,10 @@ public class ValidationWithCDITest
       return PortProviderUtil.generateURL(path, ValidationWithCDITest.class.getSimpleName());
    }
 
+   /**
+    * @tpTestDetails Tests Bean Validation constraints on method parameters
+    * @tpSince RESTEasy 3.1.0
+    */
    @Test
    public void testRoot() throws Exception
    {
@@ -88,7 +90,12 @@ public class ValidationWithCDITest
       countViolations(report, 0, 0, 0, 1, 0);
    }
 
+   /**
+    * @tpTestDetails Tests Bean Validation constraints on method parameters
+    * @tpSince RESTEasy 3.1.0
+    */
    @Test
+   @Category({NotForForwardCompatibility.class})
    public void testAsynch() throws Exception
    {  
       Client client = ClientBuilder.newClient();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/AbortMessageTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/AbortMessageTest.java
@@ -11,6 +11,7 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.test.client.resource.AbortMessageResourceFilter;
 import org.jboss.resteasy.utils.PortProviderUtil;
 import org.jboss.resteasy.utils.TestUtil;
@@ -20,15 +21,18 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
- * @tpSubChapter Resteasy-client - RESTEASY-1540
- * @tpChapter 
+ * @tpSubChapter Resteasy-client
+ * @tpChapter Client tests
+ * @tpTestCaseDetails RESTEASY-1540
  * @tpSince RESTEasy 3.1.0.Final
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({NotForForwardCompatibility.class})
 public class AbortMessageTest {
    static Client client;
 
@@ -52,6 +56,10 @@ public class AbortMessageTest {
        return PortProviderUtil.generateURL(path, AbortMessageTest.class.getSimpleName());
    }
 
+    /**
+     * @tpTestDetails Send response with "Aborted"
+     * @tpSince RESTEasy 3.1.0.Final
+     */
    @Test
    public void testAbort() throws UnsupportedEncodingException {
       WebTarget target = client.target(generateURL("/showproblem"));

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/ResteasyJAXRSImplTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/ResteasyJAXRSImplTest.java
@@ -6,17 +6,23 @@ import javax.ws.rs.ext.RuntimeDelegate;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.jboss.resteasy.test.core.basic.resource.AcceptLanguagesResource;
 import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+/**
+ * @tpSubChapter Jaxrs implementation
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails RESTEASY-1531
+ * @tpSince RESTEasy 3.1.0
+ */
 @RunWith(Arquillian.class)
 public class ResteasyJAXRSImplTest
 {
@@ -25,9 +31,14 @@ public class ResteasyJAXRSImplTest
    public static Archive<?> deploy()
    {
       WebArchive war = TestUtil.prepareArchive(ResteasyJAXRSImplTest.class.getSimpleName());
-      return TestUtil.finishContainerPrepare(war, null, AcceptLanguagesResource.class);
+      war.addClass(NotForForwardCompatibility.class);
+      return TestUtil.finishContainerPrepare(war, null, (Class<?>[]) null);
    }
 
+   /**
+    * @tpTestDetails Tests that ResteasyClientBuilder implementation corresponds to JAXRS spec ClientBuilder
+    * @tpSince RESTEasy 3.1.0
+    */
    @Test
    @RunAsClient
    public void testClientBuilder() throws Exception
@@ -35,12 +46,21 @@ public class ResteasyJAXRSImplTest
       testClientBuilderNewBuilder();
    }
 
+   /**
+    * @tpTestDetails Tests that ResteasyClientBuilder implementation corresponds to JAXRS spec ClientBuilder. Tested client
+    * is bundled in the server.
+    * @tpSince RESTEasy 3.1.0
+    */
    @Test
    public void testInContainerClientBuilder() throws Exception
    {
       testClientBuilderNewBuilder();
    }
 
+   /**
+    * @tpTestDetails Tests RuntimeDelegate instance implementation with ResteasyProviderFactory
+    * @tpSince RESTEasy 3.1.0
+    */
    @Test
    @RunAsClient
    public void testRuntimeDelegate() throws Exception
@@ -50,8 +70,13 @@ public class ResteasyJAXRSImplTest
       testResteasyProviderFactoryNewInstance();
    }
 
+   /**
+    * @tpTestDetails Tests RuntimeDelegate instance implementation with ResteasyProviderFactory in the container.
+    * @tpSince RESTEasy 3.1.0
+    */
    @Test
-   public void testInContainerRuntimeDegate() throws Exception
+   @Category({NotForForwardCompatibility.class})
+   public void testInContainerRuntimeDelegate() throws Exception
    {
       testRuntimeDelegateGetInstance();
       testResteasyProviderFactoryGetInstance();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/interceptors/FilteredCookieTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/interceptors/FilteredCookieTest.java
@@ -11,6 +11,7 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.test.core.interceptors.resource.FilteredCookieContainerRequestFilter;
 import org.jboss.resteasy.test.core.interceptors.resource.FilteredCookieResource;
 import org.jboss.resteasy.utils.PortProviderUtil;
@@ -19,6 +20,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -29,6 +31,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({NotForForwardCompatibility.class})
 public class FilteredCookieTest {
    
    private static final String OLD_COOKIE_NAME = "old-cookie";
@@ -43,7 +46,11 @@ public class FilteredCookieTest {
    private String generateURL(String path) {
        return PortProviderUtil.generateURL(path, FilteredCookieTest.class.getSimpleName());
    }
-   
+
+   /**
+    * @tpTestDetails Tests if multiple cookies are returned by the server
+    * @tpSince RESTEasy 3.1.0.Final
+    */
    @Test
    public void testServerHeaders() {
       

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/interceptors/GzipSizeTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/interceptors/GzipSizeTest.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.plugins.interceptors.AcceptEncodingGZIPFilter;
@@ -32,6 +33,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import com.google.common.net.HttpHeaders;
@@ -80,9 +82,11 @@ public class GzipSizeTest {
 
     /**
      * @tpTestDetails Test exceeding configured maximum size on server
+     * @tpInfo RESTEASY-1484
      * @tpSince RESTEasy 3.1.0.Final
      */
     @Test
+    @Category({NotForForwardCompatibility.class})
     public void testMaxConfiguredSizeSending() throws Exception {
         byte[] b = new byte[17];
         Variant variant = new Variant(MediaType.APPLICATION_OCTET_STREAM_TYPE, "", "gzip");

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/interceptors/GzipTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/interceptors/GzipTest.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ProxyBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
@@ -30,6 +31,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.InternalServerErrorException;
@@ -281,9 +283,11 @@ public class GzipTest {
     
     /**
      * @tpTestDetails Test exceeding default maximum size
+     * @tpInfo RESTEASY-1484
      * @tpSince RESTEasy 3.1.0.Final
      */
     @Test
+    @Category({NotForForwardCompatibility.class})
     public void testMaxDefaultSizeSending() throws Exception {
         byte[] b = new byte[10000001];
         Variant variant = new Variant(MediaType.APPLICATION_OCTET_STREAM_TYPE, "", "gzip");

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/crypto/SigningTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/crypto/SigningTest.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
@@ -28,6 +29,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.ProcessingException;
@@ -607,6 +609,7 @@ public class SigningTest {
      * @tpSince RESTEasy 3.0.17
      */
     @Test
+    @Category({NotForForwardCompatibility.class})
     public void testBasicVerificationBadSignatureNoBody() throws Exception {
         WebTarget target = client.target(generateURL("/signed/nobody"));
         DKIMSignature contentSignature = new DKIMSignature();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/form/Resteasy1405Test.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/form/Resteasy1405Test.java
@@ -22,6 +22,7 @@ import javax.xml.bind.Marshaller;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 import org.jboss.resteasy.test.form.resteasy1405.ByFieldForm;
 import org.jboss.resteasy.test.form.resteasy1405.BySetterForm;
@@ -35,10 +36,18 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+/**
+ * @tpSubChapter Form tests
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Injection of @FormParam InputPart fields in @MultipartForm parameters
+ * @tpSince RESTEasy 3.1.0
+ */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({NotForForwardCompatibility.class})
 public class Resteasy1405Test
 {
 
@@ -71,6 +80,10 @@ public class Resteasy1405Test
       return PortProviderUtil.generateURL(path, Resteasy1405Test.class.getSimpleName());      
    }
 
+   /**
+    * @tpTestDetails Injection of Content-type into MultiPartForm with annotated form fields
+    * @tpSince RESTEasy 3.1.0
+    */
    @Test
    public void testInputPartByField() throws Exception
    {
@@ -99,6 +112,10 @@ public class Resteasy1405Test
       }
    }
 
+   /**
+    * @tpTestDetails Injection of Content-type into MultiPartForm with annotated form setters
+    * @tpSince RESTEasy 3.1.0
+    */
    @Test
    public void testInputPartBySetter() throws Exception
    {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/atom/AtomComplexModelTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/atom/AtomComplexModelTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.providers.atom;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.plugins.providers.atom.Content;
@@ -32,6 +33,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.core.MediaType;
@@ -148,9 +150,11 @@ public class AtomComplexModelTest {
 
     /**
      * @tpTestDetails Check new client
+     * @tpInfo Not for forward compatibility due to 3.1.0.Final, see the migration notes
      * @tpSince RESTEasy 3.0.16
      */
     @Test
+    @Category({NotForForwardCompatibility.class})
     public void testNewClient() throws Exception {
         String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
                 "<entry xmlns=\"http://www.w3.org/2005/Atom\">" +

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/Jackson2Test.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/Jackson2Test.java
@@ -4,6 +4,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.providers.jackson2.resource.Jackson2JAXBResource;
@@ -23,6 +24,7 @@ import org.junit.Test;
 import org.junit.Before;
 import org.junit.After;
 
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.HashMap;
@@ -186,9 +188,11 @@ public class Jackson2Test {
      * @tpTestDetails Client sends GET request for Json resource. The request url contains 'callback' keyword which should
      * trigger processing of the response in the format callbackvalue("key":"value"). However, Jackson2JsonpInterceptor is disabled.
      * @tpPassCrit The resource returns json entities in correct format (without callback function wrapping)
+     * @tpInfo RESTEASY-1486
      * @tpSince RESTEasy 3.1.0.Final
      */
     @Test
+    @Category({NotForForwardCompatibility.class})
     public void testJacksonJsonpDisabled() throws Exception {
         WebTarget target = client.target(PortProviderUtil.generateURL("/products/333?callback=foo", JSONP_DISABLED));
         Response response = target.request().get();
@@ -203,10 +207,11 @@ public class Jackson2Test {
      * @tpTestDetails Client sends GET request for Json resource. The request url contains 'callback' keyword which should
      * trigger processing of the response in the format callbackvalue("key":"value")
      * @tpPassCrit The resource returns json entities in correct format (without callback function wrapping)
-     * @tpInfo This test fails, see RESTEASY-1168. This should be fixed in 3.0.12 release.
+     * @tpInfo RESTEASY-1486
      * @tpSince RESTEasy 3.0.16 (as testJacksonJsonp() but Jackson2JsonpInterceptor would have been enabled)
      */
     @Test
+    @Category({NotForForwardCompatibility.class})
     public void testJacksonJsonpDefault() throws Exception {
         WebTarget target = client.target(generateURL("/products/333?callback=foo"));
         Response response = target.request().get();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/JacksonJsonViewTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/JacksonJsonViewTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.providers.jackson2.resource.JacksonViewService;
@@ -18,6 +19,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.GET;
@@ -33,7 +35,7 @@ import javax.ws.rs.Produces;
 @RunAsClient
 public class JacksonJsonViewTest {
 
-    private final String ERROR_MESSAGE = "The response entity doen't contain correctly serialized value";
+    private final String ERROR_MESSAGE = "The response entity doesn't contain correctly serialized value";
 
     @Path("/json_view")
     public interface JacksonViewProxy {
@@ -85,9 +87,11 @@ public class JacksonJsonViewTest {
     /**
      * @tpTestDetails Tests Jackson JsonView with jaxr-rs
      * @tpPassCrit The response entity contains correctly serialized values. Jax-rs resource doesn't contain JsonView annotation
+     * @tpInfo RESTEASY-1366, JBEAP-5435
      * @tpSince RESTEasy 3.1.0
      */
     @Test
+    @Category({NotForForwardCompatibility.class})
     public void testJacksonProxyJsonViewTest() throws Exception {
         JacksonViewProxy proxy = client.target(generateURL("")).proxy(JacksonViewProxy.class);
         Something p = proxy.getSomething();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterSuperClassTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterSuperClassTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.providers.jackson2.jsonfilter;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.*;
 import org.jboss.resteasy.util.HttpResponseCodes;
@@ -13,6 +14,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Client;
@@ -28,6 +30,7 @@ import javax.ws.rs.core.Response;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({NotForForwardCompatibility.class})
 public class JsonFilterSuperClassTest {
 
     @Deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithInterceptorConditionalFilterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithInterceptorConditionalFilterTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.providers.jackson2.jsonfilter;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.Jackson2Product;
@@ -18,6 +19,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.WebTarget;
@@ -33,6 +35,7 @@ import javax.ws.rs.core.Response;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({NotForForwardCompatibility.class})
 public class JsonFilterWithInterceptorConditionalFilterTest {
 
     static ResteasyClient client;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithInterceptorMultipleFiltersTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithInterceptorMultipleFiltersTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.providers.jackson2.jsonfilter;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.Jackson2Person;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.Jackson2PersonResource;
@@ -16,6 +17,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Client;
@@ -32,6 +34,7 @@ import javax.ws.rs.core.Response;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({NotForForwardCompatibility.class})
 public class JsonFilterWithInterceptorMultipleFiltersTest {
 
     @Deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithInterceptrTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithInterceptrTest.java
@@ -7,6 +7,7 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.Jackson2Product;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.Jackson2Resource;
@@ -19,6 +20,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -29,6 +31,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({NotForForwardCompatibility.class})
 public class JsonFilterWithInterceptrTest {
 
     @Deployment(name = "default")

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithSerlvetFilterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithSerlvetFilterTest.java
@@ -7,6 +7,7 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.Jackson2Product;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.Jackson2Resource;
@@ -19,6 +20,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -29,6 +31,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({NotForForwardCompatibility.class})
 public class JsonFilterWithSerlvetFilterTest {
 
     @Deployment(name = "default")

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithServletConditionalFilterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithServletConditionalFilterTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.providers.jackson2.jsonfilter;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.*;
@@ -15,6 +16,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.WebTarget;
@@ -30,6 +32,7 @@ import javax.ws.rs.core.Response;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({NotForForwardCompatibility.class})
 public class JsonFilterWithServletConditionalFilterTest {
 
     static ResteasyClient client;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithServletMultipleFiltersTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithServletMultipleFiltersTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.providers.jackson2.jsonfilter;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.*;
 import org.jboss.resteasy.utils.PortProviderUtil;
@@ -12,6 +13,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Client;
@@ -28,6 +30,7 @@ import javax.ws.rs.core.Response;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({NotForForwardCompatibility.class})
 public class JsonFilterWithServletMultipleFiltersTest {
     @Deployment(name = "default")
     public static Archive<?> deploy() {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jaxb/XmlHeaderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jaxb/XmlHeaderTest.java
@@ -4,6 +4,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
@@ -22,6 +23,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -31,6 +33,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({NotForForwardCompatibility.class})
 public class XmlHeaderTest {
 
     private final Logger logger = Logger.getLogger(XmlHeaderTest.class.getName());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jettison/resource/Book.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jettison/resource/Book.java
@@ -7,15 +7,15 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "book")
 public class Book {
    private String author;
-   private String ISBN;
+   private String isbn;
    private String title;
 
    public Book() {
    }
 
-   public Book(String author, String ISBN, String title) {
+   public Book(String author, String isbn, String title) {
       this.author = author;
-      this.ISBN = ISBN;
+      this.isbn = isbn;
       this.title = title;
    }
 
@@ -29,12 +29,12 @@ public class Book {
    }
 
    @XmlElement
-   public String getISBN() {
-      return ISBN;
+   public String getIsbn() {
+      return isbn;
    }
 
-   public void setISBN(String ISBN) {
-      this.ISBN = ISBN;
+   public void setIsbn(String isbn) {
+      this.isbn = isbn;
    }
 
    @XmlAttribute

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jettison/resource/BookStoreResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jettison/resource/BookStoreResource.java
@@ -30,7 +30,7 @@ public class BookStoreResource {
    @Path("/books")
    @Consumes({"text/xml", "application/json"})
    public void addBook(Book book) {
-      availableBooks.put(book.getISBN(), book);
+      availableBooks.put(book.getIsbn(), book);
    }
 
    @GET

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/yaml/YamlPojoBindingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/yaml/YamlPojoBindingTest.java
@@ -100,7 +100,7 @@ public class YamlPojoBindingTest {
         Client client = ClientBuilder.newClient();
         WebTarget post = client.target(generateURL("/yaml"));
         Response response = post.request().post(Entity.entity("---! bad", "text/x-yaml"));
-        Assert.assertEquals(HttpResponseCodes.SC_BAD_REQUEST, response.getStatus());
+        Assert.assertEquals(TestUtil.getErrorMessageForKnownIssue("JBEAP-7614", "Response code BAD_REQUEST (400) expected"), HttpResponseCodes.SC_BAD_REQUEST, response.getStatus());
         response.close();
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/yaml/YamlProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/yaml/YamlProviderTest.java
@@ -111,7 +111,7 @@ public class YamlProviderTest {
     public void testBadPost() throws Exception {
         WebTarget target = client.target(generateURL("/yaml"));
         Response response = target.request().post(Entity.entity("---! bad", "text/x-yaml"));
-        Assert.assertEquals(HttpResponseCodes.SC_BAD_REQUEST, response.getStatus());
+        Assert.assertEquals(TestUtil.getErrorMessageForKnownIssue("JBEAP-7614", "Response code BAD_REQUEST (400) expected"), HttpResponseCodes.SC_BAD_REQUEST, response.getStatus());
         response.close();
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/MultipleEndpointsWarningTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/MultipleEndpointsWarningTest.java
@@ -8,6 +8,7 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.test.resource.basic.resource.LogHandler;
 import org.jboss.resteasy.test.resource.basic.resource.MultipleEndpointsWarningResource;
 import org.jboss.resteasy.utils.PortProviderUtil;
@@ -18,6 +19,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -80,6 +82,7 @@ public class MultipleEndpointsWarningTest
    }
 
    @Test
+   @Category({NotForForwardCompatibility.class})
    public void testDuplicate() throws Exception {
       Response response = client.target(generateURL("/duplicate")).request().get();
       Assert.assertEquals(LogHandler.MESSAGE_CODE + " should've been logged once", new Long(1), response.readEntity(long.class));

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/cdi/ApplicationScopeValidationTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/cdi/ApplicationScopeValidationTest.java
@@ -11,6 +11,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.api.validation.ViolationReport;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.test.validation.cdi.resource.ApplicationScopeIRestServiceAppScoped;
 import org.jboss.resteasy.test.validation.cdi.resource.ApplicationScopeIRestServiceReqScoped;
 import org.jboss.resteasy.test.validation.cdi.resource.ApplicationScopeMyDto;
@@ -23,6 +24,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -35,7 +37,7 @@ import org.junit.runner.RunWith;
 @RunAsClient
 public class ApplicationScopeValidationTest {
    
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> createTestArchive() {
        WebArchive war = TestUtil.prepareArchive(ApplicationScopeValidationTest.class.getSimpleName())
                .addClasses(ApplicationScopeIRestServiceAppScoped.class, ApplicationScopeIRestServiceReqScoped.class)
@@ -49,6 +51,7 @@ public class ApplicationScopeValidationTest {
    }
    
    @Test
+   @Category({NotForForwardCompatibility.class})
    public void testValidationApplicationScope()
    {
       Client client = ClientBuilder.newClient();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/xxe/SecureProcessing2Test.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/xxe/SecureProcessing2Test.java
@@ -17,10 +17,12 @@ import org.jboss.resteasy.util.HttpResponseCodes;
 import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.Assert;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Entity;
@@ -365,6 +367,24 @@ public class SecureProcessing2Test {
         doTestPassesPassesPassesFails("ffd");
     }
 
+    /**
+     * @tpTestDetails "resteasy.document.secure.processing.feature" is set to default value
+     *                "resteasy.document.secure.disableDTDs" is set to true
+     *                "resteasy.document.expand.entity.references" is set to true
+     * @tpSince RESTEasy 3.1.0
+     */
+    @Test
+    @Category({NotForForwardCompatibility.class})
+    public void testSecurityDefaultDTDsTrueExpansionTrueWithApacheLinkMessage() throws Exception {
+        doTestSkipFailsFailsSkipWithApacheLinkMessage("dtt");
+    }
+
+
+    void doTestSkipFailsFailsSkipWithApacheLinkMessage(String ext) throws Exception {
+        doMaxAttributesFails(ext);
+        doDTDFailsWithApacheLinkMessage(ext);
+    }
+
     void doTestSkipFailsFailsSkip(String ext) throws Exception {
         doMaxAttributesFails(ext);
         doDTDFails(ext);
@@ -520,6 +540,19 @@ public class SecureProcessing2Test {
     }
 
     void doDTDFails(String ext) throws Exception {
+        logger.info("entering doDTDFails(" + ext + ")");
+        Response response = client.target(generateURL("/DTD/", URL_PREFIX + ext)).request()
+                .post(Entity.entity(bar, "application/xml"));
+        logger.info("status: " + response.getStatus());
+        String entity = response.readEntity(String.class);
+        logger.info("doDTDFails(): result: " + entity);
+        Assert.assertEquals(HttpResponseCodes.SC_BAD_REQUEST, response.getStatus());
+        Assert.assertThat("Wrong exception in response", entity, startsWith("javax.xml.bind.UnmarshalException"));
+        Assert.assertThat("Wrong content of response", entity, containsString("DOCTYPE"));
+        Assert.assertThat("Wrong content of response", entity, containsString("true"));
+    }
+
+    void doDTDFailsWithApacheLinkMessage(String ext) throws Exception {
         logger.info("entering doDTDFails(" + ext + ")");
         Response response = client.target(generateURL("/DTD/", URL_PREFIX + ext)).request()
                 .post(Entity.entity(bar, "application/xml"));

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/xxe/SecureProcessingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/xxe/SecureProcessingTest.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.xxe.resource.SecureProcessingBar;
@@ -21,6 +22,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Entity;
@@ -381,6 +383,23 @@ public class SecureProcessingTest {
         doTestSkipFailsFailsSkip("ttt");
     }
 
+    /**
+     * @tpTestDetails "resteasy.document.secure.processing.feature" is set to true
+     *                "resteasy.document.secure.disableDTDs" is set to true
+     *                "resteasy.document.expand.entity.references" is set to true
+     * @tpSince RESTEasy 3.1.0
+     */
+    @Test
+    @Category({NotForForwardCompatibility.class})
+    public void testSecurityTrueDTDsTrueExpansionTrueWithApacheLinkMessage() throws Exception {
+        doTestSkipFailsFailsSkipWithApacheLinkMessage("ttt");
+    }
+
+    void doTestSkipFailsFailsSkipWithApacheLinkMessage(String ext) throws Exception {
+        doMaxAttributesFails(ext);
+        doDTDFailsWithApacheLinkMessage(ext);
+    }
+
     void doTestSkipFailsFailsSkip(String ext) throws Exception {
         doMaxAttributesFails(ext);
         doDTDFails(ext);
@@ -536,6 +555,19 @@ public class SecureProcessingTest {
     }
 
     void doDTDFails(String ext) throws Exception {
+        logger.info("entering doDTDFails(" + ext + ")");
+        Response response = client.target(generateURL("/DTD/", URL_PREFIX + ext)).request()
+                .post(Entity.entity(bar, "application/xml"));
+        logger.info("status: " + response.getStatus());
+        String entity = response.readEntity(String.class);
+        logger.info("doDTDFails(): result: " + entity);
+        Assert.assertEquals(HttpResponseCodes.SC_BAD_REQUEST, response.getStatus());
+        Assert.assertThat("Wrong exception in response", entity, startsWith("javax.xml.bind.UnmarshalException"));
+        Assert.assertThat("Wrong content of response", entity, containsString("DOCTYPE"));
+        Assert.assertThat("Wrong content of response", entity, containsString("true"));
+    }
+
+    void doDTDFailsWithApacheLinkMessage(String ext) throws Exception {
         logger.info("entering doDTDFails(" + ext + ")");
         Response response = client.target(generateURL("/DTD/", URL_PREFIX + ext)).request()
                 .post(Entity.entity(bar, "application/xml"));


### PR DESCRIPTION
YamlProvidertest - link issue JBEAP-7614 for bad request test

JaxbSmokeTest - make it pass with version com.fasterxml.jackson 2.5.x

XmlHeaderTest - not for forward compatibility

JsonView/JsonFilter forward compatibility

Jackson2Test forward compatibility

AtomComplexModelTest forward compatibility

Resteasy1405Test forward compatibility

GzipTest forward compatibility

FilteredCookieTest forward compatibility

ResteasyJAXRSImplTest forward compatibility

ValidationWithCDITest forward compatibility

AsynchCounterTest forward compatibility

SigningTest forward compatibility