### PR TITLE
[RESTEASY-1628 squashed]

### DIFF
--- a/docbook/reference/en/en-US/modules/Content_Marshalling_Providers.xml
+++ b/docbook/reference/en/en-US/modules/Content_Marshalling_Providers.xml
@@ -399,4 +399,51 @@ public class MultipartProvider implements MessageBodyReader {
    <para>to "false".</para>
    </sect1>
    
+   <sect1 id="Text_media_types">
+      <title>Text media types and character sets</title>
+   
+   <para>
+   The JAX-RS specification says
+   </para>
+
+<programlisting>
+When writing responses, implementations SHOULD respect application-supplied character
+set metadata and SHOULD use UTF-8 if a character set is not specified by the application
+or if the application specifies a character set that is unsupported.
+</programlisting>
+
+   <para>
+   On the other hand, the HTTP specification says
+   </para>
+   
+<programlisting>
+When no explicit charset parameter is provided by the sender, media subtypes of the
+"text" type are defined to have a default charset value of "ISO-8859-1" when received
+via HTTP. Data in character sets other than "ISO-8859-1" or its subsets MUST be labeled
+with an appropriate charset value.
+</programlisting>
+
+   <para>
+   It follows that, in the absence of a character set specified by a resource or resource method,
+   Resteasy SHOULD use UTF-8 as the character set for text media types, and, if it does, it MUST add an explicit 
+   charset parameter to the Content-Type response header. Resteasy started adding the explicit charset
+   parameter in releases 3.1.2.Final and 3.0.22.Final, and that new behavior could cause some compatibility problems. To
+   specify the previous behavior, in which UTF-8 was used for text media types, but the explicit charset
+   was not appended, the context parameter "resteasy.add.charset" may be set to "false". It defaults to "true".
+   </para>
+   
+   <para>
+   <emphasis role="bold">Note.</emphasis> By "text" media types, we mean
+   </para>
+   
+   <itemizedlist>
+      <listitem>a media type with type "text" and any subtype;</listitem>
+      <listitem>a media type with type ""application" and subtype beginning with "xml".</listitem>
+   </itemizedlist>
+   
+   <para>
+   The latter set includes "application/xml-external-parsed-entity" and "application/xml-dtd".
+   </para>
+   </sect1>
+   
 </chapter>

--- a/docbook/reference/en/en-US/modules/Installation_Configuration.xml
+++ b/docbook/reference/en/en-US/modules/Installation_Configuration.xml
@@ -686,7 +686,7 @@ public class MyApplication extends Application
                                 resteasy.add.charset
                             </entry>
                             <entry>
-                                false
+                                true
                             </entry>
                             <entry>
                                 If a resource method returns a text/* or application/xml* media type without

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/cache/CacheInterceptor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/cache/CacheInterceptor.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.client.jaxrs.cache;
 
 import org.jboss.resteasy.util.DateUtil;
+import org.jboss.resteasy.util.MediaTypeHelper;
 import org.jboss.resteasy.util.ReadFromStream;
 
 import javax.ws.rs.client.ClientRequestContext;
@@ -223,6 +224,11 @@ public class CacheInterceptor implements ClientRequestFilter, ClientResponseFilt
          {
             entry = cache.get(uri, accept);
             if (entry != null) return entry;
+            if (MediaTypeHelper.isTextLike(accept))
+            {
+               entry = cache.get(uri, accept.withCharset("UTF-8"));
+               if (entry != null) return entry;
+            }
          }
 
       }

--- a/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/client/ResponseObjectTest.java
+++ b/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/client/ResponseObjectTest.java
@@ -129,8 +129,8 @@ public class ResponseObjectTest
         org.junit.Assert.assertEquals(HttpResponseCodes.SC_OK, obj.status());
         org.junit.Assert.assertEquals("The response object doesn't contain the expected string", "ABC", obj.body());
         org.junit.Assert.assertEquals("The response object doesn't contain the expected header",
-                "text/plain", obj.response().getHeaders().getFirst("Content-Type"));
-        org.junit.Assert.assertEquals("The response object doesn't contain the expected header", "text/plain", obj.contentType());
+                "text/plain;charset=UTF-8", obj.response().getHeaders().getFirst("Content-Type"));
+        org.junit.Assert.assertEquals("The response object doesn't contain the expected header", "text/plain;charset=UTF-8", obj.contentType());
     }
 
     @Test

--- a/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/finegrain/resource/ResourceLocatorTest.java
+++ b/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/finegrain/resource/ResourceLocatorTest.java
@@ -351,7 +351,7 @@ public class ResourceLocatorTest
          Assert.assertEquals("got", response.getContentAsString());
          Assert.assertNotNull(response.getOutputHeaders().get("Content-Type"));
          Assert.assertTrue(response.getOutputHeaders().get("Content-Type").size() > 0);
-         Assert.assertEquals(MediaType.TEXT_PLAIN_TYPE, response.getOutputHeaders().get("Content-Type").get(0));
+         Assert.assertEquals(MediaType.TEXT_PLAIN_TYPE.withCharset("UTF-8").toString(), response.getOutputHeaders().get("Content-Type").get(0));
       }
 
       {

--- a/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/finegrain/resource/VariantsTest.java
+++ b/resteasy-jaxrs-testsuite/src/test/java/org/jboss/resteasy/test/finegrain/resource/VariantsTest.java
@@ -177,7 +177,7 @@ public class VariantsTest
       ClientResponse<String> response = request.get(String.class);
       Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
       Assert.assertEquals("GET", response.getEntity());
-      Assert.assertEquals("application/xml", response.getResponseHeaders().getFirst(HttpHeaderNames.CONTENT_TYPE));
+      Assert.assertEquals("application/xml;charset=UTF-8", response.getResponseHeaders().getFirst(HttpHeaderNames.CONTENT_TYPE));
       Assert.assertEquals("en-us", response.getResponseHeaders().getFirst(HttpHeaderNames.CONTENT_LANGUAGE));
    }
 
@@ -196,7 +196,7 @@ public class VariantsTest
       ClientResponse<String> response = request.get(String.class);
       Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
       Assert.assertEquals("GET", response.getEntity());
-      Assert.assertEquals("application/xml", response.getResponseHeaders().getFirst(HttpHeaderNames.CONTENT_TYPE));
+      Assert.assertEquals("application/xml;charset=UTF-8", response.getResponseHeaders().getFirst(HttpHeaderNames.CONTENT_TYPE));
       Assert.assertEquals("en-us", response.getResponseHeaders().getFirst(HttpHeaderNames.CONTENT_LANGUAGE));
    }
 
@@ -215,7 +215,7 @@ public class VariantsTest
       ClientResponse<String> response = request.get(String.class);
       Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
       Assert.assertEquals("GET", response.getEntity());
-      Assert.assertEquals("application/xml", response.getResponseHeaders().getFirst(HttpHeaderNames.CONTENT_TYPE));
+      Assert.assertEquals("application/xml;charset=UTF-8", response.getResponseHeaders().getFirst(HttpHeaderNames.CONTENT_TYPE));
       Assert.assertEquals("en-us", response.getResponseHeaders().getFirst(HttpHeaderNames.CONTENT_LANGUAGE));
    }
 
@@ -235,7 +235,7 @@ public class VariantsTest
       Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
       Assert.assertEquals("GET", response.getEntity());
       Assert.assertEquals("en", response.getResponseHeaders().getFirst(HttpHeaderNames.CONTENT_LANGUAGE));
-      Assert.assertEquals("text/xml", response.getResponseHeaders().getFirst(HttpHeaderNames.CONTENT_TYPE));
+      Assert.assertEquals("text/xml;charset=UTF-8", response.getResponseHeaders().getFirst(HttpHeaderNames.CONTENT_TYPE));
    }
 
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/cache/CacheInterceptor.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/client/cache/CacheInterceptor.java
@@ -8,6 +8,7 @@ import org.jboss.resteasy.spi.interception.AcceptedByMethod;
 import org.jboss.resteasy.spi.interception.ClientExecutionContext;
 import org.jboss.resteasy.spi.interception.ClientExecutionInterceptor;
 import org.jboss.resteasy.util.DateUtil;
+import org.jboss.resteasy.util.MediaTypeHelper;
 import org.jboss.resteasy.util.ReadFromStream;
 import org.jboss.resteasy.util.WeightedMediaType;
 
@@ -242,6 +243,11 @@ public class CacheInterceptor implements ClientExecutionInterceptor, AcceptedByM
          {
             entry = cache.get(uri, accept);
             if (entry != null) return entry;
+            if (MediaTypeHelper.isTextLike(accept))
+            {
+               entry = cache.get(uri, accept.withCharset("UTF-8"));
+               if (entry != null) return entry;
+            }
          }
       }
       else

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/interceptors/encoding/MessageSanitizerContainerResponseFilter.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/interceptors/encoding/MessageSanitizerContainerResponseFilter.java
@@ -3,6 +3,8 @@ package org.jboss.resteasy.plugins.interceptors.encoding;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
+
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
@@ -30,7 +32,7 @@ public class MessageSanitizerContainerResponseFilter implements ContainerRespons
             Object entity = responseContext.getEntity();
             if (entity != null && entity instanceof String) {
                 ArrayList contentTypes = (ArrayList)responseContext.getHeaders().get("Content-Type");
-                if (contentTypes != null  && contentTypes.contains(MediaType.TEXT_HTML)) {
+                if (contentTypes != null  && containsHtmlText(contentTypes)) {
                     String escapedMsg = escapeXml((String) entity);
                     responseContext.setEntity(escapedMsg);
                 }
@@ -74,5 +76,21 @@ public class MessageSanitizerContainerResponseFilter implements ContainerRespons
         return sb.toString();
     }
 
+    private boolean containsHtmlText(ArrayList<Object> list) {
+        for (Object o : list) {
+           if (o instanceof String) {
+              String mediaType = (String) o;
+              String[] partsType = mediaType.split("/");
+              if (partsType.length >= 2) {
+                 String[] partsSubtype = partsType[1].split(";");
+                 if (partsType[0].trim().equalsIgnoreCase("text") && 
+                       partsSubtype[0].trim().toLowerCase().equals("html")) {
+                    return true;
+                 }
+              }
+           }
+        }
+        return false;
+     }
 }
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/servlet/ListenerBootstrap.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/servlet/ListenerBootstrap.java
@@ -33,6 +33,7 @@ public class ListenerBootstrap extends ConfigurationBootstrap
    {
       ResteasyDeployment deployment = (ResteasyDeployment) servletContext.getAttribute(ResteasyDeployment.class.getName());
       if (deployment == null) deployment = super.createDeployment();
+      deployment.getDefaultContextObjects().put(ResteasyDeployment.class, deployment);
       deployment.getDefaultContextObjects().put(ServletContext.class, servletContext);
       deployment.getDefaultContextObjects().put(ResteasyConfiguration.class, this);
       String servletMappingPrefix = getParameter(ResteasyContextParameters.RESTEASY_SERVLET_MAPPING_PREFIX);

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyDeployment.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyDeployment.java
@@ -42,7 +42,7 @@ public class ResteasyDeployment
    protected boolean useContainerFormParams = false;
    protected boolean deploymentSensitiveFactoryEnabled = false;
    protected boolean asyncJobServiceEnabled = false;
-   protected boolean addCharset = false;
+   protected boolean addCharset = true;
    protected int asyncJobServiceMaxJobResults = 100;
    protected long asyncJobServiceMaxWait = 300000;
    protected int asyncJobServiceThreadPoolSize = 100;

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/MediaTypeHelper.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/MediaTypeHelper.java
@@ -252,4 +252,11 @@ public class MediaTypeHelper
       }
       return true;
    }
+   
+   public static boolean isTextLike(MediaType mediaType)
+   {
+      return "text".equalsIgnoreCase(mediaType.getType())
+            || ("application".equalsIgnoreCase(mediaType.getType())
+                  && mediaType.getSubtype().toLowerCase().startsWith("xml"));
+   }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsynchContextualDataTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsynchContextualDataTest.java
@@ -23,6 +23,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.experimental.categories.Category;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 
 /**
  * @tpSubChapter Asynchronous RESTEasy: RESTEASY-1225
@@ -64,6 +66,7 @@ public class AsynchContextualDataTest {
      * @tpSince RESTEasy 3.1.1.Final
      */
     @Test
+    @Category(NotForForwardCompatibility.class)
     public void testContextualData() throws Exception {
        String id = "334";
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/ResponseObjectTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/ResponseObjectTest.java
@@ -83,9 +83,9 @@ public class ResponseObjectTest {
         ResponseObjectBasicObjectIntf obj = clientProxyFactory.get();
         Assert.assertEquals(HttpResponseCodes.SC_OK, obj.status());
         Assert.assertEquals("The response object doesn't contain the expected string", "ABC", obj.body());
-        Assert.assertEquals("The response object doesn't contain the expected header" , "text/plain",
+        Assert.assertEquals("The response object doesn't contain the expected header" , "text/plain;charset=UTF-8",
                 obj.responseDeprecated().getHeaders().getFirst("Content-Type"));
-        Assert.assertEquals("The response object doesn't contain the expected header", "text/plain", obj.contentType());
+        Assert.assertEquals("The response object doesn't contain the expected header", "text/plain;charset=UTF-8", obj.contentType());
     }
 
     /**
@@ -114,11 +114,11 @@ public class ResponseObjectTest {
         Assert.assertEquals("The response object doesn't contain the expected string", "ABC", obj.body());
         try {
             Assert.assertEquals("The response object doesn't contain the expected header",
-                    "text/plain", obj.response().getHeaders().getFirst("Content-Type"));
+                    "text/plain;charset=UTF-8", obj.response().getHeaders().getFirst("Content-Type"));
         } catch (ClassCastException ex) {
             Assert.fail(TestUtil.getErrorMessageForKnownIssue("JBEAP-2446"));
         }
-        Assert.assertEquals("The response object doesn't contain the expected header", "text/plain", obj.contentType());
+        Assert.assertEquals("The response object doesn't contain the expected header", "text/plain;charset=UTF-8", obj.contentType());
     }
 
     /**

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/ReaderWriterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/ReaderWriterTest.java
@@ -92,7 +92,7 @@ public class ReaderWriterTest {
         WebTarget base = client.target(PortProviderUtil.generateURL("/implicit", ReaderWriterCustomerWriter.class.getSimpleName()));
         Response response = base.request().get();
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
-        Assert.assertEquals("application/xml", response.getStringHeaders().getFirst("content-type"));
+        Assert.assertEquals("application/xml;charset=UTF-8", response.getStringHeaders().getFirst("content-type"));
         String s = new String(response.readEntity(byte[].class), "US-ASCII");
         Assert.assertEquals("Response contains wrong content", "<customer><name>bill</name></customer>", s);
         response.close();
@@ -132,7 +132,7 @@ public class ReaderWriterTest {
         WebTarget base = client.target(PortProviderUtil.generateURL("/complex", ReaderWriterResource.class.getSimpleName()));
         Response response = base.request().get();
         Assert.assertEquals(HttpResponseCodes.SC_FOUND, response.getStatus());
-        Assert.assertEquals(response.getStringHeaders().getFirst("content-type"), "text/plain");
+        Assert.assertEquals(response.getStringHeaders().getFirst("content-type"), "text/plain;charset=UTF-8");
         byte[] responseBody = response.readEntity(byte[].class);
         String responseString = new String(responseBody, "US-ASCII");
         Assert.assertEquals("Response contains wrong content", "hello world", responseString);
@@ -148,7 +148,7 @@ public class ReaderWriterTest {
         WebTarget base = client.target(PortProviderUtil.generateURL("/simple", ReaderWriterResource.class.getSimpleName()));
         Response response = base.request().get();
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
-        Assert.assertEquals("text/plain", response.getStringHeaders().getFirst("content-type"));
+        Assert.assertEquals("text/plain;charset=UTF-8", response.getStringHeaders().getFirst("content-type"));
         String s = new String(response.readEntity(byte[].class), "US-ASCII");
         Assert.assertEquals("Response contains wrong content", "hello world", s);
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/WriterNotBuiltinTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/WriterNotBuiltinTest.java
@@ -55,7 +55,7 @@ public class WriterNotBuiltinTest {
         Response response = client.target(PortProviderUtil.generateURL("/string", WriterNotBuiltinTest.class.getSimpleName()))
                 .request().get();
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
-        Assert.assertEquals("text/plain", response.getStringHeaders().getFirst("content-type"));
+        Assert.assertEquals("text/plain;charset=UTF-8", response.getStringHeaders().getFirst("content-type"));
         Assert.assertEquals("Response contains wrong content", "hello world", response.readEntity(String.class));
         Assert.assertTrue("Wrong MessageBodyWriter was used", WriterNotBuiltinTestWriter.used);
         client.close();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jettison/ContentTypeMatchingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jettison/ContentTypeMatchingTest.java
@@ -71,7 +71,7 @@ public class ContentTypeMatchingTest {
         Response response = target.request().get();
         Assert.assertEquals("Unexpected http response code was returned", 412, response.getStatus());
         Assert.assertEquals("Wrong response content-type returned",
-                "application/xml", response.getStringHeaders().getFirst("Content-Type"));
+                "application/xml;charset=UTF-8", response.getStringHeaders().getFirst("Content-Type"));
         String error = response.readEntity(String.class);
         logger.info(error);
         Assert.assertTrue("Incorrect exception mapper was used",
@@ -99,7 +99,7 @@ public class ContentTypeMatchingTest {
         {
             Response response = target.request().accept("application/xml").get();
             Assert.assertEquals(412, response.getStatus());
-            Assert.assertEquals("application/xml", response.getStringHeaders().getFirst("Content-Type"));
+            Assert.assertEquals("application/xml;charset=UTF-8", response.getStringHeaders().getFirst("Content-Type"));
             String error = response.readEntity(String.class);
             logger.info(error);
             Assert.assertTrue("Incorrect exception mapper was used",
@@ -128,7 +128,7 @@ public class ContentTypeMatchingTest {
         {
             Response response = target.request().accept("application/xml").get();
             Assert.assertEquals(412, response.getStatus());
-            Assert.assertEquals("application/xml", response.getStringHeaders().getFirst("Content-Type"));
+            Assert.assertEquals("application/xml;charset=UTF-8", response.getStringHeaders().getFirst("Content-Type"));
             String error = response.readEntity(String.class);
             logger.info(error);
             Assert.assertTrue("Incorrect exception mapper was used",
@@ -156,7 +156,7 @@ public class ContentTypeMatchingTest {
         {
             Response response = target.request().accept("application/xml").get();
             Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
-            Assert.assertEquals("application/xml", response.getStringHeaders().getFirst("Content-Type"));
+            Assert.assertEquals("application/xml;charset=UTF-8", response.getStringHeaders().getFirst("Content-Type"));
             String error = response.readEntity(String.class);
             logger.info(error);
             Assert.assertTrue("Incorrect exception mapper was used",

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jettison/TypeMappingJettisonTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jettison/TypeMappingJettisonTest.java
@@ -85,7 +85,7 @@ public class TypeMappingJettisonTest {
     @Test
     public void extensionTest() throws Exception {
         // acceptXMLOnlyRequestNoProducesNoExtension() throws Exception {
-        requestAndAssert("noproduces", null, "application/xml", "application/xml");
+        requestAndAssert("noproduces", null, "application/xml", "application/xml;charset=UTF-8");
 
         // acceptJSONOnlyRequestNoProducesNoExtension() throws Exception {
         requestAndAssert("noproduces", null, "application/json", "application/json");
@@ -94,14 +94,14 @@ public class TypeMappingJettisonTest {
         requestAndAssert("noproduces", "json", null, "application/json");
 
         // acceptNullRequestNoProducesXMLExtension() throws Exception {
-        requestAndAssert("noproduces", "xml", null, "application/xml");
+        requestAndAssert("noproduces", "xml", null, "application/xml;charset=UTF-8");
 
 
         // acceptJSONOnlyRequestNoProducesJSONExtension() throws Exception {
         requestAndAssert("noproduces", "json", "application/json", "application/json");
 
         // acceptJSONOnlyRequestNoProducesXMLExtension() throws Exception {
-        requestAndAssert("noproduces", "xml", "application/json", "application/xml");
+        requestAndAssert("noproduces", "xml", "application/json", "application/xml;charset=UTF-8");
 
         // acceptJSONAndXMLRequestNoProducesJSONExtension() throws Exception {
         requestAndAssert("noproduces", "json", "application/json, application/xml",
@@ -112,18 +112,18 @@ public class TypeMappingJettisonTest {
                 "application/json");
 
         // acceptXMLOnlyRequestNoProducesXMLExtension() throws Exception {
-        requestAndAssert("noproduces", "xml", "application/xml", "application/xml");
+        requestAndAssert("noproduces", "xml", "application/xml", "application/xml;charset=UTF-8");
 
         // acceptXMLOnlyRequestNoProducesJSONExtension() throws Exception {
         requestAndAssert("noproduces", "json", "application/xml", "application/json");
 
         // acceptJSONAndXMLRequestNoProducesXMLExtension() throws Exception {
         requestAndAssert("noproduces", "xml", "application/json, application/xml",
-                "application/xml");
+                "application/xml;charset=UTF-8");
 
         // acceptXMLAndJSONRequestNoProducesXMLExtension() throws Exception {
         requestAndAssert("noproduces", "xml", "application/xml, application/json",
-                "application/xml");
+                "application/xml;charset=UTF-8");
     }
 
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/yaml/YamlPojoBindingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/yaml/YamlPojoBindingTest.java
@@ -63,7 +63,7 @@ public class YamlPojoBindingTest {
         Response response = get.request().get();
 
         assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
-        assertEquals(HEADER_ERROR_MSG, "text/x-yaml", response.getHeaders().getFirst("Content-Type"));
+        assertEquals(HEADER_ERROR_MSG, "text/x-yaml;charset=UTF-8", response.getHeaders().getFirst("Content-Type"));
 
         String s = response.readEntity(String.class);
         YamlPojoBindingObject o1 = YamlResource.createMyObject();
@@ -87,7 +87,7 @@ public class YamlPojoBindingTest {
         Response response = post.request().post(Entity.entity(s1, "text/x-yaml"));
 
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
-        Assert.assertEquals(HEADER_ERROR_MSG, "text/x-yaml", response.getHeaders().getFirst("Content-Type"));
+        Assert.assertEquals(HEADER_ERROR_MSG, "text/x-yaml;charset=UTF-8", response.getHeaders().getFirst("Content-Type"));
         Assert.assertEquals(RESPONSE_ERROR_MSG, s1, response.readEntity(String.class));
         response.close();
     }
@@ -120,7 +120,7 @@ public class YamlPojoBindingTest {
         Response response = post.request().post(Entity.entity(s1, "text/x-yaml"));
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
 
-        Assert.assertEquals(HEADER_ERROR_MSG, "text/plain", response.getHeaders().getFirst("Content-Type"));
+        Assert.assertEquals(HEADER_ERROR_MSG, "text/plain;charset=UTF-8", response.getHeaders().getFirst("Content-Type"));
         Assert.assertEquals(RESPONSE_ERROR_MSG, s1, response.readEntity(String.class).trim());
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/yaml/YamlProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/yaml/YamlProviderTest.java
@@ -77,7 +77,7 @@ public class YamlProviderTest {
         String stringResponse = response.readEntity(String.class);
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
         Assert.assertEquals("The response doesn't contain correct yaml header",
-                "text/x-yaml", response.getHeaders().getFirst("Content-Type"));
+                "text/x-yaml;charset=UTF-8", response.getHeaders().getFirst("Content-Type"));
         YamlProviderObject o1 = YamlProviderResource.createMyObject();
         String s1 = new Yaml().dump(o1);
         Assert.assertEquals("The entity response doesn't match the original request", s1, stringResponse);
@@ -98,7 +98,7 @@ public class YamlProviderTest {
         String stringResponse = response.readEntity(String.class);
         Assert.assertEquals(TestUtil.getErrorMessageForKnownIssue("JBEAP-1047"), HttpResponseCodes.SC_OK, response.getStatus());
         Assert.assertEquals("The response doesn't contain correct yaml header",
-                "text/x-yaml", response.getHeaders().getFirst("Content-Type"));
+                "text/x-yaml;charset=UTF-8", response.getHeaders().getFirst("Content-Type"));
         Assert.assertEquals("The entity response doesn't match the original request", s1, stringResponse);
     }
 
@@ -128,7 +128,7 @@ public class YamlProviderTest {
         WebTarget target = client.target(generateURL("/yaml/list"));
         Response response = target.request().post(Entity.entity(s1, "text/x-yaml"));
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
-        Assert.assertEquals("text/plain", response.getHeaderString("Content-Type"));
+        Assert.assertEquals("text/plain;charset=UTF-8", response.getHeaderString("Content-Type"));
         Assert.assertEquals(s1, response.readEntity(String.class).trim());
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/DefaultCharsetTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/DefaultCharsetTest.java
@@ -19,6 +19,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.experimental.categories.Category;
+import org.jboss.resteasy.category.NotForForwardCompatibility;
 
 /**
  * @tpSubChapter Resources
@@ -71,30 +73,31 @@ public class DefaultCharsetTest {
     }
     
     @Test
+    @Category(NotForForwardCompatibility.class)
     public void testCharset() throws Exception {
-       doTest("_true",    "/true",    "/nocharset",     "UTF-8");  // "resteasy.add.charset" set to true, text media type, charset not set
-       doTest("_true",    "/true",    "/charset",       "UTF-16"); // "resteasy.add.charset" set to true, text media type, charset already set
-       doTest("_true",    "/true",    "/nomediatype",   null);     // "resteasy.add.charset" set to true, no mediatype set in response
-       doTest("_true",    "/true",    "/xml_nocharset", "UTF-8");  // "resteasy.add.charset" set to true, application/xml media type, charset not set
-       doTest("_true",    "/true",    "/xml_charset",   "UTF-16"); // "resteasy.add.charset" set to true, application/xml media type, charset already set
-       doTest("_true",    "/true",    "/external",      "UTF-8");  // "resteasy.add.charset" set to true, application/xml-... media type, charset not set
-       doTest("_true",    "/true",    "/json",          null);     // "resteasy.add.charset" set to true, application/json media type, charset not set
+        doTest("_true",    "/true",    "/nocharset",     "UTF-8");  // "resteasy.add.charset" set to true, text media type, charset not set
+        doTest("_true",    "/true",    "/charset",       "UTF-16"); // "resteasy.add.charset" set to true, text media type, charset already set
+        doTest("_true",    "/true",    "/nomediatype",   null);     // "resteasy.add.charset" set to true, no mediatype set in response
+        doTest("_true",    "/true",    "/xml_nocharset", "UTF-8");  // "resteasy.add.charset" set to true, application/xml media type, charset not set
+        doTest("_true",    "/true",    "/xml_charset",   "UTF-16"); // "resteasy.add.charset" set to true, application/xml media type, charset already set
+        doTest("_true",    "/true",    "/external",      "UTF-8");  // "resteasy.add.charset" set to true, application/xml-... media type, charset not set
+        doTest("_true",    "/true",    "/json",          null);     // "resteasy.add.charset" set to true, application/json media type, charset not set
 
-       doTest("_false",   "/false",   "/nocharset",     null);     // "resteasy.add.charset" set to false, text media type, charset not set
-       doTest("_false",   "/false",   "/charset",       "UTF-16"); // "resteasy.add.charset" set to false, text media type, charset already set
-       doTest("_false",   "/false",   "/nomediatype",   null);     // "resteasy.add.charset" set to false, no media type set in response
-       doTest("_false",   "/false",   "/xml_nocharset", null);     // "resteasy.add.charset" set to false, application/xml media type, charset not set
-       doTest("_false",   "/false",   "/xml_charset",   "UTF-16"); // "resteasy.add.charset" set to false, application/xml media type, charset already set
-       doTest("_false",   "/false",   "/external",      null);     // "resteasy.add.charset" set to false, application/xml-... media type, charset not set
-       doTest("_false",   "/false",   "/json",          null);     // "resteasy.add.charset" set to false, application/json media type, charset not set
+        doTest("_false",   "/false",   "/nocharset",     null);     // "resteasy.add.charset" set to false, text media type, charset not set
+        doTest("_false",   "/false",   "/charset",       "UTF-16"); // "resteasy.add.charset" set to false, text media type, charset already set
+        doTest("_false",   "/false",   "/nomediatype",   null);     // "resteasy.add.charset" set to false, no media type set in response
+        doTest("_false",   "/false",   "/xml_nocharset", null);     // "resteasy.add.charset" set to false, application/xml media type, charset not set
+        doTest("_false",   "/false",   "/xml_charset",   "UTF-16"); // "resteasy.add.charset" set to false, application/xml media type, charset already set
+        doTest("_false",   "/false",   "/external",      null);     // "resteasy.add.charset" set to false, application/xml-... media type, charset not set
+        doTest("_false",   "/false",   "/json",          null);     // "resteasy.add.charset" set to false, application/json media type, charset not set
 
-       doTest("_default", "/default",  "/nocharset",     null);     // "resteasy.add.charset" not set, text media type, charset not set
-       doTest("_default", "/default",  "/charset",       "UTF-16"); // "resteasy.add.charset" not set, text media type, charset already set
-       doTest("_default", "/default",  "/nomediatype",   null);     // "resteasy.add.charset" not set, no mediatype set in response
-       doTest("_default", "/default", "/xml_nocharset",  null);     // "resteasy.add.charset" not set, application/xml media type, charset not set
-       doTest("_default", "/default", "/xml_charset",    "UTF-16"); // "resteasy.add.charset" not set, application/xml media type, charset already set
-       doTest("_default", "/default", "/external",       null);     // "resteasy.add.charset" not set, application/xml-... media type, charset not set
-       doTest("_default", "/default", "/json",           null);     // "resteasy.add.charset" not set, application/json media type, charset not set
+        doTest("_default", "/default",  "/nocharset",     "UTF-8");  // "resteasy.add.charset" not set, text media type, charset not set
+        doTest("_default", "/default",  "/charset",       "UTF-16"); // "resteasy.add.charset" not set, text media type, charset already set
+        doTest("_default", "/default",  "/nomediatype",   null);     // "resteasy.add.charset" not set, no mediatype set in response
+        doTest("_default", "/default",  "/xml_nocharset", "UTF-8");  // "resteasy.add.charset" not set, application/xml media type, charset not set
+        doTest("_default", "/default",  "/xml_charset",   "UTF-16"); // "resteasy.add.charset" not set, application/xml media type, charset already set
+        doTest("_default", "/default",  "/external",      "UTF-8");  // "resteasy.add.charset" not set, application/xml-... media type, charset not set
+        doTest("_default", "/default",  "/json",          null);     // "resteasy.add.charset" not set, application/json media type, charset not set
     }
 
     void doTest(String suffix, String mapping, String path, String expectedMediaType) throws Exception {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/MatchedResourceTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/MatchedResourceTest.java
@@ -86,7 +86,7 @@ public class MatchedResourceTest {
         WebTarget base = client.target(generateURL("/match"));
         Response response = base.request().header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
                 .get();
-        Assert.assertEquals("text/html", response.getHeaders().getFirst("Content-Type"));
+        Assert.assertEquals("text/html;charset=UTF-8", response.getHeaders().getFirst("Content-Type"));
         String res = response.readEntity(String.class);
         Assert.assertEquals("Wrong response content", "*/*", res);
         response.close();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/ResourceLocatorTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/ResourceLocatorTest.java
@@ -144,7 +144,7 @@ public class ResourceLocatorTest
          Assert.assertEquals("got", response.readEntity(String.class));
          Assert.assertNotNull(response.getHeaderString("Content-Type"));
          Assert.assertNotNull(response.getHeaderString("Content-Type"));
-         Assert.assertEquals(MediaType.TEXT_PLAIN, response.getHeaderString("Content-Type"));
+         Assert.assertEquals(MediaType.TEXT_PLAIN+";charset=UTF-8", response.getHeaderString("Content-Type"));
       }
 
       {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/path/ResourceMatchingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/path/ResourceMatchingTest.java
@@ -198,7 +198,7 @@ public class ResourceMatchingTest {
         MediaType mediaType = response.getMediaType();
         String actual = response.readEntity(String.class);
         Assert.assertEquals("application/xml", actual);
-        Assert.assertEquals("MediaType of the response doesn't match the expected type", "application/xml",
+        Assert.assertEquals("MediaType of the response doesn't match the expected type", "application/xml;charset=UTF-8",
                 mediaType.toString());
         response.close();
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/VariantsTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/VariantsTest.java
@@ -203,7 +203,7 @@ public class VariantsTest {
                 .acceptLanguage("en-us", "en;q=0.5").get();
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
         Assert.assertEquals("GET", response.readEntity(String.class));
-        Assert.assertEquals(MediaType.APPLICATION_XML_TYPE, response.getMediaType());
+        Assert.assertEquals(MediaType.APPLICATION_XML_TYPE.withCharset("UTF-8"), response.getMediaType());
         Assert.assertEquals("en-us", new LocaleDelegate().toString(response.getLanguage()));
         response.close();
     }
@@ -219,7 +219,7 @@ public class VariantsTest {
                 .acceptLanguage("en", "en-us").get();
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
         Assert.assertEquals("GET", response.readEntity(String.class));
-        Assert.assertEquals(MediaType.APPLICATION_XML_TYPE, response.getMediaType());
+        Assert.assertEquals(MediaType.APPLICATION_XML_TYPE.withCharset("UTF-8"), response.getMediaType());
         Assert.assertEquals("en-us", new LocaleDelegate().toString(response.getLanguage()));
         response.close();
     }
@@ -235,7 +235,7 @@ public class VariantsTest {
                 .acceptLanguage("en-us", "en;q=0.5").get();
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
         Assert.assertEquals("GET", response.readEntity(String.class));
-        Assert.assertEquals(MediaType.APPLICATION_XML_TYPE, response.getMediaType());
+        Assert.assertEquals(MediaType.APPLICATION_XML_TYPE.withCharset("UTF-8"), response.getMediaType());
         Assert.assertEquals("en-us", new LocaleDelegate().toString(response.getLanguage()));
         response.close();
     }
@@ -253,7 +253,7 @@ public class VariantsTest {
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
         Assert.assertEquals("GET", response.readEntity(String.class));
         Assert.assertEquals("en", response.getLanguage().toString());
-        Assert.assertEquals(MediaType.TEXT_XML_TYPE, response.getMediaType());
+        Assert.assertEquals(MediaType.TEXT_XML_TYPE.withCharset("UTF-8"), response.getMediaType());
         response.close();
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/CustomForbiddenMessageTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/CustomForbiddenMessageTest.java
@@ -97,7 +97,7 @@ public class CustomForbiddenMessageTest {
         Assert.assertEquals(HttpResponseCodes.SC_FORBIDDEN, response.getStatus());
         Assert.assertEquals(ACCESS_FORBIDDEN_MESSAGE, response.readEntity(String.class));
         String ct = response.getHeaderString("Content-Type");
-        Assert.assertEquals("text/plain", ct);
+        Assert.assertEquals("text/plain;charset=UTF-8", ct);
     }
 
     static class SecurityDomainSetup extends AbstractUsersRolesSecurityDomainSetup {


### PR DESCRIPTION
# The first commit's message is:

Add NotForForwardCompatibility for the new tests

# This is the 2nd commit message:

[RESTEASY-1628]

Changed treatment of text media types without charset parameter to add
"charset=UTF-8" by default.

[RESTEASY-1628]

Altered
org.jboss.resteasy.plugins.interceptors.encoding.MessageSanitizerContainerResponseFilter.containsHtmlText().