### PR TITLE
[RESTEASY-1882] Regression tests for RESTEASY-1735 (gzip tests)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <!-- maven-javadoc-plugin -->
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <!-- maven-surefire-plugin -->
-        <surefire.system.args>${modular.jdk.args} ${modular.jdk.props}</surefire.system.args>
+        <surefire.system.args>-Xms512m -Xmx512m ${modular.jdk.args} ${modular.jdk.props}</surefire.system.args>
         <!-- Plugins versions -->
         <version.org.jacoco.plugin>0.7.9</version.org.jacoco.plugin>
         <version.surefire.plugin>2.19.1</version.surefire.plugin>
@@ -217,7 +217,7 @@
                     <version>${version.surefire.plugin}</version>
                     <configuration>
                         <forkMode>once</forkMode>
-                        <argLine>-Xms512m -Xmx512m ${surefire.system.args}</argLine>
+                        <argLine>${surefire.system.args}</argLine>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -360,6 +360,8 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                     <executions>
+
+                        <!-- default test execution -->
                         <execution>
                             <id>default-test</id>
                             <phase>test</phase>
@@ -369,10 +371,17 @@
                             <configuration>
                                 <excludes>
                                      <!-- Tests requires excluding JsonBindingProvider-->
-                                     <exclude>**/JsonBindingAnnotationsJacksonTest.java</exclude>
+                                    <exclude>**/JsonBindingAnnotationsJacksonTest.java</exclude>
+                                    <exclude>**/AllowGzipOnServerAllowGzipOnClientTest.java</exclude>
+                                    <exclude>**/AllowGzipOnServerNotAllowGzipOnClientTest.java</exclude>
                                 </excludes>
+                                <systemPropertyVariables combine.children="append">
+                                    <allow.gzip.server.jvm.arg>-Dplaceholder=placeholder</allow.gzip.server.jvm.arg>
+                                </systemPropertyVariables>
                             </configuration>
                         </execution>
+
+                        <!-- execution with excluded JSON-B -->
                         <execution>
                             <id>disable-jsonb-client</id>
                             <phase>test</phase>
@@ -386,8 +395,32 @@
                                 <classpathDependencyExcludes>
                                     <classpathDependencyExclude>org.jboss.resteasy:resteasy-json-binding-provider</classpathDependencyExclude>
                                 </classpathDependencyExcludes>
+                                <systemPropertyVariables combine.children="append">
+                                    <allow.gzip.server.jvm.arg>-Dplaceholder=placeholder</allow.gzip.server.jvm.arg>
+                                </systemPropertyVariables>
                             </configuration>
                         </execution>
+
+                        <!-- execution allows gzip interceptors on server by -Dallow.gzip property -->
+                        <execution>
+                            <id>allowGzip_on_server.allowGzip_on_client</id>
+                            <phase>test</phase>
+                            <goals>
+                                <goal>test</goal>
+                            </goals>
+                            <configuration>
+                                <trimStackTrace>false</trimStackTrace>
+                                <skip>false</skip>
+                                <systemPropertyVariables combine.children="append">
+                                    <allow.gzip.server.jvm.arg>-Dresteasy.allowGzip=true</allow.gzip.server.jvm.arg>
+                                </systemPropertyVariables>
+                                <includes>
+                                    <include>**/AllowGzipOnServerAllowGzipOnClientTest.java</include>
+                                    <include>**/AllowGzipOnServerNotAllowGzipOnClientTest.java</include>
+                                </includes>
+                            </configuration>
+                        </execution>
+
                     </executions>
             </plugin>
         </plugins>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/AllowGzipOnServerAllowGzipOnClientTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/AllowGzipOnServerAllowGzipOnClientTest.java
