### PR TITLE
[RESTEASY-1737] Eliminate ex.printStackTrace() from the code base

### DIFF
--- a/eagledns/src/main/java/se/unlogic/standardutils/crypto/Base64.java
+++ b/eagledns/src/main/java/se/unlogic/standardutils/crypto/Base64.java
@@ -1,5 +1,7 @@
 package se.unlogic.standardutils.crypto;
 
+import org.apache.log4j.Logger;
+
 /**
  * <p>
  * Encodes and decodes to and from Base64 notation.
@@ -165,6 +167,8 @@ public class Base64 {
 
 	private final static byte WHITE_SPACE_ENC = -5; // Indicates white space in encoding
 	private final static byte EQUALS_SIGN_ENC = -1; // Indicates equals sign in encoding
+
+	private final static Logger logger = Logger.getLogger(Base64.class);
 
 	/* ******** S T A N D A R D B A S E 6 4 A L P H A B E T ******** */
 
@@ -1162,7 +1166,7 @@ public class Base64 {
 
 				} // end try
 				catch (java.io.IOException e) {
-					e.printStackTrace();
+					logger.error(e.getMessage(), e);
 					// Just return originally-decoded bytes
 				} // end catch
 				finally {

--- a/eagledns/src/main/java/se/unlogic/standardutils/threads/ThreadPoolTaskGroupHandler.java
+++ b/eagledns/src/main/java/se/unlogic/standardutils/threads/ThreadPoolTaskGroupHandler.java
@@ -7,6 +7,8 @@
  ******************************************************************************/
 package se.unlogic.standardutils.threads;
 
+import org.apache.log4j.Logger;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -32,7 +34,8 @@ public class ThreadPoolTaskGroupHandler<T extends TaskGroup> implements TaskGrou
 	protected Status status = Status.RUNNING;
 	
 	protected final ArrayList<Thread> threads = new ArrayList<Thread>();
-	
+
+	private final static Logger logger = Logger.getLogger(ThreadPoolTaskGroupHandler.class);
 	
 	public ThreadPoolTaskGroupHandler(int poolSize, boolean daemon){
 		
@@ -96,7 +99,7 @@ public class ThreadPoolTaskGroupHandler<T extends TaskGroup> implements TaskGrou
 					
 					}catch(Throwable e){
 						
-						e.printStackTrace();
+						logger.error(e.getMessage(), e);
 						
 					}finally{
 						

--- a/eagledns/src/main/java/se/unlogic/standardutils/xml/XMLUtils.java
+++ b/eagledns/src/main/java/se/unlogic/standardutils/xml/XMLUtils.java
@@ -7,6 +7,7 @@
  ******************************************************************************/
 package se.unlogic.standardutils.xml;
 
+import org.apache.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -39,6 +40,7 @@ public class XMLUtils {
 
 	private static DocumentBuilder documentBuilder;
 	private static DocumentBuilder namespaceAwareDocumentBuilder;
+	private final static Logger logger = Logger.getLogger(XMLUtils.class);
 
 	static {
 		try {
@@ -50,7 +52,7 @@ public class XMLUtils {
 
 			namespaceAwareDocumentBuilder = documentBuilderFactory.newDocumentBuilder();
 		} catch (ParserConfigurationException e) {
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 		}
 	}
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ContainerResponseContextImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ContainerResponseContextImpl.java
@@ -365,7 +365,7 @@ public class ContainerResponseContextImpl implements SuspendableContainerRespons
          httpServletRequest.getAsyncContext().complete();
       } catch (IOException e)
       {
-         e.printStackTrace();
+         LogMessages.LOGGER.unknownException(request.getHttpMethod(), request.getUri().getPath(), e);
       }
    }
 }

--- a/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/AsyncJaxrsResource.java
+++ b/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/AsyncJaxrsResource.java
@@ -1,5 +1,7 @@
 package org.jboss.resteasy.test;
 
+import org.jboss.logging.Logger;
+
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
@@ -21,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 public class AsyncJaxrsResource
 {
    protected boolean cancelled;
+   private final static Logger logger = Logger.getLogger(AsyncJaxrsResource.class);
 
    @GET
    @Path("resume/object")
@@ -48,7 +51,7 @@ public class AsyncJaxrsResource
    @GET
    @Path("injection-failure/{param}")
    public void injectionFailure(@Suspended final AsyncResponse response, @PathParam("param") int id) {
-      System.out.println("injectionFailure: " + id);
+      logger.debug("injectionFailure: " + id);
       throw new ForbiddenException("Should be unreachable");
    }
 
@@ -91,7 +94,7 @@ public class AsyncJaxrsResource
             }
             catch (Exception e)
             {
-               e.printStackTrace();
+               logger.error(e.getMessage(), e);
             }
          }
       };
