### PR TITLE
[RESTEASY-1559] False alarm ambiguity for /foo and /{id} -> long

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/registry/SegmentNode.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/registry/SegmentNode.java
@@ -446,12 +446,20 @@ public class SegmentNode
       }
       Collections.sort(sortList);
       SortEntry sortEntry = sortList.get(0);
-      if (targetMethods != null && targetMethods.size() > 1)
+      if (targetMethods != null && targetMethods.size() > 1 && !checkExpressionsUnique(sortList))
       {
          LogMessages.LOGGER.multipleMethodsMatch(requestToString(request), methodNames(targetMethods));
       }
       request.setAttribute(RESTEASY_CHOSEN_ACCEPT, sortEntry.getAcceptType());
       return sortEntry.match;
+   }
+
+   private boolean checkExpressionsUnique(List<SortEntry> sortList){
+      Set<String> regexps = new HashSet<>();
+      for(SortEntry elm: sortList){
+         regexps.add(elm.match.expression.getRegex());
+      }
+      return regexps.size() == sortList.size();
    }
 
    protected void addExpression(MethodExpression expression)

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/path/PathCollisionWithPathParamIdTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/path/PathCollisionWithPathParamIdTest.java
@@ -1,0 +1,81 @@
+package org.jboss.resteasy.test.resource.path;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailing;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.test.providers.jackson2.jsonfilter.JsonFilterWithInterceptrTest;
+import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.JsonFilterWriteInterceptor;
+import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.ObjectFilterModifier;
+import org.jboss.resteasy.test.resource.path.resource.PathCollisionWithPathParamIdResource;
+import org.jboss.resteasy.utils.LogCounter;
+import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.Jackson2Product;
+import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.Jackson2Resource;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
+
+/**
+ *  * @tpSubChapter Resource
+ *   * @tpChapter Integration tests
+ *    * @tpTestCaseDetails Request for a resource on a path GET "/list" matches two resources with @Path("/list") and @Path("{id}").
+ *     * See RESTEASY-1559
+ *      * @tpSince RESTEasy 3.1.1
+ *       */
+@RunWith(Arquillian.class)
+@RunAsClient
+@Category({NotForForwardCompatibility.class})
+public class PathCollisionWithPathParamIdTest {
+
+    static Client client;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        WebArchive war = TestUtil.prepareArchive(PathCollisionWithPathParamIdTest.class.getSimpleName());
+        return TestUtil.finishContainerPrepare(war, null, PathCollisionWithPathParamIdResource.class);
+    }
+
+    private String generateURL(String path) {
+        return PortProviderUtil.generateURL(path, PathCollisionWithPathParamIdTest.class.getSimpleName());
+    }
+
+    @BeforeClass
+    public static void setup() {
+        client = ClientBuilder.newClient();
+    }
+
+    @AfterClass
+    public static void close() {
+        client.close();
+    }
+
+    /**
+     * @tpTestDetails Check that correct resource was used, and warning message for multiple resource matching was generated
+     * @tpSince RESTEasy 3.1.1
+     */
+    @Test
+    public void testCollision() {
+        LogCounter countPathCollision = new LogCounter("RESTEASY002142: Multiple resource methods match request", false);
+        String response = client.target(generateURL("/list")).request().get(String.class);
+        Assert.assertThat("Incorrectly logged warning for multiple resource methods match", countPathCollision.count(), is(0));
+        Assert.assertThat("Wring resource was chosen","/list", equalToIgnoringCase(response));
+    }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/path/resource/PathCollisionWithPathParamIdResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/path/resource/PathCollisionWithPathParamIdResource.java
@@ -1,0 +1,22 @@
+package org.jboss.resteasy.test.resource.path.resource;
+
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+@Path("/")
+public class PathCollisionWithPathParamIdResource {
+
+    @GET
+    @Path("/list")
+    public String getList() {
+        return "/list";
+    }
+
+    @GET
+    @Path("/{id}")
+    public String getId(@PathParam("id") long myId) {
+        return String.valueOf(myId);
+    }
+}


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RESTEASY-1559