### PR TITLE
Async client

### DIFF
--- a/resteasy-client/pom.xml
+++ b/resteasy-client/pom.xml
@@ -28,11 +28,11 @@
             <artifactId>resteasy-jaxrs-services</artifactId>
             <version>${project.version}</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-       </dependency>
+        </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
@@ -46,12 +46,16 @@
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>
             <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
         </dependency>
     </dependencies>
-
-   <profiles>
+    <profiles>
         <profile>
             <id>i18n</id>
             <activation>
@@ -64,7 +68,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-resources-plugin</artifactId>
-                       <executions>
+                        <executions>
                             <execution>
                                 <id>copy-resources</id>
                                 <phase>initialize</phase>
@@ -72,7 +76,9 @@
                                     <goal>copy-resources</goal>
                                 </goals>
                                 <configuration>
-                                    <outputDirectory>${basedir}/src/main/resources/org/jboss/resteasy/client/jaxrs/i18n</outputDirectory>
+                                    <outputDirectory>
+                                        ${basedir}/src/main/resources/org/jboss/resteasy/client/jaxrs/i18n
+                                    </outputDirectory>
                                     <resources>
                                         <resource>
                                             <directory>${basedir}/src/test/resources/i18n</directory>
@@ -88,24 +94,24 @@
                     </plugin>
 
                     <plugin>
-                       <groupId>org.apache.maven.plugins</groupId>
-                       <artifactId>maven-surefire-plugin</artifactId>
-                       <executions>
-                           <execution>
-                               <id>i18</id>
-                               <phase>test</phase>
-                               <goals>
-                                   <goal>test</goal>
-                               </goals>
-                               <configuration>
-                                   <skip>false</skip>
-                                   <reuseForks>false</reuseForks>
-                                   <includes>
-                                       <include>**/I18nTestMessages_*.java</include>
-                                   </includes>
-                               </configuration>
-                           </execution>
-                       </executions>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>i18</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>false</skip>
+                                    <reuseForks>false</reuseForks>
+                                    <includes>
+                                        <include>**/I18nTestMessages_*.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/AsyncClientHttpEngine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/AsyncClientHttpEngine.java
@@ -1,0 +1,45 @@
+package org.jboss.resteasy.client.jaxrs;
+
+import java.util.concurrent.Future;
+
+import javax.ws.rs.client.InvocationCallback;
+
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
+import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
+
+/**
+ * Interface for an async HttpClientEngine
+ *
+ * @author Markus Kull
+ */
+public interface AsyncClientHttpEngine extends ClientHttpEngine
+{
+
+   /**
+    * Interface for extracting a result out of a ClientResponse
+    *
+    * @param <T> Result-Type
+    */
+   public interface ResultExtractor<T>
+   {
+      /**
+       * Extracts a result out of a Response
+       *
+       * @param response Response
+       * @return result
+       */
+      public T extractResult(ClientResponse response);
+   }
+
+   /**
+    * Submits an asynchronous request.
+    *
+    * @param request Request
+    * @param buffered buffer the response?
+    * @param callback Optional callback receiving the result, which is run inside the io-thread. may be null.
+    * @param extractor ResultExtractor for extracting a result out of a ClientResponse. Is run inside the io-thread
+    * @return Future with the result or Exception
+    */
+   public <T> Future<T> submit(ClientInvocation request, boolean buffered, InvocationCallback<T> callback, ResultExtractor<T> extractor);
+
+}

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ResteasyClientBuilder.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ResteasyClientBuilder.java
@@ -1,6 +1,8 @@
 package org.jboss.resteasy.client.jaxrs;
 
 import org.apache.http.HttpHost;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpAsyncClient4Engine;
 import org.jboss.resteasy.client.jaxrs.i18n.Messages;
 import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
 import org.jboss.resteasy.client.jaxrs.internal.LocalResteasyProviderFactory;
