### PR TITLE
[RESTEASY-1600] Remove jaxrs spec dependency management entry in rest…

### DIFF
--- a/resteasy-bom/pom.xml
+++ b/resteasy-bom/pom.xml
@@ -17,11 +17,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.jboss.spec.javax.ws.rs</groupId>
-                <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
-                <version>${version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-atom-provider</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
…easy-bom, as that's already controlled by the resteasy-dependencies dependencyManagement block pulled transitively by other modules