### PR TITLE
RESTEASY-1766: Closing SseEventSink should not call JAX-RS filters

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
@@ -72,9 +72,6 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
       {
          if (asyncContext.isSuspended())
          {
-            //resume(null) will call into AbstractAsynchronousResponse.internalResume(Throwable exc)
-            //The null is valid reference for Throwable:http://stackoverflow.com/questions/17576922/why-can-i-throw-null-in-java
-            //Response header will be set with original one
             asyncContext.getAsyncResponse().complete();
          }
       }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
@@ -131,9 +131,9 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
       {
          throw new IllegalStateException(Messages.MESSAGES.sseEventSinkIsClosed());
       }
-      flushResponseToClient();
       try
       {
+    	 flushResponseToClient();
          writeEvent(event);
 
       }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
@@ -75,7 +75,7 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
             //resume(null) will call into AbstractAsynchronousResponse.internalResume(Throwable exc)
             //The null is valid reference for Throwable:http://stackoverflow.com/questions/17576922/why-can-i-throw-null-in-java
             //Response header will be set with original one
-            asyncContext.getAsyncResponse().resume(Response.noContent().build());
+            asyncContext.getAsyncResponse().complete();
          }
       }
 
@@ -85,8 +85,17 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
    {
       if (!responseFlushed)
       {
-         //set back to client 200 OK to implies the SseEventOutput is ready
-         BuiltResponse jaxrsResponse = (BuiltResponse) Response.ok().type(MediaType.SERVER_SENT_EVENTS).build();
+         BuiltResponse jaxrsResponse = null;
+		 if(this.closed)
+		 {
+			 jaxrsResponse = (BuiltResponse) Response.noContent().build();
+		 }
+		 else
+		 {
+			//set back to client 200 OK to implies the SseEventOutput is ready
+			 jaxrsResponse = (BuiltResponse) Response.ok().type(MediaType.SERVER_SENT_EVENTS).build();
+		 }
+		 
          try
          {
             ServerResponseWriter.writeNomapResponse(jaxrsResponse, request, response,

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSinkClosingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSinkClosingTest.java
@@ -1,0 +1,108 @@
+package org.jboss.resteasy.test.providers.sse;
+
+import java.util.Arrays;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class SseEventSinkClosingTest {
+
+	private final static Logger logger = Logger.getLogger(SseEventSinkClosingTest.class);
+
+	@Deployment
+	public static Archive<?> deploy() {
+		WebArchive war = TestUtil.prepareArchive(SseEventSinkClosingTest.class.getSimpleName());
+		war.addClass(SseEventSinkClosingTestResource.class);
+		war.addClass(SseEventSinkClosingTestResource.ContainerFilter.class);
+		return TestUtil.finishContainerPrepare(war, null, Arrays.asList(SseEventSinkClosingTestResource.class),
+				SseEventSinkClosingTestResource.ContainerFilter.class);
+	}
+
+	private String generateURL() {
+		return PortProviderUtil.generateBaseUrl(SseEventSinkClosingTest.class.getSimpleName());
+	}
+
+	@After
+	public void reset() throws Exception {
+		Client client = ClientBuilder.newClient();
+		try {
+			client.target(generateURL()).path(SseEventSinkClosingTestResource.BASE_PATH)
+					.path(SseEventSinkClosingTestResource.RESET_RESPONSE_FILTER_INVOCATION_COUNT_PATH).request()
+					.delete();
+		} finally {
+			client.close();
+		}
+	}
+
+	@Test
+	public void Should_NotInvokeResponseFilter_When_ClosingSseEventSinkOnceMessageSent() throws Exception {
+
+		Client client = ClientBuilder.newClient();
+		try {
+
+			WebTarget baseTarget = client.target(generateURL()).path(SseEventSinkClosingTestResource.BASE_PATH);
+
+			try (Response response = baseTarget.path(SseEventSinkClosingTestResource.SEND_AND_CLOSE_PATH)
+					.request(MediaType.SERVER_SENT_EVENTS_TYPE).get()) {
+				Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+			}
+
+			try (Response response = baseTarget
+					.path(SseEventSinkClosingTestResource.GET_RESPONSE_FILTER_INVOCATION_COUNT_PATH)
+					.request(MediaType.TEXT_PLAIN_TYPE).get()) {
+				Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+				Assert.assertEquals(Integer.valueOf(1), response.readEntity(Integer.class));
+			}
+
+		} finally {
+			client.close();
+		}
+
+	}
+
+	@Test
+	public void Should_InvokeResponseFilterOnlyOnce_When_ClosingSseEventSinkWithoutSending() throws Exception {
+
+		Client client = ClientBuilder.newClient();
+		try {
+
+			WebTarget baseTarget = client.target(generateURL()).path(SseEventSinkClosingTestResource.BASE_PATH);
+
+			try (Response response = baseTarget.path(SseEventSinkClosingTestResource.CLOSE_WITHOUT_SENDING_PATH)
+					.request(MediaType.SERVER_SENT_EVENTS_TYPE).get()) {
+				Assert.assertEquals(Status.NO_CONTENT.getStatusCode(), response.getStatus());
+			}
+
+			try (Response response = baseTarget
+					.path(SseEventSinkClosingTestResource.GET_RESPONSE_FILTER_INVOCATION_COUNT_PATH)
+					.request(MediaType.TEXT_PLAIN_TYPE).get()) {
+				Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+				Assert.assertEquals(Integer.valueOf(1), response.readEntity(Integer.class));
+			}
+
+		} finally {
+			client.close();
+		}
+
+	}
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSinkClosingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSinkClosingTest.java
@@ -54,7 +54,7 @@ public class SseEventSinkClosingTest {
 	}
 
 	@Test
-	public void Should_NotInvokeResponseFilter_When_ClosingSseEventSinkOnceMessageSent() throws Exception {
+	public void testFilterForEventSent() throws Exception {
 
 		Client client = ClientBuilder.newClient();
 		try {
@@ -80,7 +80,7 @@ public class SseEventSinkClosingTest {
 	}
 
 	@Test
-	public void Should_InvokeResponseFilterOnlyOnce_When_ClosingSseEventSinkWithoutSending() throws Exception {
+	public void testFilterForMethodReturn() throws Exception {
 
 		Client client = ClientBuilder.newClient();
 		try {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSinkClosingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSinkClosingTest.java
@@ -26,8 +26,6 @@ import org.junit.runner.RunWith;
 @RunAsClient
 public class SseEventSinkClosingTest {
 
-	private final static Logger logger = Logger.getLogger(SseEventSinkClosingTest.class);
-
 	@Deployment
 	public static Archive<?> deploy() {
 		WebArchive war = TestUtil.prepareArchive(SseEventSinkClosingTest.class.getSimpleName());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSinkClosingTestResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSinkClosingTestResource.java
@@ -71,7 +71,7 @@ public class SseEventSinkClosingTestResource {
 	@GET
 	@Path(CLOSE_WITHOUT_SENDING_PATH)
 	@Produces(MediaType.SERVER_SENT_EVENTS)
-	public void closedWithourSending(@Context ContainerRequestContext requestContext, @Context Sse sse,
+	public void closedWithoutSending(@Context ContainerRequestContext requestContext, @Context Sse sse,
 			@Context SseEventSink sseEventSink) {
 		requestContext.setProperty(RESPONSE_FILTER_INVOCATION_COUNTER_PROPERTY, this.responseFilterCountInvocation);
 		sseEventSink.close();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSinkClosingTestResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSinkClosingTestResource.java
@@ -1,0 +1,93 @@
+package org.jboss.resteasy.test.providers.sse;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.sse.Sse;
+import javax.ws.rs.sse.SseEventSink;
+
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+/**
+ * 
+ * @author Nicolas NESMON
+ *
+ */
+@Path(SseEventSinkClosingTestResource.BASE_PATH)
+public class SseEventSinkClosingTestResource {
+
+	@Provider
+	public static class ContainerFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+		@Override
+		public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+				throws IOException {
+			AtomicInteger responseFilterInvocationCounter = (AtomicInteger) requestContext
+					.getProperty(RESPONSE_FILTER_INVOCATION_COUNTER_PROPERTY);
+			if (responseFilterInvocationCounter != null) {
+				responseFilterInvocationCounter.incrementAndGet();
+			}
+		}
+
+		@Override
+		public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+			ResteasyProviderFactory.pushContext(ContainerRequestContext.class, containerRequestContext);
+		}
+
+	}
+
+	public static final String BASE_PATH = "sseEventSinkClosing";
+	public static final String SEND_AND_CLOSE_PATH = "sendAndClose";
+	public static final String CLOSE_WITHOUT_SENDING_PATH = "closeWithoutSending";
+	public static final String GET_RESPONSE_FILTER_INVOCATION_COUNT_PATH = "getResponseFilterInvocationCount";
+	public static final String RESET_RESPONSE_FILTER_INVOCATION_COUNT_PATH = "resetResponseFilterInvocationCount";
+
+	private static final String RESPONSE_FILTER_INVOCATION_COUNTER_PROPERTY = "counter";
+
+	private final AtomicInteger responseFilterCountInvocation = new AtomicInteger();
+
+	@GET
+	@Path(SEND_AND_CLOSE_PATH)
+	@Produces(MediaType.SERVER_SENT_EVENTS)
+	public void sendAndClose(@Context ContainerRequestContext requestContext, @Context Sse sse,
+			@Context SseEventSink sseEventSink) {
+		requestContext.setProperty(RESPONSE_FILTER_INVOCATION_COUNTER_PROPERTY, this.responseFilterCountInvocation);
+		sseEventSink.send(sse.newEvent("message"));
+		sseEventSink.close();
+	}
+
+	@GET
+	@Path(CLOSE_WITHOUT_SENDING_PATH)
+	@Produces(MediaType.SERVER_SENT_EVENTS)
+	public void closedWithourSending(@Context ContainerRequestContext requestContext, @Context Sse sse,
+			@Context SseEventSink sseEventSink) {
+		requestContext.setProperty(RESPONSE_FILTER_INVOCATION_COUNTER_PROPERTY, this.responseFilterCountInvocation);
+		sseEventSink.close();
+	}
+
+	@GET
+	@Path(GET_RESPONSE_FILTER_INVOCATION_COUNT_PATH)
+	@Produces(MediaType.TEXT_PLAIN)
+	public Response getResponseFilterInvocationCount() {
+		return Response.ok(this.responseFilterCountInvocation.get()).build();
+	}
+
+	@DELETE
+	@Path(RESET_RESPONSE_FILTER_INVOCATION_COUNT_PATH)
+	public void resetResponseFilterInvocationCount() {
+		this.responseFilterCountInvocation.set(0);
+	}
+
+}


### PR DESCRIPTION
Closing the SseEventSink instance once an event has been sent should not return any response and thus not pass through the JAX-RS response pipeline.