### PR TITLE
[RESTEASY-1816] OnComplete callback registered via SseEventSource.register() is not called

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/plugins/providers/sse/client/SseEventSourceImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/plugins/providers/sse/client/SseEventSourceImpl.java
@@ -242,6 +242,8 @@ public class SseEventSourceImpl implements SseEventSource
          //close httpEngine to close connection
          resteasyWebTarget.getResteasyClient().httpEngine().close();
          executor.shutdownNow();
+
+         onCompleteConsumers.forEach(Runnable::run);
       }
       try
       {


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RESTEASY-1816

Test case added separately in https://github.com/kanovotn/Resteasy/commit/4cc3f12f862b45212bfe6a2fc2a3780cb6be90c0#diff-46bd7bf2136ed3b55bf449e8b0a9ee77R121