### PR TITLE
[RESTEASY-1810] Usage of Map.entrySet instead of keySet

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/cache/MapCache.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/cache/MapCache.java
@@ -33,7 +33,7 @@ public class MapCache implements BrowserCache
       }
       if (accept.isWildcardType()) {
          // if the client accepts */*, return just the first entry for requested URL
-         return parent.get(parent.keySet().iterator().next());
+         return parent.entrySet().iterator().next().getValue();
       } else if (accept.isWildcardSubtype()) {
          // if the client accepts <media>/*, return the first entry which media type starts with <media>/
          for (Map.Entry<String, Entry> parentEntry : parent.entrySet()) {

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
@@ -652,13 +652,11 @@ public class ClientInvocation implements Invocation
          });
 
          Optional<Throwable> prioritised = Optional.empty();
-         for (Optional<Throwable> throwable : errors.keySet()) {
-            if(throwable.isPresent()) {
-               if(!prioritised.isPresent())
-                  prioritised = throwable;
-               else if(errors.get(throwable)<errors.get(prioritised))
-                  prioritised = throwable;
-
+         for (Map.Entry<Optional<Throwable>,Integer> errorEntry : errors.entrySet()) {
+            if(errorEntry.getKey().isPresent()) {
+               if(!prioritised.isPresent() || errorEntry.getValue() < errors.get(prioritised)) {
+                  prioritised = errorEntry.getKey();
+               }
             }
          }
 


### PR DESCRIPTION
Use Map.entrySet instead of iterating keySet and getting value later
First round is for resteasy-client module to see if makes sense to proceed further.

https://issues.jboss.org/browse/RESTEASY-1810
