### PR TITLE
Do not stringify FormData

### DIFF
--- a/resteasy-jsapi/src/main/resources/resteasy-client.js
+++ b/resteasy-jsapi/src/main/resources/resteasy-client.js
@@ -108,7 +108,7 @@ REST.Request.prototype = {
 				}else if(this.entity instanceof Document){
 					if(!contentTypeSet || REST._isXMLMIME(contentTypeSet))
 						data = this.entity;
-				}else if(this.entity instanceof Object){
+				}else if(this.entity instanceof Object && !(this.entity instanceof FormData)){
 					if(!contentTypeSet || REST._isJSONMIME(contentTypeSet))
 						data = JSON.stringify(this.entity);
 				}


### PR DESCRIPTION
**resteasy-jsapi/resteasy-client.js** Do not stringify FormData.

Developers may send the form content inside FormData to be properly handled by XMLHttpRequest.