### PR TITLE
[RESTEASY-1627] Automatic HEAD requests breaks subsequent request(s)

### DIFF
--- a/server-adapters/resteasy-netty/src/test/java/org/jboss/resteasy/test/NettyTest.java
+++ b/server-adapters/resteasy-netty/src/test/java/org/jboss/resteasy/test/NettyTest.java
@@ -83,6 +83,8 @@ public class NettyTest
       String val = ClientInvocation.extractResult(new GenericType<String>(String.class), getResponse, null);
       Assert.assertEquals("hello world", val);
       Response headResponse = target.request().build(HttpMethod.HEAD).invoke();
+      Assert.assertFalse(headResponse.hasEntity());
+      Assert.assertTrue(getResponse.getLength() > 0);
       Assert.assertEquals("HEAD method should return the same Content-Length as the GET method", getResponse.getLength(), headResponse.getLength());
    }
 

--- a/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpRequestDecoder.java
+++ b/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/RestEasyHttpRequestDecoder.java
@@ -7,6 +7,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
 
 import java.util.List;
 
@@ -56,7 +57,7 @@ public class RestEasyHttpRequestDecoder extends MessageToMessageDecoder<io.netty
     protected void decode(ChannelHandlerContext ctx, io.netty.handler.codec.http.HttpRequest request, List<Object> out) throws Exception
     {
         boolean keepAlive = HttpHeaders.isKeepAlive(request);
-        final NettyHttpResponse response = new NettyHttpResponse(ctx, keepAlive, dispatcher.getProviderFactory());
+        final NettyHttpResponse response = new NettyHttpResponse(ctx, keepAlive, dispatcher.getProviderFactory(), request.method());
         final ResteasyHttpHeaders headers;
         final ResteasyUriInfo uriInfo;
         try


### PR DESCRIPTION
This fix the issue by avoiding the body contents to be returned in HEAD method responses, as a consequence of RESTEASY-1365 changes.
The bits on the wire are still slightly different from what we had before RESTEASY-1365: before that, resteasy-jaxrs was not handling control over to the resteasy-netty4 server adapter for dealing with responses to HEAD requests, basically only writing http status plus few headers (Connection and Content-Type headers). Now, resteasy-netty4 is still processing the response, but the contents of the ChunkOutputStream are actually not flushed to the wire, resulting in an empty chunk being written only. So an exchange with a GET request followed by a HEAD request to the same resource ends up being as follows (capture with Wireshark):


GET /test HTTP/1.1
Host: localhost:8081
Connection: Keep-Alive
User-Agent: Apache-HttpClient/4.5.2 (Java/1.8.0_77)

HTTP/1.1 200 OK
Connection: keep-alive
Content-Type: text/plain
transfer-encoding: chunked

b
hello world
0

HEAD /test HTTP/1.1
Content-Length: 0
Host: localhost:8081
Connection: Keep-Alive
User-Agent: Apache-HttpClient/4.5.2 (Java/1.8.0_77)

HTTP/1.1 200 OK
Connection: keep-alive
Content-Type: text/plain
transfer-encoding: chunked

0