### PR TITLE
Added PERMANENT_REDIRECT to HttpResponseCodes

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/HttpResponseCodes.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/HttpResponseCodes.java
@@ -141,6 +141,15 @@ public interface HttpResponseCodes
    public static final int SC_TEMPORARY_REDIRECT = 307;
 
    /**
+    * Status code (308) indicating that the requested resource
+    * resides permanently under a different URI. The permanent URI
+    * <em>SHOULD</em> be given by the <code><em>Location</em></code>
+    * field in the response.
+    */
+
+   public static final int SC_PERMANENT_REDIRECT = 308;
+
+   /**
     * Status code (400) indicating the request sent by the client was
     * syntactically incorrect.
     */


### PR DESCRIPTION
<a href="https://tools.ietf.org/html/rfc7538">RFC 7538</a> describes the behavior of the HTTP status code <strong>308</strong>. While this RFC is quite new it solves an actual problem regarding POST redirections.

And it completes quite well the 307 status code found in the <a href="https://tools.ietf.org/html/rfc7231">HTTP 1.1 RFC</a> (previously described in the obsolete <a href="https://tools.ietf.org/html/rfc2616">RFC 2616</a>).