@@ -116,7 +119,7 @@ public class AsyncJaxrsResource
             }
             catch (Exception e)
             {
-               e.printStackTrace();
+               logger.error(e.getMessage(), e);
             }
          }
       };
@@ -142,7 +145,7 @@ public class AsyncJaxrsResource
             }
             catch (Exception e)
             {
-               e.printStackTrace();
+               logger.error(e.getMessage(), e);
             }
          }
       };
@@ -154,7 +157,7 @@ public class AsyncJaxrsResource
    @Produces("text/plain")
    public void cancel(@Suspended final AsyncResponse response) throws Exception
    {
-      System.out.println("entering cancel()");
+      logger.debug("entering cancel()");
       response.setTimeout(10000, TimeUnit.MILLISECONDS);
       final CountDownLatch sync = new CountDownLatch(1);
       final CountDownLatch ready = new CountDownLatch(1);
@@ -165,24 +168,24 @@ public class AsyncJaxrsResource
          {
             try
             {
-               System.out.println("cancel(): starting thread");
+               logger.debug("cancel(): starting thread");
                sync.countDown();
                ready.await();
                Response jaxrs = Response.ok("hello").type(MediaType.TEXT_PLAIN).build();
-               System.out.println("SETTING CANCELLED");
+               logger.debug("SETTING CANCELLED");
                cancelled = !response.resume(jaxrs);
-               System.out.println("cancelled: " + cancelled);
+               logger.debug("cancelled: " + cancelled);
             }
             catch (Exception e)
             {
-               e.printStackTrace();
+               logger.error(e.getMessage(), e);
             }
          }
       };
       t.start();
 
       sync.await();
-      System.out.println("cancel(): cancelling response");
+      logger.debug("cancel(): cancelling response");
       response.cancel();
       ready.countDown();
       Thread.sleep(1000);

--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxRequestHandler.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxRequestHandler.java
@@ -79,7 +79,7 @@ public class VertxRequestHandler implements Handler<HttpServerRequest>
                vertxResponse.finish();
             } catch (IOException e)
             {
-               e.printStackTrace();
+               LogMessages.LOGGER.error(Messages.MESSAGES.unexpected(), e);
             }
          }
       });

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSinkTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSinkTest.java
@@ -17,6 +17,7 @@ import javax.ws.rs.sse.SseEventSource;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
 import org.jboss.resteasy.plugins.providers.sse.client.SseEventSourceImpl;
 import org.jboss.resteasy.utils.PortProviderUtil;
 import org.jboss.resteasy.utils.TestUtil;
@@ -31,6 +32,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 public class SseEventSinkTest {
+
+    private final static Logger logger = Logger.getLogger(SseEventSinkTest.class);
 
     @Deployment
     public static Archive<?> deploy() {
@@ -69,7 +72,7 @@ public class SseEventSinkTest {
             latch.countDown();
         }, ex -> {
             errors.incrementAndGet();
-            ex.printStackTrace();
+            logger.error(ex.getMessage(), ex);
             throw new RuntimeException(ex);
         });
         eventSource.open();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseResource.java
@@ -23,6 +23,7 @@ import javax.ws.rs.sse.Sse;
 import javax.ws.rs.sse.SseBroadcaster;
 import javax.ws.rs.sse.SseEventSink;
 
+import org.jboss.logging.Logger;
 import org.jboss.resteasy.plugins.providers.sse.SseConstants;
 
 @Path("/server-sent-events")
@@ -38,6 +39,8 @@ public class SseResource
    private volatile boolean sending = true;
    private volatile boolean isServiceAvailable = false;
    private List<OutboundSseEvent> eventsStore = new ArrayList<OutboundSseEvent>();
+   private final static Logger logger = Logger.getLogger(SseResource.class);
+
    @GET
    @Produces(MediaType.SERVER_SENT_EVENTS)
    public void getMessageQueue(@HeaderParam(SseConstants.LAST_EVENT_ID_HEADER) @DefaultValue("-1") int lastEventId, @Context SseEventSink eventSink) {
@@ -157,7 +160,7 @@ public class SseResource
             }
             catch (final InterruptedException e)
             {
-               e.printStackTrace();
+                logger.error(e.getMessage(), e);
             }
          }
       }.start();
