### PR TITLE
[RESTEASY-1840] Sync surefire version in whole TS, extract versions t…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <surefire.system.args>${modular.jdk.args} ${modular.jdk.props}</surefire.system.args>
         <!-- Plugins versions -->
         <version.org.jacoco.plugin>0.7.9</version.org.jacoco.plugin>
+        <version.surefire.plugin>2.18.1</version.surefire.plugin>
     </properties>
 
     <url>http://rest-easy.org</url>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>25</version>
+        <version>26</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -16,8 +16,7 @@
     <description>RESTEasy dependencies BOM</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dep.arquillian-bom.version>1.1.11.Final</dep.arquillian-bom.version>
-        <dep.arquillian-wildfly.version>8.2.1.Final</dep.arquillian-wildfly.version>
+        <dep.arquillian-bom.version>1.1.15.Final</dep.arquillian-bom.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.com.fasterxml.classmate>1.3.4</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.9.4</version.com.fasterxml.jackson>
@@ -51,6 +50,7 @@
         <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
         <version.org.eclipse.jetty>9.4.7.v20170914</version.org.eclipse.jetty>
         <version.org.eclipse.yasson>1.0</version.org.eclipse.yasson>
+        <version.com.github.tomakehurst.wiremock>2.10.1</version.com.github.tomakehurst.wiremock>
         <version.org.glassfish.javax.el>3.0.1-b08</version.org.glassfish.javax.el>
         <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
         <version.org.hibernate.hibernate-validator>5.2.4.Final</version.org.hibernate.hibernate-validator>
@@ -58,6 +58,7 @@
         <version.org.infinispan>8.2.8.Final</version.org.infinispan>
         <version.org.jacoco>0.7.9</version.org.jacoco>
         <version.org.javassist>3.20.0-GA</version.org.javassist>
+        <version.org.jboss.arquillian.container.arquillian-weld-embedded>2.0.0.Beta5</version.org.jboss.arquillian.container.arquillian-weld-embedded>
         <version.org.jboss.logging.jboss-logging>3.3.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-annotations>2.1.0.Final</version.org.jboss.logging.jboss-logging-annotations>
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
@@ -67,6 +68,7 @@
         <version.org.jboss.spec.javax.xml.bind-api_2.3_spec>1.0.0.Final</version.org.jboss.spec.javax.xml.bind-api_2.3_spec>
         <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>1.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>
         <version.org.jboss.shrinkwrap.resolver>2.2.4</version.org.jboss.shrinkwrap.resolver>
+        <version.org.jboss.weld.se.weld-se-core>2.4.5.Final</version.org.jboss.weld.se.weld-se-core>
         <version.microprofile.restclient>1.0</version.microprofile.restclient>
         <version.microprofile.config>1.1</version.microprofile.config>
         <version.org.slf4j>1.7.25</version.org.slf4j>
@@ -80,8 +82,6 @@
         <version.javax.validation-api>1.1.0.Final</version.javax.validation-api>
         <version.weld>2.4.3.Final</version.weld>
         <version.json.patch>1.3</version.json.patch>
-        <!-- override version from jboss-parent -->
-        <version.surefire.plugin>2.18.1</version.surefire.plugin>
         <version.org.reactivestreams>1.0.1</version.org.reactivestreams>
     </properties>
 
@@ -104,6 +104,11 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
+                <version>${version.org.slf4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-jdk14</artifactId>
                 <version>${version.org.slf4j}</version>
             </dependency>
             <dependency>
@@ -533,6 +538,11 @@
 
             <!-- testsuite dependencies -->
             <dependency>
+                <groupId>com.github.tomakehurst</groupId>
+                <artifactId>wiremock</artifactId>
+                <version>${version.com.github.tomakehurst.wiremock}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jacoco</groupId>
                 <artifactId>org.jacoco.ant</artifactId>
                 <version>${version.org.jacoco}</version>
@@ -557,6 +567,11 @@
                 <version>${dep.arquillian-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian.container</groupId>
+                <artifactId>arquillian-weld-embedded</artifactId>
+                <version>${version.org.jboss.arquillian.container.arquillian-weld-embedded}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.spec.javax.jms</groupId>
@@ -696,6 +711,11 @@
                 <groupId>org.jboss.weld.se</groupId>
                 <artifactId>weld-se</artifactId>
                 <version>${version.weld}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld.se</groupId>
+                <artifactId>weld-se-core</artifactId>
+                <version>${version.org.jboss.weld.se.weld-se-core}</version>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.core</groupId>

--- a/testsuite/microprofile-tck/pom.xml
+++ b/testsuite/microprofile-tck/pom.xml
@@ -29,7 +29,6 @@
   <packaging>jar</packaging>
 
   <properties>
-    <version.arquillian>1.1.13.Final</version.arquillian>
     <version.microprofile.restclient>1.0</version.microprofile.restclient>
     <version.microprofile-config>1.2</version.microprofile-config>
     <version.wildfly-microprofile-config>1.2.1</version.wildfly-microprofile-config>
@@ -83,14 +82,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>1.7.25</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock</artifactId>
-      <version>2.10.1</version>
       <scope>test</scope>
     </dependency>
 
@@ -103,21 +100,18 @@
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
-      <version>2.4.5.Final</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.arquillian.container</groupId>
       <artifactId>arquillian-weld-embedded</artifactId>
-      <version>2.0.0.Beta5</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>javax.json</groupId>
       <artifactId>javax.json-api</artifactId>
-      <version>1.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -131,7 +125,6 @@
     <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>javax.json</artifactId>
-      <version>1.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -157,29 +150,35 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20</version>
-        <configuration>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <dependenciesToScan>
+                <dependency>org.eclipse.microprofile.rest.client:microprofile-rest-client-tck</dependency>
+              </dependenciesToScan>
+              <excludes>
+                <!--
+                  the dependency on MP config in the resteasy client is not desireable
+                  this requires further thought
+                -->
+                <exclude>**/DefaultExceptionMapperConfigTest.java</exclude>
 
-          <dependenciesToScan>
-            <dependency>org.eclipse.microprofile.rest.client:microprofile-rest-client-tck</dependency>
-          </dependenciesToScan>
-          <excludes>
+                <!-- Challenged, see  https://github.com/eclipse/microprofile-rest-client/pull/69 -->
+                <exclude>**/InvokeWithJsonPProviderTest.java</exclude>
+                <exclude>**/InvokeWithBuiltProvidersTest.java</exclude>
+                <exclude>**/InvokeWithRegisteredProvidersTest.java</exclude>
+                <exclude>**/CDIInvokeWithRegisteredProvidersTest.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
 
-            <!--
-              the dependency on MP config in the resteasy client is not desireable
-              this requires further thought
-            -->
-            <exclude>org.eclipse.microprofile.rest.client.tck.DefaultExceptionMapperConfigTest</exclude>
-
-            <!-- Challenged, see  https://github.com/eclipse/microprofile-rest-client/pull/69 -->
-            <exclude>org.eclipse.microprofile.rest.client.tck.InvokeWithJsonPProviderTest</exclude>
-            <exclude>org.eclipse.microprofile.rest.client.tck.InvokeWithBuiltProvidersTest</exclude>
-            <exclude>org.eclipse.microprofile.rest.client.tck.InvokeWithRegisteredProvidersTest</exclude>
-            <exclude>org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeWithRegisteredProvidersTest</exclude>
-          </excludes>
-        </configuration>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
…o common version dependencies pom

* Downgrading to 2.18.1 version of surefire fixes the hpux crash issue
* Extract depedency versions from microprofile-tck testsuite module into shared dependency file and unify the surefire version used.
* Update arquillian bom