### PR TITLE
[RESTEASY-1650] Make HttpResponse closeable and always close its outp…

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ServerResponseWriter.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ServerResponseWriter.java
@@ -137,6 +137,7 @@ public class ServerResponseWriter
               providerFactory, ent, type, generic, annotations, jaxrsResponse.getMediaType(),
               jaxrsResponse.getMetadata(), os, request);
       writerContext.proceed();
+      response.setOutputStream(writerContext.getOutputStream()); //propagate interceptor changes on the outputstream to the response
       callback.commit(); // just in case the output stream is never used
    }
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/servlet/HttpServletResponseWrapper.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/servlet/HttpServletResponseWrapper.java
@@ -22,7 +22,7 @@ public class HttpServletResponseWrapper implements HttpResponse
    protected OutputStream outputStream = new DeferredOutputStream();
 
    /**
-    * RESTEASY-684 wants to defer access to outputstream until a write/flush/close happens
+    * RESTEASY-684 wants to defer access to outputstream until a write happens
     *
     */
    protected class DeferredOutputStream extends OutputStream
@@ -48,13 +48,13 @@ public class HttpServletResponseWrapper implements HttpResponse
       @Override
       public void flush() throws IOException
       {
-         response.getOutputStream().flush();
+         //NOOP (RESTEASY-1650)
       }
 
       @Override
       public void close() throws IOException
       {
-         response.getOutputStream().close();
+         //NOOP (RESTEASY-1650)
       }
    }
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/servlet/ServletContainerDispatcher.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/servlet/ServletContainerDispatcher.java
@@ -214,11 +214,10 @@ public class ServletContainerDispatcher
             return;
          }
 
-         HttpResponse theResponse = responseFactory.createResteasyHttpResponse(response);
-         HttpRequest in = requestFactory.createResteasyHttpRequest(httpMethod, request, headers, uriInfo, theResponse, response);
-
-         try
+         try (HttpResponse theResponse = responseFactory.createResteasyHttpResponse(response))
          {
+            HttpRequest in = requestFactory.createResteasyHttpRequest(httpMethod, request, headers, uriInfo, theResponse, response);
+
             ResteasyProviderFactory.pushContext(HttpServletRequest.class, request);
             ResteasyProviderFactory.pushContext(HttpServletResponse.class, response);
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/HttpResponse.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/HttpResponse.java
@@ -2,6 +2,8 @@ package org.jboss.resteasy.spi;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.NewCookie;
+
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -11,7 +13,7 @@ import java.io.OutputStream;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public interface HttpResponse
+public interface HttpResponse extends Closeable
 {
    int getStatus();
 
@@ -34,5 +36,10 @@ public interface HttpResponse
     * reset status and headers.  Will fail if response is committed
     */
    void reset();
+   
+   default void close() throws IOException {
+      // RESTEASY-1650
+      getOutputStream().close();
+   }
 
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/StreamCloseTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/StreamCloseTest.java
@@ -1,0 +1,72 @@
+package org.jboss.resteasy.test.interceptor;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.test.interceptor.resource.InterceptorStreamResource;
+import org.jboss.resteasy.test.interceptor.resource.TestInterceptor;
+import org.jboss.resteasy.util.HttpResponseCodes;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+
+/**
+ * @tpSubChapter Interceptors
+ * @tpChapter Integration tests
+ * @tpSince RESTEasy 3.1.2
+ * @tpTestCaseDetails Verify outpustream close is invoked on server side (https://issues.jboss.org/browse/RESTEASY-1650)
+ */
+@RunWith(Arquillian.class)
+public class StreamCloseTest
+{
+   @Deployment
+   public static Archive<?> deploy()
+   {
+      WebArchive war = TestUtil.prepareArchive(StreamCloseTest.class.getSimpleName());
+      return TestUtil.finishContainerPrepare(war, null, InterceptorStreamResource.class, TestInterceptor.class, PortProviderUtil.class);
+   }
+
+   static Client client;
+
+   @Before
+   public void setup()
+   {
+      client = ClientBuilder.newClient();
+   }
+
+   @After
+   public void cleanup()
+   {
+      client.close();
+   }
+
+   private String generateURL(String path)
+   {
+      return PortProviderUtil.generateURL(path, StreamCloseTest.class.getSimpleName());
+   }
+
+   @Test
+   public void testPriority() throws Exception
+   {
+      final int count = TestInterceptor.closeCounter.get();
+      Response response = client.target(generateURL("/test")).request().post(Entity.text("test"));
+      response.bufferEntity();
+      Assert.assertEquals("Wrong response status, interceptors don't work correctly", HttpResponseCodes.SC_OK,
+            response.getStatus());
+      Assert.assertEquals("Wrong content of response, interceptors don't work correctly", "test",
+            response.readEntity(String.class));
+      response.close();
+      Assert.assertEquals(1, TestInterceptor.closeCounter.get() - count);
+
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/resource/TestInterceptor.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/resource/TestInterceptor.java
@@ -1,0 +1,34 @@
+package org.jboss.resteasy.test.interceptor.resource;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.WriterInterceptor;
+import javax.ws.rs.ext.WriterInterceptorContext;
+
+@Provider
+public class TestInterceptor implements WriterInterceptor
+{
+   public static volatile AtomicInteger closeCounter = new AtomicInteger(0);
+
+   @Override
+   public void aroundWriteTo(WriterInterceptorContext context) throws IOException, WebApplicationException
+   {
+      OutputStream outputStream = new FilterOutputStream(context.getOutputStream())
+      {
+         @Override
+         public void close() throws IOException
+         {
+            closeCounter.incrementAndGet();
+            super.close();
+         }
+      };
+      context.setOutputStream(outputStream);
+      context.proceed();
+   }
+
+}


### PR DESCRIPTION
…utstream, while still avoiding flushing/closing on the lower level servlet outputstream

This solves the issue mentioned at https://issues.jboss.org/browse/RESTEASY-1650, please reads the comments too to understand the problem.
The possible downside of this patch is that it possibly breaks user applications that were explicitly calling close() or flush() on the response outputstream and expecting that to actually flush/close the underlying servlet outputstream (despite that being bad and against JAX-RS recommendations).