### PR TITLE
Remove the snapshot dependency on MP 1.1-SNAPSHOT

### DIFF
--- a/testsuite/microprofile-tck/pom.xml
+++ b/testsuite/microprofile-tck/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <version.arquillian>1.1.13.Final</version.arquillian>
-    <version.microprofile.restclient>1.1-SNAPSHOT</version.microprofile.restclient>
+    <version.microprofile.restclient>1.0</version.microprofile.restclient>
     <version.microprofile-config>1.2</version.microprofile-config>
     <version.wildfly-microprofile-config>1.2.1</version.wildfly-microprofile-config>
   </properties>


### PR DESCRIPTION
Tests run: 44, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.891 s - in TestSuite