@@ -1,0 +1,36 @@
+package org.jboss.resteasy.test.interceptor.gzip;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @tpSubChapter Gzip
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Regression test for RESTEASY-1735
+ * @tpSince RESTEasy 3.6
+ */
+public class AllowGzipOnServerAllowGzipOnClientTest extends GzipAbstractTest {
+
+    @BeforeClass
+    public static void init() {
+        System.setProperty(PROPERTY_NAME, Boolean.TRUE.toString());
+    }
+
+    @AfterClass
+    public static void clean() {
+        System.clearProperty(PROPERTY_NAME);
+    }
+
+    /**
+     * @tpTestDetails gzip is allowed on both server and client by resteasy.allowGzip system property
+     * @tpSince RESTEasy 3.6
+     */
+    @Test
+    @OperateOnDeployment("war_without_providers_file")
+    public void allowGzipOnServerAllowGzipOnClientTest() throws Exception {
+        testNormalClient(false, "true", true, true);
+    }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/AllowGzipOnServerNotAllowGzipOnClientTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/AllowGzipOnServerNotAllowGzipOnClientTest.java
@@ -1,0 +1,36 @@
+package org.jboss.resteasy.test.interceptor.gzip;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.junit.Test;
+
+/**
+ * @tpSubChapter Gzip
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Regression test for RESTEASY-1735
+ * @tpSince RESTEasy 3.6
+ */
+public class AllowGzipOnServerNotAllowGzipOnClientTest extends GzipAbstractTest {
+
+    /**
+     * @tpTestDetails gzip is allowed on server by resteasy.allowGzip system property,
+     *                gzip is allowed on client by manual import of gzip interceptors
+     * @tpSince RESTEasy 3.6
+     */
+    @Test
+    @OperateOnDeployment("war_without_providers_file")
+    public void manuallyImportOnClient() throws Exception {
+        testNormalClient(true, "true", true, true);
+    }
+
+    /**
+     * @tpTestDetails gzip is allowed on server by resteasy.allowGzip system property
+     *                gzip is disabled on client
+     * @tpSince RESTEasy 3.6
+     */
+    @Test
+    @OperateOnDeployment("war_with_providers_file")
+    public void noGzipOnClient() throws Exception {
+        testNormalClient(false, "true", false, false);
+    }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/GzipAbstractTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/GzipAbstractTest.java
@@ -1,0 +1,143 @@
+package org.jboss.resteasy.test.interceptor.gzip;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.test.interceptor.gzip.resource.GzipResource;
+import org.jboss.resteasy.test.interceptor.gzip.resource.GzipInterface;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import java.net.URL;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.hamcrest.core.StringEndsWith.endsWith;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Abstract base class for gzip tests
+ *
+ * This abstract class provides deployments, basic test methods, Arquillian RUL Resource and RESTEasy client
+ *
+ * This abstract class is extended by:
+ *      AllowGzipOnServerAllowGzipOnClientTest
+ *      AllowGzipOnServerNotAllowGzipOnClientTest
+ *      NotAllowGzipOnServerAllowGzipOnClientTest
+ *      NotAllowGzipOnServerNotAllowGzipOnClientTest
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public abstract class GzipAbstractTest {
+
+    /**
+     * Allow gzip property
+     */
+    protected static final String PROPERTY_NAME = "resteasy.allowGzip";
+
+    /**
+     * Deployment with javax.ws.rs.ext.Providers file, that contains gzip interceptor definition
+     */
+    @Deployment(name = "war_with_providers_file")
+    public static Archive<?> createWebDeploymentWithGzipProvidersFile() {
+        return createWebArchive("test_war_with_providers", true);
+    }
+
+    /**
+     * Deployment without any javax.ws.rs.ext.Providers file
+     */
+    @Deployment(name = "war_without_providers_file")
+    public static Archive<?> createWebDeploymentWithoutGzipProvidersFile() {
+        return createWebArchive("test_war_without_providers", false);
+    }
+
+    /**
+     * Prepare archive for the tests
+     */
+    private static Archive<?> createWebArchive(String name, boolean addProvidersFileWithGzipInterceptors) {
+        WebArchive war = TestUtil.prepareArchive(name);
+        war = war.addClass(GzipInterface.class);
+        war = war.addAsWebInfResource(EmptyAsset.INSTANCE, "WEB-INF/beans.xml");
+        if (addProvidersFileWithGzipInterceptors) {
+            war.addAsManifestResource(GzipAbstractTest.class.getPackage(), "GzipAbstractTest-javax.ws.rs.ext.Providers", "services/javax.ws.rs.ext.Providers");
+        }
+        return TestUtil.finishContainerPrepare(war, null, GzipResource.class);
+    }
+
+    @ArquillianResource
+    URL deploymentUrl;
+
+    private ResteasyClient client;
+
+    /**
+     * Perform gzip test
+     *
+     * @param manuallyUseGzipOnClient manually register gzip interceptors on client side
+     * @param assertAllowGzipOnServer if true, method asserts that resteasy.allowGzip == true on server side
+     * @param assertAllowGzipOnClient if true, method asserts that client send gzip header in request
+     * @param assertServerReturnGzip method asserts whether gzip encoding should be in header or should not
+     * @throws Exception
+     */
+    protected void testNormalClient(boolean manuallyUseGzipOnClient, String assertAllowGzipOnServer, boolean assertAllowGzipOnClient,
+                                    boolean assertServerReturnGzip) throws Exception {
+        client = new ResteasyClientBuilder().build();
+
+        if (manuallyUseGzipOnClient) {
+            client.register(org.jboss.resteasy.plugins.interceptors.AcceptEncodingGZIPFilter.class);
+            client.register(org.jboss.resteasy.plugins.interceptors.GZIPDecodingInterceptor.class);
+            client.register(org.jboss.resteasy.plugins.interceptors.GZIPEncodingInterceptor.class);
+        }
+
+        try {
+            // make http request
+            String url = deploymentUrl.toString() + "gzip/process";
+            WebTarget base = client.target(url);
+            String message2echo = "some statement";
+            Response response = base.queryParam("name", message2echo).request().get();
+
+            // echo URL
+            System.out.println("URL: " + url);
+
+            // check encoding in response
+            String responseEncoding = response.getHeaderString("Content-Encoding");
+            if (responseEncoding == null) {
+                responseEncoding = "";
+            }
+            System.out.println("responseEncoding: " + responseEncoding);
+            if (assertServerReturnGzip) {
+                Assert.assertThat("wrong encoding of response", responseEncoding, containsString("gzip"));
+            } else {
+                Assert.assertThat("wrong encoding of response", responseEncoding, not(containsString("gzip")));
+            }
+
+            // read data from response
+            String echo = response.readEntity(String.class);
+            assertNotNull("Response doesn't have body", echo);
+
+            // check resteasy.allowGzip property on server
+            assertThat("Server doesn't have correct value of resteasy.allowGzip property", echo, startsWith(message2echo + " ___ -Dresteasy.allowGzip=" + assertAllowGzipOnServer));
+
+            // check gzip request header
+            if (assertAllowGzipOnClient) {
+                assertThat("Server should receive request with gzip header", echo, endsWith("gzip_in_request_header_yes"));
+            } else {
+                assertThat("Server should not receive request with gzip header", echo, endsWith("gzip_in_request_header_no"));
+            }
+
+        } finally {
+            client.close();
+        }
+    }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/NotAllowGzipOnServerAllowGzipOnClientTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/NotAllowGzipOnServerAllowGzipOnClientTest.java
@@ -1,0 +1,48 @@
+package org.jboss.resteasy.test.interceptor.gzip;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @tpSubChapter Gzip
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Regression test for RESTEASY-1735
+ * @tpSince RESTEasy 3.6
+ */
+public class NotAllowGzipOnServerAllowGzipOnClientTest extends GzipAbstractTest {
+
+    @BeforeClass
+    public static void init() {
+        System.setProperty(PROPERTY_NAME, Boolean.TRUE.toString());
+    }
+
+    @AfterClass
+    public static void clean() {
+        System.clearProperty(PROPERTY_NAME);
+    }
+
+    /**
+     * @tpTestDetails gzip is disabled on server
+     *                gzip is allowed on client by resteasy.allowGzip system property
+     * @tpSince RESTEasy 3.6
+     */
+    @Test
+    @OperateOnDeployment("war_without_providers_file")
+    public void noProvidersFileOnServer() throws Exception {
+        testNormalClient(false, "null", true, false);
+    }
+
+    /**
+     * @tpTestDetails gzip is enabled on server by javax.ws.rs.ext.Providers file in deployment
+     *                gzip is allowed on client by resteasy.allowGzip system property
+     * @tpSince RESTEasy 3.6
+     */
+    @Test
+    @OperateOnDeployment("war_with_providers_file")
+    public void providersFileOnServer() throws Exception {
+        testNormalClient(false, "null", true, true);
+    }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/NotAllowGzipOnServerNotAllowGzipOnClientTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/NotAllowGzipOnServerNotAllowGzipOnClientTest.java
@@ -1,0 +1,60 @@
+package org.jboss.resteasy.test.interceptor.gzip;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.junit.Test;
+
+/**
+ * @tpSubChapter Gzip
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Regression test for RESTEASY-1735
+ * @tpSince RESTEasy 3.6
+ */
+public class NotAllowGzipOnServerNotAllowGzipOnClientTest extends GzipAbstractTest {
+
+    /**
+     * @tpTestDetails gzip is disabled on server
+     *                gzip is disabled on client
+     * @tpSince RESTEasy 3.6
+     */
+    @Test
+    @OperateOnDeployment("war_without_providers_file")
+    public void noProvidersFileNoManualImportOnClient() throws Exception {
+        testNormalClient(false, "null", false, false);
+    }
+
+    /**
+     * @tpTestDetails gzip is enabled on server by javax.ws.rs.ext.Providers file in deployment
+     *                gzip is allowed on client by manual import of gzip interceptors
+     * @tpSince RESTEasy 3.6
+     */
+    @Test
+    @OperateOnDeployment("war_with_providers_file")
+    public void providersFileManualImportOnClient() throws Exception {
+        testNormalClient(true, "null", true, true);
+    }
+
+
+    /**
+     * @tpTestDetails gzip is enabled on server by javax.ws.rs.ext.Providers file in deployment
+     *                gzip is disabled on client
+     * @tpSince RESTEasy 3.6
+     */
+    @Test
+    @OperateOnDeployment("war_with_providers_file")
+    public void providersFileNoManualImportOnClient() throws Exception {
+        testNormalClient(false, "null", false, false);
+    }
+
+
+    /**
+     * @tpTestDetails gzip is disabled on server
+     *                gzip is allowed on client by manual import of gzip interceptors
+     * @tpSince RESTEasy 3.6
+     */
+    @Test
+    @OperateOnDeployment("war_without_providers_file")
+    public void noProvidersFileManualImportOnClient() throws Exception {
+        testNormalClient(true, "null", true, false);
+    }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/resource/GzipInterface.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/resource/GzipInterface.java
@@ -1,0 +1,22 @@
+package org.jboss.resteasy.test.interceptor.gzip.resource;
+
+import org.jboss.resteasy.annotations.GZIP;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Path("/gzip")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface GzipInterface {
+	
+    @GET
+    @Path("/process")
+    @GZIP
+    String process(@QueryParam("name") String message);
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/resource/GzipResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/resource/GzipResource.java
@@ -1,0 +1,28 @@
+package org.jboss.resteasy.test.interceptor.gzip.resource;
+
+import org.jboss.logging.Logger;
+
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import java.util.Optional;
+
+
+public class GzipResource implements GzipInterface {
+
+    private static Logger log = Logger.getLogger(GzipResource.class);
+	
+    @Context HttpHeaders headers;
+
+    public String process(String message) {
+        log.info("echo " + message + " via GzipResource");
+
+        Optional<String> oEncoding = headers.getRequestHeader("Accept-Encoding").stream().findFirst();
+        String encoding = "gzip_in_request_header_no";
+        if (oEncoding.isPresent()) {
+            encoding = oEncoding.get().contains("gzip") ? "gzip_in_request_header_yes" : encoding;
+        }
+
+        return message + " ___ -Dresteasy.allowGzip=" + System.getProperty("resteasy.allowGzip", "null") + " ___ " + encoding;
+    }
+
+}

--- a/testsuite/integration-tests/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests/src/test/resources/arquillian.xml
@@ -12,7 +12,7 @@
             <!--<property name="javaVmArguments">-Xmx512m -XX:MaxPermSize=128m
                 -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y
             </property>-->
-            <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent}</property>
+            <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${allow.gzip.server.jvm.arg} ${ipv6ArquillianSettings} ${jacoco.agent}</property>
             <property name="managementAddress">${node}</property>
         </configuration>
     </container>

--- a/testsuite/integration-tests/src/test/resources/org/jboss/resteasy/test/interceptor/gzip/GzipAbstractTest-javax.ws.rs.ext.Providers
+++ b/testsuite/integration-tests/src/test/resources/org/jboss/resteasy/test/interceptor/gzip/GzipAbstractTest-javax.ws.rs.ext.Providers
@@ -1,0 +1,3 @@
+org.jboss.resteasy.plugins.interceptors.AcceptEncodingGZIPFilter
+org.jboss.resteasy.plugins.interceptors.GZIPDecodingInterceptor
+org.jboss.resteasy.plugins.interceptors.GZIPEncodingInterceptor


### PR DESCRIPTION
jira: https://issues.jboss.org/browse/RESTEASY-1882

This commit adds regression tests for https://issues.jboss.org/browse/RESTEASY-1735

The main reason for new execution in these tests is that server needs to be started with two different settings: define -Dresteasy.allowGzip=true and don't define that.

This could be implemented also by more container definitions in arquillian.xml, but if we want to use this approach, container (EAP/WF) needs to be started in class/manual mode, see some details in [1]. I don't recommend this approach.

If this PR will be approved, I create new PR for 3.6. New 3.6 PR would be slightly different, because gzip interceptors are placed in different packages in 3.6.


[1] http://arquillian.org/blog/2011/11/26/arquillian-core-1-0-0-CR6/