### PR TITLE
[RESTEASY-1692] ResourceInfoInjectionTest freeze with Undertow 1.4.18…

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/resource/ResourceInfoInjectionResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/resource/ResourceInfoInjectionResource.java
@@ -1,5 +1,7 @@
 package org.jboss.resteasy.test.resource.basic.resource;
 
+
+import org.jboss.logging.Logger;
 import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
@@ -15,6 +17,8 @@ import java.nio.charset.StandardCharsets;
 
 @Path("")
 public class ResourceInfoInjectionResource {
+    protected static final Logger logger = Logger.getLogger(ResourceInfoInjectionResource.class.getName());
+
     @Context
     private HttpServletRequest request;
 
@@ -27,32 +31,41 @@ public class ResourceInfoInjectionResource {
     @POST
     @Path("async")
     public void async(@Suspended final AsyncResponse async) throws IOException {
+        logger.info("Start async");
         final ServletInputStream inputStream = request.getInputStream();
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         inputStream.setReadListener(new ReadListener() {
             @Override
             public void onDataAvailable() throws IOException {
+                logger.info("Start onDataAvailable");
                 // copy input stream
                 byte[] buffer = new byte[4096];
                 int n1;
-                while (-1 != (n1 = inputStream.read(buffer))) {
+                while (inputStream.isReady()) {
+                    n1 = inputStream.read(buffer);
                     outputStream.write(buffer, 0, n1);
                 }
+                logger.info("End onDataAvailable");
             }
 
             @Override
             public void onAllDataRead() throws IOException {
+                logger.info("Start onAllDataRead");
                 inputStream.close();
                 outputStream.flush();
                 outputStream.close();
                 async.resume(outputStream.toString(StandardCharsets.UTF_8.name()));
+                logger.info("End onAllDataRead");
             }
 
             @Override
             public void onError(Throwable t) {
+                logger.info("Start onError");
                 async.resume(t);
+                logger.info("End onError");
             }
         });
+        logger.info("End async");
     }
 }


### PR DESCRIPTION
ResourceInfoInjectionTest freeze with newest Undertow.
* ResourceInfoInjectionTest uses ResourceInfoInjectionResource end-point.
* ResourceInfoInjectionResource end-point uses ServletInputStream and custom ReadListener class. ReadListener calls read() without calling isReady().
* But according to this Stuart's comment, calling read() without calling isReady is illegal: https://issues.jboss.org/browse/JBEAP-12223?focusedCommentId=13438437&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13438437]

RESTEasy jira: https://issues.jboss.org/browse/RESTEASY-1692
master PR: https://github.com/resteasy/Resteasy/pull/1219