### PR TITLE
Lazy HTTP 200 response from @Produces(MediaType.SERVER_SENT_EVENTS) a…

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/plugins/providers/sse/client/SseEventSourceImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/plugins/providers/sse/client/SseEventSourceImpl.java
@@ -36,7 +36,7 @@ public class SseEventSourceImpl implements SseEventSource
    private enum State {
       PENDING, OPEN, CLOSED
    }
-   private final AtomicReference<State> state = new AtomicReference<>(State.PENDING);
+   private final AtomicReference<State> state = new AtomicReference<>(State.CLOSED);
    private final List<Consumer<InboundSseEvent>> onEventConsumers = new CopyOnWriteArrayList<>();
    private final List<Consumer<Throwable>> onErrorConsumers = new CopyOnWriteArrayList<>();
    private final List<Runnable> onCompleteConsumers = new CopyOnWriteArrayList<>();
@@ -143,7 +143,7 @@ public class SseEventSourceImpl implements SseEventSource
    @Override
    public void open()
    {
-      if (!state.compareAndSet(State.PENDING, State.OPEN))
+      if (!state.compareAndSet(State.CLOSED, State.PENDING))
       {
          throw new IllegalStateException(Messages.MESSAGES.eventSourceIsNotReadyForOpen());
       }
@@ -256,12 +256,14 @@ public class SseEventSourceImpl implements SseEventSource
          SseEventInputImpl eventInput = null;
          try {
             final Invocation.Builder request = buildRequest();
-            if (state.get() == State.OPEN)
+            if (state.get() == State.PENDING)
             {
                eventInput = request.get(SseEventInputImpl.class);
             }
+            state.set(State.OPEN);
          } catch (Throwable e) {
             onErrorConsumers.forEach(consumer -> {consumer.accept(e);});
+            state.set(State.CLOSED);
             e.printStackTrace();
          } finally {
             if (connectedLatch != null) {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseTest.java
@@ -133,8 +133,6 @@ public class SseTest {
        
        //Test for eventSource subscriber
        eventSource2.register(insse -> {Assert.assertTrue("", textMessage.equals(insse.readData()));});
-       //To give some time to subscribe, otherwise the broadcast will execute before subscribe
-       Thread.sleep(3000);
        client.target(generateURL("/service/server-sent-events/broadcast")).request().post(Entity.entity(textMessage, MediaType.SERVER_SENT_EVENTS)); 
        Assert.assertTrue("Waiting for broadcast event to be delivered has timed out.", latch.await(20, TimeUnit.SECONDS));
        eventSource.close();


### PR DESCRIPTION
…nnotated resource methods

This is to be improved before merging; it's using the Cleanable abstraction as a way to run code just after the invoker is done, we most likely need a better solution.
The fix to the state machine in SseEventSourceImpl is not strictly required, but still desirable imho.