### PR TITLE
[RESTEASY-1844] Java 9 cleanup, preparation for Java 10+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>25</version>
+        <version>26</version>
         <relativePath/>
     </parent>
 
@@ -187,29 +187,6 @@
                     </dependency>
                 </dependencies>
             </dependencyManagement>
-        </profile>
-        <profile>
-          <id>jdk9</id>
-          <activation>
-            <jdk>9</jdk>
-          </activation>
-          <properties>
-            <!--<maven.compiler.verbose>true</maven.compiler.verbose>-->
-            <modular.jdk.args>--add-modules=java.se</modular.jdk.args>
-            <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true
-              -Dsun.reflect.debugModuleAccessChecks=true
-            </modular.jdk.props>
-          </properties>
-          <build>
-            <plugins>
-              <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                  <additionalparam>--add-modules=ALL-SYSTEM</additionalparam>
-                </configuration>
-              </plugin>
-            </plugins>
-          </build>
         </profile>
     </profiles>
 

--- a/resteasy-jaxrs/pom.xml
+++ b/resteasy-jaxrs/pom.xml
@@ -23,6 +23,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
         </dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/RESTEASY-1844
Java 9 cleanup, preparation for Java 10+

Java 10+ missing piece is https://github.com/jettison-json/jettison/issues/21, proposed fix is https://github.com/jettison-json/jettison/pull/22
`mvn clean install -Dversion.org.codehaus.jettison=1.3.9-SNAPSHOT` with proposed fix passes