### PR TITLE
New parameter annotations

### DIFF
--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiInjectorFactory.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiInjectorFactory.java
@@ -113,15 +113,15 @@ public class CdiInjectorFactory implements InjectorFactory
       return new CdiPropertyInjector(delegate.createPropertyInjector(resourceClass, factory), resourceClass, sessionBeanInterface, manager);
    }
 
-   public ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, Class type, Type genericType, Annotation[] annotations, ResteasyProviderFactory factory)
+   public ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, String defaultName, Class type, Type genericType, Annotation[] annotations, ResteasyProviderFactory factory)
    {
-      return delegate.createParameterExtractor(injectTargetClass, injectTarget, type, genericType, annotations, factory);
+      return delegate.createParameterExtractor(injectTargetClass, injectTarget, defaultName, type, genericType, annotations, factory);
    }
 
-   public ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, Class type,
+   public ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, String defaultName, Class type,
                                                  Type genericType, Annotation[] annotations, boolean useDefault, ResteasyProviderFactory factory)
    {
-      return delegate.createParameterExtractor(injectTargetClass, injectTarget, type, genericType, annotations, useDefault, factory);
+      return delegate.createParameterExtractor(injectTargetClass, injectTarget, defaultName, type, genericType, annotations, useDefault, factory);
    }
 
    /**

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/NewCookieParam.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/NewCookieParam.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD, PARAMETER })
+public @interface NewCookieParam
+{
+
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/NewFormParam.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/NewFormParam.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD, PARAMETER })
+public @interface NewFormParam
+{
+
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/NewHeaderParam.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/NewHeaderParam.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD, PARAMETER })
+public @interface NewHeaderParam
+{
+
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/NewMatrixParam.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/NewMatrixParam.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD, PARAMETER })
+public @interface NewMatrixParam
+{
+
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/NewPathParam.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/NewPathParam.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD, PARAMETER })
+public @interface NewPathParam
+{
+
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/NewQueryParam.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/annotations/NewQueryParam.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD, PARAMETER })
+public @interface NewQueryParam
+{
+
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ConstructorInjectorImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ConstructorInjectorImpl.java
@@ -17,7 +17,9 @@ import javax.ws.rs.WebApplicationException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -45,12 +47,14 @@ public class ConstructorInjectorImpl implements ConstructorInjector
    {
       this.constructor = constructor;
       params = new ValueInjector[constructor.getParameterTypes().length];
+      Parameter[] reflectionParameters = constructor.getParameters();
       for (int i = 0; i < constructor.getParameterTypes().length; i++)
       {
          Class type = constructor.getParameterTypes()[i];
          Type genericType = constructor.getGenericParameterTypes()[i];
          Annotation[] annotations = constructor.getParameterAnnotations()[i];
-         params[i] = factory.getInjectorFactory().createParameterExtractor(constructor.getDeclaringClass(), constructor, type, genericType, annotations, factory);
+         String name = reflectionParameters[i].getName();
+         params[i] = factory.getInjectorFactory().createParameterExtractor(constructor.getDeclaringClass(), constructor, name, type, genericType, annotations, factory);
       }
    }
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/InjectorFactoryImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/InjectorFactoryImpl.java
@@ -1,6 +1,12 @@
 package org.jboss.resteasy.core;
 
 import org.jboss.resteasy.annotations.Form;
+import org.jboss.resteasy.annotations.NewCookieParam;
+import org.jboss.resteasy.annotations.NewFormParam;
+import org.jboss.resteasy.annotations.NewHeaderParam;
+import org.jboss.resteasy.annotations.NewMatrixParam;
+import org.jboss.resteasy.annotations.NewPathParam;
+import org.jboss.resteasy.annotations.NewQueryParam;
 import org.jboss.resteasy.annotations.Query;
 import org.jboss.resteasy.annotations.Suspend;
 import org.jboss.resteasy.spi.ConstructorInjector;
@@ -130,15 +136,15 @@ public class InjectorFactoryImpl implements InjectorFactory
 
 
    @Override
-   public ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, Class type,
+   public ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, String defaultName, Class type,
                                                  Type genericType, Annotation[] annotations, ResteasyProviderFactory providerFactory)
    {
-      return createParameterExtractor(injectTargetClass, injectTarget, type, genericType, annotations, true, providerFactory);
+      return createParameterExtractor(injectTargetClass, injectTarget, defaultName, type, genericType, annotations, true, providerFactory);
    }
 
    @SuppressWarnings("deprecation")
    @Override
-   public ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, Class type, Type genericType, Annotation[] annotations, boolean useDefault, ResteasyProviderFactory providerFactory)
+   public ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, String defaultName, Class type, Type genericType, Annotation[] annotations, boolean useDefault, ResteasyProviderFactory providerFactory)
    {
       DefaultValue defaultValue = findAnnotation(annotations, DefaultValue.class);
       boolean encode = findAnnotation(annotations, Encoded.class) != null || injectTarget.isAnnotationPresent(Encoded.class) || type.isAnnotationPresent(Encoded.class);
@@ -161,6 +167,10 @@ public class InjectorFactoryImpl implements InjectorFactory
       {
          return new QueryParamInjector(type, genericType, injectTarget, queryParam.value(), defaultVal, encode, annotations, providerFactory);
       }
+      else if (findAnnotation(annotations, NewQueryParam.class) != null)
+      {
+         return new QueryParamInjector(type, genericType, injectTarget, defaultName, defaultVal, encode, annotations, providerFactory);
+      }
       else if((query = findAnnotation(annotations, Query.class)) != null) {
          return new QueryInjector(type, providerFactory);
       }
@@ -168,17 +178,33 @@ public class InjectorFactoryImpl implements InjectorFactory
       {
          return new HeaderParamInjector(type, genericType, injectTarget, header.value(), defaultVal, annotations, providerFactory);
       }
+      else if (findAnnotation(annotations, NewHeaderParam.class) != null)
+      {
+         return new HeaderParamInjector(type, genericType, injectTarget, defaultName, defaultVal, annotations, providerFactory);
+      }
       else if ((formParam = findAnnotation(annotations, FormParam.class)) != null)
       {
          return new FormParamInjector(type, genericType, injectTarget, formParam.value(), defaultVal, encode, annotations, providerFactory);
+      }
+      else if (findAnnotation(annotations, NewFormParam.class) != null)
+      {
+         return new FormParamInjector(type, genericType, injectTarget, defaultName, defaultVal, encode, annotations, providerFactory);
       }
       else if ((cookie = findAnnotation(annotations, CookieParam.class)) != null)
       {
          return new CookieParamInjector(type, genericType, injectTarget, cookie.value(), defaultVal, annotations, providerFactory);
       }
+      else if (findAnnotation(annotations, NewCookieParam.class) != null)
+      {
+         return new CookieParamInjector(type, genericType, injectTarget, defaultName, defaultVal, annotations, providerFactory);
+      }
       else if ((uriParam = findAnnotation(annotations, PathParam.class)) != null)
       {
          return new PathParamInjector(type, genericType, injectTarget, uriParam.value(), defaultVal, encode, annotations, providerFactory);
+      }
+      else if (findAnnotation(annotations, NewPathParam.class) != null)
+      {
+         return new PathParamInjector(type, genericType, injectTarget, defaultName, defaultVal, encode, annotations, providerFactory);
       }
       else if ((form = findAnnotation(annotations, Form.class)) != null)
       {
@@ -208,6 +234,10 @@ public class InjectorFactoryImpl implements InjectorFactory
       else if ((matrix = findAnnotation(annotations, MatrixParam.class)) != null)
       {
          return new MatrixParamInjector(type, genericType, injectTarget, matrix.value(), defaultVal, encode, annotations, providerFactory);
+      }
+      else if (findAnnotation(annotations, NewMatrixParam.class) != null)
+      {
+         return new MatrixParamInjector(type, genericType, injectTarget, defaultName, defaultVal, encode, annotations, providerFactory);
       }
       else if ((suspend = findAnnotation(annotations, Suspend.class)) != null)
       {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/PropertyInjectorImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/PropertyInjectorImpl.java
@@ -11,6 +11,9 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.util.FindAnnotation;
 import org.jboss.resteasy.util.MethodHashing;
 
+import static org.jboss.resteasy.util.FindAnnotation.findAnnotation;
+
+import java.beans.Introspector;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
@@ -24,6 +27,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.ws.rs.PathParam;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -65,7 +70,7 @@ public class PropertyInjectorImpl implements PropertyInjector
          Class<?> type = field.getType();
          Type genericType = field.getGenericType();
 
-         ValueInjector extractor = getParameterExtractor(clazz, factory, field, annotations, type, genericType);
+         ValueInjector extractor = getParameterExtractor(clazz, factory, field, field.getName(), annotations, type, genericType);
          if (extractor != null)
          {
             if (!Modifier.isPublic(field.getModifiers()))
@@ -86,7 +91,9 @@ public class PropertyInjectorImpl implements PropertyInjector
          Class<?> type = method.getParameterTypes()[0];
          Type genericType = method.getGenericParameterTypes()[0];
 
-         ValueInjector extractor = getParameterExtractor(clazz, factory, method, annotations, type, genericType);
+         String propertyName = Introspector.decapitalize(method.getName().substring(3));
+         
+         ValueInjector extractor = getParameterExtractor(clazz, factory, method, propertyName, annotations, type, genericType);
          if (extractor != null)
          {
             long hash = 0;
@@ -120,10 +127,10 @@ public class PropertyInjectorImpl implements PropertyInjector
    }
 
    private ValueInjector getParameterExtractor(Class<?> clazz, ResteasyProviderFactory factory, AccessibleObject accessibleObject,
-                                               Annotation[] annotations, Class<?> type, Type genericType)
+                                               String defaultName, Annotation[] annotations, Class<?> type, Type genericType)
    {
       boolean extractBody = (FindAnnotation.findAnnotation(annotations, Body.class) != null);
-      ValueInjector injector = factory.getInjectorFactory().createParameterExtractor(clazz, accessibleObject, type, genericType,
+      ValueInjector injector = factory.getInjectorFactory().createParameterExtractor(clazz, accessibleObject, defaultName, type, genericType,
               annotations, extractBody, factory);
       return injector;
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/InjectorFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/InjectorFactory.java
@@ -19,8 +19,8 @@ public interface InjectorFactory
 {
    ConstructorInjector createConstructor(Constructor constructor, ResteasyProviderFactory factory);
    PropertyInjector createPropertyInjector(Class resourceClass, ResteasyProviderFactory factory);
-   ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, Class type, Type genericType, Annotation[] annotations, ResteasyProviderFactory factory);
-   ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, Class type, Type genericType, Annotation[] annotations, boolean useDefault, ResteasyProviderFactory factory);
+   ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, String defaultName, Class type, Type genericType, Annotation[] annotations, ResteasyProviderFactory factory);
+   ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, String defaultName, Class type, Type genericType, Annotation[] annotations, boolean useDefault, ResteasyProviderFactory factory);
 
    ValueInjector createParameterExtractor(Parameter parameter, ResteasyProviderFactory providerFactory);
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ConstructorParameter.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ConstructorParameter.java
@@ -13,11 +13,12 @@ public class ConstructorParameter extends Parameter
    protected Annotation[] annotations = {};
    protected ResourceConstructor constructor;
 
-   protected ConstructorParameter(ResourceConstructor constructor, Class<?> type, Type genericType, Annotation[] annotations)
+   protected ConstructorParameter(ResourceConstructor constructor, String name, Class<?> type, Type genericType, Annotation[] annotations)
    {
       super(constructor.getResourceClass(), type, genericType);
       this.annotations = annotations;
       this.constructor = constructor;
+      this.paramName = name;
    }
 
    @Override

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/FieldParameter.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/FieldParameter.java
@@ -17,6 +17,7 @@ public class FieldParameter extends Parameter
    {
       super(declaredClass, field.getType(), field.getGenericType());
       this.field = field;
+      this.paramName = field.getName();
    }
 
    @Override

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/MethodParameter.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/MethodParameter.java
@@ -13,11 +13,12 @@ public class MethodParameter extends Parameter
    protected Annotation[] annotations = {};
    protected ResourceLocator locator;
 
-   protected MethodParameter(ResourceLocator locator, Class<?> type, Type genericType,Annotation[] annotations)
+   protected MethodParameter(ResourceLocator locator, String name, Class<?> type, Type genericType,Annotation[] annotations)
    {
       super(locator.getResourceClass(), type, genericType);
       this.annotations = annotations;
       this.locator = locator;
+      this.paramName = name;
    }
 
    @Override

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
@@ -2,6 +2,12 @@ package org.jboss.resteasy.spi.metadata;
 
 import org.jboss.resteasy.annotations.Body;
 import org.jboss.resteasy.annotations.Form;
+import org.jboss.resteasy.annotations.NewCookieParam;
+import org.jboss.resteasy.annotations.NewFormParam;
+import org.jboss.resteasy.annotations.NewHeaderParam;
+import org.jboss.resteasy.annotations.NewMatrixParam;
+import org.jboss.resteasy.annotations.NewPathParam;
+import org.jboss.resteasy.annotations.NewQueryParam;
 import org.jboss.resteasy.annotations.Query;
 import org.jboss.resteasy.annotations.Suspend;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
@@ -271,6 +277,11 @@ public class ResourceBuilder
             parameter.paramType = Parameter.ParamType.QUERY_PARAM;
             parameter.paramName = queryParam.value();
          }
+         else if (findAnnotation(annotations, NewQueryParam.class) != null)
+         {
+            parameter.paramType = Parameter.ParamType.QUERY_PARAM;
+            // don't touch paramName, which is already set
+         }
          else if(( query = findAnnotation(annotations, Query.class))!= null)
          {
             parameter.paramType = Parameter.ParamType.QUERY;
@@ -281,20 +292,40 @@ public class ResourceBuilder
             parameter.paramType = Parameter.ParamType.HEADER_PARAM;
             parameter.paramName = header.value();
          }
+         else if (findAnnotation(annotations, NewHeaderParam.class) != null)
+         {
+            parameter.paramType = Parameter.ParamType.HEADER_PARAM;
+            // don't touch paramName, which is already set
+         }
          else if ((formParam = findAnnotation(annotations, FormParam.class)) != null)
          {
             parameter.paramType = Parameter.ParamType.FORM_PARAM;
             parameter.paramName = formParam.value();
+         }
+         else if (findAnnotation(annotations, NewFormParam.class) != null)
+         {
+            parameter.paramType = Parameter.ParamType.FORM_PARAM;
+            // don't touch paramName, which is already set
          }
          else if ((cookie = findAnnotation(annotations, CookieParam.class)) != null)
          {
             parameter.paramType = Parameter.ParamType.COOKIE_PARAM;
             parameter.paramName = cookie.value();
          }
+         else if (findAnnotation(annotations, NewCookieParam.class) != null)
+         {
+            parameter.paramType = Parameter.ParamType.COOKIE_PARAM;
+            // don't touch paramName, which is already set
+         }
          else if ((uriParam = findAnnotation(annotations, PathParam.class)) != null)
          {
             parameter.paramType = Parameter.ParamType.PATH_PARAM;
             parameter.paramName = uriParam.value();
+         }
+         else if (findAnnotation(annotations, NewPathParam.class) != null)
+         {
+            parameter.paramType = Parameter.ParamType.PATH_PARAM;
+            // don't touch paramName, which is already set
          }
          else if ((form = findAnnotation(annotations, Form.class)) != null)
          {
@@ -309,6 +340,11 @@ public class ResourceBuilder
          {
             parameter.paramType = Parameter.ParamType.MATRIX_PARAM;
             parameter.paramName = matrix.value();
+         }
+         else if (findAnnotation(annotations, NewMatrixParam.class) != null)
+         {
+            parameter.paramType = Parameter.ParamType.MATRIX_PARAM;
+            // don't touch paramName, which is already set
          }
          else if ((suspend = findAnnotation(annotations, Suspend.class)) != null)
          {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceConstructor.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceConstructor.java
@@ -4,6 +4,7 @@ import org.jboss.resteasy.util.Types;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 
@@ -24,9 +25,10 @@ public class ResourceConstructor
       if (constructor.getParameterTypes() != null)
       {
          this.params = new ConstructorParameter[constructor.getParameterTypes().length];
+         Parameter[] reflectionParameters = constructor.getParameters();
          for (int i = 0; i < constructor.getParameterTypes().length; i++)
          {
-            this.params[i] = new ConstructorParameter(this, constructor.getParameterTypes()[i], constructor.getGenericParameterTypes()[i], constructor.getParameterAnnotations()[i]);
+            this.params[i] = new ConstructorParameter(this, reflectionParameters[i].getName(), constructor.getParameterTypes()[i], constructor.getGenericParameterTypes()[i], constructor.getParameterAnnotations()[i]);
          }
       }
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceLocator.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceLocator.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.spi.metadata;
 import org.jboss.resteasy.util.Types;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 
 /**
@@ -30,9 +31,10 @@ public class ResourceLocator
       this.genericReturnType = Types.resolveTypeVariables(resourceClass.getClazz(), method.getGenericReturnType());
       this.returnType = Types.getRawType(genericReturnType);
       this.params = new MethodParameter[method.getParameterTypes().length];
+      Parameter[] reflectionParameters = method.getParameters();
       for (int i = 0; i < method.getParameterTypes().length; i++)
       {
-         this.params[i] = new MethodParameter(this, method.getParameterTypes()[i], method.getGenericParameterTypes()[i], annotatedMethod.getParameterAnnotations()[i]);
+         this.params[i] = new MethodParameter(this, reflectionParameters[i].getName(), method.getParameterTypes()[i], method.getGenericParameterTypes()[i], annotatedMethod.getParameterAnnotations()[i]);
       }
    }
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/SetterParameter.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/SetterParameter.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.spi.metadata;
 
+import java.beans.Introspector;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
@@ -19,6 +20,7 @@ public class SetterParameter extends Parameter
       super(declaredClass, setter.getParameterTypes()[0], setter.getGenericParameterTypes()[0]);
       this.setter = setter;
       this.annotatedMethod = annotatedMethod;
+      this.paramName = Introspector.decapitalize(setter.getName().substring(3));
    }
 
    public Method getSetter()

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/FindAnnotation.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/FindAnnotation.java
@@ -13,11 +13,20 @@ import javax.json.bind.annotation.JsonbTypeDeserializer;
 import javax.json.bind.annotation.JsonbTypeSerializer;
 import javax.json.bind.annotation.JsonbVisibility;
 import javax.ws.rs.CookieParam;
+import javax.ws.rs.FormParam;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.MatrixParam;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
+
+import org.jboss.resteasy.annotations.NewCookieParam;
+import org.jboss.resteasy.annotations.NewFormParam;
+import org.jboss.resteasy.annotations.NewHeaderParam;
+import org.jboss.resteasy.annotations.NewMatrixParam;
+import org.jboss.resteasy.annotations.NewPathParam;
+import org.jboss.resteasy.annotations.NewQueryParam;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -42,7 +51,14 @@ public final class FindAnnotation
                    CookieParam.class,
                    PathParam.class,
                    MatrixParam.class,
-                   Context.class
+                   FormParam.class,
+                   Context.class,
+                   NewQueryParam.class,
+                   NewHeaderParam.class,
+                   NewCookieParam.class,
+                   NewPathParam.class,
+                   NewMatrixParam.class,
+                   NewFormParam.class,
            };
 
    private static final Class[] findJaxRSAnnotations_TYPE = new Class[]{};

--- a/testsuite/integration-tests-spring/deployment/src/test/java/org/jboss/resteasy/test/spring/deployment/resource/RequestScopedBeanQualifierInjectorFactoryImpl.java
+++ b/testsuite/integration-tests-spring/deployment/src/test/java/org/jboss/resteasy/test/spring/deployment/resource/RequestScopedBeanQualifierInjectorFactoryImpl.java
@@ -25,10 +25,10 @@ public class RequestScopedBeanQualifierInjectorFactoryImpl extends InjectorFacto
     @SuppressWarnings("rawtypes")
     @Override
     public ValueInjector createParameterExtractor(Class injectTargetClass,
-                                                  AccessibleObject injectTarget, Class type, Type genericType, Annotation[] annotations, ResteasyProviderFactory factory) {
+                                                  AccessibleObject injectTarget, String defaultName, Class type, Type genericType, Annotation[] annotations, ResteasyProviderFactory factory) {
         final Qualifier qualifier = FindAnnotation.findAnnotation(annotations, Qualifier.class);
         if (qualifier == null) {
-            return super.createParameterExtractor(injectTargetClass, injectTarget, type,
+            return super.createParameterExtractor(injectTargetClass, injectTarget, defaultName, type,
                     genericType, annotations, factory);
         } else {
             return new ValueInjector() {

--- a/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/resource/RequestScopedBeanQualifierInjectorFactoryImpl.java
+++ b/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/resource/RequestScopedBeanQualifierInjectorFactoryImpl.java
@@ -25,10 +25,10 @@ public class RequestScopedBeanQualifierInjectorFactoryImpl extends InjectorFacto
     @SuppressWarnings("rawtypes")
     @Override
     public ValueInjector createParameterExtractor(Class injectTargetClass,
-                                                  AccessibleObject injectTarget, Class type, Type genericType, Annotation[] annotations, ResteasyProviderFactory factory) {
+                                                  AccessibleObject injectTarget, String defaultName, Class type, Type genericType, Annotation[] annotations, ResteasyProviderFactory factory) {
         final Qualifier qualifier = FindAnnotation.findAnnotation(annotations, Qualifier.class);
         if (qualifier == null) {
-            return super.createParameterExtractor(injectTargetClass, injectTarget, type,
+            return super.createParameterExtractor(injectTargetClass, injectTarget, defaultName, type,
                     genericType, annotations, factory);
         } else {
             return new ValueInjector() {

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+    </properties>
+
     <artifactId>resteasy-integration-tests</artifactId>
     <name>RESTEasy Main testsuite: Integration tests</name>
 
@@ -391,7 +395,13 @@
                         </execution>
                     </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/NewParamAnnotationsTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/NewParamAnnotationsTest.java
@@ -1,0 +1,91 @@
+package org.jboss.resteasy.test.core.basic;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.test.core.basic.resource.AnnotationInheritanceNotAResource;
+import org.jboss.resteasy.test.core.basic.resource.AnnotationInheritanceSomeOtherInterface;
+import org.jboss.resteasy.test.core.basic.resource.AnnotationInheritanceSomeOtherResource;
+import org.jboss.resteasy.test.core.basic.resource.AnnotationInheritanceSuperInt;
+import org.jboss.resteasy.test.core.basic.resource.AnnotationInheritanceSuperIntAbstract;
+import org.jboss.resteasy.test.core.basic.resource.NewParamAnnotationsResource;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @tpSubChapter Configuration
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Test for new param annotations.
+ * @tpSince RESTEasy 4.0.0
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class NewParamAnnotationsTest {
+    static ResteasyClient client;
+
+    @Deployment
+    public static Archive<?> deploySimpleResource() {
+        WebArchive war = TestUtil.prepareArchive(NewParamAnnotationsTest.class.getSimpleName());
+        return TestUtil.finishContainerPrepare(war, null, NewParamAnnotationsResource.class);
+    }
+
+    @Before
+    public void init() {
+        client = new ResteasyClientBuilder().build();
+    }
+
+    @After
+    public void after() throws Exception {
+        client.close();
+    }
+
+    private String generateURL(String path) {
+        return PortProviderUtil.generateURL(path, NewParamAnnotationsTest.class.getSimpleName());
+    }
+
+    /**
+     * @tpTestDetails Test new param annotations
+     * @tpSince RESTEasy 4.0.0
+     */
+    @Test
+    public void testNewParamAnnotations() {
+        Response response = client.target(generateURL("/pathParam0/pathParam1/pathParam2/pathParam3"))
+              .queryParam("queryParam0", "queryParam0")
+              .queryParam("queryParam1", "queryParam1")
+              .queryParam("queryParam2", "queryParam2")
+              .queryParam("queryParam3", "queryParam3")
+              .matrixParam("matrixParam0", "matrixParam0")
+              .matrixParam("matrixParam1", "matrixParam1")
+              .matrixParam("matrixParam2", "matrixParam2")
+              .matrixParam("matrixParam3", "matrixParam3")
+              .request()
+              .header("headerParam0", "headerParam0")
+              .header("headerParam1", "headerParam1")
+              .header("headerParam2", "headerParam2")
+              .header("headerParam3", "headerParam3")
+              .cookie("cookieParam0", "cookieParam0")
+              .cookie("cookieParam1", "cookieParam1")
+              .cookie("cookieParam2", "cookieParam2")
+              .cookie("cookieParam3", "cookieParam3")
+              .post(Entity.form(new Form()
+                    .param("formParam0", "formParam0")
+                    .param("formParam1", "formParam1")
+                    .param("formParam2", "formParam2")
+                    .param("formParam3", "formParam3")
+                    ));
+        Assert.assertEquals("Success", 200, response.getStatus());
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/resource/NewParamAnnotationsResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/resource/NewParamAnnotationsResource.java
@@ -1,0 +1,211 @@
+package org.jboss.resteasy.test.core.basic.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.annotations.NewCookieParam;
+import org.jboss.resteasy.annotations.NewFormParam;
+import org.jboss.resteasy.annotations.NewHeaderParam;
+import org.jboss.resteasy.annotations.NewMatrixParam;
+import org.jboss.resteasy.annotations.NewPathParam;
+import org.jboss.resteasy.annotations.NewQueryParam;
+
+@Path("/")
+public class NewParamAnnotationsResource
+{
+
+   private String cookieParam0;
+   @NewCookieParam
+   private String cookieParam1;
+   private String cookieParam2;
+
+   private String formParam0;
+   @NewFormParam
+   private String formParam1;
+   private String formParam2;
+
+   private String headerParam0;
+   @NewHeaderParam
+   private String headerParam1;
+   private String headerParam2;
+
+   private String matrixParam0;
+   @NewMatrixParam
+   private String matrixParam1;
+   private String matrixParam2;
+
+   private String pathParam0;
+   @NewPathParam
+   private String pathParam1;
+   private String pathParam2;
+
+   private String queryParam0;
+   @NewQueryParam
+   private String queryParam1;
+   private String queryParam2;
+
+
+   public NewParamAnnotationsResource(
+         @NewCookieParam String cookieParam0,
+         @NewFormParam String formParam0,
+         @NewHeaderParam String headerParam0,
+         @NewMatrixParam String matrixParam0,
+         @NewPathParam String pathParam0,
+         @NewQueryParam String queryParam0
+         )
+   {
+      this.cookieParam0 = cookieParam0;
+      this.formParam0 = formParam0;
+      this.headerParam0 = headerParam0;
+      this.matrixParam0 = matrixParam0;
+      this.pathParam0 = pathParam0;
+      this.queryParam0 = queryParam0;
+   }
+   
+   public String getCookieParam2()
+   {
+      return cookieParam2;
+   }
+   
+   @NewCookieParam
+   public void setCookieParam2(String cookieParam2)
+   {
+      this.cookieParam2 = cookieParam2;
+   }
+
+   public String getFormParam2()
+   {
+      return formParam2;
+   }
+   
+   @NewFormParam
+   public void setFormParam2(String formParam2)
+   {
+      this.formParam2 = formParam2;
+   }
+   
+   public String getPathParam2()
+   {
+      return pathParam2;
+   }
+   
+   public String getHeaderParam2()
+   {
+      return headerParam2;
+   }
+   
+   @NewHeaderParam
+   public void setHeaderParam2(String headerParam2)
+   {
+      this.headerParam2 = headerParam2;
+   }
+   
+   public String getMatrixParam2()
+   {
+      return matrixParam2;
+   }
+   
+   @NewMatrixParam
+   public void setMatrixParam2(String matrixParam2)
+   {
+      this.matrixParam2 = matrixParam2;
+   }
+   
+   @NewPathParam
+   public void setPathParam2(String pathParam2)
+   {
+      this.pathParam2 = pathParam2;
+   }
+
+   public String getQueryParam2()
+   {
+      return queryParam2;
+   }
+   
+   @NewQueryParam
+   public void setQueryParam2(String queryParam2)
+   {
+      this.queryParam2 = queryParam2;
+   }
+   
+   @POST
+   @Path("{pathParam0}/{pathParam1}/{pathParam2}/{pathParam3}")
+   public Response post(
+         @NewCookieParam String cookieParam3,
+         @NewFormParam String formParam3,
+         @NewHeaderParam String headerParam3,
+         @NewMatrixParam String matrixParam3,
+         @NewPathParam String pathParam3, 
+         @NewQueryParam String queryParam3)
+   {
+      System.err.println("cookieParam0: "+cookieParam0);
+      System.err.println("cookieParam1: "+cookieParam1);
+      System.err.println("cookieParam2: "+cookieParam2);
+      System.err.println("cookieParam3: "+cookieParam3);
+
+      System.err.println("formParam0: "+formParam0);
+      System.err.println("formParam1: "+formParam1);
+      System.err.println("formParam2: "+formParam2);
+      System.err.println("formParam3: "+formParam3);
+
+      System.err.println("headerParam0: "+headerParam0);
+      System.err.println("headerParam1: "+headerParam1);
+      System.err.println("headerParam2: "+headerParam2);
+      System.err.println("headerParam3: "+headerParam3);
+
+      System.err.println("matrixParam0: "+matrixParam0);
+      System.err.println("matrixParam1: "+matrixParam1);
+      System.err.println("matrixParam2: "+matrixParam2);
+      System.err.println("matrixParam3: "+matrixParam3);
+
+      System.err.println("pathParam0: "+pathParam0);
+      System.err.println("pathParam1: "+pathParam1);
+      System.err.println("pathParam2: "+pathParam2);
+      System.err.println("pathParam3: "+pathParam3);
+
+      System.err.println("queryParam0: "+queryParam0);
+      System.err.println("queryParam1: "+queryParam1);
+      System.err.println("queryParam2: "+queryParam2);
+      System.err.println("queryParam3: "+queryParam3);
+
+      if(      !"cookieParam0".equals(cookieParam0)
+            || !"cookieParam1".equals(cookieParam1)
+            || !"cookieParam2".equals(cookieParam2)
+            || !"cookieParam3".equals(cookieParam3))
+         return Response.status(Response.Status.BAD_REQUEST).build();
+
+      if(      !"formParam0".equals(formParam0)
+            || !"formParam1".equals(formParam1)
+            || !"formParam2".equals(formParam2)
+            || !"formParam3".equals(formParam3))
+         return Response.status(Response.Status.BAD_REQUEST).build();
+
+      if(      !"headerParam0".equals(headerParam0)
+            || !"headerParam1".equals(headerParam1)
+            || !"headerParam2".equals(headerParam2)
+            || !"headerParam3".equals(headerParam3))
+         return Response.status(Response.Status.BAD_REQUEST).build();
+
+      if(      !"matrixParam0".equals(matrixParam0)
+            || !"matrixParam1".equals(matrixParam1)
+            || !"matrixParam2".equals(matrixParam2)
+            || !"matrixParam3".equals(matrixParam3))
+         return Response.status(Response.Status.BAD_REQUEST).build();
+
+      if(      !"pathParam0".equals(pathParam0)
+            || !"pathParam1".equals(pathParam1)
+            || !"pathParam2".equals(pathParam2)
+            || !"pathParam3".equals(pathParam3))
+         return Response.status(Response.Status.BAD_REQUEST).build();
+
+      if(      !"queryParam0".equals(queryParam0)
+            || !"queryParam1".equals(queryParam1)
+            || !"queryParam2".equals(queryParam2)
+            || !"queryParam3".equals(queryParam3))
+         return Response.status(Response.Status.BAD_REQUEST).build();
+
+      return Response.ok().build();
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomValueInjectorInjectorFactoryImpl.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomValueInjectorInjectorFactoryImpl.java
@@ -14,11 +14,11 @@ import java.lang.reflect.Type;
 
 public class CustomValueInjectorInjectorFactoryImpl extends InjectorFactoryImpl {
     @Override
-    public ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, Class type,
+    public ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, String defaultName, Class type,
                                                   Type genericType, Annotation[] annotations, ResteasyProviderFactory factory) {
         final CustomValueInjectorHello hello = FindAnnotation.findAnnotation(annotations, CustomValueInjectorHello.class);
         if (hello == null) {
-            return super.createParameterExtractor(injectTargetClass, injectTarget, type, genericType, annotations, factory);
+            return super.createParameterExtractor(injectTargetClass, injectTarget, defaultName, type, genericType, annotations, factory);
         } else {
             return new ValueInjector() {
                 public Object inject(HttpRequest request, HttpResponse response) {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/HttpRequestParameterInjectorParamFactoryImpl.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/HttpRequestParameterInjectorParamFactoryImpl.java
@@ -17,10 +17,10 @@ public class HttpRequestParameterInjectorParamFactoryImpl extends InjectorFactor
     @SuppressWarnings("unchecked")
     @Override
     public ValueInjector createParameterExtractor(Class injectTargetClass,
-                                                  AccessibleObject injectTarget, Class type, Type genericType, Annotation[] annotations, ResteasyProviderFactory factory) {
+                                                  AccessibleObject injectTarget, String defaultName, Class type, Type genericType, Annotation[] annotations, ResteasyProviderFactory factory) {
         final HttpRequestParameterInjectorClassicParam param = FindAnnotation.findAnnotation(annotations, HttpRequestParameterInjectorClassicParam.class);
         if (param == null) {
-            return super.createParameterExtractor(injectTargetClass, injectTarget, type,
+            return super.createParameterExtractor(injectTargetClass, injectTarget, defaultName, type,
                     genericType, annotations, factory);
         } else {
             return new ValueInjector() {

--- a/testsuite/legacy-integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomValueInjectorInjectorFactoryImpl.java
+++ b/testsuite/legacy-integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomValueInjectorInjectorFactoryImpl.java
@@ -14,11 +14,11 @@ import java.lang.reflect.Type;
 
 public class CustomValueInjectorInjectorFactoryImpl extends InjectorFactoryImpl {
     @Override
-    public ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, Class type,
+    public ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, String defaultName, Class type,
                                                   Type genericType, Annotation[] annotations, ResteasyProviderFactory factory) {
         final CustomValueInjectorHello hello = FindAnnotation.findAnnotation(annotations, CustomValueInjectorHello.class);
         if (hello == null) {
-            return super.createParameterExtractor(injectTargetClass, injectTarget, type, genericType, annotations, factory);
+            return super.createParameterExtractor(injectTargetClass, injectTarget, defaultName, type, genericType, annotations, factory);
         } else {
             return new ValueInjector() {
                 public Object inject(HttpRequest request, HttpResponse response) {

--- a/testsuite/legacy-integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/HttpRequestParameterInjectorParamFactoryImpl.java
+++ b/testsuite/legacy-integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/HttpRequestParameterInjectorParamFactoryImpl.java
@@ -17,10 +17,10 @@ public class HttpRequestParameterInjectorParamFactoryImpl extends InjectorFactor
     @SuppressWarnings("unchecked")
     @Override
     public ValueInjector createParameterExtractor(Class injectTargetClass,
-                                                  AccessibleObject injectTarget, Class type, Type genericType, Annotation[] annotations, ResteasyProviderFactory factory) {
+                                                  AccessibleObject injectTarget, String defaultName, Class type, Type genericType, Annotation[] annotations, ResteasyProviderFactory factory) {
         final HttpRequestParameterInjectorClassicParam param = FindAnnotation.findAnnotation(annotations, HttpRequestParameterInjectorClassicParam.class);
         if (param == null) {
-            return super.createParameterExtractor(injectTargetClass, injectTarget, type,
+            return super.createParameterExtractor(injectTargetClass, injectTarget, defaultName, type,
                     genericType, annotations, factory);
         } else {
             return new ValueInjector() {


### PR DESCRIPTION
As discussed recently, here's support for param annotations that take their names from (depending on where they're placed):

- parameter name, via reflection (requires use of `-parameters` `javac` flag, otherwise params are named `arg0..X`)
- setter property name
- field name

The new parameter names are unoriginal and should probably change. I'd call them like the originals, myself, but this may be found to be confusing by users.

Perhaps we should add an optional `String value() default ""` argument, in case you want to override the name, rather than use the old annotation?

I've added tests, but I have a feeling I only tested configuration via the `ResourceBuilder`, not via injectors. Can you confirm/deny? If I have to test the injectors, how would I go about it?

Also, I'm not sure what strategy we should have if parameter names are absent from reflection. As it is, it will default to `arg0`..`argX` names. Should we throw an error? Warning? Nothing? We currently get no warning if you pass a query param `param` to a resource expecting `@PathParam("parm") String param` (note the typo), so I'm torn between treating this as a silent user mistake, and a one-time warning ("Hey, we noticed that your parameter is named `arg0` which indicates you've very likely forgotten to compile with `-parameters`"). WDYT?