### PR TITLE
[RESTEASY-1805] Extract interfaces from resource metadata classes

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/LocatorRegistry.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/LocatorRegistry.java
@@ -26,17 +26,18 @@ public class LocatorRegistry
    public LocatorRegistry(Class<?> clazz, ResteasyProviderFactory providerFactory)
    {
       this.providerFactory = providerFactory;
+      ResourceBuilder resourceBuilder = providerFactory.getResourceBuilder();
       if (Proxy.isProxyClass(clazz))
       {
          for (Class<?> intf : clazz.getInterfaces())
          {
-            ResourceClass resourceClass = ResourceBuilder.locatorFromAnnotations(intf);
+            ResourceClass resourceClass = resourceBuilder.locatorFromAnnotations(intf);
             register(resourceClass);
          }
       }
       else
       {
-         ResourceClass resourceClass = ResourceBuilder.locatorFromAnnotations(clazz);
+         ResourceClass resourceClass = resourceBuilder.locatorFromAnnotations(clazz);
          register(resourceClass);
       }
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodRegistry.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodRegistry.java
@@ -48,11 +48,13 @@ public class ResourceMethodRegistry implements Registry
    protected RootClassNode root = new RootClassNode();
    protected boolean widerMatching;
    protected RootNode rootNode = new RootNode();
+   protected ResourceBuilder resourceBuilder;
 
 
    public ResourceMethodRegistry(ResteasyProviderFactory providerFactory)
    {
       this.providerFactory = providerFactory;
+      this.resourceBuilder = providerFactory.getResourceBuilder();
    }
 
    public boolean isWiderMatching()
@@ -67,7 +69,7 @@ public class ResourceMethodRegistry implements Registry
 
    public void addPerRequestResource(Class clazz, String basePath)
    {
-      addResourceFactory(new POJOResourceFactory(clazz), basePath);
+      addResourceFactory(new POJOResourceFactory(resourceBuilder, clazz), basePath);
 
    }
 
@@ -78,13 +80,13 @@ public class ResourceMethodRegistry implements Registry
     */
    public void addPerRequestResource(Class clazz)
    {
-      addResourceFactory(new POJOResourceFactory(clazz));
+      addResourceFactory(new POJOResourceFactory(resourceBuilder, clazz));
    }
 
    @Override
    public void addPerRequestResource(ResourceClass clazz)
    {
-      POJOResourceFactory resourceFactory = new POJOResourceFactory(clazz);
+      POJOResourceFactory resourceFactory = new POJOResourceFactory(resourceBuilder, clazz);
       register(resourceFactory, null, clazz);
       resourceFactory.registered(providerFactory);
    }
@@ -92,19 +94,21 @@ public class ResourceMethodRegistry implements Registry
    @Override
    public void addPerRequestResource(ResourceClass clazz, String basePath)
    {
-      POJOResourceFactory resourceFactory = new POJOResourceFactory(clazz);
+      POJOResourceFactory resourceFactory = new POJOResourceFactory(resourceBuilder, clazz);
       register(resourceFactory, basePath, clazz);
       resourceFactory.registered(providerFactory);
    }
 
    public void addSingletonResource(Object singleton)
    {
-      addResourceFactory(new SingletonResource(singleton));
+      ResourceClass resourceClass = resourceBuilder.rootResourceFromAnnotations(singleton.getClass());
+      addResourceFactory(new SingletonResource(singleton, resourceClass));
    }
 
    public void addSingletonResource(Object singleton, String basePath)
    {
-      addResourceFactory(new SingletonResource(singleton), basePath);
+      ResourceClass resourceClass = resourceBuilder.rootResourceFromAnnotations(singleton.getClass());
+      addResourceFactory(new SingletonResource(singleton, resourceClass), basePath);
    }
 
    @Override
@@ -118,7 +122,7 @@ public class ResourceMethodRegistry implements Registry
    @Override
    public void addSingletonResource(Object singleton, ResourceClass resourceClass, String basePath)
    {
-      SingletonResource resourceFactory = new SingletonResource(singleton);
+      SingletonResource resourceFactory = new SingletonResource(singleton, resourceClass);
       register(resourceFactory, basePath, resourceClass);
       resourceFactory.registered(providerFactory);
    }
@@ -217,13 +221,13 @@ public class ResourceMethodRegistry implements Registry
          {
             for (Class<?> intf : clazz.getInterfaces())
             {
-               ResourceClass resourceClass = ResourceBuilder.rootResourceFromAnnotations(intf);
+               ResourceClass resourceClass = resourceBuilder.rootResourceFromAnnotations(intf);
                register(ref, base, resourceClass);
             }
          }
          else
          {
-            ResourceClass resourceClass = ResourceBuilder.rootResourceFromAnnotations(clazz);
+            ResourceClass resourceClass = resourceBuilder.rootResourceFromAnnotations(clazz);
             register(ref, base, resourceClass);
          }
       }