@@ -183,7 +186,7 @@ public class SseResource
                        Thread.sleep(200);
                    }catch (final InterruptedException e)
                    {
-                       e.printStackTrace();
+                       logger.error(e.getMessage(), e);
                    }
                   
                }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseTest.java
@@ -22,6 +22,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
+import org.jboss.logging.Logger;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.plugins.providers.sse.client.SseEventSourceImpl;
 import org.jboss.resteasy.utils.PortProviderUtil;
@@ -36,6 +37,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 public class SseTest {
+
+    private final static Logger logger = Logger.getLogger(SseTest.class);
 
     @Deployment
     public static Archive<?> deploy() {
@@ -70,7 +73,7 @@ public class SseTest {
              latch.countDown();
           }, ex -> {
              errors.incrementAndGet();
-             ex.printStackTrace();
+             logger.error(ex.getMessage(), ex);
              throw new RuntimeException(ex);
           });
           eventSource.open();
@@ -133,7 +136,7 @@ public class SseTest {
        eventSource.register(event -> {
           results.add(event.readData());
           latch.countDown();
-         }, ex -> {errors.incrementAndGet(); ex.printStackTrace(); throw new RuntimeException(ex);});
+         }, ex -> {errors.incrementAndGet(); logger.error(ex.getMessage(), ex); throw new RuntimeException(ex);});
        eventSource.open();
 
        boolean waitResult = latch.await(30, TimeUnit.SECONDS);
@@ -206,7 +209,7 @@ public class SseTest {
                 closeLatch.countDown();
             }, ex -> {
                 errors.incrementAndGet();
-                ex.printStackTrace();
+                logger.error(ex.getMessage(), ex);
                 throw new RuntimeException(ex);
             });
             eventSource.open();
@@ -274,7 +277,7 @@ public class SseTest {
              latch.countDown();
           }, ex -> {
              errors.incrementAndGet();
-             ex.printStackTrace();
+             logger.error(ex.getMessage(), ex);
              throw new RuntimeException(ex);
           });
           eventSource.open();
@@ -325,7 +328,7 @@ public class SseTest {
              latch.countDown();
           }, ex -> {
              errors.incrementAndGet();
-             ex.printStackTrace();
+             logger.error(ex.getMessage(), ex);
              throw new RuntimeException(ex);
           });
           eventSource.open();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/AnotherPublisherResponseTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/AnotherPublisherResponseTest.java
@@ -10,8 +10,10 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.sse.SseEventSource;
 
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
 import org.jboss.resteasy.test.response.resource.AsyncResponseCallback;
 import org.jboss.resteasy.test.response.resource.AsyncResponseException;
 import org.jboss.resteasy.test.response.resource.AsyncResponseExceptionMapper;
