### PR TITLE
Introduce a JettyClientEngine to use jetty-client with resteasy JAX-RS Client

### DIFF
--- a/docbook/reference/en/en-US/modules/RESTEasy_Client_Framework.xml
+++ b/docbook/reference/en/en-US/modules/RESTEasy_Client_Framework.xml
@@ -74,6 +74,17 @@
         support chunked mode. See Section <link linkend='transport_layer'>Apache HTTP Client 4.x and other backends</link>
         for more information.
         </para>
+
+        <para>
+        RESTEasy defaults to using Apache AsyncHttpClient as the HTTP engine.  As an drop in replacement, you may select
+        a Jetty 9.4 based HTTP engine.  The Jetty implementation is newer and therefore not as well tested, but if
+        you run Jetty as your server already, it is nice to have a common vendor.  The Jetty Server can even share
+        execution resources with Client libraries if you configure them to use e.g. the same QueuedThreadPool.
+        </para>
+
+        <programlisting>
+          ResteasyClient client = new ResteasyClientBuilder().clientEngine(new JettyClientEngine(new HttpClient())).build();
+        </programlisting>
     </section>
     <para>
 

--- a/resteasy-client/pom.xml
+++ b/resteasy-client/pom.xml
@@ -51,6 +51,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>
             <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
         </dependency>

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/JettyClientEngine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/JettyClientEngine.java
@@ -1,0 +1,254 @@
+package org.jboss.resteasy.client.jaxrs.engines;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.InvocationCallback;
+import javax.ws.rs.client.ResponseProcessingException;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.client.util.DeferredContentProvider;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.io.ByteBufferPool;
+import org.jboss.resteasy.client.jaxrs.AsyncClientHttpEngine;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
+import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
+
+public class JettyClientEngine implements AsyncClientHttpEngine {
+    private static final InvocationCallback<ClientResponse> NOP = new InvocationCallback<ClientResponse>() {
+        @Override
+        public void completed(ClientResponse response) {
+        }
+
+        @Override
+        public void failed(Throwable throwable) {
+        }
+    };
+
+    private final HttpClient client;
+
+    public JettyClientEngine(HttpClient client) {
+        if (!client.isStarted()) {
+            try {
+                client.start();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        this.client = client;
+    }
+
+    @Override
+    public SSLContext getSslContext() {
+        return client.getSslContextFactory().getSslContext();
+    }
+
+    @Override
+    public HostnameVerifier getHostnameVerifier() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ClientResponse invoke(ClientInvocation invocation) {
+        Future<ClientResponse> future = submit(invocation, true, NOP, null);
+        try {
+            return future.get(1, TimeUnit.HOURS); // There's already an idle and connect timeout, do we need one here?
+        } catch (InterruptedException e) {
+            future.cancel(true);
+            Thread.currentThread().interrupt();
+            throw clientException(e, null);
+        } catch (TimeoutException | ExecutionException e) {
+            future.cancel(true);
+            throw clientException(e.getCause(), null);
+        }
+    }
+
+    /**
+     * Implementation note: due to lack of asynchronous message decoders the request must either be buffered,
+     * or it must have a {@code null} extractor and type parameter {@code <T>} must be {@link ClientResponse},
+     * which will read the data through its stream.  It is not possible to use the synchronous JAX-RS message
+     * decoding infrastructure without buffering or spinning up auxiliary threads (arguably more expensive than buffering).
+     *
+     * @see AsyncClientHttpEngine#submit(ClientInvocation, boolean, InvocationCallback, org.jboss.resteasy.client.jaxrs.AsyncClientHttpEngine.ResultExtractor)
+     */
+    @SuppressWarnings("resource")
+    @Override
+    public <T> Future<T> submit(ClientInvocation invocation, boolean buffered, InvocationCallback<T> callback, ResultExtractor<T> extractor) {
+        final Request request = client.newRequest(invocation.getUri());
+        final CompletableFuture<T> future = new RequestFuture<T>(request);
+
+        request.method(invocation.getMethod());
+        invocation.getHeaders().asMap().forEach((h, vs) -> vs.forEach(v -> request.header(h, v)));
+
+        final DeferredContentProvider content;
+        if (invocation.getEntity() != null) {
+            content = new DeferredContentProvider();
+            request.content(content);
+        } else {
+            content = null;
+        }
+
+        request.send(new Response.Listener.Adapter() {
+            private ClientResponse cr;
+            private JettyResponseStream stream = new JettyResponseStream();
+
+            @Override
+            public void onHeaders(Response response) {
+                cr = new JettyClientResponse(invocation.getClientConfiguration(), stream, () -> future.cancel(true));
+                cr.setProperties(invocation.getMutableProperties());
+                cr.setStatus(response.getStatus());
+                cr.setHeaders(extract(response.getHeaders()));
+                if (!buffered) {
+                    if (extractor != null) {
+                        throw new IllegalStateException("TODO: ResultExtractor is synchronous and may not be used without buffering.");
+                    }
+                    complete();
+                }
+            }
+
+            @Override
+            public void onContent(Response response, ByteBuffer content) {
+                final ByteBufferPool bufs = client.getByteBufferPool();
+                final ByteBuffer copy = bufs.acquire(content.remaining(), false);
+                copy.limit(content.remaining());
+                copy.put(content);
+                copy.flip();
+                stream.offer(copy, new ReleaseCallback(bufs, copy));
+            }
+
+            @Override
+            public void onSuccess(Response response) {
+                if (buffered) {
+                    try {
+                        complete();
+                    } catch (Exception e) {
+                        onFailure(response, e);
+                    }
+                }
+            }
+
+            private void complete() {
+                // TODO: dangerous cast, see javadoc!
+                complete(extractor == null ? (T) cr : extractor.extractResult(cr));
+            }
+
+            @Override
+            public void onFailure(Response response, Throwable failure) {
+                failed(failure);
+            }
+
+            @Override
+            public void onComplete(Result result) {
+                if (content != null) {
+                    content.close();
+                }
+                try {
+                    if (extractor != null) {
+                        stream.close();
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+
+            private void complete(T result) {
+                future.complete(result);
+                callback.completed(result);
+            }
+
+            private void failed(Throwable t) {
+                final RuntimeException x = clientException(t, cr);
+                future.completeExceptionally(x);
+                callback.failed(x);
+            }
+        });
+
+        if (content != null) {
+            client.getExecutor().execute(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        invocation.writeRequestBody(new JettyContentStream(client.getByteBufferPool(), content));
+                    } catch (IOException e) {
+                        request.abort(e);
+                        future.completeExceptionally(e);
+                    } finally {
+                        content.close();
+                    }
+                }
+            });
+        }
+        return future;
+    }
+
+    @Override
+    public void close() {
+        try {
+            client.stop();
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to close JettyHttpEngine", e);
+        }
+    }
+
+    MultivaluedMap<String, String> extract(HttpFields headers) {
+        final MultivaluedMap<String, String> extracted = new MultivaluedHashMap<>();
+        headers.forEach(h -> extracted.add(h.getName(), h.getValue()));
+        return extracted;
+    }
+
+    private static RuntimeException clientException(Throwable ex, javax.ws.rs.core.Response clientResponse) {
+        RuntimeException ret;
+        if (ex == null) {
+            final NullPointerException e = new NullPointerException();
+            e.fillInStackTrace();
+            ret = new ProcessingException(e);
+        }
+        else if (ex instanceof WebApplicationException) {
+            ret = (WebApplicationException) ex;
+        }
+        else if (ex instanceof ProcessingException) {
+            ret = (ProcessingException) ex;
+        }
+        else if (clientResponse != null) {
+            ret = new ResponseProcessingException(clientResponse, ex);
+        }
+        else {
+            ret = new ProcessingException(ex);
+        }
+        ret.fillInStackTrace();
+        return ret;
+    }
+
+    static class RequestFuture<T> extends CompletableFuture<T> {
+        private final Request request;
+
+        RequestFuture(Request request) {
+            this.request = request;
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            final boolean cancelled = super.cancel(mayInterruptIfRunning);
+            if (mayInterruptIfRunning && cancelled) {
+                request.abort(new CancellationException());
+            }
+            return cancelled;
+        }
+    }
+}

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/JettyClientEngine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/JettyClientEngine.java
@@ -133,11 +133,11 @@ public class JettyClientEngine implements AsyncClientHttpEngine {
             }
 
             @Override
-            public void onContent(Response response, ByteBuffer content) {
+            public void onContent(Response response, ByteBuffer buf) {
                 final ByteBufferPool bufs = client.getByteBufferPool();
-                final ByteBuffer copy = bufs.acquire(content.remaining(), false);
-                copy.limit(content.remaining());
-                copy.put(content);
+                final ByteBuffer copy = bufs.acquire(buf.remaining(), false);
+                copy.limit(buf.remaining());
+                copy.put(buf);
                 copy.flip();
                 stream.offer(copy, new ReleaseCallback(bufs, copy));
             }
@@ -198,6 +198,7 @@ public class JettyClientEngine implements AsyncClientHttpEngine {
                     } catch (IOException e) {
                         request.abort(e);
                         future.completeExceptionally(e);
+                        callback.failed(e);
                     } finally {
                         content.close();
                     }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/JettyClientResponse.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/JettyClientResponse.java
@@ -1,0 +1,33 @@
+package org.jboss.resteasy.client.jaxrs.engines;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
+import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
+
+class JettyClientResponse extends ClientResponse {
+    private final Runnable cancel;
+    private InputStream stream;
+
+    JettyClientResponse(ClientConfiguration configuration, InputStream stream, Runnable cancel) {
+        super(configuration);
+        this.cancel = cancel;
+        this.stream = stream;
+    }
+
+    @Override
+    protected InputStream getInputStream() {
+        return stream;
+    }
+
+    @Override
+    protected void setInputStream(InputStream is) {
+        stream = is;
+    }
+
+    @Override
+    public void releaseConnection() throws IOException {
+        cancel.run();
+    }
+}

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/JettyContentStream.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/JettyContentStream.java
@@ -24,6 +24,7 @@ class JettyContentStream extends OutputStream {
 
     @Override
     public void write(int b) throws IOException {
+        checkClose();
         if (!buf.hasRemaining()) {
             flush();
         }
@@ -32,6 +33,7 @@ class JettyContentStream extends OutputStream {
 
     @Override
     public void write(byte[] b, int off, int rem) {
+        checkClose();
         while (true) {
             if (!buf.hasRemaining() || rem == 0) {
                 flush();
@@ -47,6 +49,7 @@ class JettyContentStream extends OutputStream {
 
     @Override
     public void flush() {
+        checkClose();
         buf.flip();
         if (buf.limit() == 0) {
             bufs.release(buf);
@@ -61,6 +64,12 @@ class JettyContentStream extends OutputStream {
         if (buf != null) {
             flush();
             buf = null;
+        }
+    }
+
+    private void checkClose() {
+        if (out.isClosed()) {
+            throw new IllegalStateException("closed");
         }
     }
 

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/JettyContentStream.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/JettyContentStream.java
@@ -1,0 +1,93 @@
+package org.jboss.resteasy.client.jaxrs.engines;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+import org.eclipse.jetty.client.util.DeferredContentProvider;
+import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.util.Callback;
+
+class JettyContentStream extends OutputStream {
+    private static final int BUF_SIZE = 16 * 1024;
+
+    private final ByteBufferPool bufs;
+    private final DeferredContentProvider out;
+
+    private ByteBuffer buf;
+
+    JettyContentStream(ByteBufferPool bufs, DeferredContentProvider out) {
+        this.bufs = bufs;
+        this.out = out;
+        buf = acquire();
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        if (!buf.hasRemaining()) {
+            flush();
+        }
+        buf.put((byte)b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int rem) {
+        while (true) {
+            if (!buf.hasRemaining() || rem == 0) {
+                flush();
+                return;
+            }
+            final int r = Math.min(buf.remaining(), rem);
+            buf.put(b, off, r);
+            off += r;
+            rem -= r;
+            flush();
+        }
+    }
+
+    @Override
+    public void flush() {
+        buf.flip();
+        if (buf.limit() == 0) {
+            bufs.release(buf);
+            return;
+        }
+        out.offer(buf, new ReleaseCallback(bufs, buf));
+        buf = acquire();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (buf != null) {
+            flush();
+            buf = null;
+        }
+    }
+
+    private ByteBuffer acquire() {
+        final ByteBuffer b = bufs.acquire(BUF_SIZE, false);
+        b.limit(b.capacity());
+        return b;
+    }
+}
+
+class ReleaseCallback implements Callback {
+
+    private final ByteBufferPool bufs;
+    private final ByteBuffer buf;
+
+    ReleaseCallback(ByteBufferPool bufs, ByteBuffer buf) {
+        this.bufs = bufs;
+        this.buf = buf;
+    }
+
+    @Override
+    public void succeeded() {
+        bufs.release(buf);
+    }
+
+    @Override
+    public void failed(Throwable x) {
+        bufs.release(buf);
+    }
+}

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/JettyResponseStream.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/JettyResponseStream.java
@@ -1,0 +1,80 @@
+package org.jboss.resteasy.client.jaxrs.engines;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.function.ToIntFunction;
+
+import org.eclipse.jetty.util.Callback;
+
+class JettyResponseStream extends InputStream {
+    private final Deque<Chunk> chunks = new LinkedList<>();
+    private Chunk readTop;
+    private volatile boolean closed;
+
+    void offer(ByteBuffer content, Callback callback) {
+        if (closed) {
+            callback.succeeded();
+            return;
+        }
+        chunks.add(new Chunk(content, callback));
+    }
+
+    @Override
+    public int read() throws IOException {
+        return read0(chunk -> chunk.buf.get());
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return read0(chunk -> {
+            final int r = Math.min(chunk.buf.remaining(), len);
+            chunk.buf.get(b, off, r);
+            return r;
+        });
+    }
+
+    private int read0(ToIntFunction<Chunk> reader) throws IOException {
+        if (closed) {
+            throw new IllegalStateException("closed");
+        }
+        if (readTop == null) {
+            readTop = chunks.pollFirst();
+        }
+        if (readTop == null || closed) {
+            return -1;
+        }
+
+        final int result = reader.applyAsInt(readTop);
+        if (!readTop.buf.hasRemaining()) {
+            readTop.callback.succeeded();
+            readTop = null;
+        }
+        return result;
+    }
+
+    @Override
+    public void close() throws IOException {
+        closed = true;
+        if (readTop != null) {
+            readTop.callback.succeeded();
+            readTop = null;
+        }
+        chunks.removeIf(c -> {
+            c.callback.succeeded();
+            return true;
+        });
+    }
+
+    static class Chunk {
+        final ByteBuffer buf;
+        final Callback callback;
+
+        Chunk(ByteBuffer buf, Callback callback) {
+            this.buf = buf;
+            this.callback = callback;
+        }
+    }
+}

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/JettyResponseStream.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/JettyResponseStream.java
@@ -16,8 +16,9 @@ class JettyResponseStream extends InputStream {
 
     void offer(ByteBuffer content, Callback callback) {
         if (closed) {
-            callback.succeeded();
-            return;
+            final IllegalStateException x = new IllegalStateException("closed");
+            callback.failed(x);
+            throw x;
         }
         chunks.add(new Chunk(content, callback));
     }

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -658,6 +658,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-client</artifactId>
+                <version>${version.org.eclipse.jetty}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-deploy</artifactId>
                 <version>${version.org.eclipse.jetty}</version>
             </dependency>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -48,7 +48,7 @@
         <version.org.codehaus.jackson>1.9.13</version.org.codehaus.jackson>
         <version.org.codehaus.jettison>1.3.8</version.org.codehaus.jettison>
         <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
-        <version.org.eclipse.jetty>9.4.7.v20170914</version.org.eclipse.jetty>
+        <version.org.eclipse.jetty>9.4.9.v20180320</version.org.eclipse.jetty>
         <version.org.eclipse.yasson>1.0</version.org.eclipse.yasson>
         <version.org.glassfish.javax.el>3.0.1-b08</version.org.glassfish.javax.el>
         <version.org.glassfish.javax.json>1.1</version.org.glassfish.javax.json>

--- a/testsuite/arquillian-utils/pom.xml
+++ b/testsuite/arquillian-utils/pom.xml
@@ -191,7 +191,7 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-nop</artifactId>
+            <artifactId>slf4j-simple</artifactId>
         </dependency>
     </dependencies>
 

--- a/testsuite/unit-tests/pom.xml
+++ b/testsuite/unit-tests/pom.xml
@@ -112,5 +112,21 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/JettyClientEngineTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/JettyClientEngineTest.java
@@ -1,0 +1,112 @@
+package org.jboss.resteasy.test.client;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.engines.JettyClientEngine;
+import org.junit.After;
+import org.junit.Test;
+
+public class JettyClientEngineTest {
+    Server server = new Server(0);
+    Client client;
+
+    @After
+    public void stop() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        server.stop();
+    }
+
+    private Client client() throws Exception {
+        if (!server.isStarted()) {
+            server.start();
+        }
+        if (client == null) {
+            final HttpClient hc = new HttpClient();
+            client = new ResteasyClientBuilder().httpEngine(new JettyClientEngine(hc)).build();
+        }
+        return client;
+    }
+
+    @Test
+    public void testSimple() throws Exception {
+        server.setHandler(new AbstractHandler() {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+                baseRequest.setHandled(true);
+                if (baseRequest.getHeader("User-Agent").contains("Apache")) {
+                    response.setStatus(503);
+                } else if (!"abracadabra".equals(baseRequest.getHeader("Password"))) {
+                    response.setStatus(403);
+                } else {
+                    response.setStatus(200);
+                    response.getWriter().println("Success");
+                }
+            }
+        });
+
+        final Response response = client().target(baseUri()).request()
+            .header("Password", "abracadabra")
+            .get();
+
+        assertEquals(200, response.getStatus());
+        assertEquals("Success\n", response.readEntity(String.class));
+    }
+
+    @Test
+    public void testBigly() throws Exception {
+        server.setHandler(new AbstractHandler() {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+                baseRequest.setHandled(true);
+                response.setStatus(200);
+                int read;
+                final byte[] data = new byte[1024];
+                final ServletInputStream in = request.getInputStream();
+                final ServletOutputStream out = response.getOutputStream();
+                while ((read = in.read(data)) != -1) {
+                    out.write(data, 0, read);
+                }
+            }
+        });
+
+        final StringBuilder builder = new StringBuilder();
+        final Random r = new Random();
+        for (int i = 0; i < 2 * 1024 * 1024; i++) {
+            builder.append((char) ('a' + (char) r.nextInt('z' - 'a')));
+            if (i % 100 == 0) builder.append('\n');
+        }
+        final byte[] valuableData = builder.toString().getBytes(StandardCharsets.UTF_8);
+        final Response response = client().target(baseUri()).request()
+                .post(Entity.entity(valuableData, MediaType.APPLICATION_OCTET_STREAM_TYPE));
+
+        assertEquals(200, response.getStatus());
+        assertArrayEquals(valuableData, response.readEntity(byte[].class));
+    }
+
+    public URI baseUri() {
+        return URI.create("http://localhost:" + ((ServerConnector) server.getConnectors()[0]).getLocalPort());
+    }
+}


### PR DESCRIPTION
Jetty has a mature, efficient, and very nice client that is very handy if you are already using Jetty as your server and would prefer a single stack solution over introducing AsyncHttpClient.