### PR TITLE
limit marklimit to max value of int

### DIFF
--- a/resteasy-legacy/src/main/java/org/jboss/resteasy/client/core/SelfExpandingBufferredInputStream.java
+++ b/resteasy-legacy/src/main/java/org/jboss/resteasy/client/core/SelfExpandingBufferredInputStream.java
@@ -77,6 +77,7 @@ public class SelfExpandingBufferredInputStream extends BufferedInputStream
     */
    private void expand() throws IOException
    {
+      marklimit = marklimit * 2 > Integer.MAX_VALUE ? Integer.MAX_VALUE : marklimit * 2;
       int lastPos = pos;
       super.reset();
       super.mark(marklimit * 2);

--- a/resteasy-legacy/src/main/java/org/jboss/resteasy/client/core/SelfExpandingBufferredInputStream.java
+++ b/resteasy-legacy/src/main/java/org/jboss/resteasy/client/core/SelfExpandingBufferredInputStream.java
@@ -77,7 +77,7 @@ public class SelfExpandingBufferredInputStream extends BufferedInputStream
     */
    private void expand() throws IOException
    {
-      marklimit = marklimit * 2 > Integer.MAX_VALUE ? Integer.MAX_VALUE : marklimit * 2;
+      marklimit = marklimit * 2 > Integer.MAX_VALUE ? (Integer.MAX_VALUE - 8) : marklimit * 2;
       int lastPos = pos;
       super.reset();
       super.mark(marklimit * 2);


### PR DESCRIPTION
if marklimit expands to a number greater than max value of an int, the while loop in read() method would become an infinite loop because marklimit is negative.