### PR TITLE
[RESTEASY-1717] added proposed code and new testcase

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/InheritProducesAndConsumesTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/InheritProducesAndConsumesTest.java
@@ -1,0 +1,88 @@
+package org.jboss.resteasy.test.client.proxy;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+
+import org.jboss.resteasy.client.jaxrs.ProxyBuilder;
+import org.jboss.resteasy.test.client.proxy.resource.ProducesAndConsumesRootResource;
+import org.jboss.resteasy.test.client.proxy.resource.ProducesAndConsumesChildResource;
+import org.jboss.resteasy.test.client.proxy.resource.ProducesAndConsumesGrandChildResource;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.test.client.proxy.resource.InheritProducesAndConsumesService;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @tpSubChapter Resteasy-client
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Test for RESTEASY-1717.
+ * @tpSince RESTEasy 4.0.0
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class InheritProducesAndConsumesTest {
+
+
+   private static Client client;
+   private static final String DEP = "InheritProducesAndConsumesTest";
+
+   @Deployment
+   public static Archive<?> deploy() {
+      WebArchive war = TestUtil.prepareArchive(DEP);
+      return TestUtil.finishContainerPrepare(war, null,
+              InheritProducesAndConsumesService.class);
+   }
+
+   @BeforeClass
+   public static void setup() {
+      client = ClientBuilder.newClient();
+   }
+
+   @AfterClass
+   public static void cleanup() {
+      client.close();
+   }
+
+   private static String generateURL() {
+      return PortProviderUtil.generateBaseUrl(DEP);
+   }
+
+   @Test
+   public void intfRootTest() throws Exception {
+
+      ProducesAndConsumesRootResource rootProxy = ProxyBuilder
+              .builder(ProducesAndConsumesRootResource.class, client.target(generateURL()))
+              .build();
+      Assert.assertEquals("Service Hello", rootProxy.getRootGreeting());
+   }
+
+   @Test
+   public void intfChildTest() throws Exception {
+      ProducesAndConsumesChildResource childProxy = ProxyBuilder
+              .builder(ProducesAndConsumesChildResource.class, client.target(generateURL()))
+              .build();
+      Assert.assertEquals("Service Hello", childProxy.getChildGreeting());
+      Assert.assertEquals("Service Hello", childProxy.getRootGreeting());
+   }
+
+   @Test
+   public void intfGrandTest() throws Exception {
+       ProducesAndConsumesGrandChildResource grandChildProxy = ProxyBuilder
+       .builder(ProducesAndConsumesGrandChildResource.class, client.target(generateURL()))
+       .build();
+
+       Assert.assertEquals("Service Hello", grandChildProxy.getGrandChildGreeting());
+       Assert.assertEquals("Service Hello", grandChildProxy.getChildGreeting());
+       Assert.assertEquals("Service Hello", grandChildProxy.getRootGreeting());
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/InheritProducesAndConsumesService.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/InheritProducesAndConsumesService.java
@@ -1,0 +1,19 @@
+package org.jboss.resteasy.test.client.proxy.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+/**
+ * Created by rsearls on 9/20/17.
+ */
+@Path("/greetings")
+public class InheritProducesAndConsumesService {
+   static String msg = "Service Hello";
+   @GET
+   @Produces("text/plain")
+   public String get()
+   {
+      return msg;
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProducesAndConsumesChildResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProducesAndConsumesChildResource.java
@@ -1,0 +1,14 @@
+package org.jboss.resteasy.test.client.proxy.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * Created by rsearls on 9/18/17.
+ */
+@Path("/greetings")
+public interface ProducesAndConsumesChildResource extends ProducesAndConsumesRootResource
+{
+   @GET
+   public String getChildGreeting();
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProducesAndConsumesGrandChildResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProducesAndConsumesGrandChildResource.java
@@ -1,0 +1,15 @@
+package org.jboss.resteasy.test.client.proxy.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * Created by rsearls on 9/18/17.
+ */
+@Path("/greetings")
+public interface ProducesAndConsumesGrandChildResource extends ProducesAndConsumesChildResource
+{
+   @GET
+   public String getGrandChildGreeting();
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProducesAndConsumesRootResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProducesAndConsumesRootResource.java
@@ -1,0 +1,17 @@
+package org.jboss.resteasy.test.client.proxy.resource;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * Created by rsearls on 9/18/17.
+ */
+@Produces("text/plain")
+@Consumes("text/plain")
+@Path("/greetings")
+public interface ProducesAndConsumesRootResource {
+   @GET
+   public String getRootGreeting();
+}


### PR DESCRIPTION
What I find disconcerting about this code is that @Path does not support the @Inherit annotation like @Produces and @Consumes does.   This requires each interface subclass must have the same @Path value in order to access the endpoint.