### PR TITLE
RESTEASY-1684 - Arguments must not be null when sending a null JSON object with ResteasyWebTarget

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/MessageBodyParameterProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/MessageBodyParameterProcessor.java
@@ -33,7 +33,7 @@ public class MessageBodyParameterProcessor implements InvocationProcessor
    @Override
    public void process(ClientInvocationBuilder invocation, Object param)
    {
-      invocation.getInvocation().setEntity(Entity.entity(new GenericEntity(param, genericType), mediaType, annotations));
+      invocation.getInvocation().setEntity(Entity.entity(param == null? null : new GenericEntity<Object>(param, genericType), mediaType, annotations));
    }
 
    public void build(ClientRequest request, Object object)


### PR DESCRIPTION
Isse: https://issues.jboss.org/browse/JBEAP-11919
Upstream Issue: https://issues.jboss.org/browse/RESTEASY-1684
Upstream PR: https://github.com/resteasy/Resteasy/pull/1206