### PR TITLE
Async request filters

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
@@ -391,9 +391,9 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
       }
       if (request.getAsyncContext().isSuspended())
       {
-         if(method.getReturnType().equals(void.class))
+         if(method.isAsynchronous())
             return null;
-         // resume an async request that returns something
+         // resume a sync request that got turned async by filters
          request.getAsyncContext().getAsyncResponse().resume(rtn);
          return null;
       }
@@ -575,5 +575,10 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
    public MediaType[] getConsumes()
    {
       return method.getConsumes();
+   }
+
+   public void markMethodAsAsync()
+   {
+      method.markAsynchronous();
    }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
@@ -294,13 +294,8 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
 
       PostMatchContainerRequestContext requestContext = new PostMatchContainerRequestContext(request, this, requestFilters, 
             () -> invokeOnTargetAfterFilter(request, response, target));
-      BuiltResponse abortResponse = requestContext.filter();
-      if(abortResponse != null)
-         return abortResponse;
-      if(!requestContext.isSuspended())
-         return invokeOnTargetAfterFilter(request, response, target);
-      // don't return anything: the request has been suspended
-      return null;
+      // let it handle the continuation
+      return requestContext.filter();
    }   
 
    protected BuiltResponse invokeOnTargetAfterFilter(HttpRequest request, HttpResponse response, Object target)

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
@@ -288,31 +288,23 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
       return rtn;
    }
 
-   
-
    protected BuiltResponse invokeOnTarget(HttpRequest request, HttpResponse response, Object target)
    {
       ResteasyProviderFactory.pushContext(ResourceInfo.class, resourceInfo);  // we don't pop so writer interceptors can get at this
 
+      PostMatchContainerRequestContext requestContext = new PostMatchContainerRequestContext(request, this, requestFilters, 
+            () -> invokeOnTargetAfterFilter(request, response, target));
+      BuiltResponse abortResponse = requestContext.filter();
+      if(abortResponse != null)
+         return abortResponse;
+      if(!requestContext.isSuspended())
+         return invokeOnTargetAfterFilter(request, response, target);
+      // don't return anything: the request has been suspended
+      return null;
+   }   
 
-      PostMatchContainerRequestContext requestContext = new PostMatchContainerRequestContext(request, this);
-      for (ContainerRequestFilter filter : requestFilters)
-      {
-         try
-         {
-            filter.filter(requestContext);
-         }
-         catch (IOException e)
-         {
-            throw new ApplicationException(e);
-         }
-         BuiltResponse serverResponse = (BuiltResponse)requestContext.getResponseAbortedWith();
-         if (serverResponse != null)
-         {
-            return serverResponse;
-         }
-      }
-
+   protected BuiltResponse invokeOnTargetAfterFilter(HttpRequest request, HttpResponse response, Object target)
+   {
       if (validator != null)
       {
          if (isValidatable)
@@ -397,7 +389,15 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
          asyncStreamResponseConsumer.subscribe(rtn);
          return null;
       }
-      if (request.getAsyncContext().isSuspended() || request.wasForwarded())
+      if (request.getAsyncContext().isSuspended())
+      {
+         if(method.getReturnType().equals(void.class))
+            return null;
+         // resume an async request that returns something
+         request.getAsyncContext().getAsyncResponse().resume(rtn);
+         return null;
+      }
+      if (request.wasForwarded())
       {
          return null;
       }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ServerResponseWriter.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ServerResponseWriter.java
@@ -182,10 +182,11 @@ public class ServerResponseWriter
          ResponseContainerRequestContext requestContext = new ResponseContainerRequestContext(request);
          ContainerResponseContextImpl responseContext = new ContainerResponseContextImpl(request, response, jaxrsResponse, 
         		 requestContext, responseFilters, continuation);
+         // filter calls the continuation
          responseContext.filter();
-         if(!responseContext.isSuspended())
-        	 continuation.run();
       }
+      else
+         continuation.run();
    }
    
    protected static void setDefaultContentType(HttpRequest request, BuiltResponse jaxrsResponse, ResteasyProviderFactory providerFactory, ResourceMethodInvoker method)

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ServerResponseWriter.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ServerResponseWriter.java
@@ -63,7 +63,6 @@ public class ServerResponseWriter
       setResponseMediaType(jaxrsResponse, request, response, providerFactory, method);
       
       executeFilters(jaxrsResponse, request, response, providerFactory, method, () -> {
-         System.err.println("In response continuation");
          //[RESTEASY-1627] check on response.getOutputStream() to avoid resteasy-netty4 trying building a chunked response body for HEAD requests 
          if (jaxrsResponse.getEntity() == null || response.getOutputStream() == null)
          {
@@ -72,7 +71,6 @@ public class ServerResponseWriter
             return;
          }
 
-         System.err.println("In response continuation 2");
          Class type = jaxrsResponse.getEntityClass();
          Object ent = jaxrsResponse.getEntity();
          Type generic = jaxrsResponse.getGenericType();
@@ -89,7 +87,6 @@ public class ServerResponseWriter
             throw new NoMessageBodyWriterFoundFailure(type, mt);
          }
 
-         System.err.println("In response continuation 3");
          if(sendHeaders)
             response.setStatus(jaxrsResponse.getStatus());
          final BuiltResponse built = jaxrsResponse;
@@ -117,7 +114,6 @@ public class ServerResponseWriter
             writerInterceptors = providerFactory.getServerWriterInterceptorRegistry().postMatch(null, null);
          }
 
-         System.err.println("In response continuation 4");
          AbstractWriterInterceptorContext writerContext =  new ServerWriterInterceptorContext(writerInterceptors,
                providerFactory, ent, type, generic, annotations, mt,
                jaxrsResponse.getMetadata(), os, request);
@@ -126,7 +122,6 @@ public class ServerResponseWriter
             response.setOutputStream(writerContext.getOutputStream()); //propagate interceptor changes on the outputstream to the response
             callback.commit(); // just in case the output stream is never used
          }
-         System.err.println("In response continuation 5");
       });
    }
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SynchronousDispatcher.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SynchronousDispatcher.java
@@ -128,8 +128,6 @@ public class SynchronousDispatcher implements Dispatcher
          ContainerRequestFilter[] requestFilters = providerFactory.getContainerRequestFilterRegistry().preMatch();
          PreMatchContainerRequestContext requestContext = new PreMatchContainerRequestContext(request, requestFilters, continuation);
          aborted = requestContext.filter();
