### PR TITLE
[RESTEASY-1564] ValidationHibernateI18NTest stabilization

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ValidationHibernateI18NTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ValidationHibernateI18NTest.java
@@ -22,6 +22,8 @@ import org.junit.runner.RunWith;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import static org.hamcrest.core.StringStartsWith.startsWith;
+
 /**
  * @tpSubChapter Response
  * @tpChapter Integration tests
@@ -60,7 +62,7 @@ public class ValidationHibernateI18NTest {
      */
     @Test
     public void testI18NSetAcceptLanguage() throws Exception {
-        doTestI18NSetAcceptLanguage("fr", "la taille doit être entre");
+        doTestI18NSetAcceptLanguage("fr", "la taille doit être");
         doTestI18NSetAcceptLanguage("es", "el tama\u00F1o tiene que estar entre");
     }
 
@@ -71,7 +73,7 @@ public class ValidationHibernateI18NTest {
         ViolationReport report = response.readEntity(ViolationReport.class);
         String message = report.getReturnValueViolations().iterator().next().getMessage();
         TestUtil.countViolations(report, 0, 0, 0, 0, 1);
-        Assert.assertTrue(WRONG_ERROR_MSG, message.startsWith(expectedMessage));
+        Assert.assertThat(WRONG_ERROR_MSG, message, startsWith(expectedMessage));
         response.close();
     }
 }


### PR DESCRIPTION
Fix ValidationHibernateI18NTest test. This test check hibernate validation message, but this message was changed in new version of hibernate: https://github.com/hibernate/hibernate-validator/commit/8549a02d0457363fbc923fc9f9260eefc019f544#diff-124ed53e2f45f264c0428538f460f94cR13

Tests needs to pass with old and with new version of hibernate (it means with old WF and with new WF)