### PR TITLE
[RESTEASY-1846] dont append /* to application paths that already end in /*

### DIFF
--- a/resteasy-servlet-initializer/src/main/java/org/jboss/resteasy/plugins/servlet/ResteasyServletInitializer.java
+++ b/resteasy-servlet-initializer/src/main/java/org/jboss/resteasy/plugins/servlet/ResteasyServletInitializer.java
@@ -115,8 +115,11 @@ public class ResteasyServletInitializer implements ServletContainerInitializer
          if (!mapping.startsWith("/")) mapping = "/" + mapping;
          String prefix = mapping;
          if (!prefix.equals("/") && prefix.endsWith("/")) prefix = prefix.substring(0, prefix.length() - 1);
-         if (mapping.endsWith("/")) mapping += "*";
-         else mapping += "/*";
+         if (!mapping.endsWith("/*")) 
+         {
+            if (mapping.endsWith("/")) mapping += "*";
+            else mapping += "/*";
+         }
          // resteasy.servlet.mapping.prefix
          reg.setInitParameter("resteasy.servlet.mapping.prefix", prefix);
          reg.addMapping(mapping);


### PR DESCRIPTION
on the one hand, the spec says:
```
if the Application subclass is annotated with @ApplicationPath , implementations are REQUIRED to use the value of this annotation appended with ”/*” to define a mapping for the added server.
```
on the other the code already tries to handle the "/" suffix differently.
as-is right now though, the resulting path would end in `/*/*`, which is definitely wrong.