### PR TITLE
[RESTEASY-1669] Deprecating ApacheHttClient*Engine constructors allow…

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpClient43Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpClient43Engine.java
@@ -37,9 +37,27 @@ public class ApacheHttpClient43Engine extends ApacheHttpClient4Engine
         super(httpClient, closeHttpClient);
     }
 
+    /**
+     * Creates a client engine instance using the specified {@link org.apache.http.client.HttpClient}
+     * and {@link org.apache.http.protocol.HttpContext} instances.
+     * Note that the same instance of httpContext is passed to the engine, which may store thread unsafe
+     * attributes in it. It is hence recommended to override the HttpClient
+     * <pre>execute(HttpUriRequest request, HttpContext context)</pre> method to perform a deep
+     * copy of the context before executing the request.
+     * 
+     * @param httpClient     The http client
+     * @param httpContext    The context to be used for executing requests
+     */
+    @Deprecated
     public ApacheHttpClient43Engine(final HttpClient httpClient, final HttpContext httpContext)
     {
         super(httpClient, httpContext);
+    }
+    
+    public ApacheHttpClient43Engine(HttpClient httpClient, HttpContextProvider httpContextProvider)
+    {
+       this.httpClient = httpClient;
+       this.httpContextProvider = httpContextProvider;
     }
 
     @Override

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpClient4Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpClient4Engine.java
@@ -61,6 +61,7 @@ public class ApacheHttpClient4Engine implements ClientHttpEngine
    protected HttpClient httpClient;
    protected boolean createdHttpClient;
    protected HttpContext httpContext;
+   protected HttpContextProvider httpContextProvider;
    protected boolean closed;
    protected SSLContext sslContext;
    protected HostnameVerifier hostnameVerifier;
@@ -145,10 +146,28 @@ public class ApacheHttpClient4Engine implements ClientHttpEngine
    }
 
 
+   /**
+    * Creates a client engine instance using the specified {@link org.apache.http.client.HttpClient}
+    * and {@link org.apache.http.protocol.HttpContext} instances.
+    * Note that the same instance of httpContext is passed to the engine, which may store thread unsafe
+    * attributes in it. It is hence recommended to override the HttpClient
+    * <pre>execute(HttpUriRequest request, HttpContext context)</pre> method to perform a deep
+    * copy of the context before executing the request.
+    * 
+    * @param httpClient     The http client
+    * @param httpContext    The context to be used for executing requests
+    */
+   @Deprecated
    public ApacheHttpClient4Engine(HttpClient httpClient, HttpContext httpContext)
    {
       this.httpClient = httpClient;
       this.httpContext = httpContext;
+   }
+
+   public ApacheHttpClient4Engine(HttpClient httpClient, HttpContextProvider httpContextProvider)
+   {
+      this.httpClient = httpClient;
+      this.httpContextProvider = httpContextProvider;
    }
 
    /**
@@ -212,11 +231,13 @@ public class ApacheHttpClient4Engine implements ClientHttpEngine
       return httpClient;
    }
 
+   @Deprecated
    public HttpContext getHttpContext()
    {
       return httpContext;
    }
 
+   @Deprecated
    public void setHttpContext(HttpContext httpContext)
    {
       this.httpContext = httpContext;
@@ -274,7 +295,6 @@ public class ApacheHttpClient4Engine implements ClientHttpEngine
       return new BufferedInputStream(is, responseBufferSize);
    }
 
-   @SuppressWarnings("unchecked")
    public ClientResponse invoke(ClientInvocation request)
    {
       String uri = request.getUri().toString();
@@ -284,7 +304,12 @@ public class ApacheHttpClient4Engine implements ClientHttpEngine
       {
          loadHttpMethod(request, httpMethod);
 
-         res = httpClient.execute(httpMethod, httpContext);
+         HttpContext ctx = httpContext;
+         if (ctx == null && httpContextProvider != null)
+         {
+            ctx = httpContextProvider.getContext();
+         }
+         res = httpClient.execute(httpMethod, ctx);
       }
       catch (Exception e)
       {
@@ -651,9 +676,6 @@ public class ApacheHttpClient4Engine implements ClientHttpEngine
       LogMessages.LOGGER.warn(Messages.MESSAGES.couldNotDeleteFile(tempRequestFile.getAbsolutePath()), ex);
       tempRequestFile.deleteOnExit();
    }
-
-
-
 
    /**
     * We use {@link org.apache.http.entity.FileEntity} as the {@link HttpEntity} implementation when the request OutputStream has been

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/HttpContextProvider.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/HttpContextProvider.java
@@ -1,0 +1,8 @@
+package org.jboss.resteasy.client.jaxrs.engines;
+
+import org.apache.http.protocol.HttpContext;
+
+public interface HttpContextProvider
+{
+   HttpContext getContext();
+}

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/factory/ApacheHttpClient4EngineFactory.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/factory/ApacheHttpClient4EngineFactory.java
@@ -2,8 +2,6 @@ package org.jboss.resteasy.client.jaxrs.engines.factory;
 
 import org.apache.http.HttpHost;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.Configurable;
 import org.apache.http.protocol.HttpContext;
 import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient43Engine;


### PR DESCRIPTION
…ing to specify a HttpContext instance and explaining potential issues with that approach in the javadoc; added a new HttpContextProvider abstraction to allow users controlling the HttpContext lifecycle.