### PR TITLE
[RESTEASY-1805] (#1449)

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/LocatorRegistry.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/LocatorRegistry.java
@@ -26,17 +26,18 @@ public class LocatorRegistry
    public LocatorRegistry(Class<?> clazz, ResteasyProviderFactory providerFactory)
    {
       this.providerFactory = providerFactory;
+      ResourceBuilder resourceBuilder = providerFactory.getResourceBuilder();
       if (Proxy.isProxyClass(clazz))
       {
          for (Class<?> intf : clazz.getInterfaces())
          {
-            ResourceClass resourceClass = ResourceBuilder.locatorFromAnnotations(intf);
+            ResourceClass resourceClass = resourceBuilder.getLocatorFromAnnotations(intf);
             register(resourceClass);
          }
       }
       else
       {
-         ResourceClass resourceClass = ResourceBuilder.locatorFromAnnotations(clazz);
+         ResourceClass resourceClass = resourceBuilder.getLocatorFromAnnotations(clazz);
          register(resourceClass);
       }
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/POJOResourceFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/POJOResourceFactory.java
@@ -19,19 +19,33 @@ import org.jboss.resteasy.spi.metadata.ResourceConstructor;
  */
 public class POJOResourceFactory implements ResourceFactory
 {
+   private final ResourceBuilder resourceBuilder;
    private final Class<?> scannableClass;
    private final ResourceClass resourceClass;
    private ConstructorInjector constructorInjector;
    private PropertyInjector propertyInjector;
 
+   @Deprecated
    public POJOResourceFactory(Class<?> scannableClass)
    {
+      this(new ResourceBuilder(), scannableClass);
+   }
+
+   public POJOResourceFactory(ResourceBuilder resourceBuilder, Class<?> scannableClass)
+   {
+      this.resourceBuilder = resourceBuilder;
       this.scannableClass = scannableClass;
-      this.resourceClass = ResourceBuilder.rootResourceFromAnnotations(scannableClass);
+      this.resourceClass = resourceBuilder.getRootResourceFromAnnotations(scannableClass);
    }
 
    public POJOResourceFactory(ResourceClass resourceClass)
    {
+      this(new ResourceBuilder(), resourceClass);
+   }
+
+   public POJOResourceFactory(ResourceBuilder resourceBuilder, ResourceClass resourceClass)
+   {
+      this.resourceBuilder = resourceBuilder;
       this.scannableClass = resourceClass.getClazz();
       this.resourceClass = resourceClass;
    }
@@ -39,7 +53,7 @@ public class POJOResourceFactory implements ResourceFactory
    public void registered(ResteasyProviderFactory factory)
    {
       ResourceConstructor constructor = resourceClass.getConstructor();
-      if (constructor == null) constructor = ResourceBuilder.constructor(resourceClass.getClazz());
+      if (constructor == null) constructor = resourceBuilder.getConstructor(resourceClass.getClazz());
       if (constructor == null)
       {
          throw new RuntimeException(Messages.MESSAGES.unableToFindPublicConstructorForClass(scannableClass.getName()));

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/SingletonResource.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/SingletonResource.java
@@ -18,12 +18,13 @@ public class SingletonResource implements ResourceFactory
    private final Object obj;
    private final ResourceClass resourceClass;
 
+   @Deprecated
    public SingletonResource(Object obj)
    {
       this.obj = obj;
       this.resourceClass = ResourceBuilder.rootResourceFromAnnotations(obj.getClass());
    }
-
+   
    public SingletonResource(Object obj, ResourceClass resourceClass)
    {
       this.obj = obj;

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -43,6 +43,8 @@ import org.jboss.resteasy.spi.interception.MessageBodyReaderInterceptor;
 import org.jboss.resteasy.spi.interception.MessageBodyWriterInterceptor;
 import org.jboss.resteasy.spi.interception.PostProcessInterceptor;
 import org.jboss.resteasy.spi.interception.PreProcessInterceptor;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
+import org.jboss.resteasy.spi.metadata.ResourceClassProcessor;
 import org.jboss.resteasy.util.FeatureContextDelegate;
 import org.jboss.resteasy.util.PickConstructor;
 import org.jboss.resteasy.util.ThreadLocalStack;
@@ -283,6 +285,8 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
    protected Set<Class<?>> featureClasses;
    protected Set<Object> featureInstances;
 
+   protected ResourceBuilder resourceBuilder;
+
 
    public ResteasyProviderFactory()
    {
@@ -374,6 +378,8 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
       clientExecutionInterceptorRegistry = new InterceptorRegistry<ClientExecutionInterceptor>(ClientExecutionInterceptor.class, this);
 
       clientErrorInterceptors = new CopyOnWriteArrayList<ClientErrorInterceptor>();
+
+      resourceBuilder = new ResourceBuilder();
 
       builtinsRegistered = false;
       registerBuiltins = true;
@@ -2077,6 +2083,12 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
             throw new RuntimeException("Failed to register provider", e);
          }
       }
+      if (isA(provider, ResourceClassProcessor.class, contracts))
+      {
+         addResourceClassProcessor(provider);
+         int priority = getPriority(priorityOverride, contracts, ResourceClassProcessor.class, provider);
+         newContracts.put(ResourceClassProcessor.class, priority);
+      }
       providerClasses.add(provider);
       getClassContracts().put(provider, newContracts);
    }
@@ -2470,6 +2482,12 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
          } else {
             newContracts.put(ResponseExceptionMapper.class, ((ResponseExceptionMapper) provider).getPriority());
          }
+      }
+      if (isA(provider, ResourceClassProcessor.class, contracts))
+      {
+         addResourceClassProcessor((ResourceClassProcessor) provider);
+         int priority = getPriority(priorityOverride, contracts, ResourceClassProcessor.class, provider.getClass());
+         newContracts.put(ResourceClassProcessor.class, priority);
       }
       providerInstances.add(provider);
       getClassContracts().put(provider.getClass(), newContracts);
@@ -3064,5 +3082,32 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
    public Link.Builder createLinkBuilder()
    {
       return new LinkBuilderImpl();
+   }
+
+   public <I extends RxInvoker> RxInvokerProvider<I> getRxInvokerProvider(Class<I> clazz) {
+      for (Entry<Class<?>, Map<Class<?>, Integer>> entry : classContracts.entrySet()) {
+         if (entry.getValue().containsKey(RxInvokerProvider.class)) {
+            RxInvokerProvider<?> rip = (RxInvokerProvider<?>)createProviderInstance(entry.getKey());
+            if (rip.isProviderFor(clazz)) {
+               return (RxInvokerProvider<I>)rip;
+            }
+         }
+      }
+      return null;
+   }
+
+   protected void addResourceClassProcessor(Class<ResourceClassProcessor> processorClass)
+   {
+      ResourceClassProcessor processor = createProviderInstance(processorClass);
+      addResourceClassProcessor(processor);
+   }
+
+   protected void addResourceClassProcessor(ResourceClassProcessor processor)
+   {
+      resourceBuilder.registerResourceClassProcessor(processor);
+   }
+
+   public ResourceBuilder getResourceBuilder() {
+      return resourceBuilder;
    }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceClass.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceClass.java
@@ -1,0 +1,69 @@
+package org.jboss.resteasy.spi.metadata;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class DefaultResourceClass implements ResourceClass
+{
+   private static final FieldParameter[] EMPTY_FIELD_PARAMS = {};
+   private static final SetterParameter[] EMPTY_SETTER_PARAMETERS = {};
+   private static final ResourceMethod[] EMPTY_RESOURCE_METHODS = {};
+   private static final ResourceLocator[] EMPTY_RESOURCE_LOCATORS = {};
+
+   protected Class<?> clazz;
+   protected FieldParameter[] fields = EMPTY_FIELD_PARAMS;
+   protected SetterParameter[] setters = EMPTY_SETTER_PARAMETERS;
+   protected ResourceMethod[] resourceMethods = EMPTY_RESOURCE_METHODS;
+   protected ResourceLocator[] resourceLocators = EMPTY_RESOURCE_LOCATORS;
+   protected ResourceConstructor constructor; // only one allowed
+   protected String path;
+
+   public DefaultResourceClass(Class<?> clazz, String path)
+   {
+      this.clazz = clazz;
+      this.path = path;
+   }
+
+   @Override
+   public String getPath()
+   {
+      return path;
+   }
+
+   @Override
+   public Class<?> getClazz()
+   {
+      return clazz;
+   }
+
+   @Override
+   public ResourceConstructor getConstructor()
+   {
+      return constructor;
+   }
+
+   @Override
+   public FieldParameter[] getFields()
+   {
+      return fields;
+   }
+
+   @Override
+   public SetterParameter[] getSetters()
+   {
+      return setters;
+   }
+
+   @Override
+   public ResourceMethod[] getResourceMethods()
+   {
+      return resourceMethods;
+   }
+
+   @Override
+   public ResourceLocator[] getResourceLocators()
+   {
+      return resourceLocators;
+   }
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceConstructor.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceConstructor.java
@@ -1,0 +1,46 @@
+package org.jboss.resteasy.spi.metadata;
+
+import java.lang.reflect.Constructor;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class DefaultResourceConstructor implements ResourceConstructor
+{
+   protected ResourceClass resourceClass;
+   protected Constructor constructor;
+   protected ConstructorParameter[] params = {};
+
+   public DefaultResourceConstructor(ResourceClass resourceClass, Constructor constructor)
+   {
+      this.resourceClass = resourceClass;
+      this.constructor = constructor;
+      if (constructor.getParameterTypes() != null)
+      {
+         this.params = new ConstructorParameter[constructor.getParameterTypes().length];
+         for (int i = 0; i < constructor.getParameterTypes().length; i++)
+         {
+            this.params[i] = new ConstructorParameter(this, constructor.getParameterTypes()[i], constructor.getGenericParameterTypes()[i], constructor.getParameterAnnotations()[i]);
+         }
+      }
+   }
+
+   @Override
+   public ResourceClass getResourceClass()
+   {
+      return resourceClass;
+   }
+
+   @Override
+   public Constructor getConstructor()
+   {
+      return constructor;
+   }
+
+   @Override
+   public ConstructorParameter[] getParams()
+   {
+      return params;
+   }
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceLocator.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceLocator.java
@@ -1,0 +1,91 @@
+package org.jboss.resteasy.spi.metadata;
+
+import org.jboss.resteasy.util.Types;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class DefaultResourceLocator implements ResourceLocator
+{
+   protected ResourceClass resourceClass;
+   protected Class<?> returnType;
+   protected Type genericReturnType;
+   protected Method method;
+   protected Method annotatedMethod;
+   protected MethodParameter[] params = {};
+   protected String fullpath;
+   protected String path;
+
+   public DefaultResourceLocator(ResourceClass resourceClass, Method method, Method annotatedMethod)
+   {
+      this.resourceClass = resourceClass;
+      this.annotatedMethod = annotatedMethod;
+      this.method = method;
+      // we initialize generic types based on the method of the resource class rather than the Method that is actually
+      // annotated.  This is so we have the appropriate generic type information.
+      this.genericReturnType = Types.resolveTypeVariables(resourceClass.getClazz(), method.getGenericReturnType());
+      this.returnType = Types.getRawType(genericReturnType);
+      this.params = new MethodParameter[method.getParameterTypes().length];
+      for (int i = 0; i < method.getParameterTypes().length; i++)
+      {
+         this.params[i] = new MethodParameter(this, method.getParameterTypes()[i], method.getGenericParameterTypes()[i], annotatedMethod.getParameterAnnotations()[i]);
+      }
+   }
+
+   @Override
+   public ResourceClass getResourceClass()
+   {
+      return resourceClass;
+   }
+
+   @Override
+   public Class<?> getReturnType()
+   {
+      return returnType;
+   }
+
+   @Override
+   public Type getGenericReturnType()
+   {
+      return genericReturnType;
+   }
+
+   @Override
+   public Method getMethod()
+   {
+      return method;
+   }
+
+   @Override
+   public Method getAnnotatedMethod()
+   {
+      return annotatedMethod;
+   }
+
+   @Override
+   public MethodParameter[] getParams()
+   {
+      return params;
+   }
+
+   @Override
+   public String getFullpath()
+   {
+      return fullpath;
+   }
+
+   @Override
+   public String getPath()
+   {
+      return path;
+   }
+
+   @Override
+   public String toString() {
+      return method.toString();
+   }
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceMethod.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/DefaultResourceMethod.java
@@ -1,0 +1,55 @@
+package org.jboss.resteasy.spi.metadata;
+
+import javax.ws.rs.core.MediaType;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class DefaultResourceMethod extends DefaultResourceLocator implements ResourceMethod
+{
+   private static final MediaType[] empty = {};
+   protected Set<String> httpMethods = new HashSet<String>();
+   protected MediaType[] produces = empty;
+   protected MediaType[] consumes = empty;
+   protected boolean asynchronous;
+
+   public DefaultResourceMethod(ResourceClass declaredClass, Method method, Method annotatedMethod)
+   {
+      super(declaredClass, method, annotatedMethod);
+   }
+
+   @Override
+   public Set<String> getHttpMethods()
+   {
+      return httpMethods;
+   }
+
+   @Override
+   public MediaType[] getProduces()
+   {
+      return produces;
+   }
+
+   @Override
+   public MediaType[] getConsumes()
+   {
+      return consumes;
+   }
+
+   @Override
+   public boolean isAsynchronous()
+   {
+      return asynchronous;
+   }
+
+   @Override
+   public void markAsynchronous()
+   {
+      asynchronous = true;
+   }
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/MethodParameter.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/MethodParameter.java
@@ -23,7 +23,7 @@ public class MethodParameter extends Parameter
    @Override
    public AccessibleObject getAccessibleObject()
    {
-      return locator.method;
+      return locator.getMethod();
    }
 
    public Annotation[] getAnnotations()

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
@@ -45,6 +45,7 @@ import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.jboss.resteasy.util.FindAnnotation.findAnnotation;
@@ -58,7 +59,7 @@ public class ResourceBuilder
 {
    public static class ResourceClassBuilder
    {
-      final ResourceClass resourceClass;
+      final DefaultResourceClass resourceClass;
       List<FieldParameter> fields = new ArrayList<FieldParameter>();
       List<SetterParameter> setters = new ArrayList<SetterParameter>();
       List<ResourceMethod> resourceMethods = new ArrayList<ResourceMethod>();
@@ -66,7 +67,7 @@ public class ResourceBuilder
 
       public ResourceClassBuilder(Class<?> root, String path)
       {
-         this.resourceClass = new ResourceClass(root, path);
+         this.resourceClass = new DefaultResourceClass(root, path);
       }
 
       public ResourceMethodBuilder method(Method method)
@@ -436,7 +437,7 @@ public class ResourceBuilder
       public ResourceConstructorBuilder(ResourceClassBuilder resourceClassBuilder, Constructor constructor)
       {
          this.resourceClassBuilder = resourceClassBuilder;
-         this.constructor = new ResourceConstructor(resourceClassBuilder.resourceClass, constructor);
+         this.constructor = new DefaultResourceConstructor(resourceClassBuilder.resourceClass, constructor);
       }
       public ConstructorParameterBuilder param(int i)
       {
@@ -453,7 +454,7 @@ public class ResourceBuilder
    public static class ResourceLocatorBuilder<T extends ResourceLocatorBuilder<T>>
    {
 
-      ResourceLocator locator;
+      DefaultResourceLocator locator;
       ResourceClassBuilder resourceClassBuilder;
 
       ResourceLocatorBuilder()
@@ -463,7 +464,7 @@ public class ResourceBuilder
       public ResourceLocatorBuilder(ResourceClassBuilder resourceClassBuilder, Method method, Method annotatedMethod)
       {
          this.resourceClassBuilder = resourceClassBuilder;
-         this.locator = new ResourceLocator(resourceClassBuilder.resourceClass, method, annotatedMethod);
+         this.locator = new DefaultResourceLocator(resourceClassBuilder.resourceClass, method, annotatedMethod);
       }
 
       public T returnType(Class<?> type)
@@ -493,7 +494,7 @@ public class ResourceBuilder
       public ResourceClassBuilder buildMethod()
       {
          ResteasyUriBuilder builder = new ResteasyUriBuilder();
-         if (locator.resourceClass.path != null) builder.path(locator.resourceClass.path);
+         if (locator.resourceClass.getPath() != null) builder.path(locator.resourceClass.getPath());
          if (locator.path != null) builder.path(locator.path);
          String pathExpression = builder.getPath();
          if (pathExpression == null)
@@ -516,11 +517,11 @@ public class ResourceBuilder
 
    public static class ResourceMethodBuilder extends ResourceLocatorBuilder<ResourceMethodBuilder>
    {
-      ResourceMethod method;
+      DefaultResourceMethod method;
 
       ResourceMethodBuilder(ResourceClassBuilder resourceClassBuilder, Method method, Method annotatedMethod)
       {
-         this.method = new ResourceMethod(resourceClassBuilder.resourceClass, method, annotatedMethod);
+         this.method = new DefaultResourceMethod(resourceClassBuilder.resourceClass, method, annotatedMethod);
          this.locator = this.method;
          this.resourceClassBuilder = resourceClassBuilder;
       }
@@ -628,7 +629,7 @@ public class ResourceBuilder
       public ResourceClassBuilder buildMethod()
       {
          ResteasyUriBuilder builder = new ResteasyUriBuilder();
-         if (method.resourceClass.path != null) builder.path(method.resourceClass.path);
+         if (method.resourceClass.getPath() != null) builder.path(method.resourceClass.getPath());
          if (method.path != null) builder.path(method.path);
          String pathExpression = builder.getPath();
          if (pathExpression == null)
@@ -681,22 +682,55 @@ public class ResourceBuilder
       }
    }
 
+   private final List<ResourceClassProcessor> processors = new ArrayList<>();
 
+   /**
+    * Register a new {@link ResourceClassProcessor} which will be used to post-process all
+    * {@link ResourceClass} instances created from the builder.
+    */
+   public void registerResourceClassProcessor(ResourceClassProcessor processor)
+   {
+      this.processors.add(processor);
+   }
+
+   @Deprecated
    public static ResourceClassBuilder rootResource(Class<?> root)
+   {
+      return new ResourceBuilder().buildRootResource(root);
+   }
+
+   public ResourceClassBuilder buildRootResource(Class<?> root)
    {
       return new ResourceClassBuilder(root, "/");
    }
 
+   @Deprecated
    public static ResourceClassBuilder rootResource(Class<?> root, String path)
+   {
+      return new ResourceBuilder().buildRootResource(root, path);
+   }
+
+   protected ResourceClassBuilder buildRootResource(Class<?> root, String path)
    {
       return new ResourceClassBuilder(root, path);
    }
 
+   @Deprecated
    public static ResourceClassBuilder locator(Class<?> root)
+   {
+      return new ResourceBuilder().buildLocator(root);
+   }
+
+   protected ResourceClassBuilder buildLocator(Class<?> root)
    {
       return new ResourceClassBuilder(root, null);
    }
 
+   @Deprecated
+   public static ResourceConstructor constructor(Class<?> annotatedResourceClass)
+   {
+      return new ResourceBuilder().getConstructor(annotatedResourceClass);
+   }
 
    /**
     * Picks a constructor from an annotated resource class based on spec rules
@@ -704,19 +738,26 @@ public class ResourceBuilder
     * @param annotatedResourceClass
     * @return
     */
-   public static ResourceConstructor constructor(Class<?> annotatedResourceClass)
+   public ResourceConstructor getConstructor(Class<?> annotatedResourceClass)
    {
       Constructor constructor = PickConstructor.pickPerRequestConstructor(annotatedResourceClass);
       if (constructor == null)
       {
          throw new RuntimeException(Messages.MESSAGES.couldNotFindConstructor(annotatedResourceClass.getName()));
       }
-      ResourceConstructorBuilder builder = rootResource(annotatedResourceClass).constructor(constructor);
+      ResourceConstructorBuilder builder = buildRootResource(annotatedResourceClass).constructor(constructor);
       if (constructor.getParameterTypes() != null)
       {
          for (int i = 0; i < constructor.getParameterTypes().length; i++) builder.param(i).fromAnnotations();
       }
-      return builder.buildConstructor().buildClass().getConstructor();
+      ResourceClass resourceClass = applyProcessors(builder.buildConstructor().buildClass());
+      return resourceClass.getConstructor();
+   }
+
+   @Deprecated
+   public static ResourceClass rootResourceFromAnnotations(Class<?> clazz)
+   {
+      return new ResourceBuilder().getRootResourceFromAnnotations(clazz);
    }
 
    /**
@@ -724,17 +765,23 @@ public class ResourceBuilder
     *
     * @return
     */
-   public static ResourceClass rootResourceFromAnnotations(Class<?> clazz)
+   public ResourceClass getRootResourceFromAnnotations(Class<?> clazz)
    {
       return fromAnnotations(false, clazz);
    }
 
+   @Deprecated
    public static ResourceClass locatorFromAnnotations(Class<?> clazz)
+   {
+      return new ResourceBuilder().getLocatorFromAnnotations(clazz);
+   }
+
+   public ResourceClass getLocatorFromAnnotations(Class<?> clazz)
    {
       return fromAnnotations(true, clazz);
    }
 
-   private static ResourceClass fromAnnotations(boolean isLocator, Class<?> clazz)
+   private ResourceClass fromAnnotations(boolean isLocator, Class<?> clazz)
    {
       // stupid hack for Weld as it loses generic type information, but retains annotations.
       if (!clazz.isInterface() && clazz.getSuperclass() != null && !clazz.getSuperclass().equals(Object.class) && clazz.isSynthetic())
@@ -744,12 +791,12 @@ public class ResourceBuilder
 
 
       ResourceClassBuilder builder = null;
-      if (isLocator) builder = locator(clazz);
+      if (isLocator) builder = buildLocator(clazz);
       else
       {
          Path path = clazz.getAnnotation(Path.class);
-         if (path == null) builder = rootResource(clazz, null);
-         else builder = rootResource(clazz, path.value());
+         if (path == null) builder = buildRootResource(clazz, null);
+         else builder = buildRootResource(clazz, path.value());
       }
       for (Method method : clazz.getMethods())
       {
@@ -762,7 +809,13 @@ public class ResourceBuilder
          processFields(builder, clazz);
       }
       processSetters(builder, clazz);
-      return builder.buildClass();
+      return applyProcessors(builder.buildClass());
+   }
+
+   @Deprecated
+   public static Method findAnnotatedMethod(final Class<?> root, final Method implementation)
+   {
+      return new ResourceBuilder().getAnnotatedMethod(root, implementation);
    }
 
    /**
@@ -772,7 +825,7 @@ public class ResourceBuilder
     * @param implementation The resource method or sub-resource method / sub-resource locator implementation
     * @return The annotated resource method or sub-resource method / sub-resource locator.
     */
-   public static Method findAnnotatedMethod(final Class<?> root, final Method implementation)
+   public Method getAnnotatedMethod(final Class<?> root, final Method implementation)
    {
       if (implementation.isSynthetic())
       {
@@ -867,7 +920,7 @@ public class ResourceBuilder
       return null;
    }
 
-   protected static void processFields(ResourceClassBuilder resourceClassBuilder, Class<?> root)
+   protected void processFields(ResourceClassBuilder resourceClassBuilder, Class<?> root)
    {
       do
       {
@@ -877,7 +930,7 @@ public class ResourceBuilder
       } while (root != null && !root.equals(Object.class));
    }
 
-   protected static void processSetters(ResourceClassBuilder resourceClassBuilder, Class<?> root)
+   protected void processSetters(ResourceClassBuilder resourceClassBuilder, Class<?> root)
    {
       HashSet<Long> hashes = new HashSet<Long>();
       do
@@ -887,7 +940,7 @@ public class ResourceBuilder
       } while (root != null && !root.equals(Object.class));
    }
 
-   protected static void processDeclaredFields(ResourceClassBuilder resourceClassBuilder, final Class<?> root)
+   protected void processDeclaredFields(ResourceClassBuilder resourceClassBuilder, final Class<?> root)
    {
       Field[] fieldList = new Field[0];
       try {
@@ -913,7 +966,7 @@ public class ResourceBuilder
          builder.buildField();
       }
    }
-   protected static void processDeclaredSetters(ResourceClassBuilder resourceClassBuilder, final Class<?> root, Set<Long> visitedHashes)
+   protected void processDeclaredSetters(ResourceClassBuilder resourceClassBuilder, final Class<?> root, Set<Long> visitedHashes)
    {
       Method[] methodList = new Method[0];
       try {
@@ -953,9 +1006,9 @@ public class ResourceBuilder
       }
    }
 
-   protected static void processMethod(boolean isLocator, ResourceClassBuilder resourceClassBuilder, Class<?> root, Method implementation)
+   protected void processMethod(boolean isLocator, ResourceClassBuilder resourceClassBuilder, Class<?> root, Method implementation)
    {
-      Method method = findAnnotatedMethod(root, implementation);
+      Method method = getAnnotatedMethod(root, implementation);
       if (method != null)
       {
          Set<String> httpMethods = IsHttpMethod.getHttpMethods(method);
@@ -999,6 +1052,20 @@ public class ResourceBuilder
          }
          resourceLocatorBuilder.buildMethod();
       }
+   }
+
+   /**
+    * Apply the list of {@link ResourceClassProcessor} to the supplied {@link ResourceClass}.
+    */
+   private ResourceClass applyProcessors(ResourceClass original)
+   {
+      ResourceClass current = original;
+      for (ResourceClassProcessor processor : processors)
+      {
+         current = processor.process(current);
+         Objects.requireNonNull(current, "ResourceClassProcessor must not return null");
+      }
+      return current;
    }
 
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceClass.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceClass.java
@@ -1,62 +1,21 @@
 package org.jboss.resteasy.spi.metadata;
 
 /**
- * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
- * @version $Revision: 1 $
+ * @author Christian Kaltepoth
  */
-public class ResourceClass
+public interface ResourceClass
 {
-   private static final FieldParameter[] EMPTY_FIELD_PARAMS = {};
-   private static final SetterParameter[] EMPTY_SETTER_PARAMETERS = {};
-   private static final ResourceMethod[] EMPTY_RESOURCE_METHODS = {};
-   private static final ResourceLocator[] EMPTY_RESOURCE_LOCATORS = {};
+  String getPath();
 
-   protected Class<?> clazz;
-   protected FieldParameter[] fields = EMPTY_FIELD_PARAMS;
-   protected SetterParameter[] setters = EMPTY_SETTER_PARAMETERS;
-   protected ResourceMethod[] resourceMethods = EMPTY_RESOURCE_METHODS;
-   protected ResourceLocator[] resourceLocators = EMPTY_RESOURCE_LOCATORS;
-   protected ResourceConstructor constructor; // only one allowed
-   protected String path;
+  Class<?> getClazz();
 
-   public ResourceClass(Class<?> clazz, String path)
-   {
-      this.clazz = clazz;
-      this.path = path;
-   }
+  ResourceConstructor getConstructor();
 
-   public String getPath()
-   {
-      return path;
-   }
+  FieldParameter[] getFields();
 
-   public Class<?> getClazz()
-   {
-      return clazz;
-   }
+  SetterParameter[] getSetters();
 
-   public ResourceConstructor getConstructor()
-   {
-      return constructor;
-   }
+  ResourceMethod[] getResourceMethods();
 
-   public FieldParameter[] getFields()
-   {
-      return fields;
-   }
-
-   public SetterParameter[] getSetters()
-   {
-      return setters;
-   }
-
-   public ResourceMethod[] getResourceMethods()
-   {
-      return resourceMethods;
-   }
-
-   public ResourceLocator[] getResourceLocators()
-   {
-      return resourceLocators;
-   }
+  ResourceLocator[] getResourceLocators();
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceClassProcessor.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceClassProcessor.java
@@ -1,0 +1,21 @@
+package org.jboss.resteasy.spi.metadata;
+
+/**
+ * SPI which allows implementations to modify the resource metadata discovered by RESTEasy.
+ *
+ * @author Christian Kaltepoth
+ */
+public interface ResourceClassProcessor
+{
+
+  /**
+   * Allows the implementation of this method to modify the resource metadata represented by
+   * the supplied {@link ResourceClass} instance. Implementation will typically create
+   * wrappers which modify only certain aspects of the metadata.
+   *
+   * @param clazz The original metadata
+   * @return the (potentially modified) metadata (never null)
+   */
+  ResourceClass process(ResourceClass clazz);
+
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceConstructor.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceConstructor.java
@@ -1,48 +1,15 @@
 package org.jboss.resteasy.spi.metadata;
 
-import org.jboss.resteasy.util.Types;
-
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
 
 /**
- * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
- * @version $Revision: 1 $
+ * @author Christian Kaltepoth
  */
-public class ResourceConstructor
+public interface ResourceConstructor
 {
-   protected ResourceClass resourceClass;
-   protected Constructor constructor;
-   protected ConstructorParameter[] params = {};
+  ResourceClass getResourceClass();
 
-   public ResourceConstructor(ResourceClass resourceClass, Constructor constructor)
-   {
-      this.resourceClass = resourceClass;
-      this.constructor = constructor;
-      if (constructor.getParameterTypes() != null)
-      {
-         this.params = new ConstructorParameter[constructor.getParameterTypes().length];
-         for (int i = 0; i < constructor.getParameterTypes().length; i++)
-         {
-            this.params[i] = new ConstructorParameter(this, constructor.getParameterTypes()[i], constructor.getGenericParameterTypes()[i], constructor.getParameterAnnotations()[i]);
-         }
-      }
-   }
+  Constructor getConstructor();
 
-   public ResourceClass getResourceClass()
-   {
-      return resourceClass;
-   }
-
-   public Constructor getConstructor()
-   {
-      return constructor;
-   }
-
-   public ConstructorParameter[] getParams()
-   {
-      return params;
-   }
+  ConstructorParameter[] getParams();
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceLocator.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceLocator.java
@@ -1,83 +1,27 @@
 package org.jboss.resteasy.spi.metadata;
 
-import org.jboss.resteasy.util.Types;
-
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
 /**
- * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
- * @version $Revision: 1 $
+ * @author Christian Kaltepoth
  */
-public class ResourceLocator
+public interface ResourceLocator
 {
-   protected ResourceClass resourceClass;
-   protected Class<?> returnType;
-   protected Type genericReturnType;
-   protected Method method;
-   protected Method annotatedMethod;
-   protected MethodParameter[] params = {};
-   protected String fullpath;
-   protected String path;
+  ResourceClass getResourceClass();
 
-   public ResourceLocator(ResourceClass resourceClass, Method method, Method annotatedMethod)
-   {
-      this.resourceClass = resourceClass;
-      this.annotatedMethod = annotatedMethod;
-      this.method = method;
-      // we initialize generic types based on the method of the resource class rather than the Method that is actually
-      // annotated.  This is so we have the appropriate generic type information.
-      this.genericReturnType = Types.resolveTypeVariables(resourceClass.getClazz(), method.getGenericReturnType());
-      this.returnType = Types.getRawType(genericReturnType);
-      this.params = new MethodParameter[method.getParameterTypes().length];
-      for (int i = 0; i < method.getParameterTypes().length; i++)
-      {
-         this.params[i] = new MethodParameter(this, method.getParameterTypes()[i], method.getGenericParameterTypes()[i], annotatedMethod.getParameterAnnotations()[i]);
-      }
-   }
+  Class<?> getReturnType();
 
-   public ResourceClass getResourceClass()
-   {
-      return resourceClass;
-   }
+  Type getGenericReturnType();
 
-   public Class<?> getReturnType()
-   {
-      return returnType;
-   }
+  Method getMethod();
 
-   public Type getGenericReturnType()
-   {
-      return genericReturnType;
-   }
+  Method getAnnotatedMethod();
 
-   public Method getMethod()
-   {
-      return method;
-   }
+  MethodParameter[] getParams();
 
-   public Method getAnnotatedMethod()
-   {
-      return annotatedMethod;
-   }
+  String getFullpath();
 
-   public MethodParameter[] getParams()
-   {
-      return params;
-   }
+  String getPath();
 
-   public String getFullpath()
-   {
-      return fullpath;
-   }
-
-   public String getPath()
-   {
-      return path;
-   }
-
-   @Override
-   public String toString() {
-      return method.toString();
-   }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceMethod.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/metadata/ResourceMethod.java
@@ -1,51 +1,21 @@
 package org.jboss.resteasy.spi.metadata;
 
-import javax.ws.rs.core.MediaType;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.util.HashSet;
 import java.util.Set;
 
+import javax.ws.rs.core.MediaType;
+
 /**
- * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
- * @version $Revision: 1 $
+ * @author Christian Kaltepoth
  */
-public class ResourceMethod extends ResourceLocator
+public interface ResourceMethod extends ResourceLocator
 {
-   private static final MediaType[] empty = {};
-   protected Set<String> httpMethods = new HashSet<String>();
-   protected MediaType[] produces = empty;
-   protected MediaType[] consumes = empty;
-   protected boolean asynchronous;
+  Set<String> getHttpMethods();
 
-   public ResourceMethod(ResourceClass declaredClass, Method method, Method annotatedMethod)
-   {
-      super(declaredClass, method, annotatedMethod);
-   }
+  MediaType[] getProduces();
 
-   public Set<String> getHttpMethods()
-   {
-      return httpMethods;
-   }
+  MediaType[] getConsumes();
 
-   public MediaType[] getProduces()
-   {
-      return produces;
-   }
+  boolean isAsynchronous();
 
-   public MediaType[] getConsumes()
-   {
-      return consumes;
-   }
-
-   public boolean isAsynchronous()
-   {
-      return asynchronous;
-   }
-
-   public void markAsynchronous()
-   {
-      asynchronous = true;
-   }
+  void markAsynchronous();
 }

--- a/resteasy-jsapi/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesAbstract.java
+++ b/resteasy-jsapi/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesAbstract.java
@@ -3,6 +3,8 @@ package org.jboss.resteasy.test.i18n;
 import java.lang.reflect.Method;
 import java.util.Locale;
 
+import org.jboss.resteasy.spi.metadata.DefaultResourceClass;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.junit.Assert;
 
 import org.jboss.resteasy.core.InjectorFactoryImpl;
@@ -11,6 +13,7 @@ import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
 import org.jboss.resteasy.jsapi.i18n.Messages;
 import org.jboss.resteasy.spi.InjectorFactory;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.metadata.DefaultResourceMethod;
 import org.jboss.resteasy.spi.metadata.ResourceClass;
 import org.jboss.resteasy.spi.metadata.ResourceMethod;
 import org.junit.Test;
@@ -33,11 +36,12 @@ abstract public class TestMessagesAbstract extends TestMessagesParent
       {
          Class<?> clazz = TestMessagesAbstract.class;
          Method method = TestMessagesAbstract.class.getMethod("testLocale");
-         ResourceClass resourceClass = new ResourceClass(TestMessagesAbstract.class, "path");
-         ResourceMethod resourceMethod = new ResourceMethod(resourceClass, method, method);
+         ResourceClass resourceClass = new DefaultResourceClass(TestMessagesAbstract.class, "path");
+         ResourceMethod resourceMethod = new DefaultResourceMethod(resourceClass, method, method);
          ResteasyProviderFactory providerFactory = new ResteasyProviderFactory();
          InjectorFactory injectorFactory = new InjectorFactoryImpl();
-         POJOResourceFactory resourceFactory = new POJOResourceFactory(clazz);
+         ResourceBuilder resourceBuilder = new ResourceBuilder();
+         POJOResourceFactory resourceFactory = new POJOResourceFactory(resourceBuilder, clazz);
          testMethod = new ResourceMethodInvoker(resourceMethod, injectorFactory, resourceFactory, providerFactory);
       }
       catch (NoSuchMethodException e)

--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxRegistry.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxRegistry.java
@@ -5,6 +5,7 @@ import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.Registry;
 import org.jboss.resteasy.spi.ResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.spi.metadata.ResourceClass;
 
 /**
@@ -14,31 +15,33 @@ public class VertxRegistry implements Registry
 {
 
    private final Registry delegate;
+   private final ResourceBuilder resourceBuilder;
 
-   public VertxRegistry(Registry delegate)
+   public VertxRegistry(Registry delegate, ResourceBuilder resourceBuilder)
    {
       this.delegate = delegate;
+      this.resourceBuilder = resourceBuilder;
    }
 
 
    public void addPerInstanceResource(Class<?> clazz)
    {
-      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(clazz)));
+      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(resourceBuilder, clazz)));
    }
 
    public void addPerInstanceResource(Class<?> clazz, String basePath)
    {
-      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(clazz)), basePath);
+      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(resourceBuilder, clazz)), basePath);
    }
 
    public void addPerInstanceResource(ResourceClass resourceClass)
    {
-      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(resourceClass)));
+      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(resourceBuilder, resourceClass)));
    }
 
    public void addPerInstanceResource(ResourceClass resourceClass, String basePath)
    {
-      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(resourceClass)), basePath);
+      delegate.addResourceFactory(new VertxResourceFactory(new POJOResourceFactory(resourceBuilder, resourceClass)), basePath);
    }
 
    @Override

--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxResteasyDeployment.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxResteasyDeployment.java
@@ -15,7 +15,7 @@ public class VertxResteasyDeployment extends ResteasyDeployment
       Registry registry = super.getRegistry();
       if (!(registry instanceof VertxRegistry))
       {
-         registry = new VertxRegistry(registry);
+         registry = new VertxRegistry(registry, getProviderFactory().getResourceBuilder());
       }
       return (VertxRegistry) registry;
    }


### PR DESCRIPTION
This replaces #1455 

* [RESTEASY-1805] Extract interface from ResourceLocator

* [RESTEASY-1805] Extract interface from ResourceMethod

* [RESTEASY-1805] Extract interface from ResourceConstructor

* [RESTEASY-1805] Extract interface from ResourceClass

* [RESTEASY-1805] Let ResteasyProviderFactory manage a single ResourceBuilder

* [RESTEASY-1805] Added ResourceClassProcessor SPI

* Make POJOResourceFactory backward compatibile

* Make ResourceBuilder backward compatible

* Keep on using former APIs on tests

* Restore constructor in SingletonResource

* Deprecate old constructor in POJOResourceFactory