### PR TITLE
[RESTEASY-1824] NullPointer exception in ResteasyWadlWriter

### DIFF
--- a/resteasy-wadl/src/main/java/org/jboss/resteasy/wadl/ResteasyWadlServlet.java
+++ b/resteasy-wadl/src/main/java/org/jboss/resteasy/wadl/ResteasyWadlServlet.java
@@ -50,6 +50,7 @@ public class ResteasyWadlServlet extends HttpServlet {
         if (this.services == null) scanResources();
         if (this.services == null) {
             resp.sendError(503, Messages.MESSAGES.noResteasyDeployments());
+            return;
         }
         resp.setContentType(MediaType.APPLICATION_XML);
         this.apiWriter.writeWadl(uri, req, resp, services);


### PR DESCRIPTION
Added missing return statement, so that NPE is avoided.
Jira: https://issues.jboss.org/browse/RESTEASY-1824