### PR TITLE
[RESTEASY-1591] Change catch Throwable to IOException in ClientInvocation

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
@@ -443,7 +443,7 @@ public class ClientInvocation implements Invocation
                {
                   throw e;
                }
-               catch (Throwable e)
+               catch (IOException e)
                {
                   throw new ProcessingException(e);
                }
@@ -468,7 +468,7 @@ public class ClientInvocation implements Invocation
                {
                   throw e;
                }
-               catch (Throwable e)
+               catch (IOException e)
                {
                   throw new ResponseProcessingException(response, e);
                }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/ResponseFilterCustomExceptionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/ResponseFilterCustomExceptionTest.java
@@ -1,0 +1,65 @@
+package org.jboss.resteasy.test.interceptor;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.test.interceptor.resource.CustomException;
+import org.jboss.resteasy.test.interceptor.resource.ThrowCustomExceptionResponseFilter;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+
+/**
+ * @tpSubChapter Interceptors
+ * @tpChapter Integration tests
+ * @tpSince RESTEasy 3.0.20
+ * @tpTestCaseDetails Throw custom exception from a ClientResponseFilter [RESTEASY-1591]
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ResponseFilterCustomExceptionTest {
+    @Deployment
+    public static Archive<?> deploy() {
+        WebArchive war = TestUtil.prepareArchive(ResponseFilterCustomExceptionTest.class.getSimpleName());
+        war.addClasses(TestUtil.class, PortProviderUtil.class);
+        war.addClasses(CustomException.class);
+        return TestUtil.finishContainerPrepare(war, null, ThrowCustomExceptionResponseFilter.class);
+    }
+
+    static Client client;
+
+    @Before
+    public void setup() {
+        client = ClientBuilder.newClient();
+    }
+
+    @After
+    public void cleanup() {
+        client.close();
+    }
+
+    private String generateURL(String path) {
+        return PortProviderUtil.generateURL(path, ResponseFilterCustomExceptionTest.class.getSimpleName());
+    }
+    /**
+     * @tpTestDetails Use ClientResponseFilter
+     * @tpSince RESTEasy 3.1.0
+     */
+    @Test(expected = CustomException.class)
+    public void testThrowCustomException() throws Exception {
+        ResteasyProviderFactory factory = ResteasyProviderFactory.getInstance();
+        factory.register(ThrowCustomExceptionResponseFilter.class);
+        client.register(ThrowCustomExceptionResponseFilter.class);
+        client.target(generateURL("/testCustomException")).request().post(Entity.text("testCustomException"));
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/resource/CustomException.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/resource/CustomException.java
@@ -1,0 +1,8 @@
+package org.jboss.resteasy.test.interceptor.resource;
+
+public class CustomException extends RuntimeException {
+
+    public CustomException() {
+        super("This is a custom Exception");
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/resource/ThrowCustomExceptionResponseFilter.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/resource/ThrowCustomExceptionResponseFilter.java
@@ -1,0 +1,13 @@
+package org.jboss.resteasy.test.interceptor.resource;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+
+
+public class ThrowCustomExceptionResponseFilter implements ClientResponseFilter {
+    @Override
+    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) {
+        throw new CustomException();
+    }
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/RequestFilterTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/RequestFilterTest.java
@@ -2,11 +2,13 @@ package org.jboss.resteasy.test.client;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jboss.resteasy.test.client.resource.ClientCustomException;
 import org.jboss.resteasy.test.client.resource.RequestFilterAbortWith;
 import org.jboss.resteasy.test.client.resource.RequestFilterAcceptLanguage;
 import org.jboss.resteasy.test.client.resource.RequestFilterAnnotation;
 import org.jboss.resteasy.test.client.resource.RequestFilterGetEntity;
 import org.jboss.resteasy.test.client.resource.RequestFilterSetEntity;
+import org.jboss.resteasy.test.client.resource.RequestFilterThrowCustomException;
 import org.jboss.resteasy.util.HttpResponseCodes;
 import org.junit.Assert;
 import org.junit.AfterClass;
@@ -111,5 +113,17 @@ public class RequestFilterTest {
         Response response = client.target(dummyUrl).register(RequestFilterAnnotation.class).request().post(post);
         Assert.assertEquals("The response doesn't contain the expexted provider name",
                 Provider.class.getName(), response.readEntity(String.class));
+    }
+
+    /**
+     * @tpTestDetails Client registers implementation of ClientRequestFilter and sends GET request.
+     * The request is processed by registered filter before it is send to the server. Filter aborts processing
+     * by throwing a custom exception, which should not be wrapped in a ProcessingException. [RESTEASY-1591]
+     * @tpPassCrit Expected Exception is thrown from the Client
+     * @tpSince RESTEasy 3.0.20
+     */
+    @Test(expected = ClientCustomException.class)
+    public void ThrowCustomExceptionFilterTest() {
+        client.target(dummyUrl).register(RequestFilterThrowCustomException.class).request().get();
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/ClientCustomException.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/ClientCustomException.java
@@ -1,0 +1,8 @@
+package org.jboss.resteasy.test.client.resource;
+
+public class ClientCustomException extends RuntimeException {
+
+    public ClientCustomException() {
+        super("This is a custom Exception");
+    }
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/RequestFilterThrowCustomException.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/RequestFilterThrowCustomException.java
@@ -1,0 +1,17 @@
+package org.jboss.resteasy.test.client.resource;
+
+import org.jboss.logging.Logger;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+
+public class RequestFilterThrowCustomException implements ClientRequestFilter {
+
+    private static Logger logger = Logger.getLogger(RequestFilterThrowCustomException.class);
+
+    @Override
+    public void filter(ClientRequestContext requestContext) {
+        logger.info("*** filter throwing exception ***");
+        throw new ClientCustomException();
+    }
+}


### PR DESCRIPTION
Currently every exception in .invoke() is wrapped in a ResponseProcessingException or it is mapped to specific HTTP exception in handleErrorStatus.

This change allows a Client Request/Repsonse Filters to throw custom exceptions. 