### PR TITLE
[RESTEASY-1809] Tests for CompletionStage resource method return type

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/CompletionStageProxy.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/CompletionStageProxy.java
@@ -1,0 +1,15 @@
+package org.jboss.resteasy.test.response.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import java.util.concurrent.CompletionStage;
+
+
+@Path("")
+public interface CompletionStageProxy {
+   @GET
+   @Path("sleep")
+   @Produces("text/plain")
+   CompletionStage<String> sleep();
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/CompletionStageResponseResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/CompletionStageResponseResource.java
@@ -164,4 +164,21 @@ public class CompletionStageResponseResource {
    public String getHost(@Context UriInfo uri) {
       return uri.getRequestUri().getHost();
    }
+
+   @GET
+   @Path("sleep")
+   @Produces("text/plain")
+   public CompletionStage<String> sleep() {
+      CompletableFuture<String> cs = new CompletableFuture<>();
+      ExecutorService executor = Executors.newSingleThreadExecutor();
+      executor.submit(() -> {
+         try {
+            Thread.sleep(3000L);
+         } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+         }
+         cs.complete(HELLO);
+      });
+      return cs;
+   }
 }


### PR DESCRIPTION
jira: https://issues.jboss.org/browse/RESTEASY-1809

master PR: https://github.com/resteasy/Resteasy/pull/1418

I add "@Category({ExpectedFailing.class})" annotation to this test. If you want rather to use @Ignore annotation, or no annotation, I can change it ...