@@ -256,6 +258,12 @@ public class ResteasyClientBuilder extends ClientBuilder
    public ResteasyClientBuilder httpEngine(ClientHttpEngine httpEngine)
    {
       this.httpEngine = httpEngine;
+      return this;
+   }
+
+   public ResteasyClientBuilder useAsyncHttpEngine()
+   {
+      this.httpEngine = new ApacheHttpAsyncClient4Engine(HttpAsyncClients.createSystem(), true);
       return this;
    }
 

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpAsyncClient4Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpAsyncClient4Engine.java
@@ -1,0 +1,798 @@
+package org.jboss.resteasy.client.jaxrs.engines;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.InvocationCallback;
+import javax.ws.rs.client.ResponseProcessingException;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.ContentTooLongException;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpException;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.concurrent.BasicFuture;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.nio.ContentDecoder;
+import org.apache.http.nio.IOControl;
+import org.apache.http.nio.client.methods.HttpAsyncMethods;
+import org.apache.http.nio.entity.ContentInputStream;
+import org.apache.http.nio.protocol.AbstractAsyncResponseConsumer;
+import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
+import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
+import org.apache.http.nio.util.HeapByteBufferAllocator;
+import org.apache.http.nio.util.SharedInputBuffer;
+import org.apache.http.nio.util.SimpleInputBuffer;
+import org.apache.http.protocol.HTTP;
+import org.apache.http.protocol.HttpContext;
+import org.jboss.resteasy.client.jaxrs.AsyncClientHttpEngine;
+import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
+import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
+import org.jboss.resteasy.util.CaseInsensitiveMap;
+
+/**
+ * AsyncClientHttpEngine using apache http components HttpAsyncClient 4.<p/>
+ *
+ * Some words of caution: <ul>
+ * <li>Asynchronous IO means non-blocking IO utilizing few threads, typically at most as much threads as number of cores.
+ * As such, performance may profit from fewer thread switches and less memory usage due to fewer thread-stacks. But doing
+ * synchronous, blocking IO (the invoke-methods not returning a future) may suffer, because the data has to be transferred
+ * piecewiese to/from the io-threads.</li>
+ * <li>Request-Entities are fully buffered in memory, thus this engine is unsuitable for very large uploads.</li>
+ * <li>Response-Entities are buffered in memory, except if requesting a Response, InputStream or Reader as Result. Thus
+ * for large downloads or COMET one of these three return types must be requested, but there may be a performance penalty
+ * because the response-body is transferred piecewise from the io-threads. When using InvocationCallbacks, the response is
+ * always fully buffered in memory.</li>
+ * <li>InvocationCallbacks are called from within the io-threads and thus must not block or else the application may
+ * slow down to a halt. Reading the response is safe (because the response is buffered in memory), as are other async
+ * (and in-memory) Client-invocations (the submit-calls returning a future not containing Response, InputStream or Reader).
+ * Again, there must be no blocking IO inside InvocationCallback! (If you are wondering why not to allow blocking calls by
+ * wrapping InvocationCallbacks in extra threads: Because then the main advantage of async IO, less threading, is lost.)
+ * <li>InvocationCallbacks may be called seemingly "after" the future-object returns. Thus, responses should be handled
+ * solely in the InvocationCallback.</li>
+ * <li>InvocationCallbacks will see the same result as the future-object and vice versa. Thus, if the invocationcallback
+ * throws an exception, the future-object will not see it. Another reason to handle responses only in the InvocationCallback.
+ * </li>
+ *
+ * @author Markus Kull
+ */
+public class ApacheHttpAsyncClient4Engine implements AsyncClientHttpEngine, Closeable
+{
+   protected final CloseableHttpAsyncClient client;
+   protected final boolean closeHttpClient;
+
+   public ApacheHttpAsyncClient4Engine(CloseableHttpAsyncClient client, boolean closeHttpClient)
+   {
+      if (client == null) throw new NullPointerException("client");
+      this.client = client;
+      this.closeHttpClient = closeHttpClient;
+      if (closeHttpClient && !client.isRunning()) {
+         client.start();
+      }
+   }
+
+   @Override
+   public void close()
+   {
+      if (closeHttpClient)
+      {
+         IOUtils.closeQuietly(client);
+      }
+   }
+
+   @Override
+   public SSLContext getSslContext()
+   {
+      return null; // not supported
+   }
+
+   @Override
+   public HostnameVerifier getHostnameVerifier()
+   {
+      return null; // not supported
+   }
+
+   @Override
+   public ClientResponse invoke(ClientInvocation request)
+   {
+      // Doing blocking requests with an async httpclient is quite useless.
+      // But it is better to use the same httpclient in any case just for sharing+configuring only one connectionpool.
+      Future<ClientResponse> future = submit(request, false, null, new ResultExtractor<ClientResponse>() {
+         @Override
+         public ClientResponse extractResult(ClientResponse response)
+         {
+            return response;
+         }
+      });
+      try
+      {
+         return future.get();
+      }
+      catch (InterruptedException e)
+      {
+         future.cancel(true);
+         throw clientException(e, null);
+      }
+      catch (ExecutionException e)
+      {
+         throw clientException(e.getCause(), null);
+      }
+   }
+
+   @Override
+   public <T> Future<T> submit(
+      ClientInvocation request, boolean buffered, InvocationCallback<T> callback, ResultExtractor<T> extractor)
+   {
+      HttpUriRequest httpRequest = buildHttpRequest(request);
+
+      if (buffered)
+      {
+         // Request+Response fully buffered in memory. Optional callback is called inside io-thread after response-body and
+         // after the returned future is signaled to be completed.
+         //
+         // This differs to Resteasy 3.0.8 and earlier (which called the callback before the future completed) due to the
+         // following reasons:
+         //   * ApacheHttpcomponents BasicFuture, guavas ListenableFuture and also jersey calls the callback after completing
+         //     the future. The earlier Resteasy-behaviour may be more "safe" but any users switching from resteasy to another
+         //     jax-rs implementation may encounter a nasty surprise.
+         //   * ensure the result returned by the future is the same given to the callback.
+         //   * As good practice, the result should only be handled in one place (future OR callback, not both)
+         //   * Invocation-javadoc says "the underlying response instance will be automatically closed" seemingly implying
+         //     the future-response is unusable (bc. closed) together with a callback
+         // Of course the one big drawback is that exceptions inside the callback are not visible to the application,
+         // but callbacks are mostly treated as fire-and-forget, meaning their result is not checked anyway.
+         HttpAsyncRequestProducer requestProducer = HttpAsyncMethods.create(httpRequest);
+         HttpAsyncResponseConsumer<T> responseConsumer = new BufferingResponseConsumer<T>(request, extractor);
+         FutureCallback<T> httpCallback = callback != null ? new CallbackAdapter<T>(callback) : null;
+
+         return client.execute(requestProducer, responseConsumer, httpCallback);
+      }
+      else
+      {
+         // unbuffered: Future returns immediately after headers. Reading the response-stream blocks, but one may check
+         // InputStream#available() to prevent blocking.
+
+         // would be easy to call an InvocationCallback after response-BODY, but cant see any usecase for it.
+         if (callback != null) throw new IllegalArgumentException("unbuffered InvocationCallback is not supported");
+
+         HttpAsyncRequestProducer requestProducer = HttpAsyncMethods.create(httpRequest);
+         StreamingResponseConsumer<T> responseConsumer = new StreamingResponseConsumer<T>(request, extractor);
+
+         Future<T> httpFuture = client.execute(requestProducer, responseConsumer, null);
+         return responseConsumer.future(httpFuture);
+      }
+   }
+
+
+   /**
+    * ResponseConsumer which transfers the response piecewise from the io-thread to the blocking handler-thread.
+    * {@link #future(Future)} returns a Future which completes immediately after receiving the response-headers
+    * but reading the response-inputstream blocks until data is available.
+    */
+   private static class StreamingResponseConsumer<T> implements HttpAsyncResponseConsumer<T>
+   {
+      private ClientConfiguration configuration;
+      private Map<String, Object> properties;
+      private ResultExtractor<T> extractor;
+
+      private ResultFuture<T> future;
+      private SharedInputStream sharedStream;
+
+      private volatile boolean hasResult;
+      private volatile T result;
+      private volatile Exception exception;
+      private volatile boolean completed;
+
+      public StreamingResponseConsumer(ClientInvocation request, ResultExtractor<T> extractor)
+      {
+         this.configuration = request.getClientConfiguration();
+         this.properties = request.getMutableProperties();
+         this.extractor = extractor;
+      }
+
+      private void releaseResources()
+      {
+         this.configuration = null;
+         this.properties = null;
+         this.extractor = null;
+
+         this.future = null;
+         this.sharedStream = null;
+      }
+
+      public synchronized Future<T> future(Future<T> httpFuture)
+      {
+         if (completed)
+         {  // already failed or fully buffered
+            return httpFuture;
+         }
+         future = new ResultFuture<T>(httpFuture);
+         future.copyHttpFutureResult();
+         if (!future.isDone() && hasResult)
+         { // response(-headers) is available, but not yet the full response-stream. Return immediately the result
+            future.completed(getResult());
+         }
+         return future;
+      }
+
+      @Override
+      public synchronized void responseReceived(HttpResponse httpResponse) throws IOException, HttpException
+      {
+         SharedInputStream sharedStream = null;
+         ConnectionResponse clientResponse = null;
+         T result = null;
+         Exception exception = null;
+
+         boolean success = false;
+         try {
+            clientResponse = new ConnectionResponse(configuration, properties);
+            copyResponse(httpResponse, clientResponse);
+            final HttpEntity entity = httpResponse.getEntity();
+            if (entity != null)
+            {
+               sharedStream = new SharedInputStream(new SharedInputBuffer(16 * 1024));
+               // one could also set the stream after extracting the response, but this would prevent wrapping the stream
+               clientResponse.setConnection(sharedStream);
+               sharedStream.setException(new IOException("blocking reads inside an async io-handler are not allowed"));
+               result = extractor.extractResult(clientResponse);
+               sharedStream.setException(null);
+            }
+            else
+            {
+               result = extractor.extractResult(clientResponse);
+            }
+            success = true;
+         }
+         catch(Exception e)
+         {
+            exception = clientException(e, clientResponse);
+         }
+         finally
+         {
+            if (success)
+            {
+               this.sharedStream = sharedStream;
+               this.result = result;
+               this.hasResult = true;
+               if (future != null) future.completed(result);
+            }
+            else
+            {
+               this.exception = exception;
+               completed = true;
+               if (future != null) future.failed(exception);
+               releaseResources();
+            }
+         }
+      }
+
+      @Override
+      public synchronized void consumeContent(ContentDecoder decoder, IOControl ioctrl) throws IOException
+      {
+         if (sharedStream != null) sharedStream.consumeContent(decoder, ioctrl);
+      }
+
+      @Override
+      public synchronized void responseCompleted(HttpContext context)
+      {
+         this.completed = true;
+         try
+         {
+            if (sharedStream != null)
+            {  // only needed in case of empty response body (=null ioctrl)
+               sharedStream.consumeContent(EndOfStream.INSTANCE, null);
+            }
+         }
+         catch (IOException ioe)
+         { // cannot happen
+            throw new RuntimeException(ioe);
+         }
+         finally
+         {
+            releaseResources();
+         }
+      }
+
+      @Override
+      public Exception getException()
+      {
+         return exception;
+      }
+
+      @Override
+      public T getResult()
+      {
+         return result;
+      }
+
+      @Override
+      public boolean isDone()
+      {  // cancels in case of closing the SharedInputStream
+         return completed;
+      }
+
+      @Override
+      public synchronized void close()
+      {
+         completed = true;
+         ResultFuture<T> future = this.future;
+         if (future != null)
+         {
+            // if connect fails, then the httpclient just calls close() after setting its future, but never our failed().
+            // so copy the httpFuture-result into our ResultFuture.
+            future.copyHttpFutureResult();
+            if (!future.isDone())
+            { // doesnt happen?
+               future.failed(clientException(new IOException("connect failed"), null));
+            }
+         }
+         releaseResources();
+      }
+
+      @Override
+      public synchronized void failed(Exception ex)
+      {
+         completed = true;
+         if (future != null) future.failed(clientException(ex, null));
+         if (sharedStream != null)
+         {
+            sharedStream.setException(ioException(ex));
+            IOUtils.closeQuietly(sharedStream);
+         }
+         releaseResources();
+      }
+
+      @Override
+      public synchronized boolean cancel()
+      {
+         completed = true;
+         if (future != null) future.cancelledResult();
+         if (sharedStream != null)
+         {
+            sharedStream.setException(new IOException("cancelled"));
+            IOUtils.closeQuietly(sharedStream);
+         }
+         releaseResources();
+         return true;
+      }
+
+      private static class ResultFuture<T> extends BasicFuture<T>
+      {
+         private final Future<T> httpFuture;
+
+         public ResultFuture(final Future<T> httpFuture)
+         {
+            super(null);
+            this.httpFuture = httpFuture;
+         }
+
+         @Override
+         public boolean cancel(boolean mayInterruptIfRunning)
+         {
+            boolean cancelled = super.cancel(mayInterruptIfRunning);
+            httpFuture.cancel(mayInterruptIfRunning);
+            return cancelled;
+         }
+
+         public void cancelledResult() {
+            super.cancel(true);
+         }
+
+         public void copyHttpFutureResult()
+         {
+            if (!isDone() && httpFuture.isDone())
+            {
+               try
+               {
+                  completed(httpFuture.get());
+               }
+               catch(ExecutionException e)
+               {
+                  failed(clientException(e.getCause(), null));
+               }
+               catch (InterruptedException e)
+               { // cant happen because already isDone
+                  failed(e);
+               }
+            }
+         }
+      }
+
+      private class SharedInputStream extends ContentInputStream {
+
+         private final SharedInputBuffer sharedBuf;
+         private volatile IOException ex;
+         private volatile IOControl ioctrl;
+
+         public SharedInputStream(SharedInputBuffer sharedBuf)
+         {
+            super(sharedBuf);
+            this.sharedBuf = sharedBuf;
+         }
+
+         public void consumeContent(ContentDecoder decoder, IOControl ioctrl) throws IOException {
+            if (ioctrl != null) this.ioctrl = ioctrl;
+            sharedBuf.consumeContent(decoder, ioctrl);
+         }
+
+         @Override
+         public void close() throws IOException
+         {
+            completed = true; // next isDone() cancels.
+
+            // Workaround for deadlock: super.close() reads until no more data, but on cancellation no more data is
+            // pushed to consumeContent, thus deadlock. Instead notify the reactor by ioctrl.requestInput
+            sharedBuf.close(); // next reads will return EndOfStream. Also wakes up any waiting readers
+            IOControl ioctrl = this.ioctrl;
+            if (ioctrl != null) ioctrl.requestInput(); // notify reactor to check isDone()
+            super.close(); // does basically nothing due to closed buf
+         }
+
+         @Override
+         public int read(final byte[] b, final int off, final int len) throws IOException
+         {
+            throwIfError();
+            return super.read(b, off, len);
+         }
+
+         @Override
+         public int read(final byte[] b) throws IOException
+         {
+            throwIfError();
+            return super.read(b, 0, b.length);
+         }
+
+         @Override
+         public int read() throws IOException {
+            throwIfError();
+            return super.read();
+         }
+
+         private void throwIfError() throws IOException {
+            IOException ex = this.ex;
+            if (ex != null) {
+               throw ex;
+            }
+         }
+
+         public void setException(IOException e) {
+            this.ex = e;
+         }
+      }
+   }
+
+   /**
+    * Buffers response fully in memory.
+    *
+    * (Buffering is definitely easier to implement than streaming)
+    */
+   private static class BufferingResponseConsumer<T> extends AbstractAsyncResponseConsumer<T>
+   {
+
+      private ClientConfiguration configuration;
+      private Map<String, Object> properties;
+      private ResultExtractor<T> responseExtractor;
+      private ConnectionResponse clientResponse;
+      private SimpleInputBuffer buf;
+
+      public BufferingResponseConsumer(ClientInvocation request, ResultExtractor<T> responseExtractor)
+      {
+         this.configuration = request.getClientConfiguration();
+         this.properties = request.getMutableProperties();
+         this.responseExtractor = responseExtractor;
+      }
+
+      @Override
+      protected void onResponseReceived(HttpResponse response) throws HttpException, IOException
+      {
+         ConnectionResponse clientResponse = new ConnectionResponse(configuration, properties);
+         copyResponse(response, clientResponse);
+         final HttpEntity entity = response.getEntity();
+         if (entity != null)
+         {
+            long len = entity.getContentLength();
+            if (len > Integer.MAX_VALUE)
+            {
+               throw new ContentTooLongException("Entity content is too long: " + len);
+            }
+            if (len < 0)
+            {
+               len = 4096;
+            }
+            this.buf = new SimpleInputBuffer((int) len, new HeapByteBufferAllocator());
+         }
+         this.clientResponse = clientResponse;
+      }
+
+      @Override
+      protected void onEntityEnclosed(HttpEntity entity, ContentType contentType) throws IOException
+      {
+      }
+
+      @Override
+      protected void onContentReceived(ContentDecoder decoder, IOControl ioctrl) throws IOException
+      {
+         SimpleInputBuffer buf = this.buf;
+         if (buf == null) throw new NullPointerException("Content Buffer");
+         buf.consumeContent(decoder);
+      }
+
+      @Override
+      protected T buildResult(HttpContext context) throws Exception
+      {
+         if (buf != null) clientResponse.setConnection(new ContentInputStream(buf));
+         return responseExtractor.extractResult(clientResponse);
+      }
+
+      @Override
+      protected void releaseResources()
+      {
+         this.configuration = null;
+         this.properties = null;
+         this.responseExtractor = null;
+         this.clientResponse = null;
+         this.buf = null;
+      }
+   }
+
+   /**
+    * Adapter from http-FutureCallback<T> to InvocationCallback<T>
+    */
+   private static class CallbackAdapter<T> implements FutureCallback<T>
+   {
+      private final InvocationCallback<T> invocationCallback;
+
+      public CallbackAdapter(InvocationCallback<T> invocationCallback)
+      {
+         this.invocationCallback = invocationCallback;
+      }
+
+      @Override
+      public void cancelled()
+      {
+         invocationCallback.failed(new ProcessingException("cancelled"));
+      }
+
+      @Override
+      public void completed(T response)
+      {
+         try
+         {
+            invocationCallback.completed(response);
+         }
+         finally
+         {
+            // just to promote proper callback usage, because HttpAsyncClient is responsible
+            // for cleaning up the (buffered) connection
+            if (response instanceof Response)
+            {
+               ((Response) response).close();
+            }
+         }
+      }
+
+      @Override
+      public void failed(Exception ex)
+      {
+         invocationCallback.failed(clientException(ex, null));
+      }
+   }
+
+   /**
+    * ClientResponse with surefire releaseConnection
+    */
+   private static class ConnectionResponse extends ClientResponse
+   {
+
+      private InputStream connection;
+      private InputStream stream;
+
+      public ConnectionResponse(ClientConfiguration configuration, Map<String, Object> properties)
+      {
+         super(configuration);
+         setProperties(properties);
+      }
+
+      public synchronized void setConnection(InputStream connection)
+      {
+         this.connection = connection;
+         this.stream = connection;
+      }
+
+      @Override
+      protected synchronized void setInputStream(InputStream is)
+      {
+         stream = is;
+      }
+
+      @Override
+      public synchronized InputStream getInputStream()
+      {
+         return stream;
+      }
+
+      @Override
+      public synchronized void releaseConnection() throws IOException
+      {
+         boolean thrown = true;
+         try
+         {
+            if (stream != null) stream.close();
+            thrown = false;
+         }
+         finally
+         {
+            if (connection != null)
+            {
+               if (thrown)
+               {
+                  IOUtils.closeQuietly(connection);
+               }
+               else
+               {
+                  connection.close();
+               }
+            }
+         }
+      }
+   }
+
+   private static class EndOfStream implements ContentDecoder
+   {
+      public static EndOfStream INSTANCE = new EndOfStream();
+
+      @Override
+      public int read(ByteBuffer dst) throws IOException
+      {
+         return -1;
+      }
+
+      @Override
+      public boolean isCompleted()
+      {
+         return true;
+      }
+   }
+
+   private static HttpUriRequest buildHttpRequest(ClientInvocation request)
+   {
+      // Writers may change headers. Thus buffer the content before committing the headers.
+      // For simplicity's sake the content is buffered in memory. File-buffering (ZeroCopyConsumer...) would be
+      // possible, but resource management is error-prone.
+
+      HttpRequestBase httpRequest = createHttpMethod(request.getUri(), request.getMethod());
+      if (request.getEntity() != null)
+      {
+         byte[] requestContent = requestContent(request);
+         ByteArrayEntity entity = new ByteArrayEntity(requestContent);
+         entity.setContentType(new BasicHeader(HTTP.CONTENT_TYPE, request.getHeaders().getMediaType().toString()));
+         commitHeaders(request, httpRequest);
+         ((HttpEntityEnclosingRequest) httpRequest).setEntity(entity);
+      }
+      else
+      {
+         commitHeaders(request, httpRequest);
+      }
+
+      return httpRequest;
+   }
+
+   private static byte[] requestContent(ClientInvocation request)
+   {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      request.getDelegatingOutputStream().setDelegate(baos);
+      try
+      {
+         request.writeRequestBody(request.getEntityStream());
+         baos.close();
+         return baos.toByteArray();
+      }
+      catch (IOException e)
+      {
+         throw new RuntimeException(e);
+      }
+   }
+
+   private static HttpRequestBase createHttpMethod(URI url, String restVerb)
+   {
+      if ("GET".equals(restVerb))
+      {
+         return new HttpGet(url);
+      }
+      else if ("POST".equals(restVerb))
+      {
+         return new HttpPost(url);
+      }
+      else
+      {
+         final String verb = restVerb;
+         return new HttpPost(url)
+         {
+            @Override
+            public String getMethod()
+            {
+               return verb;
+            }
+         };
+      }
+   }
+
+   private static void commitHeaders(ClientInvocation request, HttpRequestBase httpMethod)
+   {
+      MultivaluedMap<String, String> headers = request.getHeaders().asMap();
+      for (Map.Entry<String, List<String>> header : headers.entrySet())
+      {
+         List<String> values = header.getValue();
+         for (String value : values)
+         {
+            httpMethod.addHeader(header.getKey(), value);
+         }
+      }
+   }
+
+   private static void copyResponse(HttpResponse httpResponse, ClientResponse clientResponse)
+   {
+      clientResponse.setStatus(httpResponse.getStatusLine().getStatusCode());
+      CaseInsensitiveMap<String> headers = new CaseInsensitiveMap<String>();
+      for (Header header : httpResponse.getAllHeaders())
+      {
+         headers.add(header.getName(), header.getValue());
+      }
+      clientResponse.setHeaders(headers);
+   }
+
+   private static RuntimeException clientException(Throwable ex, Response clientResponse) {
+      RuntimeException ret;
+      if (ex == null)
+      {
+         ret = new ProcessingException(new NullPointerException());
+      }
+      else if (ex instanceof WebApplicationException)
+      {
+         ret = (WebApplicationException) ex;
+      }
+      else if (ex instanceof ProcessingException)
+      {
+         ret = (ProcessingException) ex;
+      }
+      else if (clientResponse != null)
+      {
+         ret = new ResponseProcessingException(clientResponse, ex);
+      }
+      else
+      {
+         ret = new ProcessingException(ex);
+      }
+      return ret;
+   }
+
+   private static IOException ioException(Exception ex) {
+      return (ex instanceof IOException) ? (IOException) ex : new IOException(ex);
+   }
+
+}

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpAsyncClient4Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpAsyncClient4Engine.java
@@ -50,6 +50,7 @@ import org.apache.http.nio.util.SimpleInputBuffer;
 import org.apache.http.protocol.HTTP;
 import org.apache.http.protocol.HttpContext;
 import org.jboss.resteasy.client.jaxrs.AsyncClientHttpEngine;
