### PR TITLE
[RESTEASY-1638] Permission check failed when creating instance of resteasy client

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
@@ -14,6 +14,8 @@ import javax.ws.rs.core.MediaType;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Set;
@@ -24,7 +26,7 @@ public class ProxyBuilder<T>
    
 	private final Class<T> iface;
 	private final ResteasyWebTarget webTarget;
-	private ClassLoader loader = Thread.currentThread().getContextClassLoader();
+	private ClassLoader loader;
 	private MediaType serverConsumes;
 	private MediaType serverProduces;
 
@@ -93,6 +95,21 @@ public class ProxyBuilder<T>
 
    private ProxyBuilder(Class<T> iface, ResteasyWebTarget webTarget)
    {
+      if (System.getSecurityManager() == null)
+      {
+          this.loader = Thread.currentThread().getContextClassLoader();
+      }
+      else
+      {
+          this.loader = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>()
+          {
+              @Override
+              public ClassLoader run()
+              {
+                  return Thread.currentThread().getContextClassLoader();
+              }
+          });
+      }
       this.iface = iface;
       this.webTarget = webTarget;
    }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ResteasyClient.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ResteasyClient.java
@@ -3,9 +3,6 @@ package org.jboss.resteasy.client.jaxrs;
 import org.jboss.resteasy.client.jaxrs.i18n.Messages;
 import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
 import org.jboss.resteasy.client.jaxrs.internal.ClientWebTarget;
-import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
-import org.jboss.resteasy.spi.NotImplementedYetException;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -17,9 +14,10 @@ import javax.ws.rs.core.Link;
 import javax.ws.rs.core.UriBuilder;
 
 import java.net.URI;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -73,7 +71,22 @@ public class ResteasyClient implements Client
          httpEngine.close();
          if (cleanupExecutor)
          {
-            asyncInvocationExecutor.shutdown();
+            if (System.getSecurityManager() == null)
+            {
+               asyncInvocationExecutor.shutdown();
+            }
+            else
+            {
+               AccessController.doPrivileged(new PrivilegedAction<Void>()
+               {
+                  @Override
+                  public Void run()
+                  {
+                     asyncInvocationExecutor.shutdown();
+                     return null;
+                  }
+               });
+            }
          }
       }
       catch (Exception e)

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/RegisterBuiltin.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/RegisterBuiltin.java
@@ -7,10 +7,15 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import javax.ws.rs.ext.Providers;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -46,12 +51,44 @@ public class RegisterBuiltin
 
    public static void registerProviders(ResteasyProviderFactory factory) throws Exception
    {
-      Enumeration<URL> en = Thread.currentThread().getContextClassLoader().getResources("META-INF/services/" + Providers.class.getName());
+      Enumeration<URL> en;
+      if (System.getSecurityManager() == null)
+      {
+         en = Thread.currentThread().getContextClassLoader().getResources("META-INF/services/" + Providers.class.getName());
+      }
+      else
+      {
+         en = AccessController.doPrivileged(new PrivilegedExceptionAction<Enumeration<URL>>()
+         {
+            @Override
+            public Enumeration<URL> run() throws IOException
+            {
+               return Thread.currentThread().getContextClassLoader().getResources("META-INF/services/" + Providers.class.getName());
+            }
+         });
+      }
+
       Map<String, URL> origins = new HashMap<String, URL>();
       while (en.hasMoreElements())
       {
-         URL url = en.nextElement();
-         InputStream is = url.openStream();
+         final URL url = en.nextElement();
+         InputStream is;
+         if (System.getSecurityManager() == null)
+         {
+            is = url.openStream();
+         }
+         else
+         {
+            is = AccessController.doPrivileged(new PrivilegedExceptionAction<InputStream>()
+            {
+               @Override
+               public InputStream run() throws IOException
+               {
+                  return url.openStream();
+               }
+            });
+         }
+
          try
          {
             BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
@@ -68,21 +105,37 @@ public class RegisterBuiltin
             is.close();
          }
       }
-      for (Entry<String, URL> entry : origins.entrySet())
+      for (final Entry<String, URL> entry : origins.entrySet())
       {
-         String line = entry.getKey();
+         final String line = entry.getKey();
          try
          {
-            Class clazz = Thread.currentThread().getContextClassLoader().loadClass(line);
+            Class clazz;
+            if (System.getSecurityManager() == null)
+            {
+               clazz = Thread.currentThread().getContextClassLoader().loadClass(line);
+            }
+            else
+            {
+               clazz = AccessController.doPrivileged(new PrivilegedExceptionAction<Class>()
+               {
+                  @Override
+                  public Class run() throws ClassNotFoundException
+                  {
+                     return Thread.currentThread().getContextClassLoader().loadClass(line);
+                  }
+               });
+            }
+
             factory.registerProvider(clazz, true);
          }
          catch (NoClassDefFoundError e)
          {
             LogMessages.LOGGER.noClassDefFoundErrorError(line, entry.getValue(), e);
          }
-         catch (ClassNotFoundException e)
+         catch (ClassNotFoundException | PrivilegedActionException ex)
          {
-            LogMessages.LOGGER.classNotFoundException(line, entry.getValue(), e);
+            LogMessages.LOGGER.classNotFoundException(line, entry.getValue(), ex);
          }
       }
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -77,6 +77,8 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -1240,7 +1242,7 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
       }
    }
 
