### PR TITLE
Resteasy 1776: Sse feature should only be enabled when resource method only produces "text/event-stream" and is injected with @Context SseEventSink

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AsyncResponseConsumer.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AsyncResponseConsumer.java
@@ -60,23 +60,15 @@ public abstract class AsyncResponseConsumer
    }
 
    public static AsyncResponseConsumer makeAsyncResponseConsumer(ResourceMethodInvoker method, AsyncStreamProvider<?> asyncStreamProvider) {
+	  if(method.isSse())
+	  {
+		  return new AsyncStreamSseResponseConsumer(method, asyncStreamProvider);
+	  }
       for (Annotation annotation : method.getMethodAnnotations())
       {
          if(annotation.annotationType() == Stream.class)
          {
             return new AsyncStreamingResponseConsumer(method, asyncStreamProvider);
-         }
-      }
-      HttpHeaders req = ResteasyProviderFactory.getContextData(HttpHeaders.class);
-      // FIXME: probably redundant but I prefer the producer to be explicit and not just
-      // send SSE if the client accepts everything
-      if(req.getAcceptableMediaTypes().contains(MediaType.SERVER_SENT_EVENTS_TYPE)) {
-         for (MediaType mediaType : method.getProduces())
-         {
-            if(mediaType.equals(MediaType.SERVER_SENT_EVENTS_TYPE))
-            {
-               return new AsyncStreamSseResponseConsumer(method, asyncStreamProvider);
-            }
          }
       }
       return new AsyncStreamCollectorResponseConsumer(method, asyncStreamProvider);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEnablingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEnablingTest.java
@@ -1,0 +1,178 @@
+package org.jboss.resteasy.test.providers.sse;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.sse.SseEventSource;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * 
+ * @author Nicolas NESMON
+ *
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class SseEnablingTest {
+
+	@Deployment
+	public static Archive<?> deploy() {
+		WebArchive war = TestUtil.prepareArchive(SseEnablingTest.class.getSimpleName());
+		war.addClass(SseEnablingTestResource.class);
+		return TestUtil.finishContainerPrepare(war, null, SseEnablingTestResource.class);
+	}
+
+	private String generateURL() {
+		return PortProviderUtil.generateBaseUrl(SseEnablingTest.class.getSimpleName());
+	}
+
+	// Client
+	// Accept: application/xml, text/event-stream
+	//
+	// Server
+	// @GET
+	// @Produces(MediaType.APPLICATION_XML)
+	// public Response resourceMethod(@Context SseEventSink sseEventSink){
+	// ...
+	// }
+	@Test
+	public void testSseEnabling_1() throws Exception {
+		Client client = ClientBuilder.newClient();
+		try {
+			WebTarget baseTarget = client.target(generateURL()).path(SseEnablingTestResource.PATH);
+			try (Response response = baseTarget.path(SseEnablingTestResource.RESOURCE_METHOD_1_PATH)
+					.request(MediaType.APPLICATION_XML_TYPE, MediaType.SERVER_SENT_EVENTS_TYPE).get()) {
+				checkResponse(response);
+			}
+		} finally {
+			client.close();
+		}
+	}
+
+	// Client
+	// Accept: application/xml;q=0.9, text/event-stream;q=0.5
+	//
+	// Server
+	// @GET
+	// @Produces({MediaType.APPLICATION_XML, MediaType.SERVER_SENT_EVENTS})
+	// public Response resourceMethod(@Context SseEventSink sseEventSink){
+	// ...
+	// }
+	@Test
+	public void testSseEnabling_2() throws Exception {
+		Client client = ClientBuilder.newClient();
+		try {
+			WebTarget baseTarget = client.target(generateURL()).path(SseEnablingTestResource.PATH);
+			try (Response response = baseTarget.path(SseEnablingTestResource.RESOURCE_METHOD_2_PATH)
+					.request("application/xml;q=0.9", "text/event-stream;q=0.5").get()) {
+				checkResponse(response);
+			}
+		} finally {
+			client.close();
+		}
+	}
+
+	// Client
+	// Accept: application/xml, text/event-stream
+	//
+	// Server
+	// @GET
+	// @Produces({"application/xml;qs=0.9", "text/event-stream;qs=0.5"})
+	// public Response resourceMethod(@Context SseEventSink sseEventSink){
+	// ...
+	// }
+	@Test
+	public void testSseEnabling_3() throws Exception {
+		Client client = ClientBuilder.newClient();
+		try {
+			WebTarget baseTarget = client.target(generateURL()).path(SseEnablingTestResource.PATH);
+			try (Response response = baseTarget.path(SseEnablingTestResource.RESOURCE_METHOD_3_PATH)
+					.request(MediaType.APPLICATION_XML_TYPE, MediaType.SERVER_SENT_EVENTS_TYPE).get()) {
+				checkResponse(response);
+			}
+		} finally {
+			client.close();
+		}
+	}
+
+	// Client
+	// Accept: application/xml;q=0.9, application/json;q=0.5
+	//
+	// Server
+	// @GET
+	// @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON,
+	// MediaType.SERVER_SENT_EVENTS})
+	// public Response resourceMethod(@Context SseEventSink sseEventSink){
+	// ...
+	// }
+	@Test
+	public void testSseEnabling_4() throws Exception {
+		Client client = ClientBuilder.newClient();
+		try {
+			WebTarget baseTarget = client.target(generateURL()).path(SseEnablingTestResource.PATH);
+			try (Response response = baseTarget.path(SseEnablingTestResource.RESOURCE_METHOD_4_PATH)
+					.request("application/xml;q=0.9", "application/json;q=0.5").get()) {
+				checkResponse(response);
+			}
+		} finally {
+			client.close();
+		}
+	}
+
+	// Client
+	// Accept: text/event-stream
+	//
+	// Server
+	// @GET
+	// @Produces(MediaType.SERVER_SENT_EVENTS)
+	// public void resourceMethod(@Context SseEventSink sseEventSink){
+	// ...
+	// }
+	@Test
+	public void testSseEnabling_5() throws Exception {
+
+		Client client = ClientBuilder.newClient();
+		try {
+			WebTarget baseTarget = client.target(generateURL()).path(SseEnablingTestResource.PATH);
+			try (SseEventSource eventSource = SseEventSource
+					.target(baseTarget.path(SseEnablingTestResource.RESOURCE_METHOD_5_PATH)).build()) {
+				CountDownLatch countDownLatch = new CountDownLatch(1);
+				eventSource.register(event -> {
+					countDownLatch.countDown();
+				}, e -> {
+					throw new RuntimeException(e);
+				});
+				eventSource.open();
+				boolean result = countDownLatch.await(30, TimeUnit.SECONDS);
+				Assert.assertTrue("Waiting for event to be delivered has timed out.", result);
+			}
+		} finally {
+			client.close();
+		}
+	}
+
+	private void checkResponse(Response response) {
+		Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+		MediaType contentType = response.getMediaType();
+		Assert.assertEquals(MediaType.APPLICATION_XML_TYPE.getType(), contentType.getType());
+		Assert.assertEquals(MediaType.APPLICATION_XML_TYPE.getSubtype(), contentType.getSubtype());
+		Assert.assertEquals(SseEnablingTestResource.OK_MESSAGE, response.readEntity(String.class));
+	}
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEnablingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEnablingTest.java
@@ -141,17 +141,39 @@ public class SseEnablingTest {
 	// Server
 	// @GET
 	// @Produces(MediaType.SERVER_SENT_EVENTS)
-	// public void resourceMethod(@Context SseEventSink sseEventSink){
+	// public Response resourceMethod(){
 	// ...
 	// }
 	@Test
 	public void testSseEnabling_5() throws Exception {
+		Client client = ClientBuilder.newClient();
+		try {
+			WebTarget baseTarget = client.target(generateURL()).path(SseEnablingTestResource.PATH);
+			int responseSTatus = baseTarget.path(SseEnablingTestResource.RESOURCE_METHOD_5_PATH)
+					.request(MediaType.SERVER_SENT_EVENTS_TYPE).get().getStatus();
+			Assert.assertEquals(Status.NO_CONTENT.getStatusCode(), responseSTatus);
+		} finally {
+			client.close();
+		}
+	}
+
+	// Client
+	// Accept: text/event-stream
+	//
+	// Server
+	// @GET
+	// @Produces(MediaType.SERVER_SENT_EVENTS)
+	// public void resourceMethod(@Context SseEventSink sseEventSink){
+	// ...
+	// }
+	@Test
+	public void testSseEnabling_6() throws Exception {
 
 		Client client = ClientBuilder.newClient();
 		try {
 			WebTarget baseTarget = client.target(generateURL()).path(SseEnablingTestResource.PATH);
 			try (SseEventSource eventSource = SseEventSource
-					.target(baseTarget.path(SseEnablingTestResource.RESOURCE_METHOD_5_PATH)).build()) {
+					.target(baseTarget.path(SseEnablingTestResource.RESOURCE_METHOD_6_PATH)).build()) {
 				CountDownLatch countDownLatch = new CountDownLatch(1);
 				eventSource.register(event -> {
 					countDownLatch.countDown();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEnablingTestResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEnablingTestResource.java
@@ -24,6 +24,7 @@ public class SseEnablingTestResource {
 	public static final String RESOURCE_METHOD_3_PATH = "resourceMethod3";
 	public static final String RESOURCE_METHOD_4_PATH = "resourceMethod4";
 	public static final String RESOURCE_METHOD_5_PATH = "resourceMethod5";
+	public static final String RESOURCE_METHOD_6_PATH = "resourceMethod6";
 
 	public static String OK_MESSAGE = "OK";
 
@@ -79,7 +80,15 @@ public class SseEnablingTestResource {
 	@Path(RESOURCE_METHOD_5_PATH)
 	@GET
 	@Produces(MediaType.SERVER_SENT_EVENTS)
-	public void resourceMethod_5(@Context SseEventSink sseEventSink, @Context Sse sse) {
+	public Response resourceMethod_5() {
+		return Response.noContent().build();
+	}
+	
+	// Will be called by client with "Accept: text/event-stream"
+	@Path(RESOURCE_METHOD_6_PATH)
+	@GET
+	@Produces(MediaType.SERVER_SENT_EVENTS)
+	public void resourceMethod_6(@Context SseEventSink sseEventSink, @Context Sse sse) {
 		sseEventSink.send(sse.newEvent("data"));
 		sseEventSink.close();
 	}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEnablingTestResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEnablingTestResource.java
@@ -1,0 +1,87 @@
+package org.jboss.resteasy.test.providers.sse;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.sse.Sse;
+import javax.ws.rs.sse.SseEventSink;
+
+/**
+ * 
+ * @author Nicolas NESMON
+ *
+ */
+@Path(SseEnablingTestResource.PATH)
+public class SseEnablingTestResource {
+
+	public static final String PATH = "sseEnablingTest";
+	public static final String RESOURCE_METHOD_1_PATH = "resourceMethod1";
+	public static final String RESOURCE_METHOD_2_PATH = "resourceMethod2";
+	public static final String RESOURCE_METHOD_3_PATH = "resourceMethod3";
+	public static final String RESOURCE_METHOD_4_PATH = "resourceMethod4";
+	public static final String RESOURCE_METHOD_5_PATH = "resourceMethod5";
+
+	public static String OK_MESSAGE = "OK";
+
+	// Will be called by client with "Accept: application/xml,
+	// text/event-stream"
+	@Path(RESOURCE_METHOD_1_PATH)
+	@GET
+	@Produces(MediaType.APPLICATION_XML)
+	public Response resourceMethod_1(@Context SseEventSink sseEventSink) {
+		if (sseEventSink == null) {
+			return Response.ok(OK_MESSAGE).build();
+		}
+		throw new InternalServerErrorException();
+	}
+
+	// Will be called by client with "Accept: application/xml;q=0.9,
+	// text/event-stream;q=0.5"
+	@Path(RESOURCE_METHOD_2_PATH)
+	@GET
+	@Produces({ MediaType.APPLICATION_XML, MediaType.SERVER_SENT_EVENTS })
+	public Response resourceMethod_2(@Context SseEventSink sseEventSink) {
+		if (sseEventSink == null) {
+			return Response.ok(OK_MESSAGE).build();
+		}
+		throw new InternalServerErrorException();
+	}
+
+	// Will be called by client with "Accept: application/xml,
+	// text/event-stream"
+	@Path(RESOURCE_METHOD_3_PATH)
+	@GET
+	@Produces({ "application/xml;qs=0.9", "text/event-stream;qs=0.5" })
+	public Response resourceMethod_3(@Context SseEventSink sseEventSink) {
+		if (sseEventSink == null) {
+			return Response.ok(OK_MESSAGE).build();
+		}
+		throw new InternalServerErrorException();
+	}
+
+	// Will be called by client with "Accept: application/xml;q=0.9,
+	// application/json;q=0.5"
+	@Path(RESOURCE_METHOD_4_PATH)
+	@GET
+	@Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.SERVER_SENT_EVENTS })
+	public Response resourceMethod_4(@Context SseEventSink sseEventSink) {
+		if (sseEventSink == null) {
+			return Response.ok(OK_MESSAGE).build();
+		}
+		throw new InternalServerErrorException();
+	}
+
+	// Will be called by client with "Accept: text/event-stream"
+	@Path(RESOURCE_METHOD_5_PATH)
+	@GET
+	@Produces(MediaType.SERVER_SENT_EVENTS)
+	public void resourceMethod_5(@Context SseEventSink sseEventSink, @Context Sse sse) {
+		sseEventSink.send(sse.newEvent("data"));
+		sseEventSink.close();
+	}
+
+}


### PR DESCRIPTION
This pull request introduce the concept of **SSE resource method** as described in the specification:

> 9.3 Server API
> ...
> A resource method that injects an SseEventSink and produces the media type text/event-stream is an
> SSE resource method.

It helps to fixe issues listed in https://issues.jboss.org/browse/RESTEASY-1776
