### PR TITLE
[RESTEAY-1680]:Reads event with different eol; clean up charset constant

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/EventByteArrayOutputStream.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/EventByteArrayOutputStream.java
@@ -18,13 +18,4 @@ public class EventByteArrayOutputStream extends ByteArrayOutputStream
       }
       return Arrays.copyOf(buf, count);
    }
-   
-   public synchronized byte[] getEventData()
-   {
-      if (count >=1 && buf[count-1] == '\n')
-      {
-         return Arrays.copyOf(buf, count - 1);
-      }
-      return Arrays.copyOf(buf, count);
-   }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/EventByteArrayOutputStream.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/EventByteArrayOutputStream.java
@@ -5,23 +5,23 @@ import java.util.Arrays;
 
 public class EventByteArrayOutputStream extends ByteArrayOutputStream
 {
-   private void removeBlankLine()
-   {
-      if (this.count > 4)
-      {
-         count = count - 4;
-      }
-   }
-
    public synchronized byte[] getEventPayLoad()
    {
-      removeBlankLine();
+      // delimiter is \r or \n
+      if (count >=2 && this.buf[count-2] == this.buf[count-1])
+      {
+         count = count -1;
+      }
+      //delimiter is 
+      if (count >= 1 && buf[count-2] == '\r' && buf[count-1] == '\n') {
+         count = count -2;
+      }
       return Arrays.copyOf(buf, count);
    }
    
    public synchronized byte[] getEventData()
    {
-      if (buf[count] == '\n')
+      if (buf[count-1] == '\n')
       {
          return Arrays.copyOf(buf, count - 1);
       }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/EventByteArrayOutputStream.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/EventByteArrayOutputStream.java
@@ -14,7 +14,7 @@ public class EventByteArrayOutputStream extends ByteArrayOutputStream
       }
       //delimiter is \r\n
       if (count >= 2 && buf[count-2] == '\r' && buf[count-1] == '\n') {
-         Arrays.copyOf(buf, count-2);
+         return Arrays.copyOf(buf, count-2);
       }
       return Arrays.copyOf(buf, count);
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/EventByteArrayOutputStream.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/EventByteArrayOutputStream.java
@@ -10,18 +10,18 @@ public class EventByteArrayOutputStream extends ByteArrayOutputStream
       // delimiter is \r or \n
       if (count >=2 && this.buf[count-2] == this.buf[count-1])
       {
-         count = count -1;
+         return Arrays.copyOf(buf, count -1);
       }
       //delimiter is 
-      if (count >= 1 && buf[count-2] == '\r' && buf[count-1] == '\n') {
-         count = count -2;
+      if (count >= 2 && buf[count-2] == '\r' && buf[count-1] == '\n') {
+         Arrays.copyOf(buf, count-2);
       }
       return Arrays.copyOf(buf, count);
    }
    
    public synchronized byte[] getEventData()
    {
-      if (buf[count-1] == '\n')
+      if (count >=1 && buf[count-1] == '\n')
       {
          return Arrays.copyOf(buf, count - 1);
       }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/EventByteArrayOutputStream.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/EventByteArrayOutputStream.java
@@ -12,7 +12,7 @@ public class EventByteArrayOutputStream extends ByteArrayOutputStream
       {
          return Arrays.copyOf(buf, count -1);
       }
-      //delimiter is 
+      //delimiter is \r\n
       if (count >= 2 && buf[count-2] == '\r' && buf[count-1] == '\n') {
          Arrays.copyOf(buf, count-2);
       }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/InboundSseEventImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/InboundSseEventImpl.java
@@ -34,7 +34,7 @@ public class InboundSseEventImpl implements InboundSseEvent
       private String name;
       private String id;
       private long reconnectDelay = -1;
-      private final EventByteArrayOutputStream dataStream;
+      private final ByteArrayOutputStream dataStream;
       private final Annotation[] annotations;
       private final MediaType mediaType;
       private final MultivaluedMap<String, String> headers;
@@ -47,7 +47,7 @@ public class InboundSseEventImpl implements InboundSseEvent
          this.headers = headers;
 
          this.commentBuilder = new StringBuilder();
-         this.dataStream = new EventByteArrayOutputStream();
+         this.dataStream = new ByteArrayOutputStream();
       }
 
       public Builder name(String name)
@@ -102,7 +102,7 @@ public class InboundSseEventImpl implements InboundSseEvent
          //then remove the last character from the data buffer
          return new InboundSseEventImpl(name, id,
                commentBuilder.length() > 0 ? commentBuilder.substring(0, commentBuilder.length() - 1) : null,
-               reconnectDelay, dataStream.getEventData(), annotations, mediaType, headers);
+               reconnectDelay, dataStream.toByteArray(), annotations, mediaType, headers);
       }
    }
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseConstants.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseConstants.java
@@ -1,6 +1,5 @@
 package org.jboss.resteasy.plugins.providers.sse;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import javax.ws.rs.core.GenericType;
