### PR TITLE
Resteasy 1793: SseBroadcasterImpl does not follow the javadoc requirements

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseBroadcasterImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseBroadcasterImpl.java
@@ -149,7 +149,7 @@ public class SseBroadcasterImpl implements SseBroadcaster
       //return event immediately and doesn't block anything
       return CompletableFuture.runAsync(() -> {
          outputQueue.forEach(eventSink -> {
-            SseEventOutputImpl outputImpl = (SseEventOutputImpl) eventSink;
+            SseEventSink outputImpl = eventSink;
             try
 			{
 				outputImpl.send(event).whenComplete((object, err) -> {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseBroadcasterImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseBroadcasterImpl.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -12,22 +13,29 @@ import javax.ws.rs.sse.OutboundSseEvent;
 import javax.ws.rs.sse.SseBroadcaster;
 import javax.ws.rs.sse.SseEventSink;
 
+import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
+
 public class SseBroadcasterImpl implements SseBroadcaster
 {
-   private ConcurrentLinkedQueue<SseEventSink> outputQueue = new ConcurrentLinkedQueue<SseEventSink>();
+   private ConcurrentLinkedQueue<SseEventSink> outputQueue = new ConcurrentLinkedQueue<>();
 
    private final List<BiConsumer<SseEventSink, Throwable>> onErrorConsumers = new CopyOnWriteArrayList<>();
 
    private final List<Consumer<SseEventSink>> closeConsumers = new CopyOnWriteArrayList<>();
+   
+   private final AtomicBoolean closed = new AtomicBoolean();
 
    public SseBroadcasterImpl()
    {
-
    }
 
    @Override
    public void close()
    {
+	   if (!closed.compareAndSet(false, true))
+	   {
+		   return;
+	   }
       //Javadoc says close the broadcaster and all subscribed {@link SseEventSink} instances.
       //is it necessay to close the subsribed SseEventSink ?
       outputQueue.forEach(evenSink -> {
@@ -38,29 +46,40 @@ public class SseBroadcasterImpl implements SseBroadcaster
       });
       outputQueue.clear();
    }
+   
+   private void checkClosed()
+   {
+	   if (closed.get())
+	   {
+		   throw new IllegalStateException(Messages.MESSAGES.sseBroadcasterIsClosed());
+	   }
+   }
 
    @Override
    public void onError(BiConsumer<SseEventSink, Throwable> onError)
    {
+	  checkClosed();
       onErrorConsumers.add(onError);
    }
 
    @Override
    public void onClose(Consumer<SseEventSink> onClose)
    {
+	  checkClosed();
       closeConsumers.add(onClose);
    }
 
    @Override
    public void register(SseEventSink sseEventSink)
    {
+	  checkClosed();
       outputQueue.add(sseEventSink);
-
    }
 
    @Override
    public CompletionStage<?> broadcast(OutboundSseEvent event)
    {
+	  checkClosed();
       //return event immediately and doesn't block anything
       return CompletableFuture.runAsync(() -> {
          outputQueue.forEach(eventSink -> {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
@@ -86,6 +86,16 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
 
    protected void flushResponseToClient()
    {
+		try
+		{
+			internalFlushResponseToClient(false);
+		} catch (IOException e) 
+		{
+		}
+   }
+   
+   private void internalFlushResponseToClient(boolean throwIOException) throws IOException
+   {
 	  synchronized (lock)
       {
           if (!responseFlushed)
@@ -114,6 +124,10 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
              catch (IOException e)
              {
                 close();
+                if (throwIOException)
+                {
+                	throw e;
+                }
                 throw new ProcessingException(Messages.MESSAGES.failedToCreateSseEventOutput(), e);
              }
           }
@@ -144,7 +158,7 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
 	      }
 	      try
 	      {
-	    	 flushResponseToClient();
+	    	 internalFlushResponseToClient(true);
 	         writeEvent(event);
 
 	      }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
@@ -760,4 +760,7 @@ public interface Messages
    String unableToInstantiateAsyncStreamProvider();
    @Message(id = BASE + 1092, value = "SseEventSink is closed")
    String sseEventSinkIsClosed();
+   
+   @Message(id = BASE + 1093, value = "SseBroadcaster is closed")
+   String sseBroadcasterIsClosed();
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcasterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcasterTest.java
@@ -1,0 +1,193 @@
+package org.jboss.resteasy.test.providers.sse;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.ws.rs.sse.OutboundSseEvent;
+import javax.ws.rs.sse.SseEventSink;
+
+import org.jboss.resteasy.plugins.providers.sse.OutboundSseEventImpl;
+import org.jboss.resteasy.plugins.providers.sse.SseBroadcasterImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+/***
+ * 
+ * @author Nicolas NESMON
+ *
+ */
+public class SseBroadcasterTest {
+
+	@Test
+	public void Should_ThrowIllegalStateException_When_BroadcasterIsClosed() throws Exception {
+		SseBroadcasterImpl sseBroadcasterImpl = new SseBroadcasterImpl();
+		sseBroadcasterImpl.close();
+
+		try {
+			sseBroadcasterImpl.broadcast(new OutboundSseEventImpl.BuilderImpl().data("Test").build());
+			Assert.fail("Should have thrown IllegalStateException");
+		} catch (IllegalStateException e) {
+		}
+
+		try {
+			sseBroadcasterImpl.onClose(sseEventSink -> {
+			});
+			Assert.fail("Should have thrown IllegalStateException");
+		} catch (IllegalStateException e) {
+		}
+
+		try {
+			sseBroadcasterImpl.onError((sseEventSink, error) -> {
+			});
+			Assert.fail("Should have thrown IllegalStateException");
+		} catch (IllegalStateException e) {
+		}
+
+		try {
+			sseBroadcasterImpl.register(newSseEventSink());
+			Assert.fail("Should have thrown IllegalStateException");
+		} catch (IllegalStateException e) {
+		}
+	}
+
+	@Test
+	public void Should_closeAllRegisteredEventSinkAndInvokeCloseListeners_When_BroadcasterIsBeingClosed()
+			throws Exception {
+		SseBroadcasterImpl sseBroadcasterImpl = new SseBroadcasterImpl();
+
+		SseEventSink sseEventSink1 = newSseEventSink();
+		sseBroadcasterImpl.register(sseEventSink1);
+		SseEventSink sseEventSink2 = newSseEventSink();
+		sseBroadcasterImpl.register(sseEventSink2);
+
+		CountDownLatch countDownLatch = new CountDownLatch(4);
+		sseBroadcasterImpl.onClose(sseEventSink -> {
+			countDownLatch.countDown();
+		});
+		sseBroadcasterImpl.onClose(sseEventSink -> {
+			countDownLatch.countDown();
+		});
+
+		sseBroadcasterImpl.close();
+		if (!countDownLatch.await(3, TimeUnit.SECONDS)) {
+			Assert.fail("All close listeners should have been notified");
+		}
+		Assert.assertTrue(sseEventSink1.isClosed());
+		Assert.assertTrue(sseEventSink2.isClosed());
+	}
+
+	@Test
+	public void Should_InvokeCloseAndErrorListeners_When_EventSinkHasBeenClosedOnServerSide() throws Exception {
+		SseBroadcasterImpl sseBroadcasterImpl = new SseBroadcasterImpl();
+
+		SseEventSink sseEventSink = newSseEventSink();
+		sseBroadcasterImpl.register(sseEventSink);
+		sseEventSink.close();
+		Assert.assertTrue(sseEventSink.isClosed());
+
+		CountDownLatch countDownLatch = new CountDownLatch(3);
+		sseBroadcasterImpl.onClose(ses -> {
+			countDownLatch.countDown();
+		});
+		sseBroadcasterImpl.onError((ses, error) -> {
+			countDownLatch.countDown();
+		});
+		sseBroadcasterImpl.onError((ses, error) -> {
+			countDownLatch.countDown();
+		});
+
+		sseBroadcasterImpl.broadcast(new OutboundSseEventImpl.BuilderImpl().data("Test").build());
+		if (!countDownLatch.await(3, TimeUnit.SECONDS)) {
+			Assert.fail("All close and error listeners should have been notified");
+		}
+	}
+
+	@Test
+	public void Should_InvokeCloseAndErrorListeners_When_EventSinkHasBeenClosedOnClientSide() throws Exception {
+		SseBroadcasterImpl sseBroadcasterImpl = new SseBroadcasterImpl();
+
+		SseEventSink sseEventSink = newSseEventSink(new IOException());
+		sseBroadcasterImpl.register(sseEventSink);
+		Assert.assertFalse(sseEventSink.isClosed());
+
+		CountDownLatch countDownLatch = new CountDownLatch(3);
+		sseBroadcasterImpl.onClose(ses -> {
+			countDownLatch.countDown();
+		});
+		sseBroadcasterImpl.onError((ses, error) -> {
+			countDownLatch.countDown();
+		});
+		sseBroadcasterImpl.onError((ses, error) -> {
+			countDownLatch.countDown();
+		});
+
+		sseBroadcasterImpl.broadcast(new OutboundSseEventImpl.BuilderImpl().data("Test").build());
+		if (!countDownLatch.await(3, TimeUnit.SECONDS)) {
+			Assert.fail("All close and error listeners should have been notified");
+		}
+	}
+
+	@Test
+	public void Should_InvokeErrorListeners_On_BroadcastingErrorOtherThanIOException() throws Exception {
+		SseBroadcasterImpl sseBroadcasterImpl = new SseBroadcasterImpl();
+
+		SseEventSink sseEventSink = newSseEventSink(new RuntimeException());
+		sseBroadcasterImpl.register(sseEventSink);
+		Assert.assertFalse(sseEventSink.isClosed());
+
+		CountDownLatch countDownLatch = new CountDownLatch(2);
+		sseBroadcasterImpl.onClose(ses -> {
+			Assert.fail("Close listeners should not have been notified");
+		});
+		sseBroadcasterImpl.onError((ses, error) -> {
+			countDownLatch.countDown();
+		});
+		sseBroadcasterImpl.onError((ses, error) -> {
+			countDownLatch.countDown();
+		});
+
+		sseBroadcasterImpl.broadcast(new OutboundSseEventImpl.BuilderImpl().data("Test").build());
+		if (!countDownLatch.await(5, TimeUnit.SECONDS)) {
+			Assert.fail("All error listeners should have been notified");
+		}
+	}
+
+	private SseEventSink newSseEventSink() {
+		return newSseEventSink(null);
+	}
+
+	private SseEventSink newSseEventSink(Throwable error) {
+		return new SseEventSink() {
+
+			private boolean closed;
+
+			@Override
+			public CompletionStage<?> send(OutboundSseEvent event) {
+				if(closed){
+					throw new IllegalStateException();
+				}
+				CompletableFuture<Object> completableFuture = new CompletableFuture<>();
+				if (error == null) {
+					completableFuture.complete(null);
+				} else {
+					completableFuture.completeExceptionally(error);
+				}
+				return completableFuture;
+			}
+
+			@Override
+			public boolean isClosed() {
+				return closed;
+			}
+
+			@Override
+			public void close() {
+				closed = true;
+			}
+		};
+	}
+
+}


### PR DESCRIPTION
The current SseBroadcasterImpl break following java doc requirements:

Requirement from *javax.ws.rs.sse.SseBroadcaster.close()* doc:

>     Once the SseBroadcaster is closed, subsequent calls have no effect and are ignored.
>     Once the SseBroadcaster is closed, invoking any other method on the
>     broadcaster instance would result in an IllegalStateException being thrown

Requirement from *javax.ws.rs.sse.SseBroadcaster.onClose(Consumer<SseEventSink> onClose*) doc:

>     We have to notify close listeners if the SSE event output has been
>     closed (either by client closing the connection (IOException) or
>     by calling SseEventSink.close() (IllegalStateException)
>     on the server side.

Potential resource leak due to SseEventSink not closed when SseBroadCaster.close() is invoked:

Actually most of the time when a **SseEventSink** is registered to a **SseBroadcaster**, user is expected its termination to be handled by the **SseBroadcaster** itself. So user will never call **SseEventSink.close()** on each **SseEventSink** he registered but instead he will just call **SseBroadcaster.close()**.
So **SseBroadcasterImpl** must be safe enough to ensure that calling **SseBroadcasterImpl.close()** will actually close all regsitered **SseEventSink** and to prevent any concurrent access to **SseBroadcasterImpl.register()** that will add any new **SseEventSink** which will never be closed by the **SseBroadcasterImpl**.