### PR TITLE
JBEAP-8013: Impossible to use JAX-RS and Spring MVC in the same WEB app

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/servlet/ResteasyBootstrapClasses.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/servlet/ResteasyBootstrapClasses.java
@@ -11,7 +11,6 @@ public interface ResteasyBootstrapClasses
    public static String[] BOOTSTRAP_CLASSES = {
            HttpServletDispatcher.class.getName(),
            ResteasyBootstrap.class.getName(),
-           "org.springframework.web.servlet.DispatcherServlet",
            FilterDispatcher.class.getName(),
            "org.jboss.resteasy.plugins.server.servlet.JBossWebDispatcherServlet",
            "org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher",


### PR DESCRIPTION
The fix was locally tested and I am sending it if engineering agree to remove the spring servet dispatcher as a possible bootstrap servlet. 

It is important to discuss the impacts on Spring MVC + RESTEasy integration if we remove this bootstrap class. However, it is proven in JBEAP-8013 that it is breaking JAX-RS in Spring MVC apps deployed in EAP/Wildfly.