@@ -31,6 +33,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class AnotherPublisherResponseTest {
+   private final static Logger logger = Logger.getLogger(AnotherPublisherResponseTest.class);
 
    @Deployment
    public static Archive<?> deploy() {
@@ -73,7 +76,7 @@ public class AnotherPublisherResponseTest {
                future.complete(null);
             }
          }, t -> {
-            t.printStackTrace();
+            logger.error(t.getMessage(), t);
             errors.add(t);
          }, () -> {
             // bah, never called

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/PublisherResponseTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/PublisherResponseTest.java
@@ -14,6 +14,7 @@ import javax.ws.rs.sse.SseEventSource;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
 import org.jboss.resteasy.test.response.resource.AsyncResponseCallback;
 import org.jboss.resteasy.test.response.resource.AsyncResponseException;
 import org.jboss.resteasy.test.response.resource.AsyncResponseExceptionMapper;
@@ -38,6 +39,8 @@ import org.junit.runner.RunWith;
 public class PublisherResponseTest {
 
    Client client;
+
+   private final static Logger logger = Logger.getLogger(PublisherResponseTest.class);
 
    @Deployment
    public static Archive<?> deploy() {
@@ -156,7 +159,7 @@ public class PublisherResponseTest {
     	  }
       }, 
     		  t -> {
-    			  t.printStackTrace();
+    			  logger.error(t.getMessage(), t);
     			  errors.add(t);  
     		  }, 
     		  () -> {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/cdi/resource/ApplicationScopeRestServiceAppScoped.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/cdi/resource/ApplicationScopeRestServiceAppScoped.java
@@ -1,13 +1,19 @@
 package org.jboss.resteasy.test.validation.cdi.resource;
 
+import org.jboss.logging.Logger;
+
 import javax.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class ApplicationScopeRestServiceAppScoped implements ApplicationScopeIRestServiceAppScoped {
 
+    private final static Logger logger = Logger.getLogger(ApplicationScopeRestServiceAppScoped.class);
+
     public String sendDto(ApplicationScopeMyDto myDto) {
-        System.out.println("RestServiceAppScoped: Nevertheless: " + myDto);
-        new Exception("RestServiceAppScoped").printStackTrace();
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("RestServiceAppScoped: Nevertheless: " + myDto, new Exception("RestServiceAppScoped"));
+        }
         return myDto == null ? null : myDto.getPath();
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/cdi/resource/ApplicationScopeRestServiceReqScoped.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/cdi/resource/ApplicationScopeRestServiceReqScoped.java
@@ -1,14 +1,20 @@
 package org.jboss.resteasy.test.validation.cdi.resource;
 
+import org.jboss.logging.Logger;
+
 import javax.enterprise.context.RequestScoped;
 import javax.ws.rs.core.Response;
 
 @RequestScoped
 public class ApplicationScopeRestServiceReqScoped implements ApplicationScopeIRestServiceReqScoped {
-   
+
+    private final static Logger logger = Logger.getLogger(ApplicationScopeRestServiceReqScoped.class);
+
     public Response sendDto(ApplicationScopeMyDto myDto) {
-        System.out.println("RestServiceReqScoped: Nevertheless: " + myDto);
-        new Exception("RestServiceReqScoped").printStackTrace();
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("RestServiceReqScoped: Nevertheless: " + myDto, new Exception("RestServiceReqScoped"));
+        }
         return Response.ok(myDto == null ? "null" : myDto.getPath()).header("entered", "true").build();
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ChunkedTransferEncodingUnitTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ChunkedTransferEncodingUnitTest.java
@@ -10,6 +10,7 @@ import java.net.Socket;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 
+import org.jboss.logging.Logger;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
@@ -33,6 +34,7 @@ public class ChunkedTransferEncodingUnitTest
    private static Thread t;
    private static ServerSocket ss;
    private static Socket s;
+   private final static Logger logger = Logger.getLogger(ChunkedTransferEncodingUnitTest.class);
    
    private static String RESPONSE_200 =
          "HTTP/1.1 200 OK\r\n" +
@@ -86,7 +88,7 @@ public class ChunkedTransferEncodingUnitTest
                }
                return;
             } catch (IOException e) {
-               e.printStackTrace();
+               logger.error(e.getMessage(), e);
             }
          }
       };


### PR DESCRIPTION
Eliminate ex.printStackTrace() from the code base

Issue: https://issues.jboss.org/browse/RESTEASY-1737

non test classes:
 *   eagledns keeps using log4j, jboss logging is not used there
 *   resteasy-jaxrs using jboss-logging messages
 *   server-adapters using jboss-logging messages
 *   tjws won't be fixed as the classes are deprecated

test classes:
 * using jboss-logging