@@ -233,7 +237,7 @@ public class ResourceMethodRegistry implements Registry
       {
          for (Method method : getDeclaredMethods(clazz))
          {
-            Method _method = ResourceBuilder.findAnnotatedMethod(clazz, method);
+            Method _method = resourceBuilder.findAnnotatedMethod(clazz, method);
             if (_method != null && !java.lang.reflect.Modifier.isPublic(_method.getModifiers()))
             {
                LogMessages.LOGGER.JAXRSAnnotationsFoundAtNonPublicMethod(method.getDeclaringClass().getName(), method.getName());

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/POJOResourceFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/POJOResourceFactory.java
@@ -19,19 +19,22 @@ import org.jboss.resteasy.spi.metadata.ResourceConstructor;
  */
 public class POJOResourceFactory implements ResourceFactory
 {
+   private final ResourceBuilder resourceBuilder;
    private final Class<?> scannableClass;
    private final ResourceClass resourceClass;
    private ConstructorInjector constructorInjector;
    private PropertyInjector propertyInjector;
 
-   public POJOResourceFactory(Class<?> scannableClass)
+   public POJOResourceFactory(ResourceBuilder resourceBuilder, Class<?> scannableClass)
    {
+      this.resourceBuilder = resourceBuilder;
       this.scannableClass = scannableClass;
-      this.resourceClass = ResourceBuilder.rootResourceFromAnnotations(scannableClass);
+      this.resourceClass = resourceBuilder.rootResourceFromAnnotations(scannableClass);
    }
 
-   public POJOResourceFactory(ResourceClass resourceClass)
+   public POJOResourceFactory(ResourceBuilder resourceBuilder, ResourceClass resourceClass)
    {
+      this.resourceBuilder = resourceBuilder;
       this.scannableClass = resourceClass.getClazz();
       this.resourceClass = resourceClass;
    }
@@ -39,7 +42,7 @@ public class POJOResourceFactory implements ResourceFactory
    public void registered(ResteasyProviderFactory factory)
    {
       ResourceConstructor constructor = resourceClass.getConstructor();
-      if (constructor == null) constructor = ResourceBuilder.constructor(resourceClass.getClazz());
+      if (constructor == null) constructor = resourceBuilder.constructor(resourceClass.getClazz());
       if (constructor == null)
       {
          throw new RuntimeException(Messages.MESSAGES.unableToFindPublicConstructorForClass(scannableClass.getName()));

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/SingletonResource.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/SingletonResource.java
@@ -18,12 +18,6 @@ public class SingletonResource implements ResourceFactory
    private final Object obj;
    private final ResourceClass resourceClass;
 
-   public SingletonResource(Object obj)
-   {
-      this.obj = obj;
-      this.resourceClass = ResourceBuilder.rootResourceFromAnnotations(obj.getClass());
-   }
-
    public SingletonResource(Object obj, ResourceClass resourceClass)
    {
       this.obj = obj;

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -28,6 +28,7 @@ import org.jboss.resteasy.specimpl.ResponseBuilderImpl;
 import org.jboss.resteasy.specimpl.ResteasyUriBuilder;
 import org.jboss.resteasy.specimpl.VariantListBuilderImpl;
 import org.jboss.resteasy.spi.metadata.ResourceBuilder;
+import org.jboss.resteasy.spi.metadata.ResourceClassProcessor;
 import org.jboss.resteasy.util.FeatureContextDelegate;
 import org.jboss.resteasy.util.PickConstructor;
 import org.jboss.resteasy.util.ThreadLocalStack;
@@ -1875,6 +1876,10 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
             throw new RuntimeException("Failed to register provider", e);
          }
       }
+      if (isA(provider, ResourceClassProcessor.class, contracts))
+      {
+         addResourceClassProcessor(provider);
+      }
    }
 
    /**
@@ -2186,6 +2191,10 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
          } else {
             newContracts.put(ResponseExceptionMapper.class, ((ResponseExceptionMapper) provider).getPriority());
          }
+      }
+      if (isA(provider, ResourceClassProcessor.class, contracts))
+      {
+         addResourceClassProcessor((ResourceClassProcessor) provider);
       }
    }
 
@@ -2785,6 +2794,17 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
          }
       }
       return null;
+   }
+
+   protected void addResourceClassProcessor(Class<ResourceClassProcessor> processorClass)
+   {
+      ResourceClassProcessor processor = createProviderInstance(processorClass);
+      addResourceClassProcessor(processor);
+   }
+
+   protected void addResourceClassProcessor(ResourceClassProcessor processor)
+   {
+      resourceBuilder.registerResourceClassProcessor(processor);
    }
 
    public ResourceBuilder getResourceBuilder() {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -27,6 +27,7 @@ import org.jboss.resteasy.specimpl.LinkBuilderImpl;
 import org.jboss.resteasy.specimpl.ResponseBuilderImpl;
 import org.jboss.resteasy.specimpl.ResteasyUriBuilder;
 import org.jboss.resteasy.specimpl.VariantListBuilderImpl;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.util.FeatureContextDelegate;
 import org.jboss.resteasy.util.PickConstructor;
 import org.jboss.resteasy.util.ThreadLocalStack;
@@ -248,6 +249,8 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
    protected Set<Class<?>> featureClasses;
    protected Set<Object> featureInstances;
 
+   protected ResourceBuilder resourceBuilder;
+
 
    public ResteasyProviderFactory()
    {
@@ -322,6 +325,8 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
       stringParameterUnmarshallers = new ConcurrentHashMap<Class<?>, Class<? extends StringParameterUnmarshaller>>();
 
       headerDelegates = new ConcurrentHashMap<Class<?>, HeaderDelegate>();
+
+      resourceBuilder = new ResourceBuilder();
 
       initializeRegistriesAndFilters();
 
@@ -2780,5 +2785,9 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
          }
       }
       return null;
+   }
+
+   public ResourceBuilder getResourceBuilder() {
+      return resourceBuilder;
    }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceClass.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceClass.java
@@ -1,0 +1,69 @@
+package org.jboss.resteasy.spi.metadata;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class DefaultResourceClass implements ResourceClass
+{
+   private static final FieldParameter[] EMPTY_FIELD_PARAMS = {};
+   private static final SetterParameter[] EMPTY_SETTER_PARAMETERS = {};
+   private static final ResourceMethod[] EMPTY_RESOURCE_METHODS = {};
+   private static final ResourceLocator[] EMPTY_RESOURCE_LOCATORS = {};
+
+   protected Class<?> clazz;
+   protected FieldParameter[] fields = EMPTY_FIELD_PARAMS;
+   protected SetterParameter[] setters = EMPTY_SETTER_PARAMETERS;
+   protected ResourceMethod[] resourceMethods = EMPTY_RESOURCE_METHODS;
+   protected ResourceLocator[] resourceLocators = EMPTY_RESOURCE_LOCATORS;
+   protected ResourceConstructor constructor; // only one allowed
+   protected String path;
+
+   public DefaultResourceClass(Class<?> clazz, String path)
+   {
+      this.clazz = clazz;
+      this.path = path;
+   }
+
+   @Override
+   public String getPath()
+   {
+      return path;
+   }
+
+   @Override
+   public Class<?> getClazz()
+   {
+      return clazz;
+   }
+
+   @Override
+   public ResourceConstructor getConstructor()
+   {
+      return constructor;
+   }
+
+   @Override
+   public FieldParameter[] getFields()
+   {
+      return fields;
+   }
+
+   @Override
+   public SetterParameter[] getSetters()
+   {
+      return setters;
+   }
+
+   @Override
+   public ResourceMethod[] getResourceMethods()
+   {
+      return resourceMethods;
+   }
+
+   @Override
+   public ResourceLocator[] getResourceLocators()
+   {
+      return resourceLocators;
+   }
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceConstructor.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceConstructor.java
@@ -1,0 +1,46 @@
+package org.jboss.resteasy.spi.metadata;
+
+import java.lang.reflect.Constructor;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class DefaultResourceConstructor implements ResourceConstructor
+{
+   protected ResourceClass resourceClass;
+   protected Constructor constructor;
+   protected ConstructorParameter[] params = {};
+
+   public DefaultResourceConstructor(ResourceClass resourceClass, Constructor constructor)
+   {
+      this.resourceClass = resourceClass;
+      this.constructor = constructor;
+      if (constructor.getParameterTypes() != null)
+      {
+         this.params = new ConstructorParameter[constructor.getParameterTypes().length];
+         for (int i = 0; i < constructor.getParameterTypes().length; i++)
+         {
+            this.params[i] = new ConstructorParameter(this, constructor.getParameterTypes()[i], constructor.getGenericParameterTypes()[i], constructor.getParameterAnnotations()[i]);
+         }
+      }
+   }
+
+   @Override
+   public ResourceClass getResourceClass()
+   {
+      return resourceClass;
+   }
+
+   @Override
+   public Constructor getConstructor()
+   {
+      return constructor;
+   }
+
+   @Override
+   public ConstructorParameter[] getParams()
+   {
+      return params;
+   }
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceLocator.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceLocator.java
@@ -1,0 +1,91 @@
+package org.jboss.resteasy.spi.metadata;
+
+import org.jboss.resteasy.util.Types;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class DefaultResourceLocator implements ResourceLocator
+{
+   protected ResourceClass resourceClass;
+   protected Class<?> returnType;
+   protected Type genericReturnType;
+   protected Method method;
+   protected Method annotatedMethod;
+   protected MethodParameter[] params = {};
+   protected String fullpath;
+   protected String path;
+
+   public DefaultResourceLocator(ResourceClass resourceClass, Method method, Method annotatedMethod)
+   {
+      this.resourceClass = resourceClass;
+      this.annotatedMethod = annotatedMethod;
+      this.method = method;
+      // we initialize generic types based on the method of the resource class rather than the Method that is actually
+      // annotated.  This is so we have the appropriate generic type information.
+      this.genericReturnType = Types.resolveTypeVariables(resourceClass.getClazz(), method.getGenericReturnType());
+      this.returnType = Types.getRawType(genericReturnType);
+      this.params = new MethodParameter[method.getParameterTypes().length];
+      for (int i = 0; i < method.getParameterTypes().length; i++)
+      {
+         this.params[i] = new MethodParameter(this, method.getParameterTypes()[i], method.getGenericParameterTypes()[i], annotatedMethod.getParameterAnnotations()[i]);
+      }
+   }
+
+   @Override
+   public ResourceClass getResourceClass()
+   {
+      return resourceClass;
+   }
+
+   @Override
+   public Class<?> getReturnType()
+   {
+      return returnType;
+   }
+
+   @Override
+   public Type getGenericReturnType()
+   {
+      return genericReturnType;
+   }
+
+   @Override
+   public Method getMethod()
+   {
+      return method;
+   }
+
+   @Override
+   public Method getAnnotatedMethod()
+   {
+      return annotatedMethod;
+   }
+
+   @Override
+   public MethodParameter[] getParams()
+   {
+      return params;
+   }
+
+   @Override
+   public String getFullpath()
+   {
+      return fullpath;
+   }
+
+   @Override
+   public String getPath()
+   {
+      return path;
+   }
+
+   @Override
+   public String toString() {
+      return method.toString();
+   }
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceMethod.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceMethod.java
@@ -1,0 +1,55 @@
+package org.jboss.resteasy.spi.metadata;
+
+import javax.ws.rs.core.MediaType;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class DefaultResourceMethod extends DefaultResourceLocator implements ResourceMethod
+{
+   private static final MediaType[] empty = {};
+   protected Set<String> httpMethods = new HashSet<String>();
+   protected MediaType[] produces = empty;
+   protected MediaType[] consumes = empty;
+   protected boolean asynchronous;
+
+   public DefaultResourceMethod(ResourceClass declaredClass, Method method, Method annotatedMethod)
+   {
+      super(declaredClass, method, annotatedMethod);
+   }
+
+   @Override
+   public Set<String> getHttpMethods()
+   {
+      return httpMethods;
+   }
+
+   @Override
+   public MediaType[] getProduces()
+   {
+      return produces;
+   }
+
+   @Override
+   public MediaType[] getConsumes()
+   {
+      return consumes;
+   }
+
+   @Override
+   public boolean isAsynchronous()
+   {
+      return asynchronous;
+   }
+
+   @Override
+   public void markAsynchronous()
+   {
+      asynchronous = true;
+   }
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/MethodParameter.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/MethodParameter.java
@@ -23,7 +23,7 @@ public class MethodParameter extends Parameter
    @Override
    public AccessibleObject getAccessibleObject()
    {
-      return locator.method;
+      return locator.getMethod();
    }
 
    public Annotation[] getAnnotations()

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
@@ -454,7 +454,7 @@ public class ResourceBuilder
    public static class ResourceLocatorBuilder<T extends ResourceLocatorBuilder<T>>
    {
 
-      ResourceLocator locator;
+      DefaultResourceLocator locator;
       ResourceClassBuilder resourceClassBuilder;
 
       ResourceLocatorBuilder()
@@ -464,7 +464,7 @@ public class ResourceBuilder
       public ResourceLocatorBuilder(ResourceClassBuilder resourceClassBuilder, Method method, Method annotatedMethod)
       {
          this.resourceClassBuilder = resourceClassBuilder;
-         this.locator = new ResourceLocator(resourceClassBuilder.resourceClass, method, annotatedMethod);
+         this.locator = new DefaultResourceLocator(resourceClassBuilder.resourceClass, method, annotatedMethod);
       }
 
       public T returnType(Class<?> type)

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
@@ -58,7 +58,7 @@ public class ResourceBuilder
 {
    public static class ResourceClassBuilder
    {
-      final ResourceClass resourceClass;
+      final DefaultResourceClass resourceClass;
       List<FieldParameter> fields = new ArrayList<FieldParameter>();
       List<SetterParameter> setters = new ArrayList<SetterParameter>();
       List<ResourceMethod> resourceMethods = new ArrayList<ResourceMethod>();
@@ -66,7 +66,7 @@ public class ResourceBuilder
 
       public ResourceClassBuilder(Class<?> root, String path)
       {
-         this.resourceClass = new ResourceClass(root, path);
+         this.resourceClass = new DefaultResourceClass(root, path);
       }
 
       public ResourceMethodBuilder method(Method method)
@@ -494,7 +494,7 @@ public class ResourceBuilder
       public ResourceClassBuilder buildMethod()
       {
          ResteasyUriBuilder builder = new ResteasyUriBuilder();
-         if (locator.resourceClass.path != null) builder.path(locator.resourceClass.path);
+         if (locator.resourceClass.getPath() != null) builder.path(locator.resourceClass.getPath());
          if (locator.path != null) builder.path(locator.path);
          String pathExpression = builder.getPath();
          if (pathExpression == null)
@@ -629,7 +629,7 @@ public class ResourceBuilder
       public ResourceClassBuilder buildMethod()
       {
          ResteasyUriBuilder builder = new ResteasyUriBuilder();
-         if (method.resourceClass.path != null) builder.path(method.resourceClass.path);
+         if (method.resourceClass.getPath() != null) builder.path(method.resourceClass.getPath());
          if (method.path != null) builder.path(method.path);
          String pathExpression = builder.getPath();
          if (pathExpression == null)

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
@@ -683,17 +683,17 @@ public class ResourceBuilder
    }
 
 
-   public static ResourceClassBuilder rootResource(Class<?> root)
+   public ResourceClassBuilder rootResource(Class<?> root)
    {
       return new ResourceClassBuilder(root, "/");
    }
 
-   public static ResourceClassBuilder rootResource(Class<?> root, String path)
+   protected ResourceClassBuilder rootResource(Class<?> root, String path)
    {
       return new ResourceClassBuilder(root, path);
    }
 
-   public static ResourceClassBuilder locator(Class<?> root)
+   protected ResourceClassBuilder locator(Class<?> root)
    {
       return new ResourceClassBuilder(root, null);
    }
@@ -705,7 +705,7 @@ public class ResourceBuilder
     * @param annotatedResourceClass
     * @return
     */
-   public static ResourceConstructor constructor(Class<?> annotatedResourceClass)
+   public ResourceConstructor constructor(Class<?> annotatedResourceClass)
    {
       Constructor constructor = PickConstructor.pickPerRequestConstructor(annotatedResourceClass);
       if (constructor == null)
@@ -725,17 +725,17 @@ public class ResourceBuilder
     *
     * @return
     */
-   public static ResourceClass rootResourceFromAnnotations(Class<?> clazz)
+   public ResourceClass rootResourceFromAnnotations(Class<?> clazz)
    {
       return fromAnnotations(false, clazz);
    }
 
-   public static ResourceClass locatorFromAnnotations(Class<?> clazz)
+   public ResourceClass locatorFromAnnotations(Class<?> clazz)
    {
       return fromAnnotations(true, clazz);
    }
 
-   private static ResourceClass fromAnnotations(boolean isLocator, Class<?> clazz)
+   private ResourceClass fromAnnotations(boolean isLocator, Class<?> clazz)
    {
       // stupid hack for Weld as it loses generic type information, but retains annotations.
       if (!clazz.isInterface() && clazz.getSuperclass() != null && !clazz.getSuperclass().equals(Object.class) && clazz.isSynthetic())
@@ -773,7 +773,7 @@ public class ResourceBuilder
     * @param implementation The resource method or sub-resource method / sub-resource locator implementation
     * @return The annotated resource method or sub-resource method / sub-resource locator.
     */
-   public static Method findAnnotatedMethod(final Class<?> root, final Method implementation)
+   public Method findAnnotatedMethod(final Class<?> root, final Method implementation)
    {
       if (implementation.isSynthetic())
       {
@@ -868,7 +868,7 @@ public class ResourceBuilder
       return null;
    }
 
-   protected static void processFields(ResourceClassBuilder resourceClassBuilder, Class<?> root)
+   protected void processFields(ResourceClassBuilder resourceClassBuilder, Class<?> root)
    {
       do
       {
@@ -878,7 +878,7 @@ public class ResourceBuilder
       } while (root != null && !root.equals(Object.class));
    }
 
-   protected static void processSetters(ResourceClassBuilder resourceClassBuilder, Class<?> root)
+   protected void processSetters(ResourceClassBuilder resourceClassBuilder, Class<?> root)
    {
       HashSet<Long> hashes = new HashSet<Long>();
       do
@@ -888,7 +888,7 @@ public class ResourceBuilder
       } while (root != null && !root.equals(Object.class));
    }
 
-   protected static void processDeclaredFields(ResourceClassBuilder resourceClassBuilder, final Class<?> root)
+   protected void processDeclaredFields(ResourceClassBuilder resourceClassBuilder, final Class<?> root)
    {
       Field[] fieldList = new Field[0];
       try {
@@ -914,7 +914,7 @@ public class ResourceBuilder
          builder.buildField();
       }
    }
-   protected static void processDeclaredSetters(ResourceClassBuilder resourceClassBuilder, final Class<?> root, Set<Long> visitedHashes)
+   protected void processDeclaredSetters(ResourceClassBuilder resourceClassBuilder, final Class<?> root, Set<Long> visitedHashes)
    {
       Method[] methodList = new Method[0];
       try {
@@ -954,7 +954,7 @@ public class ResourceBuilder
       }
    }
 
-   protected static void processMethod(boolean isLocator, ResourceClassBuilder resourceClassBuilder, Class<?> root, Method implementation)
+   protected void processMethod(boolean isLocator, ResourceClassBuilder resourceClassBuilder, Class<?> root, Method implementation)
    {
       Method method = findAnnotatedMethod(root, implementation);
       if (method != null)

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
@@ -437,7 +437,7 @@ public class ResourceBuilder
       public ResourceConstructorBuilder(ResourceClassBuilder resourceClassBuilder, Constructor constructor)
       {
          this.resourceClassBuilder = resourceClassBuilder;
-         this.constructor = new ResourceConstructor(resourceClassBuilder.resourceClass, constructor);
+         this.constructor = new DefaultResourceConstructor(resourceClassBuilder.resourceClass, constructor);
       }
       public ConstructorParameterBuilder param(int i)
       {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
@@ -517,11 +517,11 @@ public class ResourceBuilder
 
    public static class ResourceMethodBuilder extends ResourceLocatorBuilder<ResourceMethodBuilder>
    {
-      ResourceMethod method;
+      DefaultResourceMethod method;
 
       ResourceMethodBuilder(ResourceClassBuilder resourceClassBuilder, Method method, Method annotatedMethod)
       {
-         this.method = new ResourceMethod(resourceClassBuilder.resourceClass, method, annotatedMethod);
+         this.method = new DefaultResourceMethod(resourceClassBuilder.resourceClass, method, annotatedMethod);
          this.locator = this.method;
          this.resourceClassBuilder = resourceClassBuilder;
       }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceClass.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceClass.java
@@ -1,62 +1,21 @@
 package org.jboss.resteasy.spi.metadata;
 
 /**
- * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
- * @version $Revision: 1 $
+ * @author Christian Kaltepoth
  */
-public class ResourceClass
+public interface ResourceClass
 {
-   private static final FieldParameter[] EMPTY_FIELD_PARAMS = {};
-   private static final SetterParameter[] EMPTY_SETTER_PARAMETERS = {};
-   private static final ResourceMethod[] EMPTY_RESOURCE_METHODS = {};
-   private static final ResourceLocator[] EMPTY_RESOURCE_LOCATORS = {};
+  String getPath();
 
-   protected Class<?> clazz;
-   protected FieldParameter[] fields = EMPTY_FIELD_PARAMS;
-   protected SetterParameter[] setters = EMPTY_SETTER_PARAMETERS;
-   protected ResourceMethod[] resourceMethods = EMPTY_RESOURCE_METHODS;
-   protected ResourceLocator[] resourceLocators = EMPTY_RESOURCE_LOCATORS;
-   protected ResourceConstructor constructor; // only one allowed
-   protected String path;
+  Class<?> getClazz();
 
-   public ResourceClass(Class<?> clazz, String path)
-   {
-      this.clazz = clazz;
-      this.path = path;
-   }
+  ResourceConstructor getConstructor();
 
-   public String getPath()
-   {
-      return path;
-   }
+  FieldParameter[] getFields();
 
-   public Class<?> getClazz()
-   {
-      return clazz;
-   }
+  SetterParameter[] getSetters();
 
-   public ResourceConstructor getConstructor()
-   {
-      return constructor;
-   }
+  ResourceMethod[] getResourceMethods();
 
-   public FieldParameter[] getFields()
-   {
-      return fields;
-   }
-
-   public SetterParameter[] getSetters()
-   {
-      return setters;
-   }
-
-   public ResourceMethod[] getResourceMethods()
-   {
-      return resourceMethods;
-   }
-
-   public ResourceLocator[] getResourceLocators()
-   {
-      return resourceLocators;
-   }
+  ResourceLocator[] getResourceLocators();
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceClassProcessor.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceClassProcessor.java
@@ -1,0 +1,21 @@
+package org.jboss.resteasy.spi.metadata;
+
+/**
+ * SPI which allows implementations to modify the resource metadata discovered by RESTEasy.
+ *
+ * @author Christian Kaltepoth
+ */
+public interface ResourceClassProcessor
+{
+
+  /**
+   * Allows the implementation of this method to modify the resource metadata represented by
+   * the supplied {@link ResourceClass} instance. Implementation will typically create
+   * wrappers which modify only certain aspects of the metadata.
+   *
+   * @param clazz The original metadata
+   * @return the (potentially modified) metadata (never null)
+   */
+  ResourceClass process(ResourceClass clazz);
+
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceConstructor.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceConstructor.java
@@ -1,48 +1,15 @@
 package org.jboss.resteasy.spi.metadata;
 
-import org.jboss.resteasy.util.Types;
-
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
 
 /**
- * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
- * @version $Revision: 1 $
+ * @author Christian Kaltepoth
  */
-public class ResourceConstructor
+public interface ResourceConstructor
 {
-   protected ResourceClass resourceClass;
-   protected Constructor constructor;
-   protected ConstructorParameter[] params = {};
+  ResourceClass getResourceClass();
 
-   public ResourceConstructor(ResourceClass resourceClass, Constructor constructor)
-   {
-      this.resourceClass = resourceClass;
-      this.constructor = constructor;
-      if (constructor.getParameterTypes() != null)
-      {
-         this.params = new ConstructorParameter[constructor.getParameterTypes().length];
-         for (int i = 0; i < constructor.getParameterTypes().length; i++)
-         {
-            this.params[i] = new ConstructorParameter(this, constructor.getParameterTypes()[i], constructor.getGenericParameterTypes()[i], constructor.getParameterAnnotations()[i]);
-         }
-      }
-   }
+  Constructor getConstructor();
 
-   public ResourceClass getResourceClass()
-   {
-      return resourceClass;
-   }
-
-   public Constructor getConstructor()
-   {
-      return constructor;
-   }
-
-   public ConstructorParameter[] getParams()
-   {
-      return params;
-   }
+  ConstructorParameter[] getParams();
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceLocator.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceLocator.java
@@ -1,83 +1,27 @@
 package org.jboss.resteasy.spi.metadata;
 
-import org.jboss.resteasy.util.Types;
-
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
 /**
- * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
- * @version $Revision: 1 $
+ * @author Christian Kaltepoth
  */
-public class ResourceLocator
+public interface ResourceLocator
 {
-   protected ResourceClass resourceClass;
-   protected Class<?> returnType;
-   protected Type genericReturnType;
-   protected Method method;
-   protected Method annotatedMethod;
-   protected MethodParameter[] params = {};
-   protected String fullpath;
-   protected String path;
+  ResourceClass getResourceClass();
 
-   public ResourceLocator(ResourceClass resourceClass, Method method, Method annotatedMethod)
-   {
-      this.resourceClass = resourceClass;
-      this.annotatedMethod = annotatedMethod;
-      this.method = method;
-      // we initialize generic types based on the method of the resource class rather than the Method that is actually
-      // annotated.  This is so we have the appropriate generic type information.
-      this.genericReturnType = Types.resolveTypeVariables(resourceClass.getClazz(), method.getGenericReturnType());
-      this.returnType = Types.getRawType(genericReturnType);
-      this.params = new MethodParameter[method.getParameterTypes().length];
-      for (int i = 0; i < method.getParameterTypes().length; i++)
-      {
-         this.params[i] = new MethodParameter(this, method.getParameterTypes()[i], method.getGenericParameterTypes()[i], annotatedMethod.getParameterAnnotations()[i]);
-      }
-   }
+  Class<?> getReturnType();
 
-   public ResourceClass getResourceClass()
-   {
-      return resourceClass;
-   }
+  Type getGenericReturnType();
 
-   public Class<?> getReturnType()
-   {
-      return returnType;
-   }
+  Method getMethod();
 
-   public Type getGenericReturnType()
-   {
-      return genericReturnType;
-   }
+  Method getAnnotatedMethod();
 
-   public Method getMethod()
-   {
-      return method;
-   }
+  MethodParameter[] getParams();
 
-   public Method getAnnotatedMethod()
-   {
-      return annotatedMethod;
-   }
+  String getFullpath();
 
-   public MethodParameter[] getParams()
-   {
-      return params;
-   }
+  String getPath();
 
-   public String getFullpath()
-   {
-      return fullpath;
-   }
-
-   public String getPath()
-   {
-      return path;
-   }
-
-   @Override
-   public String toString() {
-      return method.toString();
-   }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceMethod.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceMethod.java
@@ -1,9 +1,8 @@
 package org.jboss.resteasy.spi.metadata;
 
 import javax.ws.rs.core.MediaType;
-import java.lang.annotation.Annotation;
+
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -11,7 +10,7 @@ import java.util.Set;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class ResourceMethod extends ResourceLocator
+public class ResourceMethod extends DefaultResourceLocator
 {
    private static final MediaType[] empty = {};
    protected Set<String> httpMethods = new HashSet<String>();

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceMethod.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceMethod.java
@@ -1,50 +1,21 @@
 package org.jboss.resteasy.spi.metadata;
 
-import javax.ws.rs.core.MediaType;
-
-import java.lang.reflect.Method;
-import java.util.HashSet;
 import java.util.Set;
 
+import javax.ws.rs.core.MediaType;
+
 /**
- * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
- * @version $Revision: 1 $
+ * @author Christian Kaltepoth
  */
-public class ResourceMethod extends DefaultResourceLocator
+public interface ResourceMethod extends ResourceLocator
 {
-   private static final MediaType[] empty = {};
-   protected Set<String> httpMethods = new HashSet<String>();
-   protected MediaType[] produces = empty;
-   protected MediaType[] consumes = empty;
-   protected boolean asynchronous;
+  Set<String> getHttpMethods();
 
-   public ResourceMethod(ResourceClass declaredClass, Method method, Method annotatedMethod)
-   {
-      super(declaredClass, method, annotatedMethod);
-   }
+  MediaType[] getProduces();
 
-   public Set<String> getHttpMethods()
-   {
-      return httpMethods;
-   }
+  MediaType[] getConsumes();
 
-   public MediaType[] getProduces()
-   {
-      return produces;
-   }
+  boolean isAsynchronous();
 
-   public MediaType[] getConsumes()
-   {
-      return consumes;
-   }
-
-   public boolean isAsynchronous()
-   {
-      return asynchronous;
-   }
-
-   public void markAsynchronous()
-   {
-      asynchronous = true;
-   }
+  void markAsynchronous();
 }

--- a/resteasy-jsapi/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesAbstract.java
+++ b/resteasy-jsapi/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesAbstract.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Method;
 import java.util.Locale;
 
 import org.jboss.resteasy.spi.metadata.DefaultResourceClass;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.junit.Assert;
 
 import org.jboss.resteasy.core.InjectorFactoryImpl;
@@ -39,7 +40,8 @@ abstract public class TestMessagesAbstract extends TestMessagesParent
          ResourceMethod resourceMethod = new DefaultResourceMethod(resourceClass, method, method);
          ResteasyProviderFactory providerFactory = new ResteasyProviderFactory();
          InjectorFactory injectorFactory = new InjectorFactoryImpl();
-         POJOResourceFactory resourceFactory = new POJOResourceFactory(clazz);
+         ResourceBuilder resourceBuilder = new ResourceBuilder();
+         POJOResourceFactory resourceFactory = new POJOResourceFactory(resourceBuilder, clazz);
          testMethod = new ResourceMethodInvoker(resourceMethod, injectorFactory, resourceFactory, providerFactory);
       }
       catch (NoSuchMethodException e)

--- a/resteasy-jsapi/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesAbstract.java
+++ b/resteasy-jsapi/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesAbstract.java
@@ -11,6 +11,7 @@ import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
 import org.jboss.resteasy.jsapi.i18n.Messages;
 import org.jboss.resteasy.spi.InjectorFactory;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.metadata.DefaultResourceMethod;
 import org.jboss.resteasy.spi.metadata.ResourceClass;
 import org.jboss.resteasy.spi.metadata.ResourceMethod;
 import org.junit.Test;
@@ -34,7 +35,7 @@ abstract public class TestMessagesAbstract extends TestMessagesParent
          Class<?> clazz = TestMessagesAbstract.class;
          Method method = TestMessagesAbstract.class.getMethod("testLocale");
          ResourceClass resourceClass = new ResourceClass(TestMessagesAbstract.class, "path");
-         ResourceMethod resourceMethod = new ResourceMethod(resourceClass, method, method);
+         ResourceMethod resourceMethod = new DefaultResourceMethod(resourceClass, method, method);
          ResteasyProviderFactory providerFactory = new ResteasyProviderFactory();
          InjectorFactory injectorFactory = new InjectorFactoryImpl();
          POJOResourceFactory resourceFactory = new POJOResourceFactory(clazz);

--- a/resteasy-jsapi/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesAbstract.java
+++ b/resteasy-jsapi/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesAbstract.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.i18n;
 import java.lang.reflect.Method;
 import java.util.Locale;
 
+import org.jboss.resteasy.spi.metadata.DefaultResourceClass;
 import org.junit.Assert;
 
 import org.jboss.resteasy.core.InjectorFactoryImpl;
@@ -34,7 +35,7 @@ abstract public class TestMessagesAbstract extends TestMessagesParent
       {
          Class<?> clazz = TestMessagesAbstract.class;
          Method method = TestMessagesAbstract.class.getMethod("testLocale");
-         ResourceClass resourceClass = new ResourceClass(TestMessagesAbstract.class, "path");
+         ResourceClass resourceClass = new DefaultResourceClass(TestMessagesAbstract.class, "path");
          ResourceMethod resourceMethod = new DefaultResourceMethod(resourceClass, method, method);
          ResteasyProviderFactory providerFactory = new ResteasyProviderFactory();
          InjectorFactory injectorFactory = new InjectorFactoryImpl();

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestFacadeLinks.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestFacadeLinks.java
@@ -16,6 +16,7 @@ import org.jboss.resteasy.links.RESTServiceDiscovery;
 import org.jboss.resteasy.links.RESTServiceDiscovery.AtomLink;
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -67,7 +68,8 @@ public class TestFacadeLinks
 	
 	@Before
 	public void before(){
-		POJOResourceFactory noDefaults = new POJOResourceFactory(resourceType);
+		ResourceBuilder resourceBuilder = new ResourceBuilder();
+		POJOResourceFactory noDefaults = new POJOResourceFactory(resourceBuilder, resourceType);
 		dispatcher.getRegistry().addResourceFactory(noDefaults);
 		httpClient = HttpClientBuilder.create().build();
 		ApacheHttpClient4Engine engine = new ApacheHttpClient4Engine(httpClient);

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestLinkIds.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestLinkIds.java
@@ -14,6 +14,7 @@ import org.jboss.resteasy.links.RESTServiceDiscovery;
 import org.jboss.resteasy.links.RESTServiceDiscovery.AtomLink;
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -35,7 +36,8 @@ public class TestLinkIds
       server.setRootResourcePath("/");
       server.start();
       dispatcher = server.getDeployment().getDispatcher();
-      POJOResourceFactory noDefaults = new POJOResourceFactory(IDServiceTestBean.class);
+		ResourceBuilder resourceBuilder = new ResourceBuilder();
+		POJOResourceFactory noDefaults = new POJOResourceFactory(resourceBuilder, IDServiceTestBean.class);
       dispatcher.getRegistry().addResourceFactory(noDefaults);
       httpClient = HttpClientBuilder.create().build();
       ApacheHttpClient4Engine engine = new ApacheHttpClient4Engine(httpClient);

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestLinks.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestLinks.java
@@ -16,6 +16,7 @@ import org.jboss.resteasy.links.RESTServiceDiscovery;
 import org.jboss.resteasy.links.RESTServiceDiscovery.AtomLink;
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -67,7 +68,8 @@ public class TestLinks
 	
 	@Before
 	public void before(){
-		POJOResourceFactory noDefaults = new POJOResourceFactory(resourceType);
+		ResourceBuilder resourceBuilder = new ResourceBuilder();
+		POJOResourceFactory noDefaults = new POJOResourceFactory(resourceBuilder, resourceType);
 		dispatcher.getRegistry().addResourceFactory(noDefaults);
 		httpClient = HttpClientBuilder.create().build();
 		ApacheHttpClient4Engine engine = new ApacheHttpClient4Engine(httpClient);

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestSecureLinks.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestSecureLinks.java
@@ -29,6 +29,7 @@ import org.jboss.resteasy.plugins.server.embedded.SecurityDomain;
 import org.jboss.resteasy.plugins.server.embedded.SimplePrincipal;
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -95,7 +96,8 @@ public class TestSecureLinks
 
 	@Before
 	public void before(){
-		POJOResourceFactory noDefaults = new POJOResourceFactory(resourceType);
+		ResourceBuilder resourceBuilder = new ResourceBuilder();
+		POJOResourceFactory noDefaults = new POJOResourceFactory(resourceBuilder, resourceType);
 		dispatcher.getRegistry().addResourceFactory(noDefaults);
 		url = generateBaseUrl();
 		

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/el/TestLinksInvalidEL.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/el/TestLinksInvalidEL.java
@@ -17,6 +17,7 @@ import org.jboss.resteasy.core.Dispatcher;
 import org.jboss.resteasy.links.test.BookStoreService;
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -71,7 +72,8 @@ public class TestLinksInvalidEL
 	
 	@Before
 	public void before(){
-		POJOResourceFactory noDefaults = new POJOResourceFactory(resourceType);
+		ResourceBuilder resourceBuilder = new ResourceBuilder();
+		POJOResourceFactory noDefaults = new POJOResourceFactory(resourceBuilder, resourceType);
 		dispatcher.getRegistry().addResourceFactory(noDefaults);
 		httpClient = HttpClientBuilder.create().build();
 		ApacheHttpClient43Engine engine = new ApacheHttpClient43Engine(httpClient);

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/el/TestLinksNoPackage.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/el/TestLinksNoPackage.java
@@ -18,6 +18,7 @@ import org.jboss.resteasy.links.test.Book;
 import org.jboss.resteasy.links.test.BookStoreService;
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -72,7 +73,8 @@ public class TestLinksNoPackage
 	
 	@Before
 	public void before(){
-		POJOResourceFactory noDefaults = new POJOResourceFactory(resourceType);
+		ResourceBuilder resourceBuilder = new ResourceBuilder();
+		POJOResourceFactory noDefaults = new POJOResourceFactory(resourceBuilder, resourceType);
 		dispatcher.getRegistry().addResourceFactory(noDefaults);
 		httpClient = HttpClientBuilder.create().build();
 		ApacheHttpClient4Engine engine = new ApacheHttpClient4Engine(httpClient);

--- a/resteasy-rxjava/src/test/java/org/jboss/resteasy/rxjava/RxTest.java
+++ b/resteasy-rxjava/src/test/java/org/jboss/resteasy/rxjava/RxTest.java
@@ -10,6 +10,7 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.core.Dispatcher;
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -31,7 +32,8 @@ public class RxTest
       server.setRootResourcePath("/");
       server.start();
       dispatcher = server.getDeployment().getDispatcher();
-      POJOResourceFactory noDefaults = new POJOResourceFactory(RxResource.class);
+      ResourceBuilder resourceBuilder = new ResourceBuilder();
+      POJOResourceFactory noDefaults = new POJOResourceFactory(resourceBuilder, RxResource.class);
       dispatcher.getRegistry().addResourceFactory(noDefaults);
    }
 

--- a/resteasy-rxjava2/src/test/java/org/jboss/resteasy/rxjava2/RxTest.java
+++ b/resteasy-rxjava2/src/test/java/org/jboss/resteasy/rxjava2/RxTest.java
@@ -10,6 +10,7 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.core.Dispatcher;
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -31,7 +32,8 @@ public class RxTest
       server.setRootResourcePath("/");
       server.start();
       dispatcher = server.getDeployment().getDispatcher();
-      POJOResourceFactory noDefaults = new POJOResourceFactory(RxResource.class);
+      ResourceBuilder resourceBuilder = new ResourceBuilder();
+      POJOResourceFactory noDefaults = new POJOResourceFactory(resourceBuilder, RxResource.class);
       dispatcher.getRegistry().addResourceFactory(noDefaults);
    }
 

--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxRegistry.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxRegistry.java
@@ -5,6 +5,7 @@ import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.Registry;
 import org.jboss.resteasy.spi.ResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.spi.metadata.ResourceClass;
 
 /**
@@ -14,31 +15,33 @@ public class VertxRegistry implements Registry
 {
 
    private final Registry delegate;
+   private final ResourceBuilder resourceBuilder;
 
-   public VertxRegistry(Registry delegate)
+   public VertxRegistry(Registry delegate, ResourceBuilder resourceBuilder)
    {
       this.delegate = delegate;
+      this.resourceBuilder = resourceBuilder;
    }
 
 
    public void addPerInstanceResource(Class<?> clazz)
    {
-      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(clazz)));
+      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(resourceBuilder, clazz)));
    }
 
    public void addPerInstanceResource(Class<?> clazz, String basePath)
    {
-      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(clazz)), basePath);
+      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(resourceBuilder, clazz)), basePath);
    }
 
    public void addPerInstanceResource(ResourceClass resourceClass)
    {
-      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(resourceClass)));
+      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(resourceBuilder, resourceClass)));
    }
 
    public void addPerInstanceResource(ResourceClass resourceClass, String basePath)
    {
-      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(resourceClass)), basePath);
+      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(resourceBuilder, resourceClass)), basePath);
    }
 
    @Override

--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxResteasyDeployment.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxResteasyDeployment.java
@@ -15,7 +15,7 @@ public class VertxResteasyDeployment extends ResteasyDeployment
       Registry registry = super.getRegistry();
       if (!(registry instanceof VertxRegistry))
       {
-         registry = new VertxRegistry(registry);
+         registry = new VertxRegistry(registry, getProviderFactory().getResourceBuilder());
       }
       return (VertxRegistry) registry;
    }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/ProgammaticTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/ProgammaticTest.java
@@ -54,7 +54,7 @@ public class ProgammaticTest {
       Field configurable = ProgrammaticResource.class.getDeclaredField("configurable");
       Constructor<?> constructor = ProgrammaticResource.class.getConstructor(Configurable.class);
 
-      ResourceClass resourceclass = ResourceBuilder.rootResource(ProgrammaticResource.class)
+      ResourceClass resourceclass = new ResourceBuilder().rootResource(ProgrammaticResource.class)
               .constructor(constructor).param(0).context().buildConstructor()
               .method(get).get().path("test").produces("text/plain").param(0).queryParam("a").buildMethod()
               .method(put).put().path("test").consumes("text/plain").param(0).messageBody().buildMethod()
@@ -89,7 +89,7 @@ public class ProgammaticTest {
       Field uriInfo = ProgrammaticResource.class.getDeclaredField("uriInfo");
       Field configurable = ProgrammaticResource.class.getDeclaredField("configurable");
 
-      ResourceClass resourceclass = ResourceBuilder.rootResource(ProgrammaticResource.class)
+      ResourceClass resourceclass = new ResourceBuilder().rootResource(ProgrammaticResource.class)
             .method(get).get().path("test").produces("text/plain").param(0).queryParam("a").buildMethod()
             .field(uriInfo).context().buildField()
             .field(configurable).context().buildField()
@@ -119,7 +119,7 @@ public class ProgammaticTest {
       Field configurable = ProgrammaticResource.class.getDeclaredField("configurable");
       Constructor<?> constructor = ProgrammaticResource.class.getConstructor(Configurable.class);
 
-      ResourceClass resourceclass = ResourceBuilder.rootResource(ProgrammaticResource.class)
+      ResourceClass resourceclass = new ResourceBuilder().rootResource(ProgrammaticResource.class)
               .constructor(constructor).param(0).context().buildConstructor()
               .method(get).get().path("test").produces("text/html;charset=UTF-16").param(0).queryParam("a").buildMethod()
               .field(uriInfo).context().buildField()


### PR DESCRIPTION
This pull request is the first step to implement [RESTEASY-1805](https://issues.jboss.org/browse/RESTEASY-1805) as discussed here:

http://lists.jboss.org/pipermail/resteasy-dev/2017-December/000513.html

A few notes regarding this pull request:
* I extracted interfaces from `ResourceClass`, `ResourceMethod` and `ResourceLocator`.
* The new interfaces are named like the classes are named today. The default implementation got the prefix `Default`. So for example the old class `ResourceClass` was refactored to an interface `ResourceClass` with a default implementation `DefaultResourceClass`.
* There are a few other classes for which this refactoring would make sense. Especially the metadata classes describing parameters. However, I will create a separate pull request for this later.
* Each "extract method" refactoring is a separate commit. I hope this helps during the review.

Please let me know if these changes are fine or if I should change anything.