### PR TITLE
Change test id from normal-test to default-test to avoid executing a …

### DIFF
--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -359,18 +359,14 @@
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
                     <executions>
                         <execution>
-                            <id>normal-test</id>
+                            <id>default-test</id>
                             <phase>test</phase>
                             <goals>
                                 <goal>test</goal>
                             </goals>
                             <configuration>
-                                <skip>false</skip>
                                 <excludes>
                                      <!-- Tests requires excluding JsonBindingProvider-->
                                      <exclude>**/JsonBindingTest.java</exclude>
@@ -388,7 +384,6 @@
                                 <goal>test</goal>
                             </goals>
                             <configuration>
-                                <skip>false</skip>
                                 <includes>
                                     <include>**/JsonBindingTest.java</include>
                                 </includes>


### PR DESCRIPTION
…skipped test execution
-  Figured out the reason why integration tests was skipped before . It was this wrong configuration :  `<include>**/Test*.java</include>` , it should be` <include>**/*Test.java</include>` or better not defined this and used the default includes configuration like we current defined.  
-  Move id to default-test is better. Maven surefire plugin doesn't need to execute a skipped execution like this : 
` [INFO] --- maven-surefire-plugin:2.20.1:test (default-test) @ resteasy-integration-tests
  [INFO] Tests are skipped.`