### PR TITLE
[RESTEASY-1718] added utility to check for IPv6 format

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResteasyUriBuilder.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResteasyUriBuilder.java
@@ -89,6 +89,7 @@ public class ResteasyUriBuilder extends UriBuilder
    public static final Pattern opaqueUri = Pattern.compile("^([^:/?#]+):([^/].*)");
    public static final Pattern hierarchicalUri = Pattern.compile("^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?");
    private static final Pattern hostPortPattern = Pattern.compile("([^/:]+):(\\d+)");
+   private static final Pattern squareHostBrackets = Pattern.compile( "(\\[(([0-9A-Fa-f]{0,4}:){2,7})([0-9A-Fa-f]{0,4})\\]):(\\d+)" );
 
    public static boolean compare(String s1, String s2)
    {
@@ -189,20 +190,37 @@ public class ResteasyUriBuilder extends UriBuilder
             host = host.substring(at + 1);
             this. userInfo = user;
          }
+
          Matcher hostPortMatch = hostPortPattern.matcher(host);
          if (hostPortMatch.matches())
          {
             this.host = hostPortMatch.group(1);
             int val = 0;
-            try {
+            try
+            {
                this.port = Integer.parseInt(hostPortMatch.group(2));
-            }
-            catch (NumberFormatException e) {
+            } catch (NumberFormatException e)
+            {
                throw new IllegalArgumentException(Messages.MESSAGES.illegalUriTemplate(uriTemplate), e);
             }
-         }
-         else
+         } else
          {
+            if (host.startsWith("["))
+            {
+               // Must support an IPv6 hostname of format "[::1]" or [0:0:0:0:0:0:0:0]
+               Matcher bracketsMatch = squareHostBrackets.matcher(host);
+               if (bracketsMatch.matches())
+               {
+                  host = bracketsMatch.group(1);
+                  try
+                  {
+                     this.port = Integer.parseInt(bracketsMatch.group(5));
+                  } catch (NumberFormatException e)
+                  {
+                     throw new IllegalArgumentException(Messages.MESSAGES.illegalUriTemplate(uriTemplate), e);
+                  }
+               }
+            }
             this.host = host;
          }
       }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/UriBuilderTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/UriBuilderTest.java
@@ -1033,6 +1033,20 @@ public class UriBuilderTest {
                 builder.build();
             }
         }
+
+        // RESTEASY-1718 checks
+        {
+            Assert.assertEquals("http://foo", UriBuilder.fromUri("http://foo").build().toString());
+            Assert.assertEquals("http://foo:8080", UriBuilder.fromUri("http://foo:8080").build().toString());
+            Assert.assertEquals("http://[::1]", UriBuilder.fromUri("http://[::1]").build().toString());
+            Assert.assertEquals("http://[::1]:8080", UriBuilder.fromUri("http://[::1]:8080").build().toString());
+
+            Assert.assertEquals("http://[0:0:0:0:0:0:0:1]", UriBuilder.fromUri("http://[0:0:0:0:0:0:0:1]").build().toString());
+            Assert.assertEquals("http://[0:0:0:0:0:0:0:1]:8080", UriBuilder.fromUri("http://[0:0:0:0:0:0:0:1]:8080").build().toString());
+            Assert.assertEquals("http://foo", UriBuilder.fromUri("http://{host}").build("foo").toString());
+            Assert.assertEquals("http://foo:8080", UriBuilder.fromUri("http://{host}:8080").build("foo").toString());
+        }
+
     }
 
     public void printParse(String uri) {


### PR DESCRIPTION
@ronsigal @asoldano Please review.  All the variants of an IPv6 addresses can't
easily be determined by a Pattern object.  I've appropriated IPv parsing code
from URI and created utility, IPv6FormatParser.  In addition Resteasy supports 
uri "templating" (see UriBuilderTest line 87) which allows left and right brackets.
IPv format considers {} "excluded characters" because gateways and other transport
agents are known to sometimes modify such characters, so a Pattern for template
text was created and checked first so we can identify these before the IPv
address format is checked.