### PR TITLE
[RESTEASY-1590] Create a new SSLEngine for each connection

### DIFF
--- a/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
+++ b/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyJaxrsServer.java
@@ -275,11 +275,11 @@ public class NettyJaxrsServer implements EmbeddedJaxrsServer
                 }
             };
         } else if (sniConfiguration == null) {
-            final SSLEngine engine = sslContext.createSSLEngine();
-            engine.setUseClientMode(false);
             return new ChannelInitializer<SocketChannel>() {
                 @Override
                 public void initChannel(SocketChannel ch) throws Exception {
+                    SSLEngine engine = sslContext.createSSLEngine();
+                    engine.setUseClientMode(false);
                     ch.pipeline().addFirst(new SslHandler(engine));
                     setupHandlers(ch, dispatcher, HTTPS);
                 }


### PR DESCRIPTION
Bug fix: Only the first client requests are successful, any other requests issued by a new connection timeout. 
Using wireshark, it appears that the handshake is performed only at the first connection. I checked the code and indeed resteasy keep using the same SSL session for all connections.
Fix: use a new SSLEngine for each new connection.

Netty documentation about using the SSLHandler and restarting a session: 
https://netty.io/4.0/api/io/netty/handler/ssl/SslHandler.html =

Jira issue: https://issues.jboss.org/browse/RESTEASY-1590