### PR TITLE
RESTEASY-1789

### DIFF
--- a/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/RegisterBuiltin.java
+++ b/jaxrs/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/RegisterBuiltin.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.plugins.providers;
 
+import org.jboss.resteasy.plugins.interceptors.encoding.AcceptEncodingGZIPInterceptor;
 import org.jboss.resteasy.plugins.interceptors.encoding.AcceptEncodingGZIPFilter;
 import org.jboss.resteasy.plugins.interceptors.encoding.GZIPDecodingInterceptor;
 import org.jboss.resteasy.plugins.interceptors.encoding.GZIPEncodingInterceptor;
@@ -92,6 +93,7 @@ public class RegisterBuiltin
             return Boolean.parseBoolean(value);
          }
       })) {
+         factory.registerProvider(AcceptEncodingGZIPInterceptor.class, true);
          factory.registerProvider(AcceptEncodingGZIPFilter.class, true);
          factory.registerProvider(GZIPDecodingInterceptor.class, true);
          factory.registerProvider(GZIPEncodingInterceptor.class, true);

--- a/jaxrs/resteasy-jaxrs/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
+++ b/jaxrs/resteasy-jaxrs/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
@@ -14,7 +14,6 @@ org.jboss.resteasy.plugins.providers.FileRangeWriter
 org.jboss.resteasy.plugins.providers.StreamingOutputProvider
 org.jboss.resteasy.plugins.providers.IIOImageProvider
 org.jboss.resteasy.plugins.interceptors.CacheControlFeature
-org.jboss.resteasy.plugins.interceptors.encoding.AcceptEncodingGZIPInterceptor
 org.jboss.resteasy.plugins.interceptors.encoding.ClientContentEncodingAnnotationFeature
 org.jboss.resteasy.plugins.interceptors.encoding.ServerContentEncodingAnnotationFeature
 


### PR DESCRIPTION
RESTEASY-1789: RESTeasy still request for GZIP even with resteasy.allowGzip=false when using the 2.3.x client