### PR TITLE
[RESTEASY-1704] CVE-2017-7561 resteasy: Vary header not added by CORS filter leading to cache poisoning

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/interceptors/CorsFilter.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/interceptors/CorsFilter.java
@@ -147,6 +147,7 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
          return;
       }
       responseContext.getHeaders().putSingle(CorsHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+      responseContext.getHeaders().putSingle(CorsHeaders.VARY, CorsHeaders.ORIGIN);
       if (allowCredentials) responseContext.getHeaders().putSingle(CorsHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
 
       if (exposedHeaders != null) {
@@ -161,6 +162,7 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
 
       Response.ResponseBuilder builder = Response.ok();
       builder.header(CorsHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+      builder.header(CorsHeaders.VARY, CorsHeaders.ORIGIN);
       if (allowCredentials) builder.header(CorsHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
       String requestMethods = requestContext.getHeaderString(CorsHeaders.ACCESS_CONTROL_REQUEST_METHOD);
       if (requestMethods != null)

--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/CorsHeaders.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/CorsHeaders.java
@@ -15,4 +15,5 @@ public class CorsHeaders
    public static final String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
    public static final String ACCESS_CONTROL_EXPOSE_HEADERS = "Access-Control-Expose-Headers";
    public static final String ACCESS_CONTROL_REQUEST_HEADERS = "Access-Control-Request-Headers";
+   public static final String VARY = "Vary";
 }


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/JBEAP-12819
Upstream Issue: https://issues.jboss.org/browse/RESTEASY-1704
Upstream PR: https://github.com/resteasy/Resteasy/pull/1258

Backporting fix for RESTEASY-1704 to branch 3.0.19.SPX (thus for EAP 7.0.x)