@@ -8,14 +7,23 @@ import javax.ws.rs.core.GenericType;
 public class SseConstants
 {
    public static final String LAST_EVENT_ID_HEADER = "Last-Event-ID";
+
    public static final GenericType<String> STRING_AS_GENERIC_TYPE = new GenericType<>(String.class);
-   public static final Charset UTF8 = Charset.forName("UTF-8");   
+
    public static final byte[] COMMENT_LEAD = ": ".getBytes(StandardCharsets.UTF_8);
-   public static final byte[] NAME_LEAD = "event: ".getBytes(UTF8);
+
+   public static final byte[] NAME_LEAD = "event: ".getBytes(StandardCharsets.UTF_8);
+
    public static final byte[] ID_LEAD = "id: ".getBytes(StandardCharsets.UTF_8);
+
    public static final byte[] RETRY_LEAD = "retry: ".getBytes(StandardCharsets.UTF_8);
+
    public static final byte[] DATA_LEAD = "data: ".getBytes(StandardCharsets.UTF_8);
+
    public static final byte[] EOL = "\n".getBytes(StandardCharsets.UTF_8);
+
+   //event delimiter can be '\r\r', '\n\n' or '\r\n\r\n'
+   public static final byte[] EVENT_DELIMITER = "\r\n\r\n".getBytes(StandardCharsets.UTF_8);
 
    public enum EVENT {
       START, COMMENT, FIELD,

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventInputImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventInputImpl.java
@@ -25,7 +25,7 @@ public class SseEventInputImpl implements EventInput, Closeable
    private InputStream inputStream;
    private volatile boolean isClosed = false;
    private boolean lastFieldWasData;
-   private final String DELIMIETER = new String(SseConstants.EVENT_DELIMITER, StandardCharsets.UTF_8);
+   private final String DELIMITER = new String(SseConstants.EVENT_DELIMITER, StandardCharsets.UTF_8);
    public SseEventInputImpl(Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders,
          InputStream inputStream)
    {
@@ -230,7 +230,7 @@ public class SseEventInputImpl implements EventInput, Closeable
             eolBuffer[pos] = b;
             //if it meets \r\r , \n\n , \r\n\r\n or \n\r\n\r\n
             if ((pos > 0 && eolBuffer[pos] == eolBuffer[pos - 1])
-                  || (pos >= 3 && new String(eolBuffer, 0, pos, StandardCharsets.UTF_8).contains(DELIMIETER)))
+                  || (pos >= 3 && new String(eolBuffer, 0, pos, StandardCharsets.UTF_8).contains(DELIMITER)))
             {
                boundary = true;
             }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventInputImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventInputImpl.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -22,10 +23,9 @@ public class SseEventInputImpl implements EventInput, Closeable
    private MediaType mediaType;
    private MultivaluedMap<String, String> httpHeaders;
    private InputStream inputStream;
-   private final byte[] EventEND = "\r\n\r\n".getBytes();
    private volatile boolean isClosed = false;
    private boolean lastFieldWasData;
-
+   private final String DELIMIETER = new String(SseConstants.EVENT_DELIMITER, StandardCharsets.UTF_8);
    public SseEventInputImpl(Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders,
          InputStream inputStream)
    {
@@ -74,13 +74,15 @@ public class SseEventInputImpl implements EventInput, Closeable
 
       final ByteArrayInputStream entityStream = new ByteArrayInputStream(chunk);
       final ByteArrayOutputStream temSave = new ByteArrayOutputStream();
-      Charset charset = SseConstants.UTF8;
+      Charset charset = StandardCharsets.UTF_8;
       if (mediaType != null && mediaType.getParameters().get(MediaType.CHARSET_PARAMETER) != null)
       {
          charset = Charset.forName(mediaType.getParameters().get(MediaType.CHARSET_PARAMETER));
       }
+
       final InboundSseEventImpl.Builder eventBuilder = new InboundSseEventImpl.Builder(annotations, mediaType,
             httpHeaders);
+      //TODO: Look at if this can be improved
       int b = -1;
       SseConstants.EVENT currentState = SseConstants.EVENT.START;
       while ((b = entityStream.read()) != -1)
@@ -110,7 +112,7 @@ public class SseEventInputImpl implements EventInput, Closeable
             {
 
                b = readLine(entityStream, '\n', temSave);
-               String commentLine = temSave.toString(charset.toString());               
+               String commentLine = temSave.toString(charset.name());
                eventBuilder.commentLine(commentLine);
                temSave.reset();
                currentState = SseConstants.EVENT.START;
@@ -120,11 +122,11 @@ public class SseEventInputImpl implements EventInput, Closeable
             {
                temSave.write(b);
                b = readLine(entityStream, ':', temSave);
-               String fieldName = temSave.toString(charset.toString());
+               String fieldName = temSave.toString(StandardCharsets.UTF_8.name());
                temSave.reset();
                if (b == ':')
                {
-                  //space after the colon is ignored
+                  //spec says there is space after colon
                   do
                   {
                      b = entityStream.read();
@@ -172,7 +174,7 @@ public class SseEventInputImpl implements EventInput, Closeable
    private void processField(final InboundSseEventImpl.Builder inboundEventBuilder, final String name,
          final MediaType mediaType, final byte[] value)
    {
-      Charset charset = SseConstants.UTF8;
+      Charset charset = StandardCharsets.UTF_8;
       if (mediaType != null && mediaType.getParameters().get(MediaType.CHARSET_PARAMETER) != null)
       {
          charset = Charset.forName(mediaType.getParameters().get(MediaType.CHARSET_PARAMETER));
@@ -218,25 +220,40 @@ public class SseEventInputImpl implements EventInput, Closeable
       EventByteArrayOutputStream buffer = new EventByteArrayOutputStream();
       int data;
       int pos = 0;
+      boolean boundary = false;
+      byte[] eolBuffer = new byte[5];
       while ((data = in.read()) != -1)
       {
          byte b = (byte) data;
-         if (b == EventEND[pos])
+         if (b == '\r' || b == '\n')
          {
-            pos++;
+            eolBuffer[pos] = b;
+            //if it meets \r\r , \n\n , \r\n\r\n or \n\r\n\r\n
+            if ((pos > 0 && eolBuffer[pos] == eolBuffer[pos - 1])
+                  || (pos >= 3 && new String(eolBuffer, 0, pos, StandardCharsets.UTF_8).contains(DELIMIETER)))
+            {
+               boundary = true;
+            }
+            //take it a boundary if there are 5 unexpected eols  
+            if (pos++ > 4)
+            {
+               boundary = true;
+            }
          }
          else
          {
             pos = 0;
          }
          buffer.write(b);
-         if (pos >= EventEND.length && buffer.toByteArray().length > EventEND.length)
+         if (boundary && buffer.size() > pos)
          {
             return buffer.getEventPayLoad();
          }
-         if (pos >= EventEND.length && buffer.toByteArray().length == EventEND.length)
+         //if it's emtpy 
+         if (boundary && buffer.size() == pos)
          {
             pos = 0;
+            boundary=false;
             buffer.reset();
             continue;
          }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
@@ -30,7 +30,6 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
    private final ResteasyAsynchronousContext asyncContext;
    private final HttpResponse response;
    private volatile boolean closed;
-   private static final byte[] END = "\r\n\r\n".getBytes();
    private final Map<Class<?>, Object> contextDataMap;
    private boolean responseFlushed = false;
    
@@ -77,7 +76,8 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
          //set back to client 200 OK to implies the SseEventOutput is ready
          try
          {
-            response.getOutputStream().write(END);
+            response.getOutputStream().write(SseConstants.EOL);
+            response.getOutputStream().write(SseConstants.EOL);
             response.flushBuffer();
             responseFlushed = true;
          }
@@ -120,9 +120,9 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
             ByteArrayOutputStream bout = new ByteArrayOutputStream();
             writer.writeTo(event, event.getClass(), null, new Annotation[]{}, event.getMediaType(), null, bout);
             response.getOutputStream().write(bout.toByteArray());
+            response.flushBuffer();
          }
-         response.getOutputStream().write(END);
-         response.flushBuffer();
+        
       } catch (Exception e) {
          throw new ProcessingException(e);
       } finally {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventProvider.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventProvider.java
@@ -6,6 +6,7 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
@@ -47,7 +48,7 @@ public class SseEventProvider implements MessageBodyWriter<OutboundSseEvent>, Me
          MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
          throws IOException, WebApplicationException
    {
-      Charset charset = SseConstants.UTF8;
+      Charset charset = StandardCharsets.UTF_8;
       if (mediaType != null && mediaType.getParameters().get(MediaType.CHARSET_PARAMETER) != null)
       {
          charset = Charset.forName(mediaType.getParameters().get(MediaType.CHARSET_PARAMETER));
@@ -79,7 +80,7 @@ public class SseEventProvider implements MessageBodyWriter<OutboundSseEvent>, Me
          if (event.getReconnectDelay() > -1)
          {
             entityStream.write(SseConstants.RETRY_LEAD);
-            entityStream.write(Long.toString(event.getReconnectDelay()).getBytes(charset));
+            entityStream.write(Long.toString(event.getReconnectDelay()).getBytes(StandardCharsets.UTF_8));
             entityStream.write(SseConstants.EOL);
          }
 
@@ -107,7 +108,6 @@ public class SseEventProvider implements MessageBodyWriter<OutboundSseEvent>, Me
                throw new ServerErrorException(Messages.MESSAGES.notFoundMBW(payloadClass.getName()),
                      Response.Status.INTERNAL_SERVER_ERROR);
             }
-            
             writer.writeTo(event.getData(), payloadClass, payloadType, annotations, event.getMediaType(), httpHeaders,
                   new OutputStream()
                   {
@@ -151,6 +151,7 @@ public class SseEventProvider implements MessageBodyWriter<OutboundSseEvent>, Me
          }
 
       }
+      entityStream.write(SseConstants.EOL);
    }
    
    

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventProvider.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventProvider.java
@@ -49,10 +49,6 @@ public class SseEventProvider implements MessageBodyWriter<OutboundSseEvent>, Me
          throws IOException, WebApplicationException
    {
       Charset charset = StandardCharsets.UTF_8;
-      if (mediaType != null && mediaType.getParameters().get(MediaType.CHARSET_PARAMETER) != null)
-      {
-         charset = Charset.forName(mediaType.getParameters().get(MediaType.CHARSET_PARAMETER));
-      }
       if (event.getComment() != null)
       {
          for (final String comment : event.getComment().split("\n"))


### PR DESCRIPTION
Fix couple of things : 

-  each event is now ended with '\n' insteand of '\r\n' 
-  eventInputImpl can read the event with delimiter '\r', '\n' or '\r\n' (it's only '\r\n' before this change)
-  all event fields are encoded with "UTF-8" and value is encoded with mediaType's charset  if it exists.