### PR TITLE
RESTEASY-1684 - Arguments must not be null when sending a null JSON object with ResteasyWebTarget

### DIFF
--- a/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/MessageBodyParameterProcessor.java
+++ b/jaxrs/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/MessageBodyParameterProcessor.java
@@ -32,7 +32,7 @@ public class MessageBodyParameterProcessor implements InvocationProcessor
    @Override
    public void process(ClientInvocationBuilder invocation, Object param)
    {
-      invocation.getInvocation().setEntity(Entity.entity(new GenericEntity(param, genericType), mediaType, annotations));
+      invocation.getInvocation().setEntity(Entity.entity(param == null? null : new GenericEntity<Object>(param, genericType), mediaType, annotations));
    }
 
    public void build(ClientRequest request, Object object)


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/JBEAP-11860
Upstream Issue: https://issues.jboss.org/browse/RESTEASY-1684
Upstream PR: https://github.com/resteasy/Resteasy/pull/1206

Backporting fix for RESTEASY-1684 to branch 3.0.19.SPX (thus for EAP 7.0.x)