### PR TITLE
Update Interceptors.xml

### DIFF
--- a/docbook/reference/en/en-US/modules/Interceptors.xml
+++ b/docbook/reference/en/en-US/modules/Interceptors.xml
@@ -96,10 +96,12 @@
             interface is executed at deployment time for each resource method.  You just use the Configurable interface
             to register the filters and interceptors you want for the specific resource method.  @NameBinding works a lot
             like CDI interceptors.  You annotate a custom annotation with @NameBinding and then apply that custom annotation
-            to your filter and resource method
+            to your filter and resource method. The custom annotation must use @Retention(RetentionPolicy.RUNTIME) in order for the
+            attribute to be picked up by the Resteasy runtime code when it is deployed.
         </para>
         <programlisting>
             @NameBinding
+            @Retention(RetentionPolicy.RUNTIME)
             public @interface DoIt {}
 
             @DoIt


### PR DESCRIPTION
The custom attribute used for annotating filters and interceptors must have @Retention(RententionPolicy.RUNTIME) in order to actually be seen by the RestEasy runtime. This commit makes that clear in the documentation.