+import org.jboss.resteasy.client.jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
 import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
@@ -592,6 +593,10 @@ public class ApacheHttpAsyncClient4Engine implements AsyncClientHttpEngine, Clos
          try
          {
             invocationCallback.completed(response);
+         }
+         catch (Throwable t)
+         {
+            LogMessages.LOGGER.exceptionIgnored(t);
          }
          finally
          {

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpAsyncClient4Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpAsyncClient4Engine.java
@@ -108,13 +108,13 @@ public class ApacheHttpAsyncClient4Engine implements AsyncClientHttpEngine, Clos
    @Override
    public SSLContext getSslContext()
    {
-      return null; // not supported
+      throw new UnsupportedOperationException();
    }
 
    @Override
    public HostnameVerifier getHostnameVerifier()
    {
-      return null; // not supported
+      throw new UnsupportedOperationException();
    }
 
    @Override

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/i18n/LogMessages.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/i18n/LogMessages.java
@@ -2,6 +2,10 @@ package org.jboss.resteasy.client.jaxrs.i18n;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
+import org.jboss.logging.Logger.Level;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
 /**
@@ -15,4 +19,8 @@ import org.jboss.logging.annotations.MessageLogger;
 public interface LogMessages extends BasicLogger
 {
    LogMessages LOGGER = Logger.getMessageLogger(LogMessages.class, LogMessages.class.getPackage().getName());
+   
+   @LogMessage(level = Level.DEBUG)
+   @Message(id = Messages.BASE + 171, value = "Ignoring exception thrown within InvocationCallback")
+   void exceptionIgnored(@Cause Throwable ex);
 }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
@@ -9,7 +9,11 @@ import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
@@ -39,6 +43,8 @@ import javax.ws.rs.core.Variant;
 import javax.ws.rs.ext.Providers;
 import javax.ws.rs.ext.WriterInterceptor;
 
+import org.jboss.resteasy.client.jaxrs.AsyncClientHttpEngine;
+import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.core.interception.jaxrs.AbstractWriterInterceptorContext;
 import org.jboss.resteasy.core.interception.jaxrs.ClientWriterInterceptorContext;
@@ -74,10 +80,10 @@ public class ClientInvocation implements Invocation
 
    protected boolean chunked;
 
-   // todo need a better solution for this.  Apache Http Client 4 does not let you obtain the OutputStream before executing
-   // this request. is problematic for obtaining and setting
-   // the output stream.  It also does not let you modify the request headers before the output stream is available
-   // Since MessageBodyWriter allows you to modify headers, you're s
+   private static volatile Boolean NIO_SUPPORTED = null;
+
+   // todo need a better solution for this.  Apache Http Client 4 does not let you obtain the OutputStream before executing this request.
+   // That is problematic for wrapping the output stream in e.g. a RequestFilter for transparent compressing.
    protected DelegatingOutputStream delegatingOutputStream = new DelegatingOutputStream();
 
    protected OutputStream entityStream = delegatingOutputStream;
@@ -437,71 +443,21 @@ public class ClientInvocation implements Invocation
    }
 
    @Override
-   public Response invoke()
+   public ClientResponse invoke()
    {
-      Providers current = ResteasyProviderFactory.getContextData(Providers.class);
-      ResteasyProviderFactory.pushContext(Providers.class, configuration);
+      Providers current = pushProvidersContext();
       try
       {
          ClientRequestContextImpl requestContext = new ClientRequestContextImpl(this);
-         ClientRequestFilter[] requestFilters = getRequestFilters();
-         ClientResponse aborted = null;
-         if (requestFilters != null && requestFilters.length > 0)
-         {
-            for (ClientRequestFilter filter : requestFilters)
-            {
-               try
-               {
-                  filter.filter(requestContext);
-                  if (requestContext.getAbortedWithResponse() != null)
-                  {
-                     aborted = new AbortedResponse(configuration, requestContext.getAbortedWithResponse());
-                     break;
-                  }
-               }
-               catch (ProcessingException e)
-               {
-                  throw e;
-               }
-               catch (Throwable e)
-               {
-                  throw new ProcessingException(e);
-               }
-            }
-         }
-         // spec requires that aborted response go through filter/interceptor chains.
-         ClientResponse response = aborted;
-         if (response == null)
-            response = client.httpEngine().invoke(this);
-         response.setProperties(configuration.getMutableProperties());
+         ClientResponse aborted = filterRequest(requestContext);
 
-         ClientResponseFilter[] responseFilters = getResponseFilters();
-         if (responseFilters != null && responseFilters.length > 0)
-         {
-            ClientResponseContextImpl responseContext = new ClientResponseContextImpl(response);
-            for (ClientResponseFilter filter : responseFilters)
-            {
-               try
-               {
-                  filter.filter(requestContext, responseContext);
-               }
-               catch (ResponseProcessingException e)
-               {
-                  throw e;
-               }
-               catch (Throwable e)
-               {
-                  throw new ResponseProcessingException(response, e);
-               }
-            }
-         }
-         return response;
+         // spec requires that aborted response go through filter/interceptor chains.
+         ClientResponse response = (aborted != null) ? aborted : client.httpEngine().invoke(this);
+         return filterResponse(requestContext, response);
       }
       finally
       {
-         ResteasyProviderFactory.popContextData(Providers.class);
-         if (current != null)
-            ResteasyProviderFactory.pushContext(Providers.class, current);
+         popProvidersContext(current);
       }
    }
 
@@ -522,46 +478,92 @@ public class ClientInvocation implements Invocation
       Response response = invoke();
       if (responseType.getRawType().equals(Response.class))
          return (T) response;
-      return ClientInvocation.extractResult(responseType, response, null);
+      return extractResult(responseType, response, null);
    }
 
    @Override
    public Future<Response> submit()
    {
-      return client.asyncInvocationExecutor().submit(new Callable<Response>()
+      if (!asyncClientInClassPath())
       {
-         @Override
-         public Response call() throws Exception
+         return client.asyncInvocationExecutor().submit(new Callable<Response>()
          {
-            return invoke();
-         }
-      });
+            @Override
+            public Response call() throws Exception
+            {
+               return invoke();
+            }
+         });
+      }
+      else
+      {
+         return doSubmit(false, null, new AsyncClientHttpEngine.ResultExtractor<Response>()
+         {
+            @Override
+            public Response extractResult(ClientResponse response)
+            {
+               return response;
+            }
+         });
+      }
    }
 
    @Override
    public <T> Future<T> submit(final Class<T> responseType)
    {
-      return client.asyncInvocationExecutor().submit(new Callable<T>()
+      if (!asyncClientInClassPath())
       {
-         @Override
-         public T call() throws Exception
+         return client.asyncInvocationExecutor().submit(new Callable<T>()
          {
-            return invoke(responseType);
-         }
-      });
+            @Override
+            public T call() throws Exception
+            {
+               return invoke(responseType);
+            }
+         });
+      }
+      else
+      {
+         return doSubmit(false, null, new AsyncClientHttpEngine.ResultExtractor<T>()
+         {
+            @Override
+            public T extractResult(ClientResponse response)
+            {
+               if (Response.class.equals(responseType))
+                  return (T) response;
+               return ClientInvocation.extractResult(new GenericType<T>(responseType), response, null);
+            }
+         });
+      }
    }
 
    @Override
    public <T> Future<T> submit(final GenericType<T> responseType)
    {
-      return client.asyncInvocationExecutor().submit(new Callable<T>()
+      if (!asyncClientInClassPath())
       {
-         @Override
-         public T call() throws Exception
+         return client.asyncInvocationExecutor().submit(new Callable<T>()
          {
-            return invoke(responseType);
-         }
-      });
+            @Override
+            public T call() throws Exception
+            {
+               return invoke(responseType);
+            }
+         });
+      }
+      else
+      {
+         return doSubmit(false, null, new AsyncClientHttpEngine.ResultExtractor<T>()
+         {
+            @Override
+            public T extractResult(ClientResponse response)
+            {
+               if (responseType.getRawType().equals(Response.class))
+                  return (T) response;
+               return ClientInvocation.extractResult(responseType, response, null);
+            }
+         });
+      }
    }
 
    @SuppressWarnings(
@@ -579,36 +581,52 @@ public class ClientInvocation implements Invocation
       }
 
       final GenericType<T> responseType = genericType;
-      return client.asyncInvocationExecutor().submit(new Callable<T>()
+      if (!asyncClientInClassPath())
       {
-         @Override
-         public T call() throws Exception
+
+         return client.asyncInvocationExecutor().submit(new Callable<T>()
          {
-            T result = null;
-            try
+            @Override
+            public T call() throws Exception
             {
-               result = invoke(responseType);
-            }
-            catch (Exception e)
-            {
-               callback.failed(e);
-               throw e;
-            }
-            try
-            {
-               callback.completed(result);
-               return result;
-            }
-            finally
-            {
-               if (result != null && result instanceof Response)
+               T result = null;
+               try
                {
-                  ((Response) result).close();
+                  result = invoke(responseType);
+               }
+               catch (Exception e)
+               {
+                  callback.failed(e);
+                  throw e;
+               }
+               try
+               {
+                  callback.completed(result);
+                  return result;
+               }
+               finally
+               {
+                  if (result != null && result instanceof Response)
+                  {
+                     ((Response) result).close();
+                  }
                }
             }
-         }
-      });
-
+         });
+      }
+      else
+      {
+         return doSubmit(true, callback, new AsyncClientHttpEngine.ResultExtractor<T>()
+         {
+            @Override
+            public T extractResult(ClientResponse response)
+            {
+               if (responseType.getRawType().equals(Response.class))
+                  return (T) response;
+               return ClientInvocation.extractResult(responseType, response, null);
+            }
+         });
+      }
    }
 
    @Override
@@ -616,5 +634,264 @@ public class ClientInvocation implements Invocation
    {
       configuration.property(name, value);
       return this;
+   }
+
+   // internals
+
+   private Providers pushProvidersContext()
+   {
+      Providers current = ResteasyProviderFactory.getContextData(Providers.class);
+      ResteasyProviderFactory.pushContext(Providers.class, configuration);
+      return current;
+   }
+
+   private void popProvidersContext(Providers current)
+   {
+      ResteasyProviderFactory.popContextData(Providers.class);
+      if (current != null)
+         ResteasyProviderFactory.pushContext(Providers.class, current);
+   }
+
+   private ClientResponse filterRequest(ClientRequestContextImpl requestContext)
+   {
+      ClientRequestFilter[] requestFilters = getRequestFilters();
+      ClientResponse aborted = null;
+      if (requestFilters != null && requestFilters.length > 0)
+      {
+         for (ClientRequestFilter filter : requestFilters)
+         {
+            try
+            {
+               filter.filter(requestContext);
+               if (requestContext.getAbortedWithResponse() != null)
+               {
+                  aborted = new AbortedResponse(configuration, requestContext.getAbortedWithResponse());
+                  break;
+               }
+            }
+            catch (ProcessingException e)
+            {
+               throw e;
+            }
+            catch (Throwable e)
+            {
+               throw new ProcessingException(e);
+            }
+         }
+      }
+      return aborted;
+   }
+
+   private ClientResponse filterResponse(ClientRequestContextImpl requestContext, ClientResponse response)
+   {
+      response.setProperties(configuration.getMutableProperties());
+
+      ClientResponseFilter[] responseFilters = getResponseFilters();
+      if (responseFilters != null && responseFilters.length > 0)
+      {
+         ClientResponseContextImpl responseContext = new ClientResponseContextImpl(response);
+         for (ClientResponseFilter filter : responseFilters)
+         {
+            try
+            {
+               filter.filter(requestContext, responseContext);
+            }
+            catch (ResponseProcessingException e)
+            {
+               throw e;
+            }
+            catch (Throwable e)
+            {
+               throw new ResponseProcessingException(response, e);
+            }
+         }
+      }
+      return response;
+   }
+
+   private <T> Future<T> doSubmit(boolean buffered, InvocationCallback<T> callback,
+         AsyncClientHttpEngine.ResultExtractor<T> extractor)
+   {
+      ClientHttpEngine httpEngine = client.httpEngine();
+      if (httpEngine instanceof AsyncClientHttpEngine)
+      {
+         return asyncSubmit((AsyncClientHttpEngine) httpEngine, buffered, callback, extractor);
+      }
+      else
+      {
+         // never buffered, but always blocks in a thread
+         return executorSubmit(client.asyncInvocationExecutor(), callback, extractor);
+      }
+   }
+
+   private <T> Future<T> asyncSubmit(AsyncClientHttpEngine asyncHttpEngine, boolean buffered,
+         InvocationCallback<T> callback, final AsyncClientHttpEngine.ResultExtractor<T> extractor)
+   {
+      final ClientRequestContextImpl requestContext = new ClientRequestContextImpl(this);
+      Providers current = pushProvidersContext();
+      try
+      {
+         ClientResponse aborted = filterRequest(requestContext);
+         if (aborted != null)
+         {
+            // spec requires that aborted response go through filter/interceptor chains.
+            aborted = filterResponse(requestContext, aborted);
+            T result = extractor.extractResult(aborted);
+            callCompletedNoThrow(callback, result);
+            return new CompletedFuture<T>(result, null);
+         }
+      }
+      catch (Exception ex)
+      {
+         callFailedNoThrow(callback, ex);
+         return new CompletedFuture<T>(null, new ExecutionException(ex));
+      }
+      finally
+      {
+         popProvidersContext(current);
+      }
+
+      return asyncHttpEngine.submit(this, buffered, callback, new AsyncClientHttpEngine.ResultExtractor<T>()
+      {
+
+         @Override
+         public T extractResult(ClientResponse response)
+         {
+            Providers current = pushProvidersContext();
+            try
+            {
+               return extractor.extractResult(filterResponse(requestContext, response));
+            }
+            finally
+            {
+               popProvidersContext(current);
+            }
+         }
+      });
+   }
+
+   private <T> Future<T> executorSubmit(ExecutorService executor, final InvocationCallback<T> callback,
+         final AsyncClientHttpEngine.ResultExtractor<T> extractor)
+   {
+      return executor.submit(new Callable<T>()
+      {
+         @Override
+         public T call() throws Exception
+         {
+            // ensure the future and the callback see the same result
+            T result = null;
+            ClientResponse response = null;
+            try
+            {
+               response = invoke(); // does filtering too
+               result = extractor.extractResult(response);
+               callCompletedNoThrow(callback, result);
+               return result;
+            }
+            catch (Exception e)
+            {
+               callFailedNoThrow(callback, e);
+               throw e;
+            }
+            finally
+            {
+               if (response != null && callback != null)
+                  response.close();
+            }
+         }
+      });
+   }
+
+   private <T> void callCompletedNoThrow(InvocationCallback<T> callback, T result)
+   {
+      if (callback != null)
+      {
+         try
+         {
+            callback.completed(result);
+         }
+         catch (Exception e)
+         {
+            //                logger.error("ignoring exception in InvocationCallback", e);
+         }
+      }
+   }
+
+   private <T> void callFailedNoThrow(InvocationCallback<T> callback, Exception exception)
+   {
+      if (callback != null)
+      {
+         try
+         {
+            callback.failed(exception);
+         }
+         catch (Exception e)
+         {
+            //                logger.error("ignoring exception in InvocationCallback", e);
+         }
+      }
+   }
+
+   private static class CompletedFuture<T> implements Future<T>
+   {
+
+      private final T result;
+
+      private final ExecutionException ex;
+
+      public CompletedFuture(T result, ExecutionException ex)
+      {
+         this.ex = ex;
+         this.result = result;
+      }
+
+      @Override
+      public boolean cancel(boolean mayInterruptIfRunning)
+      {
+         return false;
+      }
+
+      @Override
+      public boolean isCancelled()
+      {
+         return false;
+      }
+
+      @Override
+      public boolean isDone()
+      {
+         return true;
+      }
+
+      @Override
+      public T get() throws InterruptedException, ExecutionException
+      {
+         if (ex != null)
+            throw ex;
+         return result;
+      }
+
+      @Override
+      public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException
+      {
+         return get();
+      }
+   }
+
+   private boolean asyncClientInClassPath()
+   {
+      if (NIO_SUPPORTED == null)
+      {
+         try
+         {
+            Class.forName("org.apache.http.impl.nio.client.CloseableHttpAsyncClient");
+            NIO_SUPPORTED = true;
+         }
+         catch (ClassNotFoundException e)
+         {
+            NIO_SUPPORTED = false;
+         }
+      }
+      return NIO_SUPPORTED;
    }
 }

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -40,6 +40,7 @@
         <version.net.jcip.jcip-annotations>1.0</version.net.jcip.jcip-annotations>
         <version.org.apache.httpcomponents.httpclient>4.5.2</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.5</version.org.apache.httpcomponents.httpcore>
+        <version.org.apache.httpcomponents.httpasyncclient>4.1.3</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.james.apache-mime4j>0.6</version.org.apache.james.apache-mime4j>
         <version.org.apache.maven>3.3.9</version.org.apache.maven> <!-- Used to download aether-provider -->
         <version.org.bouncycastle>1.55</version.org.bouncycastle>
@@ -231,6 +232,28 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
                 <version>${version.org.apache.httpcomponents.httpcore}</version>
+            </dependency>
+            <!-- OPTIONAL dependency to apache HttpAsyncClient.
+                 To use it in own projects one needs to manually add a dependency to httpcomponents-asyncclient,
+                 and configure ApacheHttpAsyncClient4Engine -->
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpasyncclient</artifactId>
+                <version>${version.org.apache.httpcomponents.httpasyncclient}</version>
+                <exclusions> <!-- avoid changing these transitive dependency-versions  -->
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpcore</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpclient</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>net.jcip</groupId>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -286,7 +286,10 @@
             <artifactId>httpclient</artifactId>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/AsyncBenchTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/AsyncBenchTest.java
@@ -1,0 +1,112 @@
+package org.jboss.resteasy.test.client;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.InvocationCallback;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.test.client.resource.AsyncInvokeResource;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+@Ignore
+public class AsyncBenchTest extends ClientTestBase
+{
+
+   static Client client;
+
+   static Client nioClient;
+   
+   static final int ITERATIONS = 4000;
+   static final int MAX_CONNECTIONS = 200;
+
+   @Deployment
+   public static Archive<?> deploy()
+   {
+      WebArchive war = TestUtil.prepareArchive(AsyncBenchTest.class.getSimpleName());
+      war.addClass(AsyncBenchTest.class);
+      war.addClass(ClientTestBase.class);
+      return TestUtil.finishContainerPrepare(war, null, AsyncInvokeResource.class);
+   }
+
+   @After
+   public void after() throws Exception
+   {
+      if (client != null)
+         client.close();
+      if (nioClient != null)
+         nioClient.close();
+   }
+
+   @Test
+   public void testAsyncPost() throws Exception
+   {
+      long start = System.currentTimeMillis();
+      final String oldProp = System.getProperty("http.maxConnections");
+      System.setProperty("http.maxConnections", String.valueOf(MAX_CONNECTIONS));
+      nioClient = new ResteasyClientBuilder().useAsyncHttpEngine().build();
+      WebTarget wt = nioClient.target(generateURL("/test"));
+      runCallback(wt, "NIO");
+      long end = System.currentTimeMillis() - start;
+      System.out.println("TEST NON BLOCKING IO - " + ITERATIONS + " iterations took " + end + "ms");
+      if (oldProp != null)
+      {
+         System.setProperty("http.maxConnections", oldProp);
+      }
+      else
+      {
+         System.clearProperty("http.maxConnections");
+      }
+   }
+   
+   @Test
+   public void testPost() throws Exception
+   {
+      long start = System.currentTimeMillis();
+      client = new ResteasyClientBuilder().connectionPoolSize(MAX_CONNECTIONS).maxPooledPerRoute(MAX_CONNECTIONS).build();
+      WebTarget wt2 = client.target(generateURL("/test"));
+      runCallback(wt2, "BIO");
+      long end = System.currentTimeMillis() - start;
+      System.out.println("TEST BLOCKING IO - " + ITERATIONS + " iterations took " + end + "ms");
+   }
+   
+   private void runCallback(WebTarget wt, String msg) throws Exception
+   {
+      CountDownLatch latch = new CountDownLatch(ITERATIONS);
+      for (int i = 0; i < ITERATIONS; i++) {
+         final String m = msg + i;
+         wt.request().async().post(Entity.text(m), new InvocationCallback<Response>()
+         {
+            @Override
+            public void completed(Response response)
+            {
+               String entity = response.readEntity(String.class);
+               Assert.assertEquals("post " + m, entity);
+               latch.countDown();
+            }
+   
+            @Override
+            public void failed(Throwable error)
+            {
+               throw new RuntimeException(error);               
+            }
+         });
+      }
+      latch.await();
+   }   
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/AsyncInvokeTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/AsyncInvokeTest.java
@@ -61,8 +61,7 @@ public class AsyncInvokeTest extends ClientTestBase{
     public void init() {
         client = ClientBuilder.newClient();
         
-        CloseableHttpAsyncClient asyncClient = HttpAsyncClientBuilder.create().setMaxConnTotal(1).build();
-        nioClient = new ResteasyClientBuilder().httpEngine(new ApacheHttpAsyncClient4Engine(asyncClient, true)).build();
+        nioClient = new ResteasyClientBuilder().useAsyncHttpEngine().build();
     }
 
     @After

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/InputStreamTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/InputStreamTest.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.test.client;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -73,9 +74,8 @@ public class InputStreamTest extends ClientTestBase{
     @Test
     public void testInputStream() throws Exception {
         InputStream is = client.target(generateURL("/test")).request().get(InputStream.class);
-        byte[] buf = new byte[1024];
-        int read = is.read(buf);
-        String str = new String(buf, 0, read);
+        byte[] buf = IOUtils.toByteArray(is);
+        String str = new String(buf);
         Assert.assertEquals("The returned inputStream doesn't contain expexted text", "hello world", str);
         logger.info("Text from inputstream: " + str);
         is.close();
@@ -90,10 +90,9 @@ public class InputStreamTest extends ClientTestBase{
     @Test
     public void testInputStreamProxy() throws Exception {
         InputStreamInterface proxy = client.target(generateURL("/")).proxy(InputStreamInterface.class);
-        byte[] buf = new byte[1024];
         InputStream is = proxy.get();
-        int read = is.read(buf);
-        String str = new String(buf, 0, read);
+        byte[] buf = IOUtils.toByteArray(is);
+        String str = new String(buf);
         Assert.assertEquals("The returned inputStream doesn't contain expexted text", "hello world", str);
         is.close();
     }


### PR DESCRIPTION
Followup from https://github.com/resteasy/Resteasy/pull/1228.
PR 1228 description pretended the new async/NIO engine is enabled by default when the libs are available, however that was not the case, given the new engine was not actually being constructed anywhere. I tried defaulting to the new engine, but that clearly does not fit most of the common usage scenario, as for example built-in providers can ask for blocking reads in a thread handling IO. So I think it's better to let the use decide to build a new engine and set it in the client when it makes sense.