-         System.out.println("Filter done: aborted: "+aborted);
-         System.out.println("Filter done: suspended: "+requestContext.isSuspended());
          if(aborted == null)
          {
             if(requestContext.isSuspended())
@@ -192,9 +190,7 @@ public class SynchronousDispatcher implements Dispatcher
       try
       {
          pushContextObjects(request, response);
-         System.out.println("A");
          preprocess(request, response, () -> {
-            System.out.println("In continuation");
             ResourceInvoker invoker = null;
             try
             {
@@ -234,7 +230,6 @@ public class SynchronousDispatcher implements Dispatcher
       try
       {
          pushContextObjects(request, response);
-         System.out.println("B");
          preprocess(request, response, () -> {
             ResourceInvoker invoker = null;
             try

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SynchronousDispatcher.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SynchronousDispatcher.java
@@ -99,13 +99,9 @@ public class SynchronousDispatcher implements Dispatcher
             preprocessor.preProcess(request);
          }
          ContainerRequestFilter[] requestFilters = providerFactory.getContainerRequestFilterRegistry().preMatch();
-         PreMatchContainerRequestContext requestContext = new PreMatchContainerRequestContext(request);
-         for (ContainerRequestFilter filter : requestFilters)
-         {
-            filter.filter(requestContext);
-            aborted = requestContext.getResponseAbortedWith();
-            if (aborted != null) break;
-         }
+         // FIXME: support async
+         PreMatchContainerRequestContext requestContext = new PreMatchContainerRequestContext(request, requestFilters, null);
+         aborted = requestContext.filter();
       }
       catch (Exception e)
       {
@@ -120,7 +116,7 @@ public class SynchronousDispatcher implements Dispatcher
     *
     * @return true if request should continue
     */
-   protected boolean preprocess(HttpRequest request, HttpResponse response)
+   protected void preprocess(HttpRequest request, HttpResponse response, Runnable continuation)
    {
       Response aborted = null;
       try
@@ -130,26 +126,28 @@ public class SynchronousDispatcher implements Dispatcher
             preprocessor.preProcess(request);
          }
          ContainerRequestFilter[] requestFilters = providerFactory.getContainerRequestFilterRegistry().preMatch();
-         PreMatchContainerRequestContext requestContext = new PreMatchContainerRequestContext(request);
-         for (ContainerRequestFilter filter : requestFilters)
+         PreMatchContainerRequestContext requestContext = new PreMatchContainerRequestContext(request, requestFilters, continuation);
+         aborted = requestContext.filter();
+         System.out.println("Filter done: aborted: "+aborted);
+         System.out.println("Filter done: suspended: "+requestContext.isSuspended());
+         if(aborted == null)
          {
-            filter.filter(requestContext);
-            aborted = requestContext.getResponseAbortedWith();
-            if (aborted != null) break;
+            if(requestContext.isSuspended())
+               return;
          }
       }
       catch (Exception e)
       {
          //logger.error("Failed in preprocess, mapping exception", e);
          writeException(request, response, e);
-         return false;
+         return;
       }
       if (aborted != null)
       {
          writeResponse(request, response, aborted);
-         return false;
+         return;
       }
-      return true;
+      continuation.run();
    }
 
    public void writeException(HttpRequest request, HttpResponse response, Throwable e)
@@ -194,19 +192,30 @@ public class SynchronousDispatcher implements Dispatcher
       try
       {
          pushContextObjects(request, response);
-         if (!preprocess(request, response)) return;
-         ResourceInvoker invoker = null;
-         try
-         {
-            invoker = getInvoker(request);
-         }
-         catch (Exception exception)
-         {
-            //logger.error("getInvoker() failed mapping exception", exception);
-            writeException(request, response, exception);
-            return;
-         }
-         invoke(request, response, invoker);
+         System.out.println("A");
+         preprocess(request, response, () -> {
+            System.out.println("In continuation");
+            ResourceInvoker invoker = null;
+            try
+            {
+               try
+               {
+                  invoker = getInvoker(request);
+               }
+               catch (Exception exception)
+               {
+                  //logger.error("getInvoker() failed mapping exception", exception);
+                  writeException(request, response, exception);
+                  return;
+               }
+               invoke(request, response, invoker);
+            }
+            finally
+            {
+               // we're probably clearing it twice but still required
+               clearContextData();
+            }
+         });
       }
       finally
       {
@@ -225,26 +234,36 @@ public class SynchronousDispatcher implements Dispatcher
       try
       {
          pushContextObjects(request, response);
-         if (!preprocess(request, response)) return;
-         ResourceInvoker invoker = null;
-         try
-         {
-            invoker = getInvoker(request);
-         }
-         catch (Exception failure)
-         {
-            if (failure instanceof NotFoundException)
+         System.out.println("B");
+         preprocess(request, response, () -> {
+            ResourceInvoker invoker = null;
+            try
             {
-               throw ((NotFoundException) failure);
+               try
+               {
+                  invoker = getInvoker(request);
+               }
+               catch (Exception failure)
+               {
+                  if (failure instanceof NotFoundException)
+                  {
+                     throw ((NotFoundException) failure);
+                  }
+                  else
+                  {
+                     //logger.error("getInvoker() failed mapping exception", failure);
+                     writeException(request, response, failure);
+                     return;
+                  }
+               }
+               invoke(request, response, invoker);
             }
-            else
+            finally
             {
-               //logger.error("getInvoker() failed mapping exception", failure);
-               writeException(request, response, failure);
-               return;
+               // we're probably clearing it twice but still required
+               clearContextData();
             }
-         }
-         invoke(request, response, invoker);
+         });
       }
       finally
       {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ContainerResponseContextImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ContainerResponseContextImpl.java
@@ -281,11 +281,9 @@ public class ContainerResponseContextImpl implements ContainerResponseContext
    
    public synchronized void filter()
    {
-      System.out.println("Filter");
       // FIXME: check what happens if the filter suspends and resumes/abort within the same call (same thread)
       while(currentFilter < responseFilters.length)
       {
-         System.out.println("Filter["+currentFilter+"]");
          ContainerResponseFilter filter = responseFilters[currentFilter++];
          try
          {
@@ -296,7 +294,6 @@ public class ContainerResponseContextImpl implements ContainerResponseContext
          {
             throw new ApplicationException(e);
          }
-         System.out.println("Filter["+currentFilter+"] suspended: "+suspended);
          if(suspended) {
             if(!request.getAsyncContext().isSuspended())
                request.getAsyncContext().suspend();

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ContainerResponseContextImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ContainerResponseContextImpl.java
@@ -1,17 +1,5 @@
 package org.jboss.resteasy.core.interception.jaxrs;
 
-import org.jboss.resteasy.specimpl.BuiltResponse;
-import org.jboss.resteasy.spi.HttpRequest;
-import org.jboss.resteasy.spi.HttpResponse;
-
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.core.EntityTag;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.NewCookie;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
@@ -22,6 +10,24 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.core.ServerResponseWriter.RunnableWithIOException;
+import org.jboss.resteasy.specimpl.BuiltResponse;
+import org.jboss.resteasy.spi.ApplicationException;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
@@ -31,12 +37,24 @@ public class ContainerResponseContextImpl implements ContainerResponseContext
    protected final HttpRequest request;
    protected final HttpResponse httpResponse;
    protected final BuiltResponse jaxrsResponse;
+   private ResponseContainerRequestContext requestContext;
+   private ContainerResponseFilter[] responseFilters;
+   private RunnableWithIOException continuation;
+   private int currentFilter;
+   private boolean suspended;
+   private boolean filterReturnIsMeaningful = true;
+   private Map<Class<?>, Object> contextDataMap;
 
-   public ContainerResponseContextImpl(HttpRequest request, HttpResponse httpResponse, BuiltResponse serverResponse)
+   public ContainerResponseContextImpl(HttpRequest request, HttpResponse httpResponse, BuiltResponse serverResponse, 
+         ResponseContainerRequestContext requestContext, ContainerResponseFilter[] responseFilters, RunnableWithIOException continuation)
    {
       this.request = request;
       this.httpResponse = httpResponse;
       this.jaxrsResponse = serverResponse;
+      this.requestContext = requestContext;
+      this.responseFilters = responseFilters;
+      this.continuation = continuation;
+      contextDataMap = ResteasyProviderFactory.getContextDataMap();
    }
 
    public BuiltResponse getJaxrsResponse()
@@ -244,5 +262,70 @@ public class ContainerResponseContextImpl implements ContainerResponseContext
    public String getHeaderString(String name)
    {
       return jaxrsResponse.getHeaderString(name);
+   }
+
+
+   public synchronized void suspend() {
+      if(continuation == null)
+         throw new RuntimeException("Suspend not supported yet");
+      suspended = true;
+   }
+
+   public synchronized void resume() {
+      if(!suspended)
+         throw new RuntimeException("Cannot resume: not suspended");
+      ResteasyProviderFactory.pushContextDataMap(contextDataMap);
+      // just go on
+      filter();
+   }
+   
+   public synchronized void filter()
+   {
+      System.out.println("Filter");
+      // FIXME: check what happens if the filter suspends and resumes/abort within the same call (same thread)
+      while(currentFilter < responseFilters.length)
+      {
+         System.out.println("Filter["+currentFilter+"]");
+         ContainerResponseFilter filter = responseFilters[currentFilter++];
+         try
+         {
+            suspended = false;
+            filter.filter(requestContext, this);
+         }
+         catch (IOException e)
+         {
+            throw new ApplicationException(e);
+         }
+         System.out.println("Filter["+currentFilter+"] suspended: "+suspended);
+         if(suspended) {
+            if(!request.getAsyncContext().isSuspended())
+               request.getAsyncContext().suspend();
+            // ignore any abort request until we are resumed
+            filterReturnIsMeaningful = false;
+            return;
+         }
+      }
+      // here it means we reached the last filter
+      // if we've never been suspended, the caller is valid and let it go on doing the request
+      if(filterReturnIsMeaningful)
+         return;
+      // if we've been suspended then the caller is a filter and have to invoke our continuation
+      // FIXME: we don't really know if we're already trying to send an exception, so we can't just blindly
+      // try to write it out
+      try
+      {
+         continuation.run();
+         // if we're the ones who turned the request async, nobody will call complete() for us, so we have to
+         HttpServletRequest httpServletRequest = (HttpServletRequest) contextDataMap.get(HttpServletRequest.class);
+         httpServletRequest.getAsyncContext().complete();
+      } catch (IOException e)
+      {
+         e.printStackTrace();
+      }
+   }
+
+   public boolean isSuspended()
+   {
+      return !filterReturnIsMeaningful;
    }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ContainerResponseContextImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ContainerResponseContextImpl.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.HttpHeaders;
@@ -22,8 +21,8 @@ import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 
 import org.jboss.resteasy.core.Dispatcher;
-import org.jboss.resteasy.core.SynchronousDispatcher;
 import org.jboss.resteasy.core.ServerResponseWriter.RunnableWithIOException;
+import org.jboss.resteasy.core.SynchronousDispatcher;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.specimpl.BuiltResponse;
 import org.jboss.resteasy.spi.ApplicationException;
@@ -35,7 +34,7 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class ContainerResponseContextImpl implements ContainerResponseContext
+public class ContainerResponseContextImpl implements SuspendableContainerResponseContext
 {
    protected final HttpRequest request;
    protected final HttpResponse httpResponse;
@@ -268,12 +267,14 @@ public class ContainerResponseContextImpl implements ContainerResponseContext
    }
 
 
+   @Override
    public synchronized void suspend() {
       if(continuation == null)
          throw new RuntimeException("Suspend not supported yet");
       suspended = true;
    }
 
+   @Override
    public synchronized void resume() {
       if(!suspended)
          throw new RuntimeException("Cannot resume: not suspended");
@@ -286,12 +287,13 @@ public class ContainerResponseContextImpl implements ContainerResponseContext
          writeException(t);
       }
    }
-   
+
+   @Override
    public synchronized void resume(Throwable t) {
       ResteasyProviderFactory.pushContextDataMap(contextDataMap);
       writeException(t);
    }
-   
+
    private void writeException(Throwable t)
    {
       HttpRequest httpRequest = (HttpRequest) contextDataMap.get(HttpRequest.class);

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/PostMatchContainerRequestContext.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/PostMatchContainerRequestContext.java
@@ -1,18 +1,14 @@
 package org.jboss.resteasy.core.interception.jaxrs;
 
+import java.net.URI;
+import java.util.function.Supplier;
+
+import javax.ws.rs.container.ContainerRequestFilter;
+
 import org.jboss.resteasy.core.ResourceMethodInvoker;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
 import org.jboss.resteasy.specimpl.BuiltResponse;
-import org.jboss.resteasy.spi.ApplicationException;
 import org.jboss.resteasy.spi.HttpRequest;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
-
-import java.io.IOException;
-import java.net.URI;
-import java.util.Map;
-
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.core.Response;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -23,7 +19,7 @@ public class PostMatchContainerRequestContext extends PreMatchContainerRequestCo
    protected final ResourceMethodInvoker resourceMethod;
 
    public PostMatchContainerRequestContext(HttpRequest request,ResourceMethodInvoker resourceMethod, 
-         ContainerRequestFilter[] requestFilters, Runnable continuation)
+         ContainerRequestFilter[] requestFilters, Supplier<BuiltResponse> continuation)
    {
       super(request, requestFilters, continuation);
       this.resourceMethod = resourceMethod;

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/PostMatchContainerRequestContext.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/PostMatchContainerRequestContext.java
@@ -2,9 +2,17 @@ package org.jboss.resteasy.core.interception.jaxrs;
 
 import org.jboss.resteasy.core.ResourceMethodInvoker;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
+import org.jboss.resteasy.specimpl.BuiltResponse;
+import org.jboss.resteasy.spi.ApplicationException;
 import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
+import java.io.IOException;
 import java.net.URI;
+import java.util.Map;
+
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Response;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -13,11 +21,20 @@ import java.net.URI;
 public class PostMatchContainerRequestContext extends PreMatchContainerRequestContext
 {
    protected final ResourceMethodInvoker resourceMethod;
+   private ContainerRequestFilter[] requestFilters;
+   private int currentFilter;
+   private boolean suspended;
+   private Runnable continuation;
+   private Map<Class<?>, Object> contextDataMap;
 
-   public PostMatchContainerRequestContext(HttpRequest request,ResourceMethodInvoker resourceMethod)
+   public PostMatchContainerRequestContext(HttpRequest request,ResourceMethodInvoker resourceMethod, 
+         ContainerRequestFilter[] requestFilters, Runnable continuation)
    {
       super(request);
       this.resourceMethod = resourceMethod;
+      this.requestFilters = requestFilters;
+      this.continuation = continuation;
+      contextDataMap = ResteasyProviderFactory.getContextDataMap();
    }
 
    public ResourceMethodInvoker getResourceMethod()
@@ -41,5 +58,76 @@ public class PostMatchContainerRequestContext extends PreMatchContainerRequestCo
    public void setRequestUri(URI baseUri, URI requestUri) throws IllegalStateException
    {
       throw new IllegalStateException(Messages.MESSAGES.cantSetURI());
+   }
+
+   public synchronized void suspend() {
+      suspended = true;
+   }
+   
+   @Override
+   public synchronized void abortWith(Response response)
+   {
+      ResteasyProviderFactory.pushContextDataMap(contextDataMap);
+      if(suspended)
+      {
+         httpRequest.getAsyncContext().getAsyncResponse().resume(response);
+      }
+      else
+         super.abortWith(response);
+   }
+   
+   public synchronized void resume() {
+      ResteasyProviderFactory.pushContextDataMap(contextDataMap);
+      // just go on
+      filter();
+   }
+   
+   public synchronized BuiltResponse filter()
+   {
+      // FIXME: check what happens if the filter suspends and resumes/abort within the same call (same thread)
+      while(currentFilter < requestFilters.length)
+      {
+         ContainerRequestFilter filter = requestFilters[currentFilter++];
+         try
+         {
+            suspended = false;
+            filter.filter(this);
+         }
+         catch (IOException e)
+         {
+            throw new ApplicationException(e);
+         }
+         if(suspended) {
+            if(!httpRequest.getAsyncContext().isSuspended())
+               httpRequest.getAsyncContext().suspend();
+            // ignore any abort request until we are resumed
+            response = null;
+            return null;
+         }
+         BuiltResponse serverResponse = (BuiltResponse)getResponseAbortedWith();
+         if (serverResponse != null)
+         {
+            // handle the case where we've been suspended by a previous filter
+            // FIXME: when pre-filters can also suspend this is likely to just be wrong
+            if(!httpRequest.getAsyncContext().isSuspended())
+               return serverResponse;
+            else
+               httpRequest.getAsyncContext().getAsyncResponse().resume(serverResponse);
+         }
+      }
+      // here it means we reached the last filter
+      // if we've never been suspended, the caller is valid and let it go on doing the request
+      // FIXME: when pre-filters can also suspend this is likely to just be wrong
+      if(!httpRequest.getAsyncContext().isSuspended())
+         return null;
+      // if we've been suspended then the caller is a filter and have to invoke our continuation
+      continuation.run();
+      return null;
+   }
+
+   public boolean isSuspended()
+   {
+      // FIXME: when pre-filters can also suspend this is likely to just be wrong
+      return httpRequest.getAsyncContext().isSuspended();
    }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/PostMatchContainerRequestContext.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/PostMatchContainerRequestContext.java
@@ -21,20 +21,12 @@ import javax.ws.rs.core.Response;
 public class PostMatchContainerRequestContext extends PreMatchContainerRequestContext
 {
    protected final ResourceMethodInvoker resourceMethod;
-   private ContainerRequestFilter[] requestFilters;
-   private int currentFilter;
-   private boolean suspended;
-   private Runnable continuation;
-   private Map<Class<?>, Object> contextDataMap;
 
    public PostMatchContainerRequestContext(HttpRequest request,ResourceMethodInvoker resourceMethod, 
          ContainerRequestFilter[] requestFilters, Runnable continuation)
    {
-      super(request);
+      super(request, requestFilters, continuation);
       this.resourceMethod = resourceMethod;
-      this.requestFilters = requestFilters;
-      this.continuation = continuation;
-      contextDataMap = ResteasyProviderFactory.getContextDataMap();
    }
 
    public ResourceMethodInvoker getResourceMethod()
@@ -58,76 +50,5 @@ public class PostMatchContainerRequestContext extends PreMatchContainerRequestCo
    public void setRequestUri(URI baseUri, URI requestUri) throws IllegalStateException
    {
       throw new IllegalStateException(Messages.MESSAGES.cantSetURI());
-   }
-
-   public synchronized void suspend() {
-      suspended = true;
-   }
-   
-   @Override
-   public synchronized void abortWith(Response response)
-   {
-      ResteasyProviderFactory.pushContextDataMap(contextDataMap);
-      if(suspended)
-      {
-         httpRequest.getAsyncContext().getAsyncResponse().resume(response);
-      }
-      else
-         super.abortWith(response);
-   }
-   
-   public synchronized void resume() {
-      ResteasyProviderFactory.pushContextDataMap(contextDataMap);
-      // just go on
-      filter();
-   }
-   
-   public synchronized BuiltResponse filter()
-   {
-      // FIXME: check what happens if the filter suspends and resumes/abort within the same call (same thread)
-      while(currentFilter < requestFilters.length)
-      {
-         ContainerRequestFilter filter = requestFilters[currentFilter++];
-         try
-         {
-            suspended = false;
-            filter.filter(this);
-         }
-         catch (IOException e)
-         {
-            throw new ApplicationException(e);
-         }
-         if(suspended) {
-            if(!httpRequest.getAsyncContext().isSuspended())
-               httpRequest.getAsyncContext().suspend();
-            // ignore any abort request until we are resumed
-            response = null;
-            return null;
-         }
-         BuiltResponse serverResponse = (BuiltResponse)getResponseAbortedWith();
-         if (serverResponse != null)
-         {
-            // handle the case where we've been suspended by a previous filter
-            // FIXME: when pre-filters can also suspend this is likely to just be wrong
-            if(!httpRequest.getAsyncContext().isSuspended())
-               return serverResponse;
-            else
-               httpRequest.getAsyncContext().getAsyncResponse().resume(serverResponse);
-         }
-      }
-      // here it means we reached the last filter
-      // if we've never been suspended, the caller is valid and let it go on doing the request
-      // FIXME: when pre-filters can also suspend this is likely to just be wrong
-      if(!httpRequest.getAsyncContext().isSuspended())
-         return null;
-      // if we've been suspended then the caller is a filter and have to invoke our continuation
-      continuation.run();
-      return null;
-   }
-
-   public boolean isSuspended()
-   {
-      // FIXME: when pre-filters can also suspend this is likely to just be wrong
-      return httpRequest.getAsyncContext().isSuspended();
    }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/PreMatchContainerRequestContext.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/PreMatchContainerRequestContext.java
@@ -1,9 +1,12 @@
 package org.jboss.resteasy.core.interception.jaxrs;
 
+import org.jboss.resteasy.specimpl.BuiltResponse;
+import org.jboss.resteasy.spi.ApplicationException;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -11,6 +14,8 @@ import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
+
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
@@ -29,10 +34,20 @@ public class PreMatchContainerRequestContext implements ContainerRequestContext
 {
    protected final HttpRequest httpRequest;
    protected Response response;
+   private ContainerRequestFilter[] requestFilters;
+   private int currentFilter;
+   private boolean suspended;
+   private boolean filterReturnIsMeaningful = true;
+   private Runnable continuation;
+   private Map<Class<?>, Object> contextDataMap;
 
-   public PreMatchContainerRequestContext(HttpRequest request)
+   public PreMatchContainerRequestContext(HttpRequest request, 
+         ContainerRequestFilter[] requestFilters, Runnable continuation)
    {
       this.httpRequest = request;
+      this.requestFilters = requestFilters;
+      this.continuation = continuation;
+      contextDataMap = ResteasyProviderFactory.getContextDataMap();
    }
 
    public HttpRequest getHttpRequest()
@@ -190,14 +205,83 @@ public class PreMatchContainerRequestContext implements ContainerRequestContext
    }
 
    @Override
-   public void abortWith(Response response)
-   {
-      this.response = response;
-   }
-
-   @Override
    public String getHeaderString(String name)
    {
       return httpRequest.getHttpHeaders().getHeaderString(name);
+   }
+
+   public synchronized void suspend() {
+      if(continuation == null)
+         throw new RuntimeException("Suspend not supported yet");
+      suspended = true;
+   }
+
+   @Override
+   public synchronized void abortWith(Response response)
+   {
+      ResteasyProviderFactory.pushContextDataMap(contextDataMap);
+      if(suspended)
+      {
+         httpRequest.getAsyncContext().getAsyncResponse().resume(response);
+      }
+      else
+      {
+         this.response = response;
+      }
+   }
+   
+   public synchronized void resume() {
+      if(!suspended)
+         throw new RuntimeException("Cannot resume: not suspended");
+      ResteasyProviderFactory.pushContextDataMap(contextDataMap);
+      // just go on
+      filter();
+   }
+   
+   public synchronized BuiltResponse filter()
+   {
+      // FIXME: check what happens if the filter suspends and resumes/abort within the same call (same thread)
+      while(currentFilter < requestFilters.length)
+      {
+         ContainerRequestFilter filter = requestFilters[currentFilter++];
+         try
+         {
+            suspended = false;
+            filter.filter(this);
+         }
+         catch (IOException e)
+         {
+            throw new ApplicationException(e);
+         }
+         if(suspended) {
+            if(!httpRequest.getAsyncContext().isSuspended())
+               httpRequest.getAsyncContext().suspend();
+            // ignore any abort request until we are resumed
+            filterReturnIsMeaningful = false;
+            response = null;
+            return null;
+         }
+         BuiltResponse serverResponse = (BuiltResponse)getResponseAbortedWith();
+         if (serverResponse != null)
+         {
+            // handle the case where we've been suspended by a previous filter
+            if(filterReturnIsMeaningful)
+               return serverResponse;
+            else
+               httpRequest.getAsyncContext().getAsyncResponse().resume(serverResponse);
+         }
+      }
+      // here it means we reached the last filter
+      // if we've never been suspended, the caller is valid and let it go on doing the request
+      if(filterReturnIsMeaningful)
+         return null;
+      // if we've been suspended then the caller is a filter and have to invoke our continuation
+      continuation.run();
+      return null;
+   }
+
+   public boolean isSuspended()
+   {
+      return !filterReturnIsMeaningful;
    }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/PreMatchContainerRequestContext.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/PreMatchContainerRequestContext.java
@@ -1,24 +1,5 @@
 package org.jboss.resteasy.core.interception.jaxrs;
 
-import org.jboss.resteasy.core.Dispatcher;
-import org.jboss.resteasy.core.SynchronousDispatcher;
-import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
-import org.jboss.resteasy.specimpl.BuiltResponse;
-import org.jboss.resteasy.spi.ApplicationException;
-import org.jboss.resteasy.spi.HttpRequest;
-import org.jboss.resteasy.spi.HttpResponse;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
-
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.core.Cookie;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Request;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
-import javax.ws.rs.core.UriInfo;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -30,11 +11,29 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+import org.jboss.resteasy.core.Dispatcher;
+import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
+import org.jboss.resteasy.specimpl.BuiltResponse;
+import org.jboss.resteasy.spi.ApplicationException;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class PreMatchContainerRequestContext implements ContainerRequestContext
+public class PreMatchContainerRequestContext implements SuspendableContainerRequestContext
 {
    protected final HttpRequest httpRequest;
    protected Response response;
@@ -216,6 +215,7 @@ public class PreMatchContainerRequestContext implements ContainerRequestContext
       return httpRequest.getHttpHeaders().getHeaderString(name);
    }
 
+   @Override
    public synchronized void suspend() {
       if(continuation == null)
          throw new RuntimeException("Suspend not supported yet");
@@ -238,6 +238,7 @@ public class PreMatchContainerRequestContext implements ContainerRequestContext
       }
    }
    
+   @Override
    public synchronized void resume() {
       if(!suspended)
          throw new RuntimeException("Cannot resume: not suspended");
@@ -258,6 +259,7 @@ public class PreMatchContainerRequestContext implements ContainerRequestContext
       }
    }
    
+   @Override
    public synchronized void resume(Throwable t) {
       if(!suspended)
          throw new RuntimeException("Cannot resume: not suspended");

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ResponseContainerRequestContext.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ResponseContainerRequestContext.java
@@ -17,7 +17,7 @@ public class ResponseContainerRequestContext extends PreMatchContainerRequestCon
 {
    public ResponseContainerRequestContext(HttpRequest request)
    {
-      super(request);
+      super(request, null, null);
    }
 
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/SuspendableContainerRequestContext.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/SuspendableContainerRequestContext.java
@@ -1,0 +1,37 @@
+package org.jboss.resteasy.core.interception.jaxrs;
+
+import javax.ws.rs.container.ContainerRequestContext;
+
+/**
+ * Suspendable request context, which allows the users to suspend execution of the filter
+ * chain until it is resumed normally, or abnormally with a @{link Response} or
+ * @{link Throwable}. 
+ *
+ * @author Stéphane Épardaud <stef@epardaud.fr>
+ */
+public interface SuspendableContainerRequestContext extends ContainerRequestContext
+{
+   /**
+    * Suspends the current request. This makes the current request asynchronous. No
+    * further request filter is executed until this request is resumed.
+    * 
+    * No reply is going to be sent to the client until this request is resumed either
+    * with {@link #resume()} or aborted with {@link #resume(Throwable)} or 
+    * {@link #abortWith(javax.ws.rs.core.Response)}.
+    */
+   public void suspend();
+   
+   /**
+    * Resumes the current request, and proceeds to the next request filter, if any,
+    * or to the resource method.
+    */
+   public void resume();
+   
+   /**
+    * Aborts the current request with the given exception. This behaves as if the request
+    * filter threw this exception synchronously.
+    * 
+    * @param t the exception to send back to the client, as mapped by the application.
+    */
+   public void resume(Throwable t);
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/SuspendableContainerResponseContext.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/SuspendableContainerResponseContext.java
@@ -1,0 +1,38 @@
+package org.jboss.resteasy.core.interception.jaxrs;
+
+import javax.ws.rs.container.ContainerResponseContext;
+
+/**
+ * Suspendable response context, which allows the users to suspend execution of the filter
+ * chain until it is resumed normally, or abnormally with a @{link Response} or
+ * @{link Throwable}. 
+ *
+ * @author Stéphane Épardaud <stef@epardaud.fr>
+ */
+public interface SuspendableContainerResponseContext extends ContainerResponseContext
+{
+   /**
+    * Suspends the current response. This makes the current request asynchronous. No
+    * further response filter is executed until this response is resumed.
+    * 
+    * No reply is going to be sent to the client until this response is resumed either
+    * with {@link #resume()} or aborted with {@link #resume(Throwable)} or 
+    * {@link #abortWith(javax.ws.rs.core.Response)}.
+    */
+   public void suspend();
+   
+   /**
+    * Resumes the current response, and proceeds to the next response filter, if any,
+    * or to send the response.
+    */
+   public void resume();
+   
+   /**
+    * Aborts the current response with the given exception. This behaves as if the request
+    * filter threw this exception synchronously.
+    * 
+    * @param t the exception to send back to the client, as mapped by the application.
+    */
+   public void resume(Throwable t);
+
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventSinkInterceptor.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventSinkInterceptor.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.Provider;
 import javax.ws.rs.sse.SseEventSink;
 
+import org.jboss.resteasy.core.interception.jaxrs.PostMatchContainerRequestContext;
 import org.jboss.resteasy.plugins.server.servlet.Cleanable;
 import org.jboss.resteasy.plugins.server.servlet.Cleanables;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
@@ -22,6 +23,10 @@ public class SseEventSinkInterceptor implements ContainerRequestFilter
    {
       if (requestContext.getAcceptableMediaTypes().contains(MediaType.SERVER_SENT_EVENTS_TYPE)) {
          SseEventOutputImpl sink = new SseEventOutputImpl(new SseEventProvider());
+         // make sure we register this as being an async method
+         if(requestContext instanceof PostMatchContainerRequestContext) {
+            ((PostMatchContainerRequestContext) requestContext).getResourceMethod().markMethodAsAsync();
+         }
          ResteasyProviderFactory.getContextDataMap().put(SseEventSink.class, sink);
          ResteasyProviderFactory.getContextData(Cleanables.class).addCleanable(new Cleanable()
          {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceMethod.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceMethod.java
@@ -43,4 +43,9 @@ public class ResourceMethod extends ResourceLocator
    {
       return asynchronous;
    }
+
+   public void markAsynchronous()
+   {
+      asynchronous = true;
+   }
 }

--- a/resteasy-legacy/src/main/java/org/jboss/resteasy/core/interception/ContainerResponseContextImpl.java
+++ b/resteasy-legacy/src/main/java/org/jboss/resteasy/core/interception/ContainerResponseContextImpl.java
@@ -15,7 +15,7 @@ public class ContainerResponseContextImpl extends org.jboss.resteasy.core.interc
 
    public ContainerResponseContextImpl(HttpRequest request, HttpResponse httpResponse, BuiltResponse serverResponse)
    {
-      super(request, httpResponse, serverResponse);
+      super(request, httpResponse, serverResponse, null, null, null);
    }
 
 }

--- a/resteasy-legacy/src/main/java/org/jboss/resteasy/core/interception/PostMatchContainerRequestContext.java
+++ b/resteasy-legacy/src/main/java/org/jboss/resteasy/core/interception/PostMatchContainerRequestContext.java
@@ -14,6 +14,6 @@ public class PostMatchContainerRequestContext extends org.jboss.resteasy.core.in
 
    public PostMatchContainerRequestContext(HttpRequest request, ResourceMethodInvoker resourceMethod)
    {
-      super(request, resourceMethod);
+      super(request, resourceMethod, null, null);
    }
 }

--- a/resteasy-legacy/src/main/java/org/jboss/resteasy/core/interception/PreMatchContainerRequestContext.java
+++ b/resteasy-legacy/src/main/java/org/jboss/resteasy/core/interception/PreMatchContainerRequestContext.java
@@ -13,6 +13,6 @@ public class PreMatchContainerRequestContext extends org.jboss.resteasy.core.int
 
    public PreMatchContainerRequestContext(HttpRequest request)
    {
-      super(request);
+      super(request, null, null);
    }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncRequestFilterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncRequestFilterTest.java
@@ -1,0 +1,164 @@
+package org.jboss.resteasy.test.asynch;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.test.asynch.resource.AsyncRequestFilter;
+import org.jboss.resteasy.test.asynch.resource.AsyncRequestFilter1;
+import org.jboss.resteasy.test.asynch.resource.AsyncRequestFilter2;
+import org.jboss.resteasy.test.asynch.resource.AsyncRequestFilter3;
+import org.jboss.resteasy.test.asynch.resource.AsyncRequestFilterResource;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @tpSubChapter CDI
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Async Request Filter test.
+ * @tpSince RESTEasy 4.0.0
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class AsyncRequestFilterTest {
+    protected static final Logger log = LogManager.getLogger(AsyncRequestFilterTest.class.getName());
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+
+        WebArchive war = TestUtil.prepareArchive(AsyncRequestFilterTest.class.getSimpleName());
+        war.addClasses(AsyncRequestFilterResource.class, AsyncRequestFilter.class, AsyncRequestFilter1.class, AsyncRequestFilter2.class, AsyncRequestFilter3.class);
+        return war;
+    }
+
+    private String generateURL(String path) {
+        return PortProviderUtil.generateURL(path, AsyncRequestFilterTest.class.getSimpleName());
+    }
+
+    /**
+     * @tpTestDetails Interceptors work
+     * @tpSince RESTEasy 4.0.0
+     */
+    @Test
+    public void testRequestFilters() throws Exception {
+        Client client = ClientBuilder.newClient();
+
+        // Create book.
+        WebTarget base = client.target(generateURL("/"));
+
+        // all sync
+        
+        Response response = base.request()
+           .header("Filter1", "sync-pass")
+           .header("Filter2", "sync-pass")
+           .header("Filter3", "sync-pass")
+           .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("resource", response.readEntity(String.class));
+
+        response = base.request()
+              .header("Filter1", "sync-fail")
+              .header("Filter2", "sync-fail")
+              .header("Filter3", "sync-fail")
+              .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("Filter1", response.readEntity(String.class));
+
+        response = base.request()
+              .header("Filter1", "sync-pass")
+              .header("Filter2", "sync-fail")
+              .header("Filter3", "sync-fail")
+              .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("Filter2", response.readEntity(String.class));
+
+        response = base.request()
+              .header("Filter1", "sync-pass")
+              .header("Filter2", "sync-pass")
+              .header("Filter3", "sync-fail")
+              .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("Filter3", response.readEntity(String.class));
+
+        // async
+        response = base.request()
+              .header("Filter1", "async-pass")
+              .header("Filter2", "sync-pass")
+              .header("Filter3", "sync-pass")
+              .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("resource", response.readEntity(String.class));
+
+        response = base.request()
+              .header("Filter1", "async-pass")
+              .header("Filter2", "async-pass")
+              .header("Filter3", "sync-pass")
+              .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("resource", response.readEntity(String.class));
+
+        response = base.request()
+              .header("Filter1", "async-pass")
+              .header("Filter2", "async-pass")
+              .header("Filter3", "async-pass")
+              .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("resource", response.readEntity(String.class));
+
+        response = base.request()
+              .header("Filter1", "async-pass")
+              .header("Filter2", "sync-pass")
+              .header("Filter3", "async-pass")
+              .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("resource", response.readEntity(String.class));
+
+        response = base.request()
+              .header("Filter1", "sync-pass")
+              .header("Filter2", "async-pass")
+              .header("Filter3", "sync-pass")
+              .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("resource", response.readEntity(String.class));
+
+        // async failures
+
+        response = base.request()
+              .header("Filter1", "async-fail")
+              .header("Filter2", "sync-fail")
+              .header("Filter3", "sync-fail")
+              .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("Filter1", response.readEntity(String.class));
+
+        response = base.request()
+              .header("Filter1", "async-pass")
+              .header("Filter2", "sync-fail")
+              .header("Filter3", "sync-pass")
+              .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("Filter2", response.readEntity(String.class));
+
+        response = base.request()
+              .header("Filter1", "async-pass")
+              .header("Filter2", "async-fail")
+              .header("Filter3", "sync-pass")
+              .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("Filter2", response.readEntity(String.class));
+
+        client.close();
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncRequestFilterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncRequestFilterTest.java
@@ -169,6 +169,23 @@ public class AsyncRequestFilterTest {
         assertEquals(200, response.getStatus());
         assertEquals("Filter2", response.readEntity(String.class));
 
+        // async instantaneous
+        response = base.request()
+              .header("Filter1", "async-pass-instant")
+              .header("Filter2", "sync-pass")
+              .header("Filter3", "sync-pass")
+              .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("resource", response.readEntity(String.class));
+
+        response = base.request()
+              .header("Filter1", "async-fail-instant")
+              .header("Filter2", "sync-pass")
+              .header("Filter3", "sync-pass")
+              .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("Filter1", response.readEntity(String.class));
+        
         client.close();
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncPreMatchRequestFilter1.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncPreMatchRequestFilter1.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import javax.annotation.Priority;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.ext.Provider;
+
+@PreMatching
+@Priority(1)
+@Provider
+public class AsyncPreMatchRequestFilter1 extends AsyncRequestFilter {
+
+   public AsyncPreMatchRequestFilter1()
+   {
+      super("PreMatchFilter1");
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncPreMatchRequestFilter2.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncPreMatchRequestFilter2.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import javax.annotation.Priority;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.ext.Provider;
+
+@PreMatching
+@Priority(2)
+@Provider
+public class AsyncPreMatchRequestFilter2 extends AsyncRequestFilter {
+
+   public AsyncPreMatchRequestFilter2()
+   {
+      super("PreMatchFilter2");
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncPreMatchRequestFilter3.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncPreMatchRequestFilter3.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import javax.annotation.Priority;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.ext.Provider;
+
+@PreMatching
+@Priority(3)
+@Provider
+public class AsyncPreMatchRequestFilter3 extends AsyncRequestFilter {
+
+   public AsyncPreMatchRequestFilter3()
+   {
+      super("PreMatchFilter3");
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter.java
@@ -8,7 +8,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Response;
 
-import org.jboss.resteasy.core.interception.jaxrs.PostMatchContainerRequestContext;
+import org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext;
 
 public abstract class AsyncRequestFilter implements ContainerRequestFilter {
 
@@ -22,7 +22,7 @@ public abstract class AsyncRequestFilter implements ContainerRequestFilter {
    @Override
    public void filter(ContainerRequestContext requestContext) throws IOException
    {
-      PostMatchContainerRequestContext ctx = (PostMatchContainerRequestContext) requestContext;
+      PreMatchContainerRequestContext ctx = (PreMatchContainerRequestContext) requestContext;
       String action = ctx.getHeaderString(name);
       System.err.println("Filter request for "+name+" with action: "+action);
       if("sync-pass".equals(action)) {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter.java
@@ -33,10 +33,16 @@ public abstract class AsyncRequestFilter implements ContainerRequestFilter {
          ctx.suspend();
          ExecutorService executor = Executors.newSingleThreadExecutor();
          executor.submit(() -> ctx.resume());
+      }else if("async-pass-instant".equals(action)) {
+         ctx.suspend();
+         ctx.resume();
       }else if("async-fail".equals(action)) {
          ctx.suspend();
          ExecutorService executor = Executors.newSingleThreadExecutor();
          executor.submit(() -> ctx.abortWith(Response.ok(name).build()));
+      }else if("async-fail-instant".equals(action)) {
+         ctx.suspend();
+         ctx.abortWith(Response.ok(name).build());
       }
       System.err.println("Filter request for "+name+" with action: "+action+" done");
    }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter.java
@@ -1,0 +1,44 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.core.interception.jaxrs.PostMatchContainerRequestContext;
+
+public abstract class AsyncRequestFilter implements ContainerRequestFilter {
+
+   private String name;
+   
+   public AsyncRequestFilter(String name)
+   {
+      this.name = name;
+   }
+
+   @Override
+   public void filter(ContainerRequestContext requestContext) throws IOException
+   {
+      PostMatchContainerRequestContext ctx = (PostMatchContainerRequestContext) requestContext;
+      String action = ctx.getHeaderString(name);
+      System.err.println("Filter request for "+name+" with action: "+action);
+      if("sync-pass".equals(action)) {
+         // do nothing
+      }else if("sync-fail".equals(action)) {
+         ctx.abortWith(Response.ok(name).build());
+      }else if("async-pass".equals(action)) {
+         ctx.suspend();
+         ExecutorService executor = Executors.newSingleThreadExecutor();
+         executor.submit(() -> ctx.resume());
+      }else if("async-fail".equals(action)) {
+         ctx.suspend();
+         ExecutorService executor = Executors.newSingleThreadExecutor();
+         executor.submit(() -> ctx.abortWith(Response.ok(name).build()));
+      }
+      System.err.println("Filter request for "+name+" with action: "+action+" done");
+   }
+   
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter.java
@@ -8,7 +8,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Response;
 
-import org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext;
+import org.jboss.resteasy.core.interception.jaxrs.SuspendableContainerRequestContext;
 
 public abstract class AsyncRequestFilter implements ContainerRequestFilter {
 
@@ -22,7 +22,7 @@ public abstract class AsyncRequestFilter implements ContainerRequestFilter {
    @Override
    public void filter(ContainerRequestContext requestContext) throws IOException
    {
-      PreMatchContainerRequestContext ctx = (PreMatchContainerRequestContext) requestContext;
+      SuspendableContainerRequestContext ctx = (SuspendableContainerRequestContext) requestContext;
       String action = ctx.getHeaderString(name);
       System.err.println("Filter request for "+name+" with action: "+action);
       if("sync-pass".equals(action)) {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter1.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter1.java
@@ -1,0 +1,14 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import javax.annotation.Priority;
+import javax.ws.rs.ext.Provider;
+
+@Priority(1)
+@Provider
+public class AsyncRequestFilter1 extends AsyncRequestFilter {
+
+   public AsyncRequestFilter1()
+   {
+      super("Filter1");
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter2.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter2.java
@@ -1,0 +1,14 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import javax.annotation.Priority;
+import javax.ws.rs.ext.Provider;
+
+@Priority(2)
+@Provider
+public class AsyncRequestFilter2 extends AsyncRequestFilter {
+
+   public AsyncRequestFilter2()
+   {
+      super("Filter2");
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter3.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter3.java
@@ -1,0 +1,14 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import javax.annotation.Priority;
+import javax.ws.rs.ext.Provider;
+
+@Priority(3)
+@Provider
+public class AsyncRequestFilter3 extends AsyncRequestFilter {
+
+   public AsyncRequestFilter3()
+   {
+      super("Filter3");
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilterResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilterResource.java
@@ -20,14 +20,20 @@ public class AsyncRequestFilterResource {
           @HeaderParam("PreMatchFilter1") @DefaultValue("") String preMatchFilter1,
           @HeaderParam("PreMatchFilter2") @DefaultValue("") String preMatchFilter2,
           @HeaderParam("PreMatchFilter3") @DefaultValue("") String preMatchFilter3) {
-       boolean async = filter1.contains("async")
-             || filter2.contains("async")
-             || filter3.contains("async")
-             || preMatchFilter1.contains("async")
-             || preMatchFilter2.contains("async")
-             || preMatchFilter3.contains("async");
+       boolean async = isAsync(filter1)
+             || isAsync(filter2)
+             || isAsync(filter3)
+             || isAsync(preMatchFilter1)
+             || isAsync(preMatchFilter2)
+             || isAsync(preMatchFilter3);
        if(async != request.getAsyncContext().isSuspended())
           return Response.serverError().entity("Request suspention is wrong").build();
        return Response.ok("resource").build();
     }
+
+   private boolean isAsync(String filter)
+   {
+      return filter.equals("async-pass")
+            || filter.equals("async-fail");
+   }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilterResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilterResource.java
@@ -16,13 +16,16 @@ public class AsyncRequestFilterResource {
     public Response threeSyncRequestFilters(@Context HttpRequest request,
           @HeaderParam("Filter1") @DefaultValue("") String filter1,
           @HeaderParam("Filter2") @DefaultValue("") String filter2,
-          @HeaderParam("Filter3") @DefaultValue("") String filter3) {
+          @HeaderParam("Filter3") @DefaultValue("") String filter3,
+          @HeaderParam("PreMatchFilter1") @DefaultValue("") String preMatchFilter1,
+          @HeaderParam("PreMatchFilter2") @DefaultValue("") String preMatchFilter2,
+          @HeaderParam("PreMatchFilter3") @DefaultValue("") String preMatchFilter3) {
        boolean async = filter1.contains("async")
              || filter2.contains("async")
-             || filter3.contains("async");
-       System.err.println("Got request with filter1: "+filter1);
-       System.err.println("Got request with filter2: "+filter2);
-       System.err.println("Got request with filter3: "+filter3);
+             || filter3.contains("async")
+             || preMatchFilter1.contains("async")
+             || preMatchFilter2.contains("async")
+             || preMatchFilter3.contains("async");
        if(async != request.getAsyncContext().isSuspended())
           return Response.serverError().entity("Request suspention is wrong").build();
        return Response.ok("resource").build();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilterResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilterResource.java
@@ -1,0 +1,30 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.spi.HttpRequest;
+
+@Path("/")
+public class AsyncRequestFilterResource {
+   
+    @GET
+    public Response threeSyncRequestFilters(@Context HttpRequest request,
+          @HeaderParam("Filter1") @DefaultValue("") String filter1,
+          @HeaderParam("Filter2") @DefaultValue("") String filter2,
+          @HeaderParam("Filter3") @DefaultValue("") String filter3) {
+       boolean async = filter1.contains("async")
+             || filter2.contains("async")
+             || filter3.contains("async");
+       System.err.println("Got request with filter1: "+filter1);
+       System.err.println("Got request with filter2: "+filter2);
+       System.err.println("Got request with filter3: "+filter3);
+       if(async != request.getAsyncContext().isSuspended())
+          return Response.serverError().entity("Request suspention is wrong").build();
+       return Response.ok("resource").build();
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter.java
@@ -5,13 +5,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.core.Response;
 
-import org.jboss.resteasy.core.interception.jaxrs.ContainerResponseContextImpl;
-import org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext;
+import org.jboss.resteasy.core.interception.jaxrs.SuspendableContainerResponseContext;
 
 public abstract class AsyncResponseFilter implements ContainerResponseFilter {
 
@@ -26,7 +23,7 @@ public abstract class AsyncResponseFilter implements ContainerResponseFilter {
    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
          throws IOException
    {
-      ContainerResponseContextImpl ctx = (ContainerResponseContextImpl) responseContext;
+      SuspendableContainerResponseContext ctx = (SuspendableContainerResponseContext) responseContext;
       String action = requestContext.getHeaderString(name);
       System.err.println("Filter response for "+name+" with action: "+action);
       if("sync-pass".equals(action)) {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter.java
@@ -1,0 +1,50 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.core.interception.jaxrs.ContainerResponseContextImpl;
+import org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext;
+
+public abstract class AsyncResponseFilter implements ContainerResponseFilter {
+
+   private String name;
+   
+   public AsyncResponseFilter(String name)
+   {
+      this.name = name;
+   }
+
+   @Override
+   public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+         throws IOException
+   {
+      ContainerResponseContextImpl ctx = (ContainerResponseContextImpl) responseContext;
+      String action = requestContext.getHeaderString(name);
+      System.err.println("Filter response for "+name+" with action: "+action);
+      if("sync-pass".equals(action)) {
+         // do nothing
+      }else if("sync-fail".equals(action)) {
+         ctx.setEntity(name);
+      }else if("async-pass".equals(action)) {
+         ctx.suspend();
+         ExecutorService executor = Executors.newSingleThreadExecutor();
+         executor.submit(() -> ctx.resume());
+      }else if("async-fail".equals(action)) {
+         ctx.suspend();
+         ExecutorService executor = Executors.newSingleThreadExecutor();
+         executor.submit(() -> {
+            ctx.setEntity(name);
+            ctx.resume();
+         });
+      }
+      System.err.println("Filter response for "+name+" with action: "+action+" done");
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter1.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter1.java
@@ -1,0 +1,15 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import javax.annotation.Priority;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.ext.Provider;
+
+@Priority(1)
+@Provider
+public class AsyncResponseFilter1 extends AsyncResponseFilter {
+
+   public AsyncResponseFilter1()
+   {
+      super("ResponseFilter1");
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter2.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter2.java
@@ -1,0 +1,15 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import javax.annotation.Priority;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.ext.Provider;
+
+@Priority(2)
+@Provider
+public class AsyncResponseFilter2 extends AsyncResponseFilter {
+
+   public AsyncResponseFilter2()
+   {
+      super("ResponseFilter2");
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter3.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter3.java
@@ -1,0 +1,15 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import javax.annotation.Priority;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.ext.Provider;
+
+@Priority(3)
+@Provider
+public class AsyncResponseFilter3 extends AsyncResponseFilter {
+
+   public AsyncResponseFilter3()
+   {
+      super("ResponseFilter3");
+   }
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/ContainerRequestContextTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/ContainerRequestContextTest.java
@@ -40,7 +40,7 @@ public class ContainerRequestContextTest {
      */
     @Test
     public void testQueryParamatersClear() throws URISyntaxException {
-        ContainerRequestContext containerRequestContext = new PreMatchContainerRequestContext(request);
+        ContainerRequestContext containerRequestContext = new PreMatchContainerRequestContext(request, null, null);
 
         logger.info("request uri: " + containerRequestContext.getUriInfo().getRequestUri());
 

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/AcceptParameterHttpPreprocessorTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/AcceptParameterHttpPreprocessorTest.java
@@ -38,7 +38,7 @@ public class AcceptParameterHttpPreprocessorTest {
 
         MediaType mediaType = MediaType.valueOf(type);
 
-        PreMatchContainerRequestContext context = new PreMatchContainerRequestContext(request);
+        PreMatchContainerRequestContext context = new PreMatchContainerRequestContext(request, null, null);
         processor.filter(context);
 
         List<MediaType> list = request.getHttpHeaders().getAcceptableMediaTypes();
@@ -60,7 +60,7 @@ public class AcceptParameterHttpPreprocessorTest {
         List<MediaType> expected = Arrays.asList(MediaType.TEXT_XML_TYPE, MediaType.TEXT_PLAIN_TYPE, MediaType.TEXT_HTML_TYPE, MediaType.APPLICATION_XHTML_XML_TYPE);
 
         MockHttpRequest request = MockHttpRequest.get("foo?" + acceptParamName + "=" + expected.get(0) + "," + expected.get(1));
-        PreMatchContainerRequestContext context = new PreMatchContainerRequestContext(request);
+        PreMatchContainerRequestContext context = new PreMatchContainerRequestContext(request, null, null);
 
         request.accept(expected.get(2));
         request.accept(expected.get(3));
@@ -88,7 +88,7 @@ public class AcceptParameterHttpPreprocessorTest {
         List<MediaType> expected = Arrays.asList(MediaType.TEXT_PLAIN_TYPE, MediaType.TEXT_HTML_TYPE);
 
         MockHttpRequest request = MockHttpRequest.get("foo");
-        PreMatchContainerRequestContext context = new PreMatchContainerRequestContext(request);
+        PreMatchContainerRequestContext context = new PreMatchContainerRequestContext(request, null, null);
         request.accept(expected.get(0));
         request.accept(expected.get(1));
 
@@ -124,7 +124,7 @@ public class AcceptParameterHttpPreprocessorTest {
                 "foo?" + acceptParamName + "=" + param1 + "&" +
                         acceptParamName + "=" + param2);
 
-        PreMatchContainerRequestContext context = new PreMatchContainerRequestContext(request);
+        PreMatchContainerRequestContext context = new PreMatchContainerRequestContext(request, null, null);
         processor.filter(context);
 
         List<MediaType> actual = request.getHttpHeaders().getAcceptableMediaTypes();


### PR DESCRIPTION
Hi,

This is a proto for supporting async request filters, which I need in another project.

This is not done by far, but given as a PR for discussion (do not merge it).

I only support post-match requests going async, and for backwards compat the default behaviour is to be synchronous in post-match filters. To go async from within a filter, you need to cast the context argument and invoke `suspend()` on it. After that you can resume the filtering with `abortWith` (existing method) or `resume()` to move on to the next filter or the resource method itself.

It's possible to have a filter that goes async, and a non-async filter or a non-async resource method after it, and we do handle this case. In the case of non-async resource methods, I assume that if the method is not declared as returning `void`, it's a non-async method and we should use its return value. Perhaps this is wrong and we can make it better.

I'm not too happy with how I implemented this in the context because the implementation is confusing by requiring a mix of async/sync filters, but I'm not sure how to make this easier to maintain, short of having a context instance per filter.

The biggest question I have is: what sort of API can we have that is backwards compatible. The current approach to keep the existing filter and context API and require the filter to typecast the passed context into a more capable subclass is not ideal, but perhaps you have other ideas?

If we can find ways to fix those issues and we can agree to add this, I'll go ahead and add async support for pre-match request and response filters too.

WDYT?