-   public List<ContextResolver> getContextResolvers(Class<?> clazz, MediaType type)
+   public List<ContextResolver> getContextResolvers(final Class<?> clazz, MediaType type)
    {
       MediaTypeMap<SortedKey<ContextResolver>> resolvers = getContextResolvers().get(clazz);
       if (resolvers == null) return null;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncPostProcessingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncPostProcessingTest.java
@@ -23,7 +23,10 @@ import org.jboss.logging.Logger;
 
 import javax.ws.rs.core.Response;
 import java.lang.reflect.ReflectPermission;
+import java.net.SocketPermission;
+import java.security.SecurityPermission;
 import java.util.PropertyPermission;
+import java.util.logging.LoggingPermission;
 
 /**
  * @tpSubChapter Asynchronous RESTEasy
@@ -44,8 +47,16 @@ public class AsyncPostProcessingTest {
         war.addAsWebInfResource(AsyncPostProcessingTest.class.getPackage(), "AsyncPostProcessingTestWeb.xml", "web.xml");
         // Arquillian in the deployment
         war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
+                new LoggingPermission("control", ""),
+                new PropertyPermission("arquillian.*", "read"),
+                new PropertyPermission("ipv6", "read"),
+                new PropertyPermission("node", "read"),
+                new PropertyPermission("org.jboss.resteasy.port", "read"),
                 new RuntimePermission("accessDeclaredMembers"),
-                new PropertyPermission("arquillian.*", "read")), "permissions.xml");
+                new RuntimePermission("getenv.RESTEASY_PORT"),
+                new SecurityPermission("insertProvider"),
+                new SocketPermission(PortProviderUtil.getHost(), "connect,resolve")
+        ), "permissions.xml");
         return TestUtil.finishContainerPrepare(war, null, AsyncPostProcessingResource.class,
                 AsyncPostProcessingMsgBodyWriterInterceptor.class, AsyncPostProcessingInterceptor.class);
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsynchBasicTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsynchBasicTest.java
@@ -20,12 +20,14 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.lang.reflect.ReflectPermission;
+import java.net.SocketPermission;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.PropertyPermission;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.LoggingPermission;
 
 import static org.jboss.resteasy.utils.PortProviderUtil.generateURL;
 
@@ -57,8 +59,15 @@ public class AsynchBasicTest {
         }
         // Arquillian in the deployment
         war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
+                new LoggingPermission("control", ""),
+                new PropertyPermission("arquillian.*", "read"),
+                new PropertyPermission("ipv6", "read"),
+                new PropertyPermission("node", "read"),
+                new PropertyPermission("org.jboss.resteasy.port", "read"),
                 new RuntimePermission("accessDeclaredMembers"),
-                new PropertyPermission("arquillian.*", "read")), "permissions.xml");
+                new RuntimePermission("getenv.RESTEASY_PORT"),
+                new SocketPermission(PortProviderUtil.getHost(), "connect,resolve")
+        ), "permissions.xml");
         return TestUtil.finishContainerPrepare(war, contextParam, AsynchBasicResource.class);
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/EJBTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/EJBTest.java
@@ -37,8 +37,11 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import java.lang.reflect.ReflectPermission;
+import java.net.SocketPermission;
+import java.security.SecurityPermission;
 import java.util.Hashtable;
 import java.util.PropertyPermission;
+import java.util.logging.LoggingPermission;
 
 import static org.junit.Assert.assertEquals;
 
@@ -77,8 +80,16 @@ public class EJBTest {
             .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
         // Arquillian in the deployment
         war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
+                new LoggingPermission("control", ""),
+                new PropertyPermission("arquillian.*", "read"),
+                new PropertyPermission("ipv6", "read"),
+                new PropertyPermission("node", "read"),
+                new PropertyPermission("org.jboss.resteasy.port", "read"),
                 new RuntimePermission("accessDeclaredMembers"),
-                new PropertyPermission("arquillian.*", "read")), "permissions.xml");
+                new SecurityPermission("insertProvider"),
+                new RuntimePermission("getenv.RESTEASY_PORT"),
+                new SocketPermission(PortProviderUtil.getHost(), "connect,resolve")
+        ), "permissions.xml");
         return war;
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/extensions/ScopeExtensionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/extensions/ScopeExtensionTest.java
@@ -29,6 +29,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import java.lang.reflect.ReflectPermission;
+import java.net.SocketPermission;
 import java.util.PropertyPermission;
 import java.util.logging.Logger;
 import java.util.logging.LoggingPermission;
@@ -59,9 +60,17 @@ public class ScopeExtensionTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsServiceProvider(Extension.class, ScopeExtensionPlannedObsolescenceExtension.class);
         // Arquillian in the deployment
-        war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
+        war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
+                new LoggingPermission("control", ""),
+                new PropertyPermission("arquillian.*", "read"),
+                new PropertyPermission("ipv6", "read"),
+                new PropertyPermission("node", "read"),
+                new PropertyPermission("org.jboss.resteasy.port", "read"),
+                new ReflectPermission("suppressAccessChecks"),
                 new RuntimePermission("accessDeclaredMembers"),
-                new PropertyPermission("arquillian.*", "read")), "permissions.xml");
+                new RuntimePermission("getenv.RESTEASY_PORT"),
+                new SocketPermission(PortProviderUtil.getHost(), "connect,resolve")
+        ), "permissions.xml");
         return war;
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/extensions/ScopeExtensionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/extensions/ScopeExtensionTest.java
@@ -28,7 +28,6 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
-import java.io.FilePermission;
 import java.lang.reflect.ReflectPermission;
 import java.util.PropertyPermission;
 import java.util.logging.Logger;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/ReverseInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/ReverseInjectionTest.java
@@ -71,10 +71,12 @@ import java.io.StringWriter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.ReflectPermission;
 import java.lang.reflect.Type;
+import java.net.SocketPermission;
 import java.util.Collection;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.PropertyPermission;
+import java.util.logging.LoggingPermission;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -151,8 +153,15 @@ public class ReverseInjectionTest extends AbstractInjectionTestBase {
                 .addAsResource(ReverseInjectionTest.class.getPackage(), "persistence.xml", "META-INF/persistence.xml");
         // Arquillian in the deployment
         war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
+                new LoggingPermission("control", ""),
+                new PropertyPermission("arquillian.*", "read"),
+                new PropertyPermission("ipv6", "read"),
+                new PropertyPermission("node", "read"),
+                new PropertyPermission("org.jboss.resteasy.port", "read"),
                 new RuntimePermission("accessDeclaredMembers"),
-                new PropertyPermission("arquillian.*", "read")), "permissions.xml");
+                new RuntimePermission("getenv.RESTEASY_PORT"),
+                new SocketPermission(PortProviderUtil.getHost(), "connect,resolve")
+        ), "permissions.xml");
         return war;
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/AbortMessageTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/AbortMessageTest.java
@@ -2,6 +2,7 @@ package org.jboss.resteasy.test.client;
 
 
 import java.io.UnsupportedEncodingException;
+import java.util.logging.LoggingPermission;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -13,6 +14,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.test.client.resource.AbortMessageResourceFilter;
+import org.jboss.resteasy.utils.PermissionUtil;
 import org.jboss.resteasy.utils.PortProviderUtil;
 import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
@@ -49,6 +51,10 @@ public class AbortMessageTest {
    @Deployment
    public static Archive<?> deploy() {
        WebArchive war = TestUtil.prepareArchive(AbortMessageTest.class.getSimpleName());
+       war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
+               new LoggingPermission("control", ""),
+               new RuntimePermission("accessDeclaredMembers")
+       ), "permissions.xml");
        return TestUtil.finishContainerPrepare(war, null, AbortMessageResourceFilter.class);
    }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FilePermission;
 import java.lang.reflect.ReflectPermission;
 import java.util.PropertyPermission;
+import java.util.logging.LoggingPermission;
 
 /**
  * @tpSubChapter Resteasy-client
@@ -37,11 +38,13 @@ public class ClientBuilderTest {
         war.addClass(NotForForwardCompatibility.class);
         // Arquillian in the deployment and use of TestUtil
         war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
-                new RuntimePermission("accessDeclaredMembers"),
+                new FilePermission(TestUtil.getJbossHome() + File.separator + "standalone" + File.separator + "log" +
+                        File.separator + "server.log", "read"),
+                new LoggingPermission("control", ""),
                 new PropertyPermission("arquillian.*", "read"),
                 new PropertyPermission("jboss.home.dir", "read"),
-                new FilePermission(TestUtil.getJbossHome() + File.separator + "standalone" + File.separator + "log" +
-                        File.separator + "server.log", "read")), "permissions.xml");
+                new RuntimePermission("accessDeclaredMembers")
+        ), "permissions.xml");
         return TestUtil.finishContainerPrepare(war, null, (Class<?>[]) null);
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientCacheTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientCacheTest.java
@@ -23,7 +23,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.ReflectPermission;
+import java.net.SocketPermission;
 import java.util.PropertyPermission;
+import java.util.logging.LoggingPermission;
 
 
 /**
@@ -48,12 +50,16 @@ public class ClientCacheTest {
         war.addClasses(ClientCacheProxy.class, ClientCacheTest.class, TestUtil.class, PortProviderUtil.class);
         // Arquillian in the deployment and use of PortProviderUtil and Test util in the deployment
         war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
-                new RuntimePermission("accessDeclaredMembers"),
+                new LoggingPermission("control", ""),
                 new PropertyPermission("arquillian.*", "read"),
-                new PropertyPermission("node", "read"),
                 new PropertyPermission("ipv6", "read"),
+                new PropertyPermission("node", "read"),
+                new PropertyPermission("org.jboss.resteasy.port", "read"),
+                new RuntimePermission("accessDeclaredMembers"),
                 new RuntimePermission("getenv.RESTEASY_PORT"),
-                new PropertyPermission("org.jboss.resteasy.port", "read")), "permissions.xml");
+                new SocketPermission(PortProviderUtil.getHost(), "connect,resolve")
+        ), "permissions.xml");
+        war.addClasses(ClientCacheProxy.class, ClientCacheTest.class, TestUtil.class, PortProviderUtil.class);
         return TestUtil.finishContainerPrepare(war, null, ClientCacheService.class);
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/InternalDispatcherTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/InternalDispatcherTest.java
@@ -22,10 +22,12 @@ import org.junit.runner.RunWith;
 import javax.ws.rs.core.Response;
 
 import java.lang.reflect.ReflectPermission;
+import java.net.SocketPermission;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.PropertyPermission;
+import java.util.logging.LoggingPermission;
 
 /**
  * @tpSubChapter Core
@@ -52,8 +54,15 @@ public class InternalDispatcherTest {
         singletons.add(InternalDispatcherForwardingResource.class);
         // Arquillian in the deployment
         war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
+                new LoggingPermission("control", ""),
+                new PropertyPermission("arquillian.*", "read"),
+                new PropertyPermission("ipv6", "read"),
+                new PropertyPermission("node", "read"),
+                new PropertyPermission("org.jboss.resteasy.port", "read"),
                 new RuntimePermission("accessDeclaredMembers"),
-                new PropertyPermission("arquillian.*", "read")), "permissions.xml");
+                new RuntimePermission("getenv.RESTEASY_PORT"),
+                new SocketPermission(PortProviderUtil.getHost(), "connect,resolve")
+        ), "permissions.xml");
         return TestUtil.finishContainerPrepare(war, null, singletons, (Class<?>[]) null);
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/interceptors/CorsFiltersTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/interceptors/CorsFiltersTest.java
@@ -21,9 +21,11 @@ import org.junit.runner.RunWith;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import java.lang.reflect.ReflectPermission;
+import java.net.SocketPermission;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.PropertyPermission;
+import java.util.logging.LoggingPermission;
 
 import static org.hamcrest.core.Is.is;
 
@@ -44,12 +46,15 @@ public class CorsFiltersTest {
         singletons.add(CorsFilter.class);
         // Arquillian in the deployment and use of PortProviderUtil
         war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
-                new RuntimePermission("accessDeclaredMembers"),
+                new LoggingPermission("control", ""),
                 new PropertyPermission("arquillian.*", "read"),
                 new PropertyPermission("node", "read"),
                 new PropertyPermission("ipv6", "read"),
+                new PropertyPermission("org.jboss.resteasy.port", "read"),
+                new RuntimePermission("accessDeclaredMembers"),
                 new RuntimePermission("getenv.RESTEASY_PORT"),
-                new PropertyPermission("org.jboss.resteasy.port", "read")), "permissions.xml");
+                new SocketPermission(PortProviderUtil.getHost(), "connect,resolve")
+        ), "permissions.xml");
         return TestUtil.finishContainerPrepare(war, null, singletons, CorsFiltersResource.class);
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/PriorityExecutionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/PriorityExecutionTest.java
@@ -41,9 +41,11 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 import java.lang.reflect.ReflectPermission;
+import java.net.SocketPermission;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.PropertyPermission;
+import java.util.logging.LoggingPermission;
 
 /**
  * @tpSubChapter Interceptors
@@ -83,8 +85,15 @@ public class PriorityExecutionTest {
                 PriorityExecutionClientRequestFilterMin.class);
         // Arquillian in the deployment
         war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
+                new LoggingPermission("control", ""),
+                new PropertyPermission("arquillian.*", "read"),
+                new PropertyPermission("ipv6", "read"),
+                new PropertyPermission("node", "read"),
+                new PropertyPermission("org.jboss.resteasy.port", "read"),
                 new RuntimePermission("accessDeclaredMembers"),
-                new PropertyPermission("arquillian.*", "read")), "permissions.xml");
+                new RuntimePermission("getenv.RESTEASY_PORT"),
+                new SocketPermission(PortProviderUtil.getHost(), "connect,resolve")
+        ), "permissions.xml");
         return TestUtil.finishContainerPrepare(war, null, PriorityExecutionResource.class);
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/DuplicateProviderRegistrationTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/DuplicateProviderRegistrationTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.FilePermission;
 import java.lang.reflect.ReflectPermission;
 import java.util.PropertyPermission;
+import java.util.logging.LoggingPermission;
 
 /**
  * @tpSubChapter Providers
@@ -44,11 +45,13 @@ public class DuplicateProviderRegistrationTest {
         war.addClass(NotForForwardCompatibility.class);
         // Arquillian in the deployment, test reads the server.log
         war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
-                new RuntimePermission("accessDeclaredMembers"),
+                new FilePermission(TestUtil.getJbossHome() + File.separator + "standalone" + File.separator + "log" +
+                        File.separator + "server.log", "read"),
+                new LoggingPermission("control", ""),
                 new PropertyPermission("arquillian.*", "read"),
                 new PropertyPermission("jboss.home.dir", "read"),
-                new FilePermission(TestUtil.getJbossHome() + File.separator + "standalone" + File.separator + "log" +
-                        File.separator + "server.log", "read")), "permissions.xml");
+                new RuntimePermission("accessDeclaredMembers")
+        ), "permissions.xml");
         return TestUtil.finishContainerPrepare(war, null, (Class<?>[]) null);
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/WriterNotBuiltinTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/WriterNotBuiltinTest.java
@@ -19,9 +19,12 @@ import org.junit.runner.RunWith;
 
 import javax.ws.rs.core.Response;
 import java.lang.reflect.ReflectPermission;
+import java.net.SocketPermission;
+import java.security.SecurityPermission;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.PropertyPermission;
+import java.util.logging.LoggingPermission;
 
 /**
  * @tpSubChapter Providers
@@ -42,9 +45,18 @@ public class WriterNotBuiltinTest {
         Map<String, String> contextParams = new HashMap<>();
         contextParams.put("resteasy.use.builtin.providers", "false");
         // Arquillian in the deployment
-        war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
+        war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
+                new LoggingPermission("control", ""),
+                new PropertyPermission("arquillian.*", "read"),
+                new PropertyPermission("ipv6", "read"),
+                new PropertyPermission("node", "read"),
+                new PropertyPermission("org.jboss.resteasy.port", "read"),
+                new ReflectPermission("suppressAccessChecks"),
                 new RuntimePermission("accessDeclaredMembers"),
-                new PropertyPermission("arquillian.*", "read")), "permissions.xml");
+                new RuntimePermission("getenv.RESTEASY_PORT"),
+                new SecurityPermission("insertProvider"),
+                new SocketPermission(PortProviderUtil.getHost(), "connect,resolve")
+        ), "permissions.xml");
         return TestUtil.finishContainerPrepare(war, contextParams, WriterNotBuiltinTestWriter.class, ReaderWriterResource.class);
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jaxb/JaxbMarshallingSoakTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jaxb/JaxbMarshallingSoakTest.java
@@ -27,6 +27,9 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import java.io.ByteArrayInputStream;
 import java.lang.reflect.ReflectPermission;
+import java.net.SocketPermission;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.PropertyPermission;
@@ -35,6 +38,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.LoggingPermission;
 
 /**
  * @tpSubChapter Jaxb provider
@@ -77,9 +81,17 @@ public class JaxbMarshallingSoakTest {
         contextParam.put("resteasy.async.job.service.enabled", "true");
         // Arquillian in the deployment use if TimeoutUtil in the deployment
         war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
-                new RuntimePermission("accessDeclaredMembers"),
+                new LoggingPermission("control", ""),
                 new PropertyPermission("arquillian.*", "read"),
-                new PropertyPermission("ts.timeout.factor", "read")), "permissions.xml");
+                new PropertyPermission("ipv6", "read"),
+                new PropertyPermission("node", "read"),
+                new PropertyPermission("org.jboss.resteasy.port", "read"),
+                new PropertyPermission("ts.timeout.factor", "read"),
+                new RuntimePermission("accessDeclaredMembers"),
+                new RuntimePermission("getClassLoader"),
+                new RuntimePermission("getenv.RESTEASY_PORT"),
+                new SocketPermission(PortProviderUtil.getHost(), "connect,resolve")
+        ), "permissions.xml");
         return TestUtil.finishContainerPrepare(war, contextParam, JaxbMarshallingSoakAsyncService.class);
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jaxb/XmlJavaTypeAdapterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jaxb/XmlJavaTypeAdapterTest.java
@@ -1,7 +1,9 @@
 package org.jboss.resteasy.test.providers.jaxb;
 
 import java.lang.reflect.ReflectPermission;
+import java.net.SocketPermission;
 import java.util.*;
+import java.util.logging.LoggingPermission;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericEntity;
@@ -48,12 +50,15 @@ public class XmlJavaTypeAdapterTest {
         war.addClass(XmlJavaTypeAdapterTest.class);
         // Arquillian in the deployment and use of PortProviderUtil in the deployment
         war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new PropertyPermission("node", "read"),
+                new LoggingPermission("control", ""),
+                new PropertyPermission("arquillian.*", "read"),
                 new PropertyPermission("ipv6", "read"),
-                new RuntimePermission("getenv.RESTEASY_PORT"),
                 new PropertyPermission("org.jboss.resteasy.port", "read"),
                 new ReflectPermission("suppressAccessChecks"),
                 new RuntimePermission("accessDeclaredMembers"),
-                new PropertyPermission("arquillian.*", "read")), "permissions.xml");
+                new RuntimePermission("getenv.RESTEASY_PORT"),
+                new SocketPermission(PortProviderUtil.getHost(), "connect,resolve")
+        ), "permissions.xml");
         return TestUtil.finishContainerPrepare(war, null, XmlJavaTypeAdapterAlien.class, XmlJavaTypeAdapterAlienAdapter.class,
                 XmlJavaTypeAdapterFoo.class, XmlJavaTypeAdapterHuman.class, XmlJavaTypeAdapterResource.class, PortProviderUtil.class);
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/HeaderDelegateTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/HeaderDelegateTest.java
@@ -30,8 +30,10 @@ import org.junit.runner.RunWith;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Response;
 import java.lang.reflect.ReflectPermission;
+import java.net.SocketPermission;
 import java.util.Date;
 import java.util.PropertyPermission;
+import java.util.logging.LoggingPermission;
 
 /**
  * @tpSubChapter Parameters
@@ -59,9 +61,17 @@ public class HeaderDelegateTest {
         war.addClass(PortProviderUtil.class);
         war.addClass(HeaderDelegateTest.class);
         // Arquillian in the deployment
-        war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
+        war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
+                new LoggingPermission("control", ""),
+                new PropertyPermission("arquillian.*", "read"),
+                new PropertyPermission("ipv6", "read"),
+                new PropertyPermission("node", "read"),
+                new PropertyPermission("org.jboss.resteasy.port", "read"),
+                new ReflectPermission("suppressAccessChecks"),
                 new RuntimePermission("accessDeclaredMembers"),
-                new PropertyPermission("arquillian.*", "read")), "permissions.xml");
+                new RuntimePermission("getenv.RESTEASY_PORT"),
+                new SocketPermission(PortProviderUtil.getHost(), "connect,resolve")
+        ), "permissions.xml");
         return TestUtil.finishContainerPrepare(war, null, HeaderDelegateResource.class);
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ValidationComplexTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ValidationComplexTest.java
@@ -76,7 +76,9 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.lang.reflect.ReflectPermission;
+import java.net.SocketPermission;
 import java.util.*;
+import java.util.logging.LoggingPermission;
 
 /**
  * @tpSubChapter Response
@@ -127,9 +129,17 @@ public class ValidationComplexTest {
                 ValidationComplexClassValidatorSuperInheritance.class,
                 ValidationComplexClassConstraint2.class, ValidationComplexClassValidator2.class);
         // Arquillian in the deployment
-        war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
+        war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
+                new LoggingPermission("control", ""),
+                new PropertyPermission("arquillian.*", "read"),
+                new PropertyPermission("ipv6", "read"),
+                new PropertyPermission("node", "read"),
+                new PropertyPermission("org.jboss.resteasy.port", "read"),
+                new ReflectPermission("suppressAccessChecks"),
                 new RuntimePermission("accessDeclaredMembers"),
-                new PropertyPermission("arquillian.*", "read")), "permissions.xml");
+                new RuntimePermission("getenv.RESTEASY_PORT"),
+                new SocketPermission(PortProviderUtil.getHost(), "connect,resolve")
+        ), "permissions.xml");
         war.addClasses(TestUtil.class, PortProviderUtil.class);
         return war;
     }


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/RESTEASY-1638

@asoldano, this PR contains several changes that might need extra attention to make sure it doesn't affect other parts of the code. So far I did run a full build and tested all failing tests referred on the JIRA. The one test that still fails is `JaxbMarshallingSoakTest` due to `JAXBContext.newInstance()` requiring FilePermission to a JAR file that I couldn't get around.