### PR TITLE
[RESTEASY-1905] Async injection

### DIFF
--- a/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/PatchMethodFilter.java
+++ b/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/PatchMethodFilter.java
@@ -57,7 +57,23 @@ public class PatchMethodFilter implements ContainerRequestFilter
             throw new ProcessingException("Get method not found and patch method failed");
          }
          ResourceMethodInvoker methodInvoker = (ResourceMethodInvoker) resourceInovker;
+<<<<<<< HEAD
          Object object;
+=======
+         Object object = methodInvoker.invokeDryRun(request, response).toCompletableFuture().getNow(null);
+
+         ByteArrayOutputStream tmpOutputStream = new ByteArrayOutputStream();
+         MessageBodyWriter msgBodyWriter = ResteasyProviderFactory.getInstance().getMessageBodyWriter(
+               object.getClass(), object.getClass(), methodInvoker.getMethodAnnotations(),
+               MediaType.APPLICATION_JSON_TYPE);
+         msgBodyWriter.writeTo(object, object.getClass(), object.getClass(), methodInvoker.getMethodAnnotations(),
+               MediaType.APPLICATION_JSON_TYPE, new MultivaluedTreeMap<String, Object>(), tmpOutputStream);
+         ObjectMapper mapper = new ObjectMapper();
+         JsonNode targetJson = mapper.readValue(tmpOutputStream.toByteArray(), JsonNode.class);
+         JsonPatch patch = JsonPatch.fromJson(mapper.readValue(request.getInputStream(), JsonNode.class));
+
+         JsonNode result = null;
+>>>>>>> Fixed bug with PatchMethodFilter due to my changes
          try
          {
             object = methodInvoker.invokeDryRun(request, response);

--- a/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/PatchMethodFilter.java
+++ b/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/PatchMethodFilter.java
@@ -57,26 +57,10 @@ public class PatchMethodFilter implements ContainerRequestFilter
             throw new ProcessingException("Get method not found and patch method failed");
          }
          ResourceMethodInvoker methodInvoker = (ResourceMethodInvoker) resourceInovker;
-<<<<<<< HEAD
          Object object;
-=======
-         Object object = methodInvoker.invokeDryRun(request, response).toCompletableFuture().getNow(null);
-
-         ByteArrayOutputStream tmpOutputStream = new ByteArrayOutputStream();
-         MessageBodyWriter msgBodyWriter = ResteasyProviderFactory.getInstance().getMessageBodyWriter(
-               object.getClass(), object.getClass(), methodInvoker.getMethodAnnotations(),
-               MediaType.APPLICATION_JSON_TYPE);
-         msgBodyWriter.writeTo(object, object.getClass(), object.getClass(), methodInvoker.getMethodAnnotations(),
-               MediaType.APPLICATION_JSON_TYPE, new MultivaluedTreeMap<String, Object>(), tmpOutputStream);
-         ObjectMapper mapper = new ObjectMapper();
-         JsonNode targetJson = mapper.readValue(tmpOutputStream.toByteArray(), JsonNode.class);
-         JsonPatch patch = JsonPatch.fromJson(mapper.readValue(request.getInputStream(), JsonNode.class));
-
-         JsonNode result = null;
->>>>>>> Fixed bug with PatchMethodFilter due to my changes
          try
          {
-            object = methodInvoker.invokeDryRun(request, response);
+            object = methodInvoker.invokeDryRun(request, response).toCompletableFuture().getNow(null);
             ByteArrayOutputStream tmpOutputStream = new ByteArrayOutputStream();
             MessageBodyWriter msgBodyWriter = ResteasyProviderFactory.getInstance().getMessageBodyWriter(
                   object.getClass(), object.getClass(), methodInvoker.getMethodAnnotations(),

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiConstructorInjector.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiConstructorInjector.java
@@ -39,7 +39,7 @@ public class CdiConstructorInjector implements ConstructorInjector
    }
 
    @Override
-   public CompletionStage<Object> construct()
+   public CompletionStage<Object> construct(boolean unwrapAsync)
    {
       Set<Bean<?>> beans = manager.getBeans(type);
       
@@ -72,18 +72,20 @@ public class CdiConstructorInjector implements ConstructorInjector
    }
 
    @Override
-   public CompletionStage<Object> construct(HttpRequest request, HttpResponse response) throws Failure, WebApplicationException, ApplicationException
+   public CompletionStage<Object> construct(HttpRequest request, HttpResponse response, boolean unwrapAsync) throws Failure, WebApplicationException, ApplicationException
    {
-      return construct();
+      return construct(unwrapAsync);
    }
 
-   public CompletionStage<Object[]> injectableArguments()
+   @Override
+   public CompletionStage<Object[]> injectableArguments(boolean unwrapAsync)
    {
       return CompletableFuture.completedFuture(new Object[0]);
    }
 
-   public CompletionStage<Object[]> injectableArguments(HttpRequest request, HttpResponse response) throws Failure
+   @Override
+   public CompletionStage<Object[]> injectableArguments(HttpRequest request, HttpResponse response, boolean unwrapAsync) throws Failure
    {
-      return injectableArguments();
+      return injectableArguments(unwrapAsync);
    }
 }

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiConstructorInjector.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiConstructorInjector.java
@@ -17,6 +17,8 @@ import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * This ConstructorInjector implementation uses CDI's BeanManager to obtain
@@ -36,7 +38,8 @@ public class CdiConstructorInjector implements ConstructorInjector
       this.manager = manager;
    }
 
-   public Object construct()
+   @Override
+   public CompletionStage<Object> construct()
    {
       Set<Bean<?>> beans = manager.getBeans(type);
       
@@ -65,20 +68,21 @@ public class CdiConstructorInjector implements ConstructorInjector
       
       Bean<?> bean = manager.resolve(beans);
       CreationalContext<?> context = manager.createCreationalContext(bean);
-      return manager.getReference(bean, type, context);
+      return CompletableFuture.completedFuture(manager.getReference(bean, type, context));
    }
 
-   public Object construct(HttpRequest request, HttpResponse response) throws Failure, WebApplicationException, ApplicationException
+   @Override
+   public CompletionStage<Object> construct(HttpRequest request, HttpResponse response) throws Failure, WebApplicationException, ApplicationException
    {
       return construct();
    }
 
-   public Object[] injectableArguments()
+   public CompletionStage<Object[]> injectableArguments()
    {
-      return new Object[0];
+      return CompletableFuture.completedFuture(new Object[0]);
    }
 
-   public Object[] injectableArguments(HttpRequest request, HttpResponse response) throws Failure
+   public CompletionStage<Object[]> injectableArguments(HttpRequest request, HttpResponse response) throws Failure
    {
       return injectableArguments();
    }

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiPropertyInjector.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiPropertyInjector.java
@@ -64,21 +64,21 @@ public class CdiPropertyInjector implements PropertyInjector
    }
    
    @Override
-   public CompletionStage<Void> inject(Object target)
+   public CompletionStage<Void> inject(Object target, boolean unwrapAsync)
    {
       if (injectorEnabled)
       {
-         return delegate.inject(target);
+         return delegate.inject(target, unwrapAsync);
       }
       return CompletableFuture.completedFuture(null);
    }
 
    @Override
-   public CompletionStage<Void> inject(HttpRequest request, HttpResponse response, Object target) throws Failure, WebApplicationException, ApplicationException
+   public CompletionStage<Void> inject(HttpRequest request, HttpResponse response, Object target, boolean unwrapAsync) throws Failure, WebApplicationException, ApplicationException
    {
       if (injectorEnabled)
       {
-         return delegate.inject(request, response, target);
+         return delegate.inject(request, response, target, unwrapAsync);
       }
       return CompletableFuture.completedFuture(null);
    }

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiPropertyInjector.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiPropertyInjector.java
@@ -31,6 +31,8 @@ import javax.enterprise.inject.spi.BeanManager;
 import javax.ws.rs.WebApplicationException;
 import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * JAX-RS property injection is performed twice on CDI Beans. Firstly by the JaxrsInjectionTarget
@@ -62,21 +64,23 @@ public class CdiPropertyInjector implements PropertyInjector
    }
    
    @Override
-   public void inject(Object target)
+   public CompletionStage<Void> inject(Object target)
    {
       if (injectorEnabled)
       {
-         delegate.inject(target);
+         return delegate.inject(target);
       }
+      return CompletableFuture.completedFuture(null);
    }
 
    @Override
-   public void inject(HttpRequest request, HttpResponse response, Object target) throws Failure, WebApplicationException, ApplicationException
+   public CompletionStage<Void> inject(HttpRequest request, HttpResponse response, Object target) throws Failure, WebApplicationException, ApplicationException
    {
       if (injectorEnabled)
       {
-         delegate.inject(request, response, target);
+         return delegate.inject(request, response, target);
       }
+      return CompletableFuture.completedFuture(null);
    }
 
    @Override

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/JaxrsInjectionTarget.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/JaxrsInjectionTarget.java
@@ -55,11 +55,11 @@ public class JaxrsInjectionTarget<T> implements InjectionTarget<T>
 
       if ((request != null) && (response != null))
       {
-         propertyInjector.inject(request, response, instance);
+         propertyInjector.inject(request, response, instance, false);
       }
       else
       {
-         propertyInjector.inject(instance);
+         propertyInjector.inject(instance, false);
       }
       
       if (request != null)

--- a/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/GuiceResourceFactory.java
+++ b/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/GuiceResourceFactory.java
@@ -1,6 +1,9 @@
 package org.jboss.resteasy.plugins.guice;
 
 import com.google.inject.Provider;
+
+import java.util.concurrent.CompletionStage;
+
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.PropertyInjector;
@@ -30,11 +33,12 @@ public class GuiceResourceFactory implements ResourceFactory
       propertyInjector = factory.getInjectorFactory().createPropertyInjector(scannableClass, factory);
    }
 
-   public Object createResource(final HttpRequest request, final HttpResponse response, final ResteasyProviderFactory factory)
+   @Override
+   public CompletionStage<Object> createResource(final HttpRequest request, final HttpResponse response, final ResteasyProviderFactory factory)
    {
       final Object resource = provider.get();
-      propertyInjector.inject(request, response, resource);
-      return resource;
+      return propertyInjector.inject(request, response, resource)
+    		  .thenApply(v -> resource);
    }
 
    public void requestFinished(final HttpRequest request, final HttpResponse response, final Object resource)

--- a/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/GuiceResourceFactory.java
+++ b/resteasy-guice/src/main/java/org/jboss/resteasy/plugins/guice/GuiceResourceFactory.java
@@ -37,7 +37,7 @@ public class GuiceResourceFactory implements ResourceFactory
    public CompletionStage<Object> createResource(final HttpRequest request, final HttpResponse response, final ResteasyProviderFactory factory)
    {
       final Object resource = provider.get();
-      return propertyInjector.inject(request, response, resource)
+      return propertyInjector.inject(request, response, resource, true)
     		  .thenApply(v -> resource);
    }
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AbstractCollectionFormInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AbstractCollectionFormInjector.java
@@ -42,7 +42,7 @@ public abstract class AbstractCollectionFormInjector<T> extends PrefixedFormInje
     * {@inheritDoc} Creates a collection instance and fills it with content by using the super implementation.
     */
    @Override
-   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync)
    {
       T result = createInstance(collectionType);
       CompletionStage<Void> ret = CompletableFuture.completedFuture(null);
@@ -51,7 +51,7 @@ public abstract class AbstractCollectionFormInjector<T> extends PrefixedFormInje
          Matcher matcher = pattern.matcher(collectionPrefix);
          matcher.matches();
          String key = matcher.group(1);
-         ret = ret.thenCompose(v -> super.doInject(collectionPrefix, request, response)
+         ret = ret.thenCompose(v -> super.doInject(collectionPrefix, request, response, unwrapAsync)
                .thenAccept(value -> {
                   addTo(result, key, value);
                }));

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AsynchronousResponseInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AsynchronousResponseInjector.java
@@ -26,13 +26,13 @@ public class AsynchronousResponseInjector implements ValueInjector
    }
 
    @Override
-   public CompletionStage<Object> inject()
+   public CompletionStage<Object> inject(boolean unwrapAsync)
    {
       throw new IllegalStateException(Messages.MESSAGES.cannotInjectAsynchronousResponse());
    }
 
    @Override
-   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync)
    {
       ResteasyAsynchronousResponse asynchronousResponse = null;
       if (timeout == -1)

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AsynchronousResponseInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AsynchronousResponseInjector.java
@@ -8,6 +8,8 @@ import org.jboss.resteasy.spi.ResteasyAsynchronousResponse;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -24,13 +26,13 @@ public class AsynchronousResponseInjector implements ValueInjector
    }
 
    @Override
-   public Object inject()
+   public CompletionStage<Object> inject()
    {
       throw new IllegalStateException(Messages.MESSAGES.cannotInjectAsynchronousResponse());
    }
 
    @Override
-   public Object inject(HttpRequest request, HttpResponse response)
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
    {
       ResteasyAsynchronousResponse asynchronousResponse = null;
       if (timeout == -1)
@@ -44,6 +46,6 @@ public class AsynchronousResponseInjector implements ValueInjector
       ResourceMethodInvoker invoker =  (ResourceMethodInvoker)request.getAttribute(ResourceMethodInvoker.class.getName());
       invoker.initializeAsync(asynchronousResponse);
 
-      return asynchronousResponse;
+      return CompletableFuture.completedFuture(asynchronousResponse);
    }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ContextParameterInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ContextParameterInjector.java
@@ -73,7 +73,7 @@ public class ContextParameterInjector implements ValueInjector
          try
          {
            
-            Object delegate = ResteasyProviderFactory.getContextData(type);
+            Object delegate = factory.getContextData(rawType, genericType);
             if (delegate == null)
             {
                String name = method.getName();

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/CookieParamInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/CookieParamInjector.java
@@ -40,7 +40,7 @@ public class CookieParamInjector extends StringParameterInjector implements Valu
    }
 
    @Override
-   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync)
    {
       Cookie cookie = request.getHttpHeaders().getCookies().get(paramName);
       if (type.equals(Cookie.class)) return CompletableFuture.completedFuture(cookie);
@@ -52,7 +52,7 @@ public class CookieParamInjector extends StringParameterInjector implements Valu
    }
 
    @Override
-   public CompletionStage<Object> inject()
+   public CompletionStage<Object> inject(boolean unwrapAsync)
    {
       throw new RuntimeException(Messages.MESSAGES.illegalToInjectCookieParam());
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/CookieParamInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/CookieParamInjector.java
@@ -13,6 +13,8 @@ import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -37,18 +39,20 @@ public class CookieParamInjector extends StringParameterInjector implements Valu
       }
    }
 
-   public Object inject(HttpRequest request, HttpResponse response)
+   @Override
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
    {
       Cookie cookie = request.getHttpHeaders().getCookies().get(paramName);
-      if (type.equals(Cookie.class)) return cookie;
+      if (type.equals(Cookie.class)) return CompletableFuture.completedFuture(cookie);
 
-      if (cookie == null) return extractValues(null);
+      if (cookie == null) return CompletableFuture.completedFuture(extractValues(null));
       List<String> values = new ArrayList<String>();
       values.add(cookie.getValue());
-      return extractValues(values);
+      return CompletableFuture.completedFuture(extractValues(values));
    }
 
-   public Object inject()
+   @Override
+   public CompletionStage<Object> inject()
    {
       throw new RuntimeException(Messages.MESSAGES.illegalToInjectCookieParam());
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/FormInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/FormInjector.java
@@ -41,16 +41,16 @@ public class FormInjector implements ValueInjector
    }
 
    @Override
-   public CompletionStage<Object> inject()
+   public CompletionStage<Object> inject(boolean unwrapAsync)
    {
       throw new IllegalStateException(Messages.MESSAGES.cannotInjectIntoForm());
    }
 
    @Override
-   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync)
    {
-      return constructorInjector.construct()
-            .thenCompose(target -> propertyInjector.inject(request, response, target)
+      return constructorInjector.construct(unwrapAsync)
+            .thenCompose(target -> propertyInjector.inject(request, response, target, unwrapAsync)
                                     .thenApply(v -> target));
    }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/FormInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/FormInjector.java
@@ -8,6 +8,7 @@ import org.jboss.resteasy.spi.PropertyInjector;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 import java.lang.reflect.Constructor;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -39,15 +40,17 @@ public class FormInjector implements ValueInjector
 
    }
 
-   public Object inject()
+   @Override
+   public CompletionStage<Object> inject()
    {
       throw new IllegalStateException(Messages.MESSAGES.cannotInjectIntoForm());
    }
 
-   public Object inject(HttpRequest request, HttpResponse response)
+   @Override
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
    {
-      Object target = constructorInjector.construct();
-      propertyInjector.inject(request, response, target);
-      return target;
+      return constructorInjector.construct()
+            .thenCompose(target -> propertyInjector.inject(request, response, target)
+                                    .thenApply(v -> target));
    }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/FormParamInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/FormParamInjector.java
@@ -14,6 +14,8 @@ import java.lang.reflect.Type;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -28,12 +30,13 @@ public class FormParamInjector extends StringParameterInjector implements ValueI
       super(type, genericType, header, FormParam.class, defaultValue, target, annotations, factory);
       this.encode = encode;
    }
-
-   public Object inject(HttpRequest request, HttpResponse response)
+   
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
    {
       List<String> list = request.getDecodedFormParameters().get(paramName);
       if (list == null)
       {
+         // FIXME: looks like a bug, no?
          extractValues(null);
       }
       else if (encode)
@@ -45,10 +48,10 @@ public class FormParamInjector extends StringParameterInjector implements ValueI
          }
          list = encodedList;
       }
-      return extractValues(list);
+      return CompletableFuture.completedFuture(extractValues(list));
    }
 
-   public Object inject()
+   public CompletionStage<Object> inject()
    {
       throw new RuntimeException(Messages.MESSAGES.illegalToInjectFormParam());
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/FormParamInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/FormParamInjector.java
@@ -31,7 +31,8 @@ public class FormParamInjector extends StringParameterInjector implements ValueI
       this.encode = encode;
    }
    
-   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
+   @Override
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync)
    {
       List<String> list = request.getDecodedFormParameters().get(paramName);
       if (list == null)
@@ -51,7 +52,8 @@ public class FormParamInjector extends StringParameterInjector implements ValueI
       return CompletableFuture.completedFuture(extractValues(list));
    }
 
-   public CompletionStage<Object> inject()
+   @Override
+   public CompletionStage<Object> inject(boolean unwrapAsync)
    {
       throw new RuntimeException(Messages.MESSAGES.illegalToInjectFormParam());
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/HeaderParamInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/HeaderParamInjector.java
@@ -11,6 +11,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -24,13 +26,15 @@ public class HeaderParamInjector extends StringParameterInjector implements Valu
       super(type, genericType, header, HeaderParam.class, defaultValue, target, annotations, factory);
    }
 
-   public Object inject(HttpRequest request, HttpResponse response)
+   @Override
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
    {
       List<String> list = request.getHttpHeaders().getRequestHeaders().get(paramName);
-      return extractValues(list);
+      return CompletableFuture.completedFuture(extractValues(list));
    }
 
-   public Object inject()
+   @Override
+   public CompletionStage<Object> inject()
    {
       throw new RuntimeException(Messages.MESSAGES.illegalToInjectHeaderParam());
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/HeaderParamInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/HeaderParamInjector.java
@@ -27,14 +27,14 @@ public class HeaderParamInjector extends StringParameterInjector implements Valu
    }
 
    @Override
-   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync)
    {
       List<String> list = request.getHttpHeaders().getRequestHeaders().get(paramName);
       return CompletableFuture.completedFuture(extractValues(list));
    }
 
    @Override
-   public CompletionStage<Object> inject()
+   public CompletionStage<Object> inject(boolean unwrapAsync)
    {
       throw new RuntimeException(Messages.MESSAGES.illegalToInjectHeaderParam());
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/InjectorFactoryImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/InjectorFactoryImpl.java
@@ -118,7 +118,7 @@ public class InjectorFactoryImpl implements InjectorFactory
          case SUSPEND:
             return new SuspendInjector(parameter.getSuspendTimeout(), parameter.getType());
          case CONTEXT:
-            return new ContextParameterInjector(null, parameter.getType(), providerFactory);
+            return new ContextParameterInjector(null, parameter.getType(), parameter.getGenericType(), providerFactory);
          case SUSPENDED:
             return new AsynchronousResponseInjector();
          case MESSAGE_BODY:
@@ -239,7 +239,7 @@ public class InjectorFactoryImpl implements InjectorFactory
       }
       else if (findAnnotation(annotations, Context.class) != null)
       {
-         return new ContextParameterInjector(null, type, providerFactory);
+         return new ContextParameterInjector(null, type, genericType, providerFactory);
       }
       else if ((suspended = findAnnotation(annotations, Suspended.class)) != null)
       {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/InjectorFactoryImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/InjectorFactoryImpl.java
@@ -118,7 +118,7 @@ public class InjectorFactoryImpl implements InjectorFactory
          case SUSPEND:
             return new SuspendInjector(parameter.getSuspendTimeout(), parameter.getType());
          case CONTEXT:
-            return new ContextParameterInjector(null, parameter.getType(), parameter.getGenericType(), providerFactory);
+            return new ContextParameterInjector(null, parameter.getType(), parameter.getGenericType(), parameter.getAnnotations(), providerFactory);
          case SUSPENDED:
             return new AsynchronousResponseInjector();
          case MESSAGE_BODY:
@@ -239,7 +239,7 @@ public class InjectorFactoryImpl implements InjectorFactory
       }
       else if (findAnnotation(annotations, Context.class) != null)
       {
-         return new ContextParameterInjector(null, type, genericType, providerFactory);
+         return new ContextParameterInjector(null, type, genericType, annotations, providerFactory);
       }
       else if ((suspended = findAnnotation(annotations, Suspended.class)) != null)
       {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/MatrixParamInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/MatrixParamInjector.java
@@ -32,7 +32,7 @@ public class MatrixParamInjector extends StringParameterInjector implements Valu
    }
 
    @Override
-   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync)
    {
       ArrayList<String> values = new ArrayList<String>();
       if (encode)
@@ -63,7 +63,7 @@ public class MatrixParamInjector extends StringParameterInjector implements Valu
    }
 
    @Override
-   public CompletionStage<Object> inject()
+   public CompletionStage<Object> inject(boolean unwrapAsync)
    {
       throw new RuntimeException(Messages.MESSAGES.illegalToInjectMatrixParam());
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/MatrixParamInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/MatrixParamInjector.java
@@ -14,6 +14,8 @@ import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -29,7 +31,8 @@ public class MatrixParamInjector extends StringParameterInjector implements Valu
       this.encode = encode;
    }
 
-   public Object inject(HttpRequest request, HttpResponse response)
+   @Override
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
    {
       ArrayList<String> values = new ArrayList<String>();
       if (encode)
@@ -48,8 +51,8 @@ public class MatrixParamInjector extends StringParameterInjector implements Valu
             if (list != null) values.addAll(list);
          }
       }
-      if (values.size() == 0) return extractValues(null);
-      else return extractValues(values);
+      if (values.size() == 0) return CompletableFuture.completedFuture(extractValues(null));
+      else return CompletableFuture.completedFuture(extractValues(values));
    }
 
    @Override
@@ -59,7 +62,8 @@ public class MatrixParamInjector extends StringParameterInjector implements Valu
 
    }
 
-   public Object inject()
+   @Override
+   public CompletionStage<Object> inject()
    {
       throw new RuntimeException(Messages.MESSAGES.illegalToInjectMatrixParam());
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/MessageBodyParameterInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/MessageBodyParameterInjector.java
@@ -127,7 +127,7 @@ public class MessageBodyParameterInjector implements ValueInjector, JaxrsInterce
 
 
    @Override
-   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync)
    {
       Object o = getBody();
       if (o != null)
@@ -238,7 +238,7 @@ public class MessageBodyParameterInjector implements ValueInjector, JaxrsInterce
    }
 
    @Override
-   public CompletionStage<Object> inject()
+   public CompletionStage<Object> inject(boolean unwrapAsync)
    {
       throw new RuntimeException(Messages.MESSAGES.illegalToInjectMessageBody(this.target));
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/MessageBodyParameterInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/MessageBodyParameterInjector.java
@@ -8,6 +8,8 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -124,12 +126,13 @@ public class MessageBodyParameterInjector implements ValueInjector, JaxrsInterce
    }
 
 
-   public Object inject(HttpRequest request, HttpResponse response)
+   @Override
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
    {
       Object o = getBody();
       if (o != null)
       {
-         return o;
+         return CompletableFuture.completedFuture(o);
       }
       MediaType mediaType = request.getHttpHeaders().getMediaType();
       if (mediaType == null)
@@ -201,7 +204,7 @@ public class MessageBodyParameterInjector implements ValueInjector, JaxrsInterce
          {
             InputStreamToByteArray isba = (InputStreamToByteArray) is;
             final byte[] bytes = isba.toByteArray();
-            return new MarshalledEntity()
+            return CompletableFuture.completedFuture(new MarshalledEntity()
             {
                @Override
                public byte[] getMarshalledBytes()
@@ -214,11 +217,11 @@ public class MessageBodyParameterInjector implements ValueInjector, JaxrsInterce
                {
                   return obj;
                }
-            };
+            });
          }
          else
          {
-            return obj;
+            return CompletableFuture.completedFuture(obj);
          }
       }
       catch (Exception e)
@@ -234,7 +237,8 @@ public class MessageBodyParameterInjector implements ValueInjector, JaxrsInterce
       }
    }
 
-   public Object inject()
+   @Override
+   public CompletionStage<Object> inject()
    {
       throw new RuntimeException(Messages.MESSAGES.illegalToInjectMessageBody(this.target));
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/MethodInjectorImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/MethodInjectorImpl.java
@@ -93,7 +93,7 @@ public class MethodInjectorImpl implements MethodInjector
             for (ValueInjector extractor : params)
             {
                int j = i++;
-               ret = ret.thenCompose(v -> extractor.inject(input, response)
+               ret = ret.thenCompose(v -> extractor.inject(input, response, true)
                                        .thenApply(value -> args[j] = value));
             }
             return ret.thenApply(v -> args);

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/MethodInjectorImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/MethodInjectorImpl.java
@@ -19,6 +19,8 @@ import javax.ws.rs.WebApplicationException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -78,21 +80,26 @@ public class MethodInjectorImpl implements MethodInjector
       return params;
    }
 
-   public Object[] injectArguments(HttpRequest input, HttpResponse response)
+   @Override
+   public CompletionStage<Object[]> injectArguments(HttpRequest input, HttpResponse response)
    {
       try
       {
-         Object[] args = null;
          if (params != null && params.length > 0)
          {
-            args = new Object[params.length];
+            Object[] args = new Object[params.length];
             int i = 0;
+            CompletionStage<Object> ret = CompletableFuture.completedFuture(null);
             for (ValueInjector extractor : params)
             {
-               args[i++] = extractor.inject(input, response);
+               int j = i++;
+               ret = ret.thenCompose(v -> extractor.inject(input, response)
+                                       .thenApply(value -> args[j] = value));
             }
+            return ret.thenApply(v -> args);
          }
-         return args;
+         else
+            return CompletableFuture.completedFuture(null);
       }
       catch (WebApplicationException we)
       {
@@ -110,9 +117,14 @@ public class MethodInjectorImpl implements MethodInjector
       }
    }
 
-   public Object invoke(HttpRequest request, HttpResponse httpResponse, Object resource) throws Failure, ApplicationException
+   public CompletionStage<Object> invoke(HttpRequest request, HttpResponse httpResponse, Object resource) throws Failure, ApplicationException
    {
-      Object[] args = injectArguments(request, httpResponse);
+      return injectArguments(request, httpResponse)
+            .thenApply(args -> invoke(request, httpResponse, resource, args));
+   }
+
+   private Object invoke(HttpRequest request, HttpResponse httpResponse, Object resource, Object[] args)
+   {
       GeneralValidator validator = GeneralValidator.class.cast(request.getAttribute(GeneralValidator.class.getName()));
       if (validator != null)
       {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/PathParamInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/PathParamInjector.java
@@ -17,6 +17,8 @@ import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -72,7 +74,8 @@ public class PathParamInjector implements ValueInjector
       return (List.class.equals(type) || ArrayList.class.equals(type)) && collectionBaseType != null && collectionBaseType.equals(PathSegment.class);
    }
 
-   public Object inject(HttpRequest request, HttpResponse response)
+   @Override
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
    {
       if (extractor == null) // we are a PathSegment
       {
@@ -95,15 +98,15 @@ public class PathParamInjector implements ValueInjector
          {
             PathSegment[] segments = new PathSegment[segmentList.size()];
             segments = segmentList.toArray(segments);
-            return segments;
+            return CompletableFuture.completedFuture(segments);
          }
          else if (pathSegmentList)
          {
-            return segmentList;
+            return CompletableFuture.completedFuture(segmentList);
          }
          else
          {
-            return segmentList.get(segmentList.size() - 1);
+            return CompletableFuture.completedFuture(segmentList.get(segmentList.size() - 1));
          }
       }
       else
@@ -113,25 +116,26 @@ public class PathParamInjector implements ValueInjector
          {
             if (extractor.isCollectionOrArray())
             {
-               return extractor.extractValues(null);
+               return CompletableFuture.completedFuture(extractor.extractValues(null));
             }
             else
             {
-               return extractor.extractValue(null);
+               return CompletableFuture.completedFuture(extractor.extractValue(null));
             }
          }
          if (extractor.isCollectionOrArray())
          {
-            return extractor.extractValues(list);
+            return CompletableFuture.completedFuture(extractor.extractValues(list));
          }
          else
          {
-            return extractor.extractValue(list.get(list.size() - 1));
+            return CompletableFuture.completedFuture(extractor.extractValue(list.get(list.size() - 1)));
          }
       }
    }
 
-   public Object inject()
+   @Override
+   public CompletionStage<Object> inject()
    {
       throw new RuntimeException(Messages.MESSAGES.illegalToInjectPathParam());
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/PathParamInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/PathParamInjector.java
@@ -75,7 +75,7 @@ public class PathParamInjector implements ValueInjector
    }
 
    @Override
-   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync)
    {
       if (extractor == null) // we are a PathSegment
       {
@@ -135,7 +135,7 @@ public class PathParamInjector implements ValueInjector
    }
 
    @Override
-   public CompletionStage<Object> inject()
+   public CompletionStage<Object> inject(boolean unwrapAsync)
    {
       throw new RuntimeException(Messages.MESSAGES.illegalToInjectPathParam());
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/PrefixedFormInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/PrefixedFormInjector.java
@@ -31,21 +31,21 @@ public class PrefixedFormInjector extends FormInjector
     * {@inheritDoc} Wraps the request in a
     */
    @Override
-   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync)
    {
       if (!containsPrefixedFormFieldsWithValue(request.getDecodedFormParameters()))
       {
          return CompletableFuture.completedFuture(null);
       }
-      return doInject(prefix, request, response);
+      return doInject(prefix, request, response, unwrapAsync);
    }
 
    /**
     * Calls the super {@link #inject(org.jboss.resteasy.spi.HttpRequest, org.jboss.resteasy.spi.HttpResponse)} method.
     */
-   protected CompletionStage<Object> doInject(String prefix, HttpRequest request, HttpResponse response)
+   protected CompletionStage<Object> doInject(String prefix, HttpRequest request, HttpResponse response, boolean unwrapAsync)
    {
-      return super.inject(new PrefixedFormFieldsHttpRequest(prefix, request), response);
+      return super.inject(new PrefixedFormFieldsHttpRequest(prefix, request), response, unwrapAsync);
    }
 
    /**

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/PrefixedFormInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/PrefixedFormInjector.java
@@ -7,6 +7,8 @@ import org.jboss.resteasy.util.PrefixedFormFieldsHttpRequest;
 
 import javax.ws.rs.core.MultivaluedMap;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Extension of {@link FormInjector} that handles prefixes for associated classes.
@@ -29,11 +31,11 @@ public class PrefixedFormInjector extends FormInjector
     * {@inheritDoc} Wraps the request in a
     */
    @Override
-   public Object inject(HttpRequest request, HttpResponse response)
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
    {
       if (!containsPrefixedFormFieldsWithValue(request.getDecodedFormParameters()))
       {
-         return null;
+         return CompletableFuture.completedFuture(null);
       }
       return doInject(prefix, request, response);
    }
@@ -41,7 +43,7 @@ public class PrefixedFormInjector extends FormInjector
    /**
     * Calls the super {@link #inject(org.jboss.resteasy.spi.HttpRequest, org.jboss.resteasy.spi.HttpResponse)} method.
     */
-   protected Object doInject(String prefix, HttpRequest request, HttpResponse response)
+   protected CompletionStage<Object> doInject(String prefix, HttpRequest request, HttpResponse response)
    {
       return super.inject(new PrefixedFormFieldsHttpRequest(prefix, request), response);
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/PropertyInjectorImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/PropertyInjectorImpl.java
@@ -138,12 +138,12 @@ public class PropertyInjectorImpl implements PropertyInjector
    }
 
    @Override
-   public CompletionStage<Void> inject(HttpRequest request, HttpResponse response, Object target) throws Failure
+   public CompletionStage<Void> inject(HttpRequest request, HttpResponse response, Object target, boolean unwrapAsync) throws Failure
    {
       CompletionStage<Void> ret = CompletableFuture.completedFuture(null);
       for (Map.Entry<Field, ValueInjector> entry : fieldMap.entrySet())
       {
-         ret = ret.thenCompose(v -> entry.getValue().inject(request, response)
+         ret = ret.thenCompose(v -> entry.getValue().inject(request, response, unwrapAsync)
                .thenAccept(value -> {
                try
                {
@@ -157,7 +157,7 @@ public class PropertyInjectorImpl implements PropertyInjector
       }
       for (SetterMethod setter : setters)
       {
-         ret = ret.thenCompose(v -> setter.extractor.inject(request, response)
+         ret = ret.thenCompose(v -> setter.extractor.inject(request, response, unwrapAsync)
                .thenAccept(value -> {
                try
                {
@@ -177,12 +177,12 @@ public class PropertyInjectorImpl implements PropertyInjector
    }
 
    @Override
-   public CompletionStage<Void> inject(Object target)
+   public CompletionStage<Void> inject(Object target, boolean unwrapAsync)
    {
       CompletionStage<Void> ret = CompletableFuture.completedFuture(null);
       for (Map.Entry<Field, ValueInjector> entry : fieldMap.entrySet())
       {
-         ret = ret.thenCompose(v -> entry.getValue().inject()
+         ret = ret.thenCompose(v -> entry.getValue().inject(unwrapAsync)
                .thenAccept(value -> {
                try
                {
@@ -196,7 +196,7 @@ public class PropertyInjectorImpl implements PropertyInjector
       }
       for (SetterMethod setter : setters)
       {
-         ret = ret.thenCompose(v -> setter.extractor.inject()
+         ret = ret.thenCompose(v -> setter.extractor.inject(unwrapAsync)
                .thenAccept(value -> {
                try
                {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/PropertyInjectorImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/PropertyInjectorImpl.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import javax.ws.rs.PathParam;
 
@@ -135,64 +137,82 @@ public class PropertyInjectorImpl implements PropertyInjector
       return injector;
    }
 
-   public void inject(HttpRequest request, HttpResponse response, Object target) throws Failure
+   @Override
+   public CompletionStage<Void> inject(HttpRequest request, HttpResponse response, Object target) throws Failure
    {
+      CompletionStage<Void> ret = CompletableFuture.completedFuture(null);
       for (Map.Entry<Field, ValueInjector> entry : fieldMap.entrySet())
       {
-         try
-         {
-            entry.getKey().set(target, entry.getValue().inject(request, response));
-         }
-         catch (IllegalAccessException e)
-         {
-            throw new InternalServerErrorException(e);
-         }
+         ret = ret.thenCompose(v -> entry.getValue().inject(request, response)
+               .thenAccept(value -> {
+               try
+               {
+                  entry.getKey().set(target, value);
+               }
+               catch (IllegalAccessException e)
+               {
+                  throw new InternalServerErrorException(e);
+               }
+            }));
       }
       for (SetterMethod setter : setters)
       {
-         try
-         {
-            setter.method.invoke(target, setter.extractor.inject(request, response));
-         }
-         catch (IllegalAccessException e)
-         {
-            throw new InternalServerErrorException(e);
-         }
-         catch (InvocationTargetException e)
-         {
-            throw new ApplicationException(e.getCause());
-         }
+         ret = ret.thenCompose(v -> setter.extractor.inject(request, response)
+               .thenAccept(value -> {
+               try
+               {
+                  setter.method.invoke(target, value);
+               }
+               catch (IllegalAccessException e)
+               {
+                  throw new InternalServerErrorException(e);
+               }
+               catch (InvocationTargetException e)
+               {
+                  throw new ApplicationException(e.getCause());
+               }
+            }));
       }
+      return ret;
    }
 
-   public void inject(Object target)
+   @Override
+   public CompletionStage<Void> inject(Object target)
    {
+      CompletionStage<Void> ret = CompletableFuture.completedFuture(null);
       for (Map.Entry<Field, ValueInjector> entry : fieldMap.entrySet())
       {
-         try
-         {
-            entry.getKey().set(target, entry.getValue().inject());
-         }
-         catch (IllegalAccessException e)
-         {
-            throw new RuntimeException(e);
-         }
+         ret = ret.thenCompose(v -> entry.getValue().inject()
+               .thenAccept(value -> {
+               try
+               {
+                  entry.getKey().set(target, value);
+               }
+               catch (IllegalAccessException e)
+               {
+                  throw new InternalServerErrorException(e);
+               }
+            }));
       }
       for (SetterMethod setter : setters)
       {
-         try
-         {
-            setter.method.invoke(target, setter.extractor.inject());
-         }
-         catch (IllegalAccessException e)
-         {
-            throw new RuntimeException(e);
-         }
-         catch (InvocationTargetException e)
-         {
-            throw new RuntimeException(e);
-         }
+         ret = ret.thenCompose(v -> setter.extractor.inject()
+               .thenAccept(value -> {
+               try
+               {
+                  setter.method.invoke(target, value);
+               }
+               catch (IllegalAccessException e)
+               {
+                  throw new InternalServerErrorException(e);
+               }
+               catch (InvocationTargetException e)
+               {
+                  throw new ApplicationException(e.getCause());
+               }
+            }));
       }
+      return ret;
    }
 
    private Field[] getDeclaredFields(final Class<?> clazz)

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/QueryInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/QueryInjector.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.core;
 import org.jboss.resteasy.spi.*;
 
 import java.lang.reflect.Constructor;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Created by Simon Ström on 7/17/14.
@@ -32,14 +33,14 @@ public class QueryInjector implements ValueInjector {
    }
 
    @Override
-   public Object inject() {
+   public CompletionStage<Object> inject() {
       throw new IllegalStateException("You cannot inject outside the scope of an HTTP request");
    }
 
    @Override
-   public Object inject(HttpRequest request, HttpResponse response) {
-      Object target = constructorInjector.construct();
-      propertyInjector.inject(request, response, target);
-      return target;
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+      return constructorInjector.construct()
+            .thenCompose(target -> propertyInjector.inject(request, response, target)
+                                 .thenApply(v -> target));
    }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/QueryInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/QueryInjector.java
@@ -33,14 +33,14 @@ public class QueryInjector implements ValueInjector {
    }
 
    @Override
-   public CompletionStage<Object> inject() {
+   public CompletionStage<Object> inject(boolean unwrapAsync) {
       throw new IllegalStateException("You cannot inject outside the scope of an HTTP request");
    }
 
    @Override
-   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
-      return constructorInjector.construct()
-            .thenCompose(target -> propertyInjector.inject(request, response, target)
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
+      return constructorInjector.construct(unwrapAsync)
+            .thenCompose(target -> propertyInjector.inject(request, response, target, unwrapAsync)
                                  .thenApply(v -> target));
    }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/QueryParamInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/QueryParamInjector.java
@@ -49,7 +49,7 @@ public class QueryParamInjector extends StringParameterInjector implements Value
    }
 
    @Override
-   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync)
    {
       if (encode)
       {
@@ -65,7 +65,7 @@ public class QueryParamInjector extends StringParameterInjector implements Value
    }
 
    @Override
-   public CompletionStage<Object> inject()
+   public CompletionStage<Object> inject(boolean unwrapAsync)
    {
       throw new RuntimeException(Messages.MESSAGES.illegalToInjectQueryParam());
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/QueryParamInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/QueryParamInjector.java
@@ -16,6 +16,8 @@ import java.lang.reflect.Type;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -46,22 +48,24 @@ public class QueryParamInjector extends StringParameterInjector implements Value
       throw new NotFoundException(message, cause);
    }
 
-   public Object inject(HttpRequest request, HttpResponse response)
+   @Override
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
    {
       if (encode)
       {
          List<String> list = request.getUri().getQueryParameters(false).get(encodedName);
-         return extractValues(list);
+         return CompletableFuture.completedFuture(extractValues(list));
       }
       else
       {
          List<String> list = request.getUri().getQueryParameters().get(paramName);
-         return extractValues(list);
+         return CompletableFuture.completedFuture(extractValues(list));
 
       }
    }
 
-   public Object inject()
+   @Override
+   public CompletionStage<Object> inject()
    {
       throw new RuntimeException(Messages.MESSAGES.illegalToInjectQueryParam());
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceInvoker.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceInvoker.java
@@ -5,6 +5,7 @@ import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -12,8 +13,8 @@ import java.lang.reflect.Method;
  */
 public interface ResourceInvoker
 {
-   BuiltResponse invoke(HttpRequest request, HttpResponse response);
-   BuiltResponse invoke(HttpRequest request, HttpResponse response, Object target);
+   CompletionStage<BuiltResponse> invoke(HttpRequest request, HttpResponse response);
+   CompletionStage<BuiltResponse> invoke(HttpRequest request, HttpResponse response, Object target);
 
    Method getMethod();
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceLocatorInvoker.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceLocatorInvoker.java
@@ -60,7 +60,9 @@ public class ResourceLocatorInvoker implements ResourceInvoker
          .exceptionally(t -> {
             if(t.getCause() instanceof NotFoundException && lastException != null)
                throw lastException;
-            throw (CompletionException)t;
+            SynchronousDispatcher.rethrow(t);
+            // never reached
+            return null;
          }).thenApply(args -> {
             try
             {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
@@ -539,7 +539,11 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
             postResourceMethodInvokers.clear();
          }
          if(exception != null)
-            throw (CompletionException)exception;
+         {
+            SynchronousDispatcher.rethrow(exception);
+            // never reached
+            return null;
+         }
          return ret;
 		});
 	}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
@@ -43,7 +43,11 @@ import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -298,19 +302,19 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
       return method.getMethod();
    }
 
-   public Object invokeDryRun(HttpRequest request, HttpResponse response) {
-      Object target = resource.createResource(request, response, resourceMethodProviderFactory);
-      return invokeDryRun(request, response, target);
+   public CompletionStage<Object> invokeDryRun(HttpRequest request, HttpResponse response) {
+      return resource.createResource(request, response, resourceMethodProviderFactory)
+            .thenCompose(target -> invokeDryRun(request, response, target));
    }
 
 
-   public BuiltResponse invoke(HttpRequest request, HttpResponse response)
+   public CompletionStage<BuiltResponse> invoke(HttpRequest request, HttpResponse response)
    {
-      Object target = resource.createResource(request, response, resourceMethodProviderFactory);
-      return invoke(request, response, target);
+      return resource.createResource(request, response, resourceMethodProviderFactory)
+            .thenCompose(target -> invoke(request, response, target));
    }
 
-   public Object invokeDryRun(HttpRequest request, HttpResponse response, Object target)
+   public CompletionStage<Object> invokeDryRun(HttpRequest request, HttpResponse response, Object target)
    {
       request.setAttribute(ResourceMethodInvoker.class.getName(), this);
       incrementMethodCount(request.getHttpMethod());
@@ -320,11 +324,10 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
          uriInfo.pushMatchedURI(uriInfo.getMatchingPath());
       }
       uriInfo.pushCurrentResource(target);
-      Object rtn = invokeOnTargetDryRun(request, response, target);
-      return rtn;
+      return invokeOnTargetDryRun(request, response, target);
    }
    
-   public BuiltResponse invoke(HttpRequest request, HttpResponse response, Object target)
+   public CompletionStage<BuiltResponse> invoke(HttpRequest request, HttpResponse response, Object target)
    {
       request.setAttribute(ResourceMethodInvoker.class.getName(), this);
       incrementMethodCount(request.getHttpMethod());
@@ -335,14 +338,15 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
       }
       uriInfo.pushCurrentResource(target);
       BuiltResponse rtn = invokeOnTarget(request, response, target);
-      return rtn;
+      // FIXME: async
+      return CompletableFuture.completedFuture(rtn);
    }
    
-   protected Object invokeOnTargetDryRun(HttpRequest request, HttpResponse response, Object target)
+   protected CompletionStage<Object> invokeOnTargetDryRun(HttpRequest request, HttpResponse response, Object target)
    {
       ResteasyProviderFactory.pushContext(ResourceInfo.class, resourceInfo);  // we don't pop so writer interceptors can get at this
 
-      Object rtn = null;
+      CompletionStage<Object> rtn = null;
       try
       {
          rtn = internalInvokeOnTarget(request, response, target);
@@ -383,7 +387,7 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
          }
       }
       
-      AsyncResponseConsumer asyncResponseConsumer = null;
+      final AsyncResponseConsumer asyncResponseConsumer;
       if (asyncResponseProvider != null)
       {
          asyncResponseConsumer = AsyncResponseConsumer.makeAsyncResponseConsumer(this, asyncResponseProvider);
@@ -392,50 +396,33 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
       {
     	 asyncResponseConsumer = AsyncResponseConsumer.makeAsyncResponseConsumer(this, asyncStreamProvider);
       }
+      else
+      {
+          asyncResponseConsumer = null;
+      }
 
-      Object rtn = null;
       try
       {
-         rtn = internalInvokeOnTarget(request, response, target);
+         CompletionStage<BuiltResponse> stage = internalInvokeOnTarget(request, response, target) 
+               .thenApply(rtn -> afterInvoke(request, asyncResponseConsumer, rtn));
+         return stage.toCompletableFuture().getNow(null);
+      }
+      catch (CompletionException ex)
+      {
+         if(ex.getCause() instanceof RuntimeException)
+            return handleInvocationException(asyncResponseConsumer, request, (RuntimeException) ex.getCause());
+         SynchronousDispatcher.rethrow(ex.getCause());
+         // never reached
+         return null;
       }
       catch (RuntimeException ex)
       {
-         if (asyncResponseConsumer != null)
-         {
-            // WARNING: this can throw if the exception is not mapped by the user, in
-            // which case we haven't completed the connection and called the callbacks
-            try 
-            {
-               AsyncResponseConsumer consumer = asyncResponseConsumer;
-               asyncResponseConsumer.internalResume(ex, t -> consumer.complete(ex));
-            }
-            catch(UnhandledException x) 
-            {
-               // make sure we call the callbacks before throwing to the container
-               request.getAsyncContext().getAsyncResponse().completionCallbacks(ex);
-               throw x;
-            }
-            return null;
-         }
-         else if (request.getAsyncContext().isSuspended())
-         {
-            try
-            {
-               request.getAsyncContext().getAsyncResponse().resume(ex);
-            }
-            catch (Exception e)
-            {
-               LogMessages.LOGGER.errorResumingFailedAsynchOperation(e);
-            }
-            return null;
-         }
-         else
-         {
-            throw ex;
-         }
-
-      }
-
+         return handleInvocationException(asyncResponseConsumer, request, ex);
+      } 
+   }
+   
+	private BuiltResponse afterInvoke(HttpRequest request, AsyncResponseConsumer asyncResponseConsumer, Object rtn)
+   {
       if(asyncResponseConsumer != null)
       {
          asyncResponseConsumer.subscribe(rtn);
@@ -500,21 +487,61 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
       jaxrsResponse.addMethodAnnotations(getMethodAnnotations());
       return jaxrsResponse;
    }
-   
-	private Object internalInvokeOnTarget(HttpRequest request, HttpResponse response, Object target) {
+
+   private BuiltResponse handleInvocationException(AsyncResponseConsumer asyncStreamResponseConsumer, HttpRequest request, RuntimeException ex)
+   {
+      if (asyncStreamResponseConsumer != null)
+      {
+         // WARNING: this can throw if the exception is not mapped by the user, in
+         // which case we haven't completed the connection and called the callbacks
+         try 
+         {
+            AsyncResponseConsumer consumer = asyncStreamResponseConsumer;
+            asyncStreamResponseConsumer.internalResume(ex, t -> consumer.complete(ex));
+         }
+         catch(UnhandledException x) 
+         {
+            // make sure we call the callbacks before throwing to the container
+            request.getAsyncContext().getAsyncResponse().completionCallbacks(ex);
+            throw x;
+         }
+         return null;
+      }
+      else if (request.getAsyncContext().isSuspended())
+      {
+         try
+         {
+            request.getAsyncContext().getAsyncResponse().resume(ex);
+         }
+         catch (Exception e)
+         {
+            LogMessages.LOGGER.errorResumingFailedAsynchOperation(e);
+         }
+         return null;
+      }
+      else
+      {
+         throw ex;
+      }
+   }
+
+   private CompletionStage<Object> internalInvokeOnTarget(HttpRequest request, HttpResponse response, Object target) {
 		PostResourceMethodInvokers postResourceMethodInvokers = ResteasyProviderFactory
 				.getContextData(PostResourceMethodInvokers.class);
-		try {
-			Object toReturn = this.methodInjector.invoke(request, response, target);
-			if (postResourceMethodInvokers != null) {
-				postResourceMethodInvokers.getInvokers().forEach(e -> e.invoke());
-			}
-			return toReturn;
-		} finally {
-			if (postResourceMethodInvokers != null) {
-				postResourceMethodInvokers.clear();
-			}
-		}
+		return this.methodInjector.invoke(request, response, target)
+		      .handle((ret, exception) -> {
+         // on success
+         if (exception == null && postResourceMethodInvokers != null) {
+            postResourceMethodInvokers.getInvokers().forEach(e -> e.invoke());
+         }
+         // finally
+         if (postResourceMethodInvokers != null) {
+            postResourceMethodInvokers.clear();
+         }
+         if(exception != null)
+            throw (CompletionException)exception;
+         return ret;
+		});
 	}
    
    public void initializeAsync(ResteasyAsynchronousResponse asyncResponse)

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourcePropertyInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourcePropertyInjector.java
@@ -83,13 +83,14 @@ public class ResourcePropertyInjector implements PropertyInjector
       }
    }
 
-   public CompletionStage<Void> inject(HttpRequest request, HttpResponse response, Object target) throws Failure
+   @Override
+   public CompletionStage<Void> inject(HttpRequest request, HttpResponse response, Object target, boolean unwrapAsync) throws Failure
    {
       CompletionStage<Void> ret = CompletableFuture.completedFuture(null);
       for (FieldInjector injector : fields)
       {
          ret = ret.thenCompose(v -> 
-            injector.injector.inject(request, response)
+            injector.injector.inject(request, response, unwrapAsync)
             .thenAccept(value -> {
                try
                {
@@ -104,7 +105,7 @@ public class ResourcePropertyInjector implements PropertyInjector
       for (SetterInjector injector : setters)
       {
          ret = ret.thenCompose(v -> 
-            injector.injector.inject(request, response)
+            injector.injector.inject(request, response, unwrapAsync)
             .thenAccept(value -> {
                      try
                      {
@@ -123,13 +124,14 @@ public class ResourcePropertyInjector implements PropertyInjector
       return ret;
    }
 
-   public CompletionStage<Void> inject(Object target)
+   @Override
+   public CompletionStage<Void> inject(Object target, boolean unwrapAsync)
    {
       CompletionStage<Void> ret = CompletableFuture.completedFuture(null);
       for (FieldInjector injector : fields)
       {
          ret = ret.thenCompose(v -> 
-            injector.injector.inject()
+            injector.injector.inject(unwrapAsync)
             .thenAccept(value -> {
                try
                {
@@ -144,7 +146,7 @@ public class ResourcePropertyInjector implements PropertyInjector
       for (SetterInjector injector : setters)
       {
          ret = ret.thenCompose(v -> 
-            injector.injector.inject()
+            injector.injector.inject(unwrapAsync)
             .thenAccept(value -> {
                      try
                      {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SuspendInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SuspendInjector.java
@@ -34,13 +34,13 @@ public class SuspendInjector implements ValueInjector
    }
 
    @Override
-   public CompletionStage<Object> inject()
+   public CompletionStage<Object> inject(boolean unwrapAsync)
    {
       throw new IllegalStateException(Messages.MESSAGES.cannotInjectIntoForm());
    }
 
    @Override
-   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response)
+   public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync)
    {
       final ResteasyAsynchronousContext asynchronousContext = request.getAsyncContext();
       final ResteasyAsynchronousResponse asynchronousResponse = asynchronousContext.suspend(suspend);

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SynchronousDispatcher.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SynchronousDispatcher.java
@@ -319,13 +319,13 @@ public class SynchronousDispatcher implements Dispatcher
          @Override
          public <T> T getResource(Class<T> resourceClass)
          {
-            return providerFactory.injectedInstance(resourceClass, request, response).toCompletableFuture().getNow(null);
+            return providerFactory.injectedInstance(resourceClass, request, response);
          }
 
          @Override
          public <T> T initResource(T resource)
          {
-            providerFactory.injectProperties(resource, request, response).toCompletableFuture().getNow(null);
+            providerFactory.injectProperties(resource, request, response);
             return resource;
          }
       };

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SynchronousDispatcher.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SynchronousDispatcher.java
@@ -319,29 +319,13 @@ public class SynchronousDispatcher implements Dispatcher
          @Override
          public <T> T getResource(Class<T> resourceClass)
          {
-            try
-            {
-               // FIXME: provide clue that we can't unwrap CS
-               return providerFactory.injectedInstance(resourceClass, request, response).toCompletableFuture().get();
-            }
-            catch (InterruptedException | ExecutionException e)
-            {
-               throw new RuntimeException(e);
-            }
+            return providerFactory.injectedInstance(resourceClass, request, response).toCompletableFuture().getNow(null);
          }
 
          @Override
          public <T> T initResource(T resource)
          {
-            try
-            {
-               // FIXME: provide clue that we can't unwrap CS
-               providerFactory.injectProperties(resource, request, response).toCompletableFuture().get();
-            }
-            catch (InterruptedException | ExecutionException e)
-            {
-               throw new RuntimeException(e);
-            }
+            providerFactory.injectProperties(resource, request, response).toCompletableFuture().getNow(null);
             return resource;
          }
       };

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletionStage;
 
 import org.jboss.resteasy.core.interception.jaxrs.ClientRequestFilterRegistry;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.*;
@@ -90,15 +91,15 @@ public class ThreadLocalResteasyProviderFactory extends ResteasyProviderFactory 
    }
 
    @Override
-   public <T> T injectedInstance(Class<? extends T> clazz, HttpRequest request, HttpResponse response)
+   public <T> CompletionStage<T> injectedInstance(Class<? extends T> clazz, HttpRequest request, HttpResponse response)
    {
       return getDelegate().injectedInstance(clazz, request, response);
    }
 
    @Override
-   public void injectProperties(Object obj, HttpRequest request, HttpResponse response)
+   public CompletionStage<Void> injectProperties(Object obj, HttpRequest request, HttpResponse response)
    {
-      getDelegate().injectProperties(obj, request, response);
+      return getDelegate().injectProperties(obj, request, response);
    }
 
    public static void push(ResteasyProviderFactory factory)
@@ -409,9 +410,9 @@ public class ThreadLocalResteasyProviderFactory extends ResteasyProviderFactory 
    }
 
    @Override
-   public void injectProperties(Object obj)
+   public CompletionStage<Void> injectProperties(Object obj)
    {
-      getDelegate().injectProperties(obj);
+      return getDelegate().injectProperties(obj);
    }
 
    @Override

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
@@ -92,15 +92,15 @@ public class ThreadLocalResteasyProviderFactory extends ResteasyProviderFactory 
    }
 
    @Override
-   public <T> CompletionStage<T> injectedInstance(Class<? extends T> clazz, HttpRequest request, HttpResponse response)
+   public <T> T injectedInstance(Class<? extends T> clazz, HttpRequest request, HttpResponse response)
    {
       return getDelegate().injectedInstance(clazz, request, response);
    }
 
    @Override
-   public CompletionStage<Void> injectProperties(Object obj, HttpRequest request, HttpResponse response)
+   public void injectProperties(Object obj, HttpRequest request, HttpResponse response)
    {
-      return getDelegate().injectProperties(obj, request, response);
+      getDelegate().injectProperties(obj, request, response);
    }
 
    public static void push(ResteasyProviderFactory factory)
@@ -411,9 +411,9 @@ public class ThreadLocalResteasyProviderFactory extends ResteasyProviderFactory 
    }
 
    @Override
-   public CompletionStage<Void> injectProperties(Object obj)
+   public void injectProperties(Object obj)
    {
-      return getDelegate().injectProperties(obj);
+      getDelegate().injectProperties(obj);
    }
 
    @Override
@@ -606,9 +606,9 @@ public class ThreadLocalResteasyProviderFactory extends ResteasyProviderFactory 
    }
 
    @Override
-   public <T> T getContextData(Class<T> rawType, Type genericType, Annotation[] annotations)
+   public <T> T getContextData(Class<T> rawType, Type genericType, Annotation[] annotations, boolean unwrapAsync)
    {
-      return getDelegate().getContextData(rawType, genericType, annotations);
+      return getDelegate().getContextData(rawType, genericType, annotations, unwrapAsync);
    }
    
    @Override

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
@@ -37,6 +37,7 @@ import org.jboss.resteasy.core.interception.jaxrs.WriterInterceptorRegistry;
 import org.jboss.resteasy.spi.AsyncResponseProvider;
 import org.jboss.resteasy.spi.AsyncStreamProvider;
 import org.jboss.resteasy.spi.ConstructorInjector;
+import org.jboss.resteasy.spi.ContextInjector;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.InjectorFactory;
@@ -604,6 +605,18 @@ public class ThreadLocalResteasyProviderFactory extends ResteasyProviderFactory 
       return getDelegate().createHeaderDelegate(tClass);
    }
 
+   @Override
+   public <T> T getContextData(Class<T> rawType, Type genericType)
+   {
+      return getDelegate().getContextData(rawType, genericType);
+   }
+   
+   @Override
+   public Map<Type, ContextInjector> getContextInjectors()
+   {
+      return getDelegate().getContextInjectors();
+   }
+   
    @Override
    public <T> MessageBodyWriter<T> getClientMessageBodyWriter(Class<T> type, Type genericType, Annotation[] annotations, MediaType mediaType)
    {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
@@ -616,7 +616,13 @@ public class ThreadLocalResteasyProviderFactory extends ResteasyProviderFactory 
    {
       return getDelegate().getContextInjectors();
    }
-   
+
+   @Override
+   public Map<Type, ContextInjector> getAsyncContextInjectors()
+   {
+      return getDelegate().getAsyncContextInjectors();
+   }
+
    @Override
    public <T> MessageBodyWriter<T> getClientMessageBodyWriter(Class<T> type, Type genericType, Annotation[] annotations, MediaType mediaType)
    {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
@@ -606,9 +606,9 @@ public class ThreadLocalResteasyProviderFactory extends ResteasyProviderFactory 
    }
 
    @Override
-   public <T> T getContextData(Class<T> rawType, Type genericType)
+   public <T> T getContextData(Class<T> rawType, Type genericType, Annotation[] annotations)
    {
-      return getDelegate().getContextData(rawType, genericType);
+      return getDelegate().getContextData(rawType, genericType, annotations);
    }
    
    @Override

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ValueInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ValueInjector.java
@@ -17,7 +17,7 @@ public interface ValueInjector
     *
     * @return
     */
-   CompletionStage<Object> inject();
+   CompletionStage<Object> inject(boolean unwrapAsync);
 
    /**
     * Inject inside the context of an HTTP request.
@@ -26,5 +26,5 @@ public interface ValueInjector
     * @param response
     * @return
     */
-   CompletionStage<Object> inject(HttpRequest request, HttpResponse response);
+   CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync);
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ValueInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ValueInjector.java
@@ -1,5 +1,7 @@
 package org.jboss.resteasy.core;
 
+import java.util.concurrent.CompletionStage;
+
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
 
@@ -15,7 +17,7 @@ public interface ValueInjector
     *
     * @return
     */
-   Object inject();
+   CompletionStage<Object> inject();
 
    /**
     * Inject inside the context of an HTTP request.
@@ -24,5 +26,5 @@ public interface ValueInjector
     * @param response
     * @return
     */
-   Object inject(HttpRequest request, HttpResponse response);
+   CompletionStage<Object> inject(HttpRequest request, HttpResponse response);
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/JndiComponentResourceFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/JndiComponentResourceFactory.java
@@ -5,6 +5,9 @@ import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.ResourceFactory;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
@@ -42,9 +45,9 @@ public class JndiComponentResourceFactory implements ResourceFactory
    {
    }
 
-   public Object createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory)
+   public CompletionStage<Object> createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory)
    {
-      if (reference != null) return reference;
+      if (reference != null) return CompletableFuture.completedFuture(reference);
       Object ref = reference;
       if (ref == null)
       {
@@ -64,7 +67,7 @@ public class JndiComponentResourceFactory implements ResourceFactory
             }
          }
       }
-      return ref;
+      return CompletableFuture.completedFuture(ref);
    }
 
    public void unregistered()

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/JndiResourceFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/JndiResourceFactory.java
@@ -5,6 +5,9 @@ import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.ResourceFactory;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
@@ -34,11 +37,11 @@ public class JndiResourceFactory implements ResourceFactory
    {
    }
 
-   public Object createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory)
+   public CompletionStage<Object> createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory)
    {
       try
       {
-         return ctx.lookup(jndiName);
+         return CompletableFuture.completedFuture(ctx.lookup(jndiName));
       }
       catch (NamingException e)
       {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/POJOResourceFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/POJOResourceFactory.java
@@ -66,8 +66,8 @@ public class POJOResourceFactory implements ResourceFactory
 
    public CompletionStage<Object> createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory)
    {
-      return constructorInjector.construct(request, response)
-         .thenCompose(obj -> propertyInjector.inject(request, response, obj).thenApply(v -> obj));
+      return constructorInjector.construct(request, response, true)
+         .thenCompose(obj -> propertyInjector.inject(request, response, obj, true).thenApply(v -> obj));
    }
 
    public void unregistered()

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/POJOResourceFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/POJOResourceFactory.java
@@ -1,5 +1,7 @@
 package org.jboss.resteasy.plugins.server.resourcefactory;
 
+import java.util.concurrent.CompletionStage;
+
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
 import org.jboss.resteasy.spi.ConstructorInjector;
 import org.jboss.resteasy.spi.HttpRequest;
@@ -62,11 +64,10 @@ public class POJOResourceFactory implements ResourceFactory
       this.propertyInjector = factory.getInjectorFactory().createPropertyInjector(resourceClass, factory);
    }
 
-   public Object createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory)
+   public CompletionStage<Object> createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory)
    {
-      Object obj = constructorInjector.construct(request, response);
-      propertyInjector.inject(request, response, obj);
-      return obj;
+      return constructorInjector.construct(request, response)
+         .thenCompose(obj -> propertyInjector.inject(request, response, obj).thenApply(v -> obj));
    }
 
    public void unregistered()

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/SingletonResource.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/SingletonResource.java
@@ -1,5 +1,8 @@
 package org.jboss.resteasy.plugins.server.resourcefactory;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.ResourceFactory;
@@ -36,9 +39,9 @@ public class SingletonResource implements ResourceFactory
       factory.getInjectorFactory().createPropertyInjector(resourceClass, factory).inject(obj);
    }
 
-   public Object createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory)
+   public CompletionStage<Object> createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory)
    {
-      return obj;
+      return CompletableFuture.completedFuture(obj);
    }
 
    public void unregistered()

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/SingletonResource.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/SingletonResource.java
@@ -36,7 +36,7 @@ public class SingletonResource implements ResourceFactory
 
    public void registered(ResteasyProviderFactory factory)
    {
-      factory.getInjectorFactory().createPropertyInjector(resourceClass, factory).inject(obj);
+      factory.getInjectorFactory().createPropertyInjector(resourceClass, factory).inject(obj, false);
    }
 
    public CompletionStage<Object> createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory)

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
@@ -780,4 +780,7 @@ public interface Messages
    
    @Message(id = BASE + 1093, value = "SseBroadcaster is closed")
    String sseBroadcasterIsClosed();
+
+   @Message(id = BASE + 1094, value = "Unable to instantiate ContextInjector")
+   String unableToInstantiateContextInjector();
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ConstructorInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ConstructorInjector.java
@@ -15,7 +15,7 @@ public interface ConstructorInjector
     *
     * @return
     */
-   CompletionStage<Object> construct();
+   CompletionStage<Object> construct(boolean unwrapAsync);
 
    /**
     * construct inside the scope of an HTTP request.
@@ -25,7 +25,7 @@ public interface ConstructorInjector
     * @return
     * @throws Failure
     */
-   CompletionStage<Object> construct(HttpRequest request, HttpResponse response) throws Failure, WebApplicationException, ApplicationException;
+   CompletionStage<Object> construct(HttpRequest request, HttpResponse response, boolean unwrapAsync) throws Failure, WebApplicationException, ApplicationException;
 
    /**
     * Create an arguments list from injectable tings outside the scope of an HTTP request.  Useful for singleton factories
@@ -34,7 +34,7 @@ public interface ConstructorInjector
     *
     * @return
     */
-   CompletionStage<Object[]> injectableArguments();
+   CompletionStage<Object[]> injectableArguments(boolean unwrapAsync);
 
    /**
     * Create an argument list inside the scope of an HTTP request.
@@ -46,5 +46,5 @@ public interface ConstructorInjector
     * @return
     * @throws Failure
     */
-   CompletionStage<Object[]> injectableArguments(HttpRequest request, HttpResponse response) throws Failure;
+   CompletionStage<Object[]> injectableArguments(HttpRequest request, HttpResponse response, boolean unwrapAsync) throws Failure;
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ConstructorInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ConstructorInjector.java
@@ -1,5 +1,7 @@
 package org.jboss.resteasy.spi;
 
+import java.util.concurrent.CompletionStage;
+
 import javax.ws.rs.WebApplicationException;
 
 /**
@@ -13,7 +15,7 @@ public interface ConstructorInjector
     *
     * @return
     */
-   Object construct();
+   CompletionStage<Object> construct();
 
    /**
     * construct inside the scope of an HTTP request.
@@ -23,7 +25,7 @@ public interface ConstructorInjector
     * @return
     * @throws Failure
     */
-   Object construct(HttpRequest request, HttpResponse response) throws Failure, WebApplicationException, ApplicationException;
+   CompletionStage<Object> construct(HttpRequest request, HttpResponse response) throws Failure, WebApplicationException, ApplicationException;
 
    /**
     * Create an arguments list from injectable tings outside the scope of an HTTP request.  Useful for singleton factories
@@ -32,7 +34,7 @@ public interface ConstructorInjector
     *
     * @return
     */
-   Object[] injectableArguments();
+   CompletionStage<Object[]> injectableArguments();
 
    /**
     * Create an argument list inside the scope of an HTTP request.
@@ -44,5 +46,5 @@ public interface ConstructorInjector
     * @return
     * @throws Failure
     */
-   Object[] injectableArguments(HttpRequest request, HttpResponse response) throws Failure;
+   CompletionStage<Object[]> injectableArguments(HttpRequest request, HttpResponse response) throws Failure;
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ContextInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ContextInjector.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.spi;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
-public interface ContextInjector<T> {
-   public T resolve(Class<? extends T> rawType, Type genericType, Annotation[] annotations);
+public interface ContextInjector<WrappedType, UnwrappedType> {
+   // FIXME: remove rawType and genericType?
+   public WrappedType resolve(Class<? extends WrappedType> rawType, Type genericType, Annotation[] annotations);
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ContextInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ContextInjector.java
@@ -1,0 +1,8 @@
+package org.jboss.resteasy.spi;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+public interface ContextInjector<T> {
+   public T resolve(Class<? extends T> rawType, Type genericType, Annotation[] annotations);
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/MethodInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/MethodInjector.java
@@ -1,5 +1,7 @@
 package org.jboss.resteasy.spi;
 
+import java.util.concurrent.CompletionStage;
+
 import org.jboss.resteasy.core.ValueInjector;
 
 /**
@@ -19,7 +21,7 @@ public interface MethodInjector
     * @return
     * @throws Failure
     */
-   Object invoke(HttpRequest request, HttpResponse response, Object target) throws Failure, ApplicationException;
+   CompletionStage<Object> invoke(HttpRequest request, HttpResponse response, Object target) throws Failure, ApplicationException;
 
    /**
     * Create the arguments that would be used to invoke the method in the context of an HTTP request.
@@ -29,7 +31,7 @@ public interface MethodInjector
     * @return
     * @throws Failure
     */
-   Object[] injectArguments(HttpRequest request, HttpResponse response) throws Failure;
+   CompletionStage<Object[]> injectArguments(HttpRequest request, HttpResponse response) throws Failure;
 
    ValueInjector[] getParams();
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/PropertyInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/PropertyInjector.java
@@ -1,5 +1,7 @@
 package org.jboss.resteasy.spi;
 
+import java.util.concurrent.CompletionStage;
+
 import javax.ws.rs.WebApplicationException;
 
 /**
@@ -14,7 +16,7 @@ public interface PropertyInjector
     *
     * @param target
     */
-   void inject(Object target);
+   CompletionStage<Void> inject(Object target);
 
    /**
     * Inject values into annotated properties (fields/setter methods) of the target object.
@@ -25,5 +27,5 @@ public interface PropertyInjector
     * @param target
     * @throws Failure
     */
-   void inject(HttpRequest request, HttpResponse response, Object target) throws Failure, WebApplicationException, ApplicationException;
+   CompletionStage<Void> inject(HttpRequest request, HttpResponse response, Object target) throws Failure, WebApplicationException, ApplicationException;
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/PropertyInjector.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/PropertyInjector.java
@@ -16,7 +16,7 @@ public interface PropertyInjector
     *
     * @param target
     */
-   CompletionStage<Void> inject(Object target);
+   CompletionStage<Void> inject(Object target, boolean unwrapAsync);
 
    /**
     * Inject values into annotated properties (fields/setter methods) of the target object.
@@ -27,5 +27,5 @@ public interface PropertyInjector
     * @param target
     * @throws Failure
     */
-   CompletionStage<Void> inject(HttpRequest request, HttpResponse response, Object target) throws Failure, WebApplicationException, ApplicationException;
+   CompletionStage<Void> inject(HttpRequest request, HttpResponse response, Object target, boolean unwrapAsync) throws Failure, WebApplicationException, ApplicationException;
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResourceFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResourceFactory.java
@@ -1,5 +1,7 @@
 package org.jboss.resteasy.spi;
 
+import java.util.concurrent.CompletionStage;
+
 /**
  * Implementations of this interface are registered through the Registry class.
  *
@@ -30,7 +32,7 @@ public interface ResourceFactory
     * @param factory
     * @return
     */
-   Object createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory);
+   CompletionStage<Object> createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory);
 
 
    /**

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyDeployment.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyDeployment.java
@@ -359,7 +359,7 @@ public class ResteasyDeployment
       dispatcher.getDefaultContextObjects().put(Application.class, app);
       ResteasyProviderFactory.pushContext(Application.class, app);
       PropertyInjector propertyInjector = providerFactory.getInjectorFactory().createPropertyInjector(clazz, providerFactory);
-      propertyInjector.inject(app);
+      propertyInjector.inject(app, false);
       return app;
    }
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -599,6 +599,11 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
       return (T) getContextDataMap().get(type);
    }
 
+   public boolean hasAsyncContextData(Type genericType) {
+      Type newGenericType = new Types.ResteasyParameterizedType(new Type[]{genericType}, CompletionStage.class, null);
+      return getContextInjectors().containsKey(newGenericType);
+   }
+   
    public <T> T getContextData(Class<T> rawType, Type genericType, Annotation[] annotations)
    {
       T ret = (T) getContextDataMap().get(rawType);

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -609,8 +609,7 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
    }
 
    public boolean hasAsyncContextData(Type genericType) {
-      Type newGenericType = new Types.ResteasyParameterizedType(new Type[]{genericType}, CompletionStage.class, null);
-      return getContextInjectors().containsKey(newGenericType);
+      return getAsyncContextInjectors().containsKey(Types.boxPrimitives(genericType));
    }
    
    public <T> T getContextData(Class<T> rawType, Type genericType, Annotation[] annotations, boolean unwrapAsync)
@@ -622,7 +621,7 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
       boolean async = false;
       if(contextInjector == null && unwrapAsync)
       {
-         contextInjector = getAsyncContextInjectors().get(genericType);
+         contextInjector = getAsyncContextInjectors().get(Types.boxPrimitives(genericType));
          async = true;
       }
       

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -599,7 +599,7 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
       return (T) getContextDataMap().get(type);
    }
 
-   public <T> T getContextData(Class<T> rawType, Type genericType)
+   public <T> T getContextData(Class<T> rawType, Type genericType, Annotation[] annotations)
    {
       T ret = (T) getContextDataMap().get(rawType);
       if(ret != null)
@@ -611,7 +611,7 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
          contextInjector = getContextInjectors().get(newGenericType);
       }
       if(contextInjector != null)
-         return (T) contextInjector.resolve(rawType, genericType, null);
+         return (T) contextInjector.resolve(rawType, genericType, annotations);
       return null;
    }
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/Types.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/Types.java
@@ -707,19 +707,19 @@ public class Types
          if(other instanceof ParameterizedType == false)
             return false;
          ParameterizedType b = (ParameterizedType) other;
-         return Objects.deepEquals(getActualTypeArguments(), b.getActualTypeArguments())
-               && Objects.equals(getRawType(), b.getRawType())
-               && Objects.equals(getOwnerType(), b.getOwnerType());
+         // WARNING: contract defined by ParameterizedType
+         return Arrays.equals(actuals, b.getActualTypeArguments())
+               && Objects.equals(rawType, b.getRawType())
+               && Objects.equals(ownerType, b.getOwnerType());
       }
       
       @Override
       public int hashCode()
       {
-         int ret = 31;
-         ret = 37 * ret + Arrays.hashCode(getActualTypeArguments());
-         ret = 37 * ret + getRawType().hashCode();
-         ret = 37 * ret + Objects.hashCode(getOwnerType());
-         return ret;
+         // WARNING: stay true to http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/sun/reflect/generics/reflectiveObjects/ParameterizedTypeImpl.java
+         return Arrays.hashCode(actuals)
+            ^ Objects.hashCode(ownerType)
+            ^ Objects.hashCode(rawType);
       }
       
       @Override

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/Types.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/util/Types.java
@@ -747,4 +747,25 @@ public class Types
       }
 
    }
+
+   public static Type boxPrimitives(Type genericType)
+   {
+      if(genericType == Boolean.TYPE)
+         return Boolean.class;
+      if(genericType == Character.TYPE)
+         return Character.class;
+      if(genericType == Byte.TYPE)
+         return Byte.class;
+      if(genericType == Short.TYPE)
+         return Short.class;
+      if(genericType == Integer.TYPE)
+         return Integer.class;
+      if(genericType == Long.TYPE)
+         return Long.class;
+      if(genericType == Float.TYPE)
+         return Float.class;
+      if(genericType == Double.TYPE)
+         return Double.class;
+      return genericType;
+   }
 }

--- a/resteasy-legacy/src/main/java/org/jboss/resteasy/core/interception/InterceptorRegistry.java
+++ b/resteasy-legacy/src/main/java/org/jboss/resteasy/core/interception/InterceptorRegistry.java
@@ -144,7 +144,7 @@ public class InterceptorRegistry<T>
       @Override
       public Object postMatch(Class declaring, AccessibleObject target)
       {
-         final Object inter = constructorInjector.construct().toCompletableFuture().getNow(null);
+         final Object inter = constructorInjector.construct(false).toCompletableFuture().getNow(null);
          return binding(declaring, target, inter);
       }
    }

--- a/resteasy-legacy/src/main/java/org/jboss/resteasy/core/interception/InterceptorRegistry.java
+++ b/resteasy-legacy/src/main/java/org/jboss/resteasy/core/interception/InterceptorRegistry.java
@@ -144,7 +144,7 @@ public class InterceptorRegistry<T>
       @Override
       public Object postMatch(Class declaring, AccessibleObject target)
       {
-         final Object inter = constructorInjector.construct();
+         final Object inter = constructorInjector.construct().toCompletableFuture().getNow(null);
          return binding(declaring, target, inter);
       }
    }

--- a/resteasy-legacy/src/main/java/org/jboss/resteasy/spi/old/ThreadLocalResteasyProviderFactory.java
+++ b/resteasy-legacy/src/main/java/org/jboss/resteasy/spi/old/ThreadLocalResteasyProviderFactory.java
@@ -93,15 +93,15 @@ public class ThreadLocalResteasyProviderFactory extends org.jboss.resteasy.spi.o
    }
 
    @Override
-   public <T> CompletionStage<T> injectedInstance(Class<? extends T> clazz, HttpRequest request, HttpResponse response)
+   public <T> T injectedInstance(Class<? extends T> clazz, HttpRequest request, HttpResponse response)
    {
       return getDelegate().injectedInstance(clazz, request, response);
    }
 
    @Override
-   public CompletionStage<Void> injectProperties(Object obj, HttpRequest request, HttpResponse response)
+   public void injectProperties(Object obj, HttpRequest request, HttpResponse response)
    {
-      return getDelegate().injectProperties(obj, request, response);
+      getDelegate().injectProperties(obj, request, response);
    }
 
    public static void push(ResteasyProviderFactory factory)
@@ -475,9 +475,9 @@ public class ThreadLocalResteasyProviderFactory extends org.jboss.resteasy.spi.o
    }
 
    @Override
-   public CompletionStage<Void> injectProperties(Object obj)
+   public void injectProperties(Object obj)
    {
-      return getDelegate().injectProperties(obj);
+      getDelegate().injectProperties(obj);
    }
 
    @Override

--- a/resteasy-legacy/src/main/java/org/jboss/resteasy/spi/old/ThreadLocalResteasyProviderFactory.java
+++ b/resteasy-legacy/src/main/java/org/jboss/resteasy/spi/old/ThreadLocalResteasyProviderFactory.java
@@ -35,6 +35,7 @@ import org.jboss.resteasy.core.interception.JaxrsInterceptorRegistry;
 import org.jboss.resteasy.core.interception.ReaderInterceptorRegistry;
 import org.jboss.resteasy.core.interception.WriterInterceptorRegistry;
 import org.jboss.resteasy.spi.ConstructorInjector;
+import org.jboss.resteasy.spi.ContextInjector;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.InjectorFactory;
@@ -652,5 +653,17 @@ public class ThreadLocalResteasyProviderFactory extends org.jboss.resteasy.spi.o
    public <T> MessageBodyWriter<T> getServerMessageBodyWriter(Class<T> type, Type genericType, Annotation[] annotations, MediaType mediaType)
    {
       return getDelegate().getServerMessageBodyWriter(type, genericType, annotations, mediaType);
+   }
+   
+   @Override
+   public Map<Type, ContextInjector> getContextInjectors() 
+   {
+	   return getDelegate().getContextInjectors();
+   }
+   
+   @Override
+   public Map<Type, ContextInjector> getAsyncContextInjectors() 
+   {
+	   return getDelegate().getAsyncContextInjectors();
    }
 }

--- a/resteasy-legacy/src/main/java/org/jboss/resteasy/spi/old/ThreadLocalResteasyProviderFactory.java
+++ b/resteasy-legacy/src/main/java/org/jboss/resteasy/spi/old/ThreadLocalResteasyProviderFactory.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletionStage;
 
 import javax.ws.rs.RuntimeType;
 import javax.ws.rs.client.ClientRequestFilter;
@@ -92,15 +93,15 @@ public class ThreadLocalResteasyProviderFactory extends org.jboss.resteasy.spi.o
    }
 
    @Override
-   public <T> T injectedInstance(Class<? extends T> clazz, HttpRequest request, HttpResponse response)
+   public <T> CompletionStage<T> injectedInstance(Class<? extends T> clazz, HttpRequest request, HttpResponse response)
    {
       return getDelegate().injectedInstance(clazz, request, response);
    }
 
    @Override
-   public void injectProperties(Object obj, HttpRequest request, HttpResponse response)
+   public CompletionStage<Void> injectProperties(Object obj, HttpRequest request, HttpResponse response)
    {
-      getDelegate().injectProperties(obj, request, response);
+      return getDelegate().injectProperties(obj, request, response);
    }
 
    public static void push(ResteasyProviderFactory factory)
@@ -474,9 +475,9 @@ public class ThreadLocalResteasyProviderFactory extends org.jboss.resteasy.spi.o
    }
 
    @Override
-   public void injectProperties(Object obj)
+   public CompletionStage<Void> injectProperties(Object obj)
    {
-      getDelegate().injectProperties(obj);
+      return getDelegate().injectProperties(obj);
    }
 
    @Override

--- a/resteasy-rxjava/src/test/java/org/jboss/resteasy/rxjava/Async.java
+++ b/resteasy-rxjava/src/test/java/org/jboss/resteasy/rxjava/Async.java
@@ -1,0 +1,15 @@
+package org.jboss.resteasy.rxjava;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Async
+{
+
+}

--- a/resteasy-rxjava/src/test/java/org/jboss/resteasy/rxjava/RxInjector.java
+++ b/resteasy-rxjava/src/test/java/org/jboss/resteasy/rxjava/RxInjector.java
@@ -1,0 +1,41 @@
+package org.jboss.resteasy.rxjava;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ContextInjector;
+
+import rx.Single;
+
+@Provider
+public class RxInjector implements ContextInjector<Single<Integer>, Integer>{
+
+	@Override
+	public Single<Integer> resolve(Class<? extends Single<Integer>> rawType, Type genericType,
+			Annotation[] annotations) {
+	   boolean async = false;
+	   for (Annotation annotation : annotations)
+      {
+         if(annotation.annotationType() == Async.class)
+            async = true;
+      }
+	   if(!async)
+	      return Single.just(42);
+	   return Single.create(emitter -> {
+	      new Thread(() -> {
+	         try
+            {
+               Thread.sleep(1000);
+            } catch (InterruptedException e)
+            {
+               emitter.onError(e);
+               return;
+            }
+	         emitter.onSuccess(42);
+	      }).start();
+	   });
+	}
+
+}

--- a/resteasy-rxjava/src/test/java/org/jboss/resteasy/rxjava/RxResource.java
+++ b/resteasy-rxjava/src/test/java/org/jboss/resteasy/rxjava/RxResource.java
@@ -78,4 +78,18 @@ public class RxResource
          return str;
       });
    }
+
+   @Path("injection")
+   @GET
+   public Single<Integer> injection(@Context Integer value)
+   {
+      return Single.just(value);
+   }
+
+   @Path("injection-async")
+   @GET
+   public Single<Integer> injectionAsync(@Async @Context Integer value)
+   {
+      return Single.just(value);
+   }
 }

--- a/resteasy-rxjava2/src/test/java/org/jboss/resteasy/rxjava2/Async.java
+++ b/resteasy-rxjava2/src/test/java/org/jboss/resteasy/rxjava2/Async.java
@@ -1,0 +1,15 @@
+package org.jboss.resteasy.rxjava2;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Async
+{
+
+}

--- a/resteasy-rxjava2/src/test/java/org/jboss/resteasy/rxjava2/RxInjector.java
+++ b/resteasy-rxjava2/src/test/java/org/jboss/resteasy/rxjava2/RxInjector.java
@@ -1,0 +1,42 @@
+package org.jboss.resteasy.rxjava2;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ContextInjector;
+
+import io.reactivex.Single;
+
+
+@Provider
+public class RxInjector implements ContextInjector<Single<Integer>, Integer>{
+
+	@Override
+	public Single<Integer> resolve(Class<? extends Single<Integer>> rawType, Type genericType,
+			Annotation[] annotations) {
+	   boolean async = false;
+	   for (Annotation annotation : annotations)
+      {
+         if(annotation.annotationType() == Async.class)
+            async = true;
+      }
+	   if(!async)
+	      return Single.just(42);
+	   return Single.create(emitter -> {
+	      new Thread(() -> {
+	         try
+            {
+               Thread.sleep(1000);
+            } catch (InterruptedException e)
+            {
+               emitter.onError(e);
+               return;
+            }
+	         emitter.onSuccess(42);
+	      }).start();
+	   });
+	}
+
+}

--- a/resteasy-rxjava2/src/test/java/org/jboss/resteasy/rxjava2/RxResource.java
+++ b/resteasy-rxjava2/src/test/java/org/jboss/resteasy/rxjava2/RxResource.java
@@ -109,4 +109,18 @@ public class RxResource
          return str;
       });
    }
+   
+   @Path("injection")
+   @GET
+   public Single<Integer> injection(@Context Integer value)
+   {
+      return Single.just(value);
+   }
+
+   @Path("injection-async")
+   @GET
+   public Single<Integer> injectionAsync(@Async @Context Integer value)
+   {
+      return Single.just(value);
+   }
 }

--- a/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringBeanProcessor.java
+++ b/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringBeanProcessor.java
@@ -112,7 +112,7 @@ public class SpringBeanProcessor implements BeanFactoryPostProcessor, SmartAppli
          if (providerNames.contains(beanName))
          {
             PropertyInjector injector = getInjector(AopUtils.getTargetClass(bean));
-            injector.inject(bean);
+            injector.inject(bean, false);
             providerFactory.registerProviderInstance(bean);
          }
 
@@ -159,12 +159,12 @@ public class SpringBeanProcessor implements BeanFactoryPostProcessor, SmartAppli
          HttpRequest request = ResteasyProviderFactory.getContextData(HttpRequest.class);
          if (request == null || isSingleton(beanName))
          {
-            propertyInjector.inject(bean);
+            propertyInjector.inject(bean, false);
          }
          else
          {
             HttpResponse response = ResteasyProviderFactory.getContextData(HttpResponse.class);
-            propertyInjector.inject(request, response, bean);
+            propertyInjector.inject(request, response, bean, false);
          }
       }
 

--- a/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringResourceFactory.java
+++ b/resteasy-spring/src/main/java/org/jboss/resteasy/plugins/spring/SpringResourceFactory.java
@@ -1,5 +1,8 @@
 package org.jboss.resteasy.plugins.spring;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.PropertyInjector;
@@ -35,10 +38,10 @@ public class SpringResourceFactory implements ResourceFactory
       return propertyInjector;
    }
 
-   public Object createResource(HttpRequest request, HttpResponse response,
+   public CompletionStage<Object> createResource(HttpRequest request, HttpResponse response,
                                 ResteasyProviderFactory factory)
    {
-      return beanFactory.getBean(beanName);
+      return CompletableFuture.completedFuture(beanFactory.getBean(beanName));
    }
 
    public Class<?> getScannableClass()

--- a/resteasy-spring/src/main/java/org/jboss/resteasy/springmvc/ResteasyHandlerAdapter.java
+++ b/resteasy-spring/src/main/java/org/jboss/resteasy/springmvc/ResteasyHandlerAdapter.java
@@ -15,6 +15,7 @@ import org.springframework.web.servlet.View;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.concurrent.CompletionException;
 
 /**
  * @author <a href="mailto:sduskis@gmail.com">Solomn Duskis</a>
@@ -93,7 +94,11 @@ public class ResteasyHandlerAdapter extends
          BuiltResponse jaxrsResponse = null;
          try
          {
-            jaxrsResponse = (BuiltResponse) requestWrapper.getInvoker().invoke(request, response);
+            jaxrsResponse = (BuiltResponse) requestWrapper.getInvoker().invoke(request, response).toCompletableFuture().getNow(null);
+         }
+         catch (CompletionException e)
+         {
+            dispatcher.writeException(request, response, e.getCause(), t -> {});
          }
          catch (Exception e)
          {

--- a/resteasy-spring/src/main/java/org/jboss/resteasy/springmvc/ResteasyWebArgumentResolver.java
+++ b/resteasy-spring/src/main/java/org/jboss/resteasy/springmvc/ResteasyWebArgumentResolver.java
@@ -89,7 +89,7 @@ public class ResteasyWebArgumentResolver implements WebArgumentResolver
 
             return new CookieParamInjector(type, genericType, method,
                     cookieParam.value(), defaultVal, annotations, factory).inject(request,
-                    null);
+                    null, false);
          }
       }
       return null;

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/PortProviderUtil.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/PortProviderUtil.java
@@ -22,7 +22,7 @@ public class PortProviderUtil {
     private static int port;
 
     // HOST_PROPERTY_NAME is enforced by maven-enforcer-plugin
-    private static String host = System.getProperty(HOST_PROPERTY_NAME);
+    private static String host = System.getProperty(HOST_PROPERTY_NAME, "localhost");
 
     public static final String ASYNC_JOB_SERVICE_CONTEXT_KEY = "resteasy.async.job.service.enabled";
 

--- a/testsuite/integration-tests-spring/deployment/src/test/java/org/jboss/resteasy/test/spring/deployment/resource/RequestScopedBeanQualifierInjectorFactoryImpl.java
+++ b/testsuite/integration-tests-spring/deployment/src/test/java/org/jboss/resteasy/test/spring/deployment/resource/RequestScopedBeanQualifierInjectorFactoryImpl.java
@@ -35,12 +35,12 @@ public class RequestScopedBeanQualifierInjectorFactoryImpl extends InjectorFacto
         } else {
             return new ValueInjector() {
                 @Override
-                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
                    return CompletableFuture.completedFuture(beanFactory.getBean(qualifier.value()));
                 }
 
                 @Override
-                public CompletionStage<Object> inject() {
+                public CompletionStage<Object> inject(boolean unwrapAsync) {
                    // do nothing.
                    return CompletableFuture.completedFuture(null);
                 }
@@ -56,12 +56,12 @@ public class RequestScopedBeanQualifierInjectorFactoryImpl extends InjectorFacto
         } else {
             return new ValueInjector() {
                 @Override
-                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
                    return CompletableFuture.completedFuture(beanFactory.getBean(qualifier.value()));
                 }
 
                 @Override
-                public CompletionStage<Object> inject() {
+                public CompletionStage<Object> inject(boolean unwrapAsync) {
                    // do nothing.
                    return CompletableFuture.completedFuture(null);
                 }

--- a/testsuite/integration-tests-spring/deployment/src/test/java/org/jboss/resteasy/test/spring/deployment/resource/RequestScopedBeanQualifierInjectorFactoryImpl.java
+++ b/testsuite/integration-tests-spring/deployment/src/test/java/org/jboss/resteasy/test/spring/deployment/resource/RequestScopedBeanQualifierInjectorFactoryImpl.java
@@ -16,6 +16,8 @@ import javax.ws.rs.ext.Provider;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 @Provider
 public class RequestScopedBeanQualifierInjectorFactoryImpl extends InjectorFactoryImpl implements
@@ -32,13 +34,15 @@ public class RequestScopedBeanQualifierInjectorFactoryImpl extends InjectorFacto
                     genericType, annotations, factory);
         } else {
             return new ValueInjector() {
-                public Object inject(HttpRequest request, HttpResponse response) {
-                    return beanFactory.getBean(qualifier.value());
+                @Override
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                   return CompletableFuture.completedFuture(beanFactory.getBean(qualifier.value()));
                 }
 
-                public Object inject() {
-                    // do nothing.
-                    return null;
+                @Override
+                public CompletionStage<Object> inject() {
+                   // do nothing.
+                   return CompletableFuture.completedFuture(null);
                 }
             };
         }
@@ -51,13 +55,15 @@ public class RequestScopedBeanQualifierInjectorFactoryImpl extends InjectorFacto
             return super.createParameterExtractor(parameter, providerFactory);
         } else {
             return new ValueInjector() {
-                public Object inject(HttpRequest request, HttpResponse response) {
-                    return beanFactory.getBean(qualifier.value());
+                @Override
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                   return CompletableFuture.completedFuture(beanFactory.getBean(qualifier.value()));
                 }
 
-                public Object inject() {
-                    // do nothing.
-                    return null;
+                @Override
+                public CompletionStage<Object> inject() {
+                   // do nothing.
+                   return CompletableFuture.completedFuture(null);
                 }
             };
         }

--- a/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/resource/RequestScopedBeanQualifierInjectorFactoryImpl.java
+++ b/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/resource/RequestScopedBeanQualifierInjectorFactoryImpl.java
@@ -35,12 +35,12 @@ public class RequestScopedBeanQualifierInjectorFactoryImpl extends InjectorFacto
         } else {
             return new ValueInjector() {
                 @Override
-                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
                    return CompletableFuture.completedFuture(beanFactory.getBean(qualifier.value()));
                 }
 
                 @Override
-                public CompletionStage<Object> inject() {
+                public CompletionStage<Object> inject(boolean unwrapAsync) {
                    // do nothing.
                    return CompletableFuture.completedFuture(null);
                 }
@@ -56,12 +56,12 @@ public class RequestScopedBeanQualifierInjectorFactoryImpl extends InjectorFacto
         } else {
             return new ValueInjector() {
                 @Override
-                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
                    return CompletableFuture.completedFuture(beanFactory.getBean(qualifier.value()));
                 }
 
                 @Override
-                public CompletionStage<Object> inject() {
+                public CompletionStage<Object> inject(boolean unwrapAsync) {
                    // do nothing.
                    return CompletableFuture.completedFuture(null);
                 }

--- a/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/resource/RequestScopedBeanQualifierInjectorFactoryImpl.java
+++ b/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/resource/RequestScopedBeanQualifierInjectorFactoryImpl.java
@@ -16,6 +16,8 @@ import javax.ws.rs.ext.Provider;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 @Provider
 public class RequestScopedBeanQualifierInjectorFactoryImpl extends InjectorFactoryImpl implements
@@ -32,13 +34,15 @@ public class RequestScopedBeanQualifierInjectorFactoryImpl extends InjectorFacto
                     genericType, annotations, factory);
         } else {
             return new ValueInjector() {
-                public Object inject(HttpRequest request, HttpResponse response) {
-                    return beanFactory.getBean(qualifier.value());
+                @Override
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                   return CompletableFuture.completedFuture(beanFactory.getBean(qualifier.value()));
                 }
 
-                public Object inject() {
-                    // do nothing.
-                    return null;
+                @Override
+                public CompletionStage<Object> inject() {
+                   // do nothing.
+                   return CompletableFuture.completedFuture(null);
                 }
             };
         }
@@ -51,13 +55,15 @@ public class RequestScopedBeanQualifierInjectorFactoryImpl extends InjectorFacto
             return super.createParameterExtractor(parameter, providerFactory);
         } else {
             return new ValueInjector() {
-                public Object inject(HttpRequest request, HttpResponse response) {
-                    return beanFactory.getBean(qualifier.value());
+                @Override
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                   return CompletableFuture.completedFuture(beanFactory.getBean(qualifier.value()));
                 }
 
-                public Object inject() {
-                    // do nothing.
-                    return null;
+                @Override
+                public CompletionStage<Object> inject() {
+                   // do nothing.
+                   return CompletableFuture.completedFuture(null);
                 }
             };
         }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/UndertowTestRunner.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/UndertowTestRunner.java
@@ -1,0 +1,90 @@
+package org.jboss.resteasy.test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import javax.ws.rs.core.Application;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.ClassAsset;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+
+import io.undertow.Undertow;
+
+/**
+ * Test runner to use instead of Arquillian to run tests in the IDE
+ *
+ * @author Stéphane Épardaud <stef@epardaud.fr>
+ */
+public class UndertowTestRunner extends BlockJUnit4ClassRunner
+{
+
+   private Set<Class<?>> classes = new HashSet<>();
+   
+   public UndertowTestRunner(Class<?> klass) throws InitializationError
+   {
+      super(klass);
+      loadDeployment(klass);
+   }
+
+   private void loadDeployment(Class<?> klass)
+   {
+      for (Method method : klass.getDeclaredMethods())
+      {
+         if(Modifier.isStatic(method.getModifiers())
+               && method.isAnnotationPresent(Deployment.class)) 
+         {
+            try
+            {
+               Archive<?> archive = (Archive<?>) method.invoke(null);
+               for (Entry<ArchivePath, Node> entry : archive.getContent().entrySet())
+               {
+                  Asset asset = entry.getValue().getAsset();
+                  if(asset instanceof ClassAsset)
+                     classes.add(((ClassAsset)asset).getSource());
+               }
+               return;
+            } 
+            catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e)
+            {
+               throw new RuntimeException(e);
+            }
+         }
+      }
+      throw new RuntimeException("Could not find method annotated with @Deployment to guess class names");
+   }
+
+   @Override
+   public void run(RunNotifier notifier)
+   {
+      UndertowJaxrsServer server = new UndertowJaxrsServer().start(Undertow.builder()
+            .addHttpListener(8080, "localhost"));
+      server.deploy(new Application() {
+         @Override
+        public Set<Class<?>> getClasses()
+        {
+            return classes;
+        }
+      }, super.getTestClass().getJavaClass().getSimpleName());
+      try 
+      {
+         super.run(notifier);
+      }
+      finally 
+      {
+         server.stop();
+      }
+      
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
@@ -15,9 +15,12 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.test.UndertowTestRunner;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContext;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextAsyncSpecifier;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextErrorSpecifier;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextInjector;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextInterface;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextInterfaceInjector;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionException;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionExceptionMapper;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionResource;
 import org.jboss.resteasy.test.asynch.resource.AsyncPreMatchRequestFilter1;
 import org.jboss.resteasy.test.asynch.resource.AsyncPreMatchRequestFilter2;
@@ -57,7 +60,8 @@ public class AsyncInjectionTest {
         return TestUtil.finishContainerPrepare(war, null, AsyncInjectionResource.class, 
               AsyncInjectionContext.class, AsyncInjectionContextInjector.class,
               AsyncInjectionContextInterface.class, AsyncInjectionContextInterfaceInjector.class,
-              AsyncInjectionContextAsyncSpecifier.class);
+              AsyncInjectionContextAsyncSpecifier.class, AsyncInjectionContextErrorSpecifier.class,
+              AsyncInjectionException.class, AsyncInjectionExceptionMapper.class);
     }
 
     private String generateURL(String path) {
@@ -128,6 +132,40 @@ public class AsyncInjectionTest {
         Response response = base.request()
            .get();
         assertEquals("Non-200 result: "+response.readEntity(String.class), 200, response.getStatus());
+        
+        client.close();
+    }
+
+    /**
+     * @tpTestDetails Async Injection with exceptions
+     * @tpSince RESTEasy 4.0.0
+     */
+    @Test
+    public void testAsyncInjectionException() throws Exception {
+        Client client = ClientBuilder.newClient();
+
+        WebTarget base = client.target(generateURL("/exception"));
+
+        Response response = base.request()
+           .get();
+        assertEquals("Non-202 result: "+response.readEntity(String.class), 202, response.getStatus());
+        
+        client.close();
+    }
+
+    /**
+     * @tpTestDetails Async Injection with async exceptions
+     * @tpSince RESTEasy 4.0.0
+     */
+    @Test
+    public void testAsyncInjectionExceptionAsync() throws Exception {
+        Client client = ClientBuilder.newClient();
+
+        WebTarget base = client.target(generateURL("/exception-async"));
+
+        Response response = base.request()
+           .get();
+        assertEquals("Non-202 result: "+response.readEntity(String.class), 202, response.getStatus());
         
         client.close();
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
@@ -66,12 +66,45 @@ public class AsyncInjectionTest {
     public void testAsyncInjection() throws Exception {
         Client client = ClientBuilder.newClient();
 
-        // Create book.
         WebTarget base = client.target(generateURL("/"));
 
         Response response = base.request()
            .get();
-        assertEquals(200, response.getStatus());
+        assertEquals("Non-200 result: "+response.readEntity(String.class), 200, response.getStatus());
+        
+        client.close();
+    }
+
+    /**
+     * @tpTestDetails Async Injection does not suspend request if already resolved
+     * @tpSince RESTEasy 4.0.0
+     */
+    @Test
+    public void testAsyncInjectionResolved() throws Exception {
+        Client client = ClientBuilder.newClient();
+
+        WebTarget base = client.target(generateURL("/resolved"));
+
+        Response response = base.request()
+           .get();
+        assertEquals("Non-200 result: "+response.readEntity(String.class), 200, response.getStatus());
+        
+        client.close();
+    }
+
+    /**
+     * @tpTestDetails Async Injection suspends request if not yet resolved
+     * @tpSince RESTEasy 4.0.0
+     */
+    @Test
+    public void testAsyncInjectionSuspended() throws Exception {
+        Client client = ClientBuilder.newClient();
+
+        WebTarget base = client.target(generateURL("/suspended"));
+
+        Response response = base.request()
+           .get();
+        assertEquals("Non-200 result: "+response.readEntity(String.class), 200, response.getStatus());
         
         client.close();
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
@@ -48,8 +48,8 @@ import org.junit.runner.RunWith;
  * @tpTestCaseDetails Async Request Filter test.
  * @tpSince RESTEasy 4.0.0
  */
-//@RunWith(Arquillian.class)
-@RunWith(UndertowTestRunner.class)
+@RunWith(Arquillian.class)
+//@RunWith(UndertowTestRunner.class)
 @RunAsClient
 public class AsyncInjectionTest {
     protected static final Logger log = LogManager.getLogger(AsyncInjectionTest.class.getName());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
@@ -15,6 +15,8 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.test.UndertowTestRunner;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContext;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextInjector;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextInterface;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextInterfaceInjector;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionResource;
 import org.jboss.resteasy.test.asynch.resource.AsyncPreMatchRequestFilter1;
 import org.jboss.resteasy.test.asynch.resource.AsyncPreMatchRequestFilter2;
@@ -51,7 +53,9 @@ public class AsyncInjectionTest {
     public static Archive<?> createTestArchive() {
 
         WebArchive war = TestUtil.prepareArchive(AsyncInjectionTest.class.getSimpleName());
-        return TestUtil.finishContainerPrepare(war, null, AsyncInjectionResource.class, AsyncInjectionContext.class, AsyncInjectionContextInjector.class);
+        return TestUtil.finishContainerPrepare(war, null, AsyncInjectionResource.class, 
+              AsyncInjectionContext.class, AsyncInjectionContextInjector.class,
+              AsyncInjectionContextInterface.class, AsyncInjectionContextInterfaceInjector.class);
     }
 
     private String generateURL(String path) {
@@ -67,6 +71,23 @@ public class AsyncInjectionTest {
         Client client = ClientBuilder.newClient();
 
         WebTarget base = client.target(generateURL("/"));
+
+        Response response = base.request()
+           .get();
+        assertEquals("Non-200 result: "+response.readEntity(String.class), 200, response.getStatus());
+        
+        client.close();
+    }
+
+    /**
+     * @tpTestDetails Async Injection works for interfaces
+     * @tpSince RESTEasy 4.0.0
+     */
+    @Test
+    public void testAsyncInjectionInterface() throws Exception {
+        Client client = ClientBuilder.newClient();
+
+        WebTarget base = client.target(generateURL("/interface"));
 
         Response response = base.request()
            .get();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
@@ -14,6 +14,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.test.UndertowTestRunner;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContext;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextAsyncSpecifier;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextInjector;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextInterface;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextInterfaceInjector;
@@ -55,7 +56,8 @@ public class AsyncInjectionTest {
         WebArchive war = TestUtil.prepareArchive(AsyncInjectionTest.class.getSimpleName());
         return TestUtil.finishContainerPrepare(war, null, AsyncInjectionResource.class, 
               AsyncInjectionContext.class, AsyncInjectionContextInjector.class,
-              AsyncInjectionContextInterface.class, AsyncInjectionContextInterfaceInjector.class);
+              AsyncInjectionContextInterface.class, AsyncInjectionContextInterfaceInjector.class,
+              AsyncInjectionContextAsyncSpecifier.class);
     }
 
     private String generateURL(String path) {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
@@ -22,6 +22,7 @@ import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextInterfaceInj
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionException;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionExceptionMapper;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionResource;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionResource2;
 import org.jboss.resteasy.test.asynch.resource.AsyncPreMatchRequestFilter1;
 import org.jboss.resteasy.test.asynch.resource.AsyncPreMatchRequestFilter2;
 import org.jboss.resteasy.test.asynch.resource.AsyncPreMatchRequestFilter3;
@@ -61,7 +62,8 @@ public class AsyncInjectionTest {
               AsyncInjectionContext.class, AsyncInjectionContextInjector.class,
               AsyncInjectionContextInterface.class, AsyncInjectionContextInterfaceInjector.class,
               AsyncInjectionContextAsyncSpecifier.class, AsyncInjectionContextErrorSpecifier.class,
-              AsyncInjectionException.class, AsyncInjectionExceptionMapper.class);
+              AsyncInjectionException.class, AsyncInjectionExceptionMapper.class,
+              AsyncInjectionResource2.class);
     }
 
     private String generateURL(String path) {
@@ -166,6 +168,23 @@ public class AsyncInjectionTest {
         Response response = base.request()
            .get();
         assertEquals("Non-202 result: "+response.readEntity(String.class), 202, response.getStatus());
+        
+        client.close();
+    }
+
+    /**
+     * @tpTestDetails Async Injection in places where it does not work
+     * @tpSince RESTEasy 4.0.0
+     */
+    @Test
+    public void testAsyncInjectionExceptionLate() throws Exception {
+        Client client = ClientBuilder.newClient();
+
+        WebTarget base = client.target(generateURL("/late"));
+
+        Response response = base.request()
+           .get();
+        assertEquals("Non-200 result: "+response.readEntity(String.class), 200, response.getStatus());
         
         client.close();
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
@@ -13,28 +13,25 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.test.UndertowTestRunner;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionBooleanInjector;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionByteInjector;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionCharInjector;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContext;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextAsyncSpecifier;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextErrorSpecifier;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextInjector;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextInterface;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextInterfaceInjector;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionDoubleInjector;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionException;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionExceptionMapper;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionFloatInjector;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionIntInjector;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionLongInjector;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionPrimitiveInjectorSpecifier;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionResource;
 import org.jboss.resteasy.test.asynch.resource.AsyncInjectionResource2;
-import org.jboss.resteasy.test.asynch.resource.AsyncPreMatchRequestFilter1;
-import org.jboss.resteasy.test.asynch.resource.AsyncPreMatchRequestFilter2;
-import org.jboss.resteasy.test.asynch.resource.AsyncPreMatchRequestFilter3;
-import org.jboss.resteasy.test.asynch.resource.AsyncRequestFilter;
-import org.jboss.resteasy.test.asynch.resource.AsyncRequestFilter1;
-import org.jboss.resteasy.test.asynch.resource.AsyncRequestFilter2;
-import org.jboss.resteasy.test.asynch.resource.AsyncRequestFilter3;
-import org.jboss.resteasy.test.asynch.resource.AsyncRequestFilterResource;
-import org.jboss.resteasy.test.asynch.resource.AsyncResponseFilter;
-import org.jboss.resteasy.test.asynch.resource.AsyncResponseFilter1;
-import org.jboss.resteasy.test.asynch.resource.AsyncResponseFilter2;
-import org.jboss.resteasy.test.asynch.resource.AsyncResponseFilter3;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionShortInjector;
 import org.jboss.resteasy.utils.PortProviderUtil;
 import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
@@ -63,7 +60,11 @@ public class AsyncInjectionTest {
               AsyncInjectionContextInterface.class, AsyncInjectionContextInterfaceInjector.class,
               AsyncInjectionContextAsyncSpecifier.class, AsyncInjectionContextErrorSpecifier.class,
               AsyncInjectionException.class, AsyncInjectionExceptionMapper.class,
-              AsyncInjectionResource2.class);
+              AsyncInjectionResource2.class, AsyncInjectionPrimitiveInjectorSpecifier.class,
+              AsyncInjectionBooleanInjector.class, AsyncInjectionCharInjector.class,
+              AsyncInjectionByteInjector.class, AsyncInjectionShortInjector.class,
+              AsyncInjectionIntInjector.class, AsyncInjectionLongInjector.class,
+              AsyncInjectionFloatInjector.class, AsyncInjectionDoubleInjector.class);
     }
 
     private String generateURL(String path) {
@@ -181,6 +182,23 @@ public class AsyncInjectionTest {
         Client client = ClientBuilder.newClient();
 
         WebTarget base = client.target(generateURL("/late"));
+
+        Response response = base.request()
+           .get();
+        assertEquals("Non-200 result: "+response.readEntity(String.class), 200, response.getStatus());
+        
+        client.close();
+    }
+
+    /**
+     * @tpTestDetails Async Injection of primitive types
+     * @tpSince RESTEasy 4.0.0
+     */
+    @Test
+    public void testAsyncInjectionPrimitives() throws Exception {
+        Client client = ClientBuilder.newClient();
+
+        WebTarget base = client.target(generateURL("/primitives"));
 
         Response response = base.request()
            .get();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncInjectionTest.java
@@ -1,0 +1,78 @@
+package org.jboss.resteasy.test.asynch;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.test.UndertowTestRunner;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContext;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionContextInjector;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionResource;
+import org.jboss.resteasy.test.asynch.resource.AsyncPreMatchRequestFilter1;
+import org.jboss.resteasy.test.asynch.resource.AsyncPreMatchRequestFilter2;
+import org.jboss.resteasy.test.asynch.resource.AsyncPreMatchRequestFilter3;
+import org.jboss.resteasy.test.asynch.resource.AsyncRequestFilter;
+import org.jboss.resteasy.test.asynch.resource.AsyncRequestFilter1;
+import org.jboss.resteasy.test.asynch.resource.AsyncRequestFilter2;
+import org.jboss.resteasy.test.asynch.resource.AsyncRequestFilter3;
+import org.jboss.resteasy.test.asynch.resource.AsyncRequestFilterResource;
+import org.jboss.resteasy.test.asynch.resource.AsyncResponseFilter;
+import org.jboss.resteasy.test.asynch.resource.AsyncResponseFilter1;
+import org.jboss.resteasy.test.asynch.resource.AsyncResponseFilter2;
+import org.jboss.resteasy.test.asynch.resource.AsyncResponseFilter3;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @tpSubChapter CDI
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Async Request Filter test.
+ * @tpSince RESTEasy 4.0.0
+ */
+//@RunWith(Arquillian.class)
+@RunWith(UndertowTestRunner.class)
+@RunAsClient
+public class AsyncInjectionTest {
+    protected static final Logger log = LogManager.getLogger(AsyncInjectionTest.class.getName());
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+
+        WebArchive war = TestUtil.prepareArchive(AsyncInjectionTest.class.getSimpleName());
+        return TestUtil.finishContainerPrepare(war, null, AsyncInjectionResource.class, AsyncInjectionContext.class, AsyncInjectionContextInjector.class);
+    }
+
+    private String generateURL(String path) {
+        return PortProviderUtil.generateURL(path, AsyncInjectionTest.class.getSimpleName());
+    }
+
+    /**
+     * @tpTestDetails Async Injection works
+     * @tpSince RESTEasy 4.0.0
+     */
+    @Test
+    public void testAsyncInjection() throws Exception {
+        Client client = ClientBuilder.newClient();
+
+        // Create book.
+        WebTarget base = client.target(generateURL("/"));
+
+        Response response = base.request()
+           .get();
+        assertEquals(200, response.getStatus());
+        
+        client.close();
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionBooleanInjector.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionBooleanInjector.java
@@ -1,0 +1,38 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ContextInjector;
+
+@Provider
+public class AsyncInjectionBooleanInjector implements ContextInjector<CompletionStage<Boolean>, Boolean>
+{
+
+   @Override
+   public CompletionStage<Boolean> resolve(
+         Class<? extends CompletionStage<Boolean>> rawType, Type genericType, Annotation[] annotations)
+   {
+      for (Annotation annotation : annotations)
+      {
+         if(annotation.annotationType() == AsyncInjectionPrimitiveInjectorSpecifier.class) {
+            AsyncInjectionPrimitiveInjectorSpecifier.Type value = ((AsyncInjectionPrimitiveInjectorSpecifier)annotation).value();
+            switch(value) {
+            case NO_RESULT:
+               return null;
+            case NULL:
+               return CompletableFuture.completedFuture(null);
+            case VALUE:
+               return CompletableFuture.completedFuture(true);
+            }
+            break;
+         }
+      }
+      return CompletableFuture.completedFuture(true);
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionByteInjector.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionByteInjector.java
@@ -1,0 +1,38 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ContextInjector;
+
+@Provider
+public class AsyncInjectionByteInjector implements ContextInjector<CompletionStage<Byte>, Byte>
+{
+
+   @Override
+   public CompletionStage<Byte> resolve(
+         Class<? extends CompletionStage<Byte>> rawType, Type genericType, Annotation[] annotations)
+   {
+      for (Annotation annotation : annotations)
+      {
+         if(annotation.annotationType() == AsyncInjectionPrimitiveInjectorSpecifier.class) {
+            AsyncInjectionPrimitiveInjectorSpecifier.Type value = ((AsyncInjectionPrimitiveInjectorSpecifier)annotation).value();
+            switch(value) {
+            case NO_RESULT:
+               return null;
+            case NULL:
+               return CompletableFuture.completedFuture(null);
+            case VALUE:
+               return CompletableFuture.completedFuture((byte)42);
+            }
+            break;
+         }
+      }
+      return CompletableFuture.completedFuture((byte)42);
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionCharInjector.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionCharInjector.java
@@ -1,0 +1,38 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ContextInjector;
+
+@Provider
+public class AsyncInjectionCharInjector implements ContextInjector<CompletionStage<Character>, Character>
+{
+
+   @Override
+   public CompletionStage<Character> resolve(
+         Class<? extends CompletionStage<Character>> rawType, Type genericType, Annotation[] annotations)
+   {
+      for (Annotation annotation : annotations)
+      {
+         if(annotation.annotationType() == AsyncInjectionPrimitiveInjectorSpecifier.class) {
+            AsyncInjectionPrimitiveInjectorSpecifier.Type value = ((AsyncInjectionPrimitiveInjectorSpecifier)annotation).value();
+            switch(value) {
+            case NO_RESULT:
+               return null;
+            case NULL:
+               return CompletableFuture.completedFuture(null);
+            case VALUE:
+               return CompletableFuture.completedFuture('s');
+            }
+            break;
+         }
+      }
+      return CompletableFuture.completedFuture('s');
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContext.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContext.java
@@ -1,0 +1,11 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+public class AsyncInjectionContext
+{
+
+   public int foo()
+   {
+      return 42;
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContext.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContext.java
@@ -1,8 +1,9 @@
 package org.jboss.resteasy.test.asynch.resource;
 
-public class AsyncInjectionContext
+public class AsyncInjectionContext implements AsyncInjectionContextInterface
 {
 
+   @Override
    public int foo()
    {
       return 42;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextAsyncSpecifier.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextAsyncSpecifier.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD, PARAMETER })
+public @interface AsyncInjectionContextAsyncSpecifier
+{
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextErrorSpecifier.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextErrorSpecifier.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD, PARAMETER })
+public @interface AsyncInjectionContextErrorSpecifier
+{
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextInjector.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextInjector.java
@@ -10,7 +10,7 @@ import javax.ws.rs.ext.Provider;
 import org.jboss.resteasy.spi.ContextInjector;
 
 @Provider
-public class AsyncInjectionContextInjector implements ContextInjector<CompletionStage<AsyncInjectionContext>>
+public class AsyncInjectionContextInjector implements ContextInjector<CompletionStage<AsyncInjectionContext>, AsyncInjectionContext>
 {
 
    @Override

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextInjector.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextInjector.java
@@ -1,0 +1,23 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ContextInjector;
+
+@Provider
+public class AsyncInjectionContextInjector implements ContextInjector<CompletionStage<AsyncInjectionContext>>
+{
+
+   @Override
+   public CompletionStage<AsyncInjectionContext> resolve(
+         Class<? extends CompletionStage<AsyncInjectionContext>> rawType, Type genericType, Annotation[] annotations)
+   {
+      return CompletableFuture.completedFuture(new AsyncInjectionContext());
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextInjector.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextInjector.java
@@ -2,6 +2,7 @@ package org.jboss.resteasy.test.asynch.resource;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -17,6 +18,30 @@ public class AsyncInjectionContextInjector implements ContextInjector<Completion
    public CompletionStage<AsyncInjectionContext> resolve(
          Class<? extends CompletionStage<AsyncInjectionContext>> rawType, Type genericType, Annotation[] annotations)
    {
+      boolean async = false;
+      for (Annotation annotation : annotations)
+      {
+         if(annotation.annotationType() == AsyncInjectionContextAsyncSpecifier.class)
+         {
+            async = true;
+            break;
+         }
+      }
+      if(async)
+      {
+         CompletableFuture<AsyncInjectionContext> ret = new CompletableFuture<>();
+         new Thread(() -> {
+            try
+            {
+               Thread.sleep(1000);
+            } catch (InterruptedException e)
+            {
+               throw new RuntimeException(e);
+            }
+            ret.complete(new AsyncInjectionContext());
+         }).start();
+         return ret;
+      }
       return CompletableFuture.completedFuture(new AsyncInjectionContext());
    }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextInterface.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextInterface.java
@@ -1,0 +1,6 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+public interface AsyncInjectionContextInterface
+{
+   public int foo();
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextInterfaceInjector.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextInterfaceInjector.java
@@ -1,0 +1,23 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ContextInjector;
+
+@Provider
+public class AsyncInjectionContextInterfaceInjector implements ContextInjector<CompletionStage<AsyncInjectionContextInterface>>
+{
+
+   @Override
+   public CompletionStage<AsyncInjectionContextInterface> resolve(
+         Class<? extends CompletionStage<AsyncInjectionContextInterface>> rawType, Type genericType, Annotation[] annotations)
+   {
+      return CompletableFuture.completedFuture(new AsyncInjectionContext());
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextInterfaceInjector.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionContextInterfaceInjector.java
@@ -10,7 +10,7 @@ import javax.ws.rs.ext.Provider;
 import org.jboss.resteasy.spi.ContextInjector;
 
 @Provider
-public class AsyncInjectionContextInterfaceInjector implements ContextInjector<CompletionStage<AsyncInjectionContextInterface>>
+public class AsyncInjectionContextInterfaceInjector implements ContextInjector<CompletionStage<AsyncInjectionContextInterface>, AsyncInjectionContextInterface>
 {
 
    @Override

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionDoubleInjector.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionDoubleInjector.java
@@ -1,0 +1,38 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ContextInjector;
+
+@Provider
+public class AsyncInjectionDoubleInjector implements ContextInjector<CompletionStage<Double>, Double>
+{
+
+   @Override
+   public CompletionStage<Double> resolve(
+         Class<? extends CompletionStage<Double>> rawType, Type genericType, Annotation[] annotations)
+   {
+      for (Annotation annotation : annotations)
+      {
+         if(annotation.annotationType() == AsyncInjectionPrimitiveInjectorSpecifier.class) {
+            AsyncInjectionPrimitiveInjectorSpecifier.Type value = ((AsyncInjectionPrimitiveInjectorSpecifier)annotation).value();
+            switch(value) {
+            case NO_RESULT:
+               return null;
+            case NULL:
+               return CompletableFuture.completedFuture(null);
+            case VALUE:
+               return CompletableFuture.completedFuture(4.2);
+            }
+            break;
+         }
+      }
+      return CompletableFuture.completedFuture(4.2);
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionException.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionException.java
@@ -1,0 +1,12 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+@SuppressWarnings("serial")
+public class AsyncInjectionException extends Exception
+{
+
+   public AsyncInjectionException(String message)
+   {
+      super(message);
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionExceptionMapper.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionExceptionMapper.java
@@ -1,0 +1,18 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class AsyncInjectionExceptionMapper implements ExceptionMapper<AsyncInjectionException>
+{
+
+   @Override
+   public Response toResponse(AsyncInjectionException exception)
+   {
+      return Response.ok("exception was mapped").status(Status.ACCEPTED).build();
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionFloatInjector.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionFloatInjector.java
@@ -1,0 +1,38 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ContextInjector;
+
+@Provider
+public class AsyncInjectionFloatInjector implements ContextInjector<CompletionStage<Float>, Float>
+{
+
+   @Override
+   public CompletionStage<Float> resolve(
+         Class<? extends CompletionStage<Float>> rawType, Type genericType, Annotation[] annotations)
+   {
+      for (Annotation annotation : annotations)
+      {
+         if(annotation.annotationType() == AsyncInjectionPrimitiveInjectorSpecifier.class) {
+            AsyncInjectionPrimitiveInjectorSpecifier.Type value = ((AsyncInjectionPrimitiveInjectorSpecifier)annotation).value();
+            switch(value) {
+            case NO_RESULT:
+               return null;
+            case NULL:
+               return CompletableFuture.completedFuture(null);
+            case VALUE:
+               return CompletableFuture.completedFuture(4.2f);
+            }
+            break;
+         }
+      }
+      return CompletableFuture.completedFuture(4.2f);
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionIntInjector.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionIntInjector.java
@@ -1,0 +1,38 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ContextInjector;
+
+@Provider
+public class AsyncInjectionIntInjector implements ContextInjector<CompletionStage<Integer>, Integer>
+{
+
+   @Override
+   public CompletionStage<Integer> resolve(
+         Class<? extends CompletionStage<Integer>> rawType, Type genericType, Annotation[] annotations)
+   {
+      for (Annotation annotation : annotations)
+      {
+         if(annotation.annotationType() == AsyncInjectionPrimitiveInjectorSpecifier.class) {
+            AsyncInjectionPrimitiveInjectorSpecifier.Type value = ((AsyncInjectionPrimitiveInjectorSpecifier)annotation).value();
+            switch(value) {
+            case NO_RESULT:
+               return null;
+            case NULL:
+               return CompletableFuture.completedFuture(null);
+            case VALUE:
+               return CompletableFuture.completedFuture(42);
+            }
+            break;
+         }
+      }
+      return CompletableFuture.completedFuture(42);
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionLongInjector.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionLongInjector.java
@@ -1,0 +1,38 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ContextInjector;
+
+@Provider
+public class AsyncInjectionLongInjector implements ContextInjector<CompletionStage<Long>, Long>
+{
+
+   @Override
+   public CompletionStage<Long> resolve(
+         Class<? extends CompletionStage<Long>> rawType, Type genericType, Annotation[] annotations)
+   {
+      for (Annotation annotation : annotations)
+      {
+         if(annotation.annotationType() == AsyncInjectionPrimitiveInjectorSpecifier.class) {
+            AsyncInjectionPrimitiveInjectorSpecifier.Type value = ((AsyncInjectionPrimitiveInjectorSpecifier)annotation).value();
+            switch(value) {
+            case NO_RESULT:
+               return null;
+            case NULL:
+               return CompletableFuture.completedFuture(null);
+            case VALUE:
+               return CompletableFuture.completedFuture(42l);
+            }
+            break;
+         }
+      }
+      return CompletableFuture.completedFuture(42l);
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionPrimitiveInjectorSpecifier.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionPrimitiveInjectorSpecifier.java
@@ -1,0 +1,21 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD, PARAMETER })
+public @interface AsyncInjectionPrimitiveInjectorSpecifier
+{
+   public enum Type {
+      VALUE, NULL, NO_RESULT;
+   }
+   
+   Type value() default Type.VALUE;
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionResource.java
@@ -10,6 +10,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.test.asynch.resource.AsyncInjectionPrimitiveInjectorSpecifier.Type;
 
 @Path("/")
 public class AsyncInjectionResource
@@ -167,6 +168,124 @@ public class AsyncInjectionResource
          return Response.serverError().entity("Resolved context field problem").build();
       if(resource.resolvedContextFieldAsync != null)
          return Response.serverError().entity("Resolved async context field problem").build();
+      return Response.ok("resource").build();
+   }
+
+   @Path("/primitives")
+   @GET
+   public Response asyncInjectionPrimitives(@Context Boolean boolBoxedTrue,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NULL) Boolean boolBoxedNull,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NO_RESULT) Boolean boolBoxedNull2,
+         @Context boolean bool,
+         
+         @Context Character charBoxedS,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NULL) Character charBoxedNull,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NO_RESULT) Character charBoxedNull2,
+         @Context char c,
+         
+         @Context Byte byteBoxed42,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NULL) Byte byteBoxedNull,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NO_RESULT) Byte byteBoxedNull2,
+         @Context byte b,
+
+         @Context Short shortBoxed42,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NULL) Short shortBoxedNull,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NO_RESULT) Short shortBoxedNull2,
+         @Context short s,
+
+         @Context Integer intBoxed42,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NULL) Integer intBoxedNull,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NO_RESULT) Integer intBoxedNull2,
+         @Context int i,
+
+         @Context Long longBoxed42,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NULL) Long longBoxedNull,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NO_RESULT) Long longBoxedNull2,
+         @Context long l,
+
+         @Context Float floatBoxed42,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NULL) Float floatBoxedNull,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NO_RESULT) Float floatBoxedNull2,
+         @Context float f,
+
+         @Context Double doubleBoxed42,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NULL) Double doubleBoxedNull,
+         @Context @AsyncInjectionPrimitiveInjectorSpecifier(Type.NO_RESULT) Double doubleBoxedNull2,
+         @Context double d)
+         throws InterruptedException, ExecutionException
+   {
+      if(boolBoxedTrue == null || !boolBoxedTrue.booleanValue())
+         return Response.serverError().entity("Missing boxed boolean").build();
+      if(boolBoxedNull != null)
+         return Response.serverError().entity("Non-null boxed boolean").build();
+      if(boolBoxedNull2 != null)
+         return Response.serverError().entity("Non-null boxed boolean 2").build();
+      if(!bool)
+         return Response.serverError().entity("Missing boolean").build();
+
+      if(charBoxedS == null || charBoxedS.charValue() != 's')
+         return Response.serverError().entity("Missing boxed char").build();
+      if(charBoxedNull != null)
+         return Response.serverError().entity("Non-null boxed char").build();
+      if(charBoxedNull2 != null)
+         return Response.serverError().entity("Non-null boxed char 2").build();
+      if(c != 's')
+         return Response.serverError().entity("Missing char").build();
+
+      if(byteBoxed42 == null || byteBoxed42.intValue() != 42)
+         return Response.serverError().entity("Missing boxed byte").build();
+      if(byteBoxedNull != null)
+         return Response.serverError().entity("Non-null boxed byte").build();
+      if(byteBoxedNull2 != null)
+         return Response.serverError().entity("Non-null boxed byte 2").build();
+      if(b != 42)
+         return Response.serverError().entity("Missing byte").build();
+
+      if(shortBoxed42 == null || shortBoxed42.intValue() != 42)
+         return Response.serverError().entity("Missing boxed short").build();
+      if(shortBoxedNull != null)
+         return Response.serverError().entity("Non-null boxed short").build();
+      if(shortBoxedNull2 != null)
+         return Response.serverError().entity("Non-null boxed short 2").build();
+      if(s != 42)
+         return Response.serverError().entity("Missing short").build();
+
+      if(intBoxed42 == null || intBoxed42.intValue() != 42)
+         return Response.serverError().entity("Missing boxed int").build();
+      if(intBoxedNull != null)
+         return Response.serverError().entity("Non-null boxed int").build();
+      if(intBoxedNull2 != null)
+         return Response.serverError().entity("Non-null boxed int 2").build();
+      if(i != 42)
+         return Response.serverError().entity("Missing int").build();
+
+      if(longBoxed42 == null || longBoxed42.intValue() != 42)
+         return Response.serverError().entity("Missing boxed long").build();
+      if(longBoxedNull != null)
+         return Response.serverError().entity("Non-null boxed long").build();
+      if(longBoxedNull2 != null)
+         return Response.serverError().entity("Non-null boxed long 2").build();
+      if(l != 42)
+         return Response.serverError().entity("Missing long").build();
+
+      if(floatBoxed42 == null || floatBoxed42.floatValue() != 4.2f)
+         return Response.serverError().entity("Missing boxed float").build();
+      if(floatBoxedNull != null)
+         return Response.serverError().entity("Non-null boxed float").build();
+      if(floatBoxedNull2 != null)
+         return Response.serverError().entity("Non-null boxed float 2").build();
+      if(f != 4.2f)
+         return Response.serverError().entity("Missing float").build();
+
+      if(doubleBoxed42 == null || doubleBoxed42.doubleValue() != 4.2)
+         return Response.serverError().entity("Missing boxed double").build();
+      if(doubleBoxedNull != null)
+         return Response.serverError().entity("Non-null boxed double").build();
+      if(doubleBoxedNull2 != null)
+         return Response.serverError().entity("Non-null boxed double 2").build();
+      if(d != 4.2)
+         return Response.serverError().entity("Missing double").build();
+
       return Response.ok("resource").build();
    }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionResource.java
@@ -131,4 +131,24 @@ public class AsyncInjectionResource
 
       return Response.ok("resource").build();
    }
+
+   @Path("/exception")
+   @GET
+   public Response asyncInjectionInterface(@AsyncInjectionContextErrorSpecifier @Context AsyncInjectionContext resolvedContextParam,
+         @AsyncInjectionContextErrorSpecifier @Context CompletionStage<AsyncInjectionContext> asyncContextParam)
+         throws InterruptedException, ExecutionException
+   {
+      return Response.serverError().entity("Should have thrown").build();
+   }
+
+   @Path("/exception-async")
+   @GET
+   public Response asyncInjectionInterfaceAsync(@AsyncInjectionContextErrorSpecifier @AsyncInjectionContextAsyncSpecifier 
+         @Context AsyncInjectionContext resolvedContextParam,
+         @AsyncInjectionContextErrorSpecifier @AsyncInjectionContextAsyncSpecifier 
+         @Context CompletionStage<AsyncInjectionContext> asyncContextParam)
+         throws InterruptedException, ExecutionException
+   {
+      return Response.serverError().entity("Should have thrown").build();
+   }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionResource.java
@@ -117,4 +117,18 @@ public class AsyncInjectionResource
       
       return Response.ok("resource").build();
    }
+
+   @Path("/interface")
+   @GET
+   public Response asyncInjectionInterface(@Context AsyncInjectionContextInterface resolvedContextParam,
+         @Context CompletionStage<AsyncInjectionContextInterface> asyncContextParam)
+         throws InterruptedException, ExecutionException
+   {
+      if (resolvedContextParam == null || resolvedContextParam.foo() != 42)
+         return Response.serverError().entity("Missing injected resolved context param").build();
+      if (asyncContextParam == null || asyncContextParam.toCompletableFuture().get().foo() != 42)
+         return Response.serverError().entity("Missing injected async context param").build();
+
+      return Response.ok("resource").build();
+   }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionResource.java
@@ -1,0 +1,82 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+public class AsyncInjectionResource
+{
+
+   @Context
+   AsyncInjectionContext resolvedContextField;
+   @Context
+   CompletionStage<AsyncInjectionContext> asyncContextField;
+
+   AsyncInjectionContext resolvedContextConstructor;
+   CompletionStage<AsyncInjectionContext> asyncContextConstructor;
+
+   AsyncInjectionContext resolvedContextProperty;
+   CompletionStage<AsyncInjectionContext> asyncContextProperty;
+
+   public AsyncInjectionResource(@Context AsyncInjectionContext resolvedContextConstructor,
+         @Context CompletionStage<AsyncInjectionContext> asyncContextConstructor)
+   {
+      this.resolvedContextConstructor = resolvedContextConstructor;
+      this.asyncContextConstructor = asyncContextConstructor;
+   }
+   
+   public CompletionStage<AsyncInjectionContext> getAsyncContextProperty()
+   {
+      return asyncContextProperty;
+   }
+   
+   @Context
+   public void setAsyncContextProperty(CompletionStage<AsyncInjectionContext> asyncContextProperty)
+   {
+      this.asyncContextProperty = asyncContextProperty;
+   }
+   
+   public AsyncInjectionContext getResolvedContextProperty()
+   {
+      return resolvedContextProperty;
+   }
+   
+   @Context
+   public void setResolvedContextProperty(AsyncInjectionContext resolvedContextProperty)
+   {
+      this.resolvedContextProperty = resolvedContextProperty;
+   }
+   
+   @GET
+   public Response asyncInjection(@Context AsyncInjectionContext resolvedContextParam,
+         @Context CompletionStage<AsyncInjectionContext> asyncContextParam)
+         throws InterruptedException, ExecutionException
+   {
+      if (resolvedContextParam == null || resolvedContextParam.foo() != 42)
+         return Response.serverError().entity("Missing injected resolved context param").build();
+      if (asyncContextParam == null || asyncContextParam.toCompletableFuture().get().foo() != 42)
+         return Response.serverError().entity("Missing injected async context param").build();
+
+      if (resolvedContextField == null || resolvedContextField.foo() != 42)
+         return Response.serverError().entity("Missing injected resolved context field").build();
+      if (asyncContextField == null || asyncContextField.toCompletableFuture().get().foo() != 42)
+         return Response.serverError().entity("Missing injected async context field").build();
+
+      if (resolvedContextProperty == null || resolvedContextProperty.foo() != 42)
+         return Response.serverError().entity("Missing injected resolved context property").build();
+      if (asyncContextProperty == null || asyncContextProperty.toCompletableFuture().get().foo() != 42)
+         return Response.serverError().entity("Missing injected async context property").build();
+
+      if (resolvedContextConstructor == null || resolvedContextConstructor.foo() != 42)
+         return Response.serverError().entity("Missing injected resolved context constructor").build();
+      if (asyncContextConstructor == null || asyncContextConstructor.toCompletableFuture().get().foo() != 42)
+         return Response.serverError().entity("Missing injected async context constructor").build();
+
+      return Response.ok("resource").build();
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionResource2.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionResource2.java
@@ -1,0 +1,24 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+
+@Path("/")
+public class AsyncInjectionResource2
+{
+
+   @Context
+   AsyncInjectionContext resolvedContextField;
+   @Context
+   CompletionStage<AsyncInjectionContext> asyncContextField;
+
+   @Context
+   @AsyncInjectionContextAsyncSpecifier
+   AsyncInjectionContext resolvedContextFieldAsync;
+
+   public AsyncInjectionResource2()
+   {
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionShortInjector.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncInjectionShortInjector.java
@@ -1,0 +1,38 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ContextInjector;
+
+@Provider
+public class AsyncInjectionShortInjector implements ContextInjector<CompletionStage<Short>, Short>
+{
+
+   @Override
+   public CompletionStage<Short> resolve(
+         Class<? extends CompletionStage<Short>> rawType, Type genericType, Annotation[] annotations)
+   {
+      for (Annotation annotation : annotations)
+      {
+         if(annotation.annotationType() == AsyncInjectionPrimitiveInjectorSpecifier.class) {
+            AsyncInjectionPrimitiveInjectorSpecifier.Type value = ((AsyncInjectionPrimitiveInjectorSpecifier)annotation).value();
+            switch(value) {
+            case NO_RESULT:
+               return null;
+            case NULL:
+               return CompletableFuture.completedFuture(null);
+            case VALUE:
+               return CompletableFuture.completedFuture((short)42);
+            }
+            break;
+         }
+      }
+      return CompletableFuture.completedFuture((short)42);
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/resource/LazyInitUriInfoInjectionSingletonResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/resource/LazyInitUriInfoInjectionSingletonResource.java
@@ -1,5 +1,8 @@
 package org.jboss.resteasy.test.cdi.injection.resource;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.ResourceFactory;
@@ -18,7 +21,7 @@ public class LazyInitUriInfoInjectionSingletonResource implements ResourceFactor
 
     }
 
-    public Object createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory) {
+    public CompletionStage<Object> createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory) {
         if (obj == null) {
             try {
                 obj = clazz.newInstance();
@@ -27,9 +30,10 @@ public class LazyInitUriInfoInjectionSingletonResource implements ResourceFactor
             } catch (IllegalAccessException e) {
                 throw new RuntimeException(e);
             }
-            factory.getInjectorFactory().createPropertyInjector(clazz, factory).inject(obj);
+            return factory.getInjectorFactory().createPropertyInjector(clazz, factory).inject(obj)
+                  .thenApply(v -> obj);
         }
-        return obj;
+        return CompletableFuture.completedFuture(obj);
     }
 
     public void unregistered() {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/resource/LazyInitUriInfoInjectionSingletonResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/resource/LazyInitUriInfoInjectionSingletonResource.java
@@ -30,7 +30,7 @@ public class LazyInitUriInfoInjectionSingletonResource implements ResourceFactor
             } catch (IllegalAccessException e) {
                 throw new RuntimeException(e);
             }
-            return factory.getInjectorFactory().createPropertyInjector(clazz, factory).inject(obj)
+            return factory.getInjectorFactory().createPropertyInjector(clazz, factory).inject(obj, true)
                   .thenApply(v -> obj);
         }
         return CompletableFuture.completedFuture(obj);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomValueInjectorInjectorFactoryImpl.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomValueInjectorInjectorFactoryImpl.java
@@ -11,6 +11,8 @@ import org.jboss.resteasy.util.FindAnnotation;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public class CustomValueInjectorInjectorFactoryImpl extends InjectorFactoryImpl {
     @Override
@@ -21,13 +23,15 @@ public class CustomValueInjectorInjectorFactoryImpl extends InjectorFactoryImpl 
             return super.createParameterExtractor(injectTargetClass, injectTarget, defaultName, type, genericType, annotations, factory);
         } else {
             return new ValueInjector() {
-                public Object inject(HttpRequest request, HttpResponse response) {
-                    return hello.value();
-                }
+               @Override
+               public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                  return CompletableFuture.completedFuture(hello.value());
+               }
 
-                public Object inject() {
-                    return hello.value();
-                }
+               @Override
+               public CompletionStage<Object> inject() {
+                  return CompletableFuture.completedFuture(hello.value());
+               }
             };
         }
     }
@@ -39,13 +43,15 @@ public class CustomValueInjectorInjectorFactoryImpl extends InjectorFactoryImpl 
             return super.createParameterExtractor(parameter, providerFactory);
         } else {
             return new ValueInjector() {
-                public Object inject(HttpRequest request, HttpResponse response) {
-                    return hello.value();
-                }
+               @Override
+               public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                  return CompletableFuture.completedFuture(hello.value());
+               }
 
-                public Object inject() {
-                    return hello.value();
-                }
+               @Override
+               public CompletionStage<Object> inject() {
+                  return CompletableFuture.completedFuture(hello.value());
+               }
             };
         }
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomValueInjectorInjectorFactoryImpl.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomValueInjectorInjectorFactoryImpl.java
@@ -24,12 +24,12 @@ public class CustomValueInjectorInjectorFactoryImpl extends InjectorFactoryImpl 
         } else {
             return new ValueInjector() {
                @Override
-               public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+               public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
                   return CompletableFuture.completedFuture(hello.value());
                }
 
                @Override
-               public CompletionStage<Object> inject() {
+               public CompletionStage<Object> inject(boolean unwrapAsync) {
                   return CompletableFuture.completedFuture(hello.value());
                }
             };
@@ -44,12 +44,12 @@ public class CustomValueInjectorInjectorFactoryImpl extends InjectorFactoryImpl 
         } else {
             return new ValueInjector() {
                @Override
-               public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+               public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
                   return CompletableFuture.completedFuture(hello.value());
                }
 
                @Override
-               public CompletionStage<Object> inject() {
+               public CompletionStage<Object> inject(boolean unwrapAsync) {
                   return CompletableFuture.completedFuture(hello.value());
                }
             };

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/HttpRequestParameterInjectorParamFactoryImpl.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/HttpRequestParameterInjectorParamFactoryImpl.java
@@ -27,13 +27,13 @@ public class HttpRequestParameterInjectorParamFactoryImpl extends InjectorFactor
         } else {
             return new ValueInjector() {
                @Override
-               public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+               public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
                   return CompletableFuture.completedFuture(ResteasyProviderFactory.getContextData(HttpServletRequest.class)
                         .getParameter(param.value()));
                }
 
                @Override
-               public CompletionStage<Object> inject() {
+               public CompletionStage<Object> inject(boolean unwrapAsync) {
                   // do nothing.
                   return CompletableFuture.completedFuture(null);
                }
@@ -49,13 +49,13 @@ public class HttpRequestParameterInjectorParamFactoryImpl extends InjectorFactor
         } else {
             return new ValueInjector() {
                @Override
-               public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+               public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
                   return CompletableFuture.completedFuture(ResteasyProviderFactory.getContextData(HttpServletRequest.class)
                         .getParameter(param.value()));
                }
 
                @Override
-               public CompletionStage<Object> inject() {
+               public CompletionStage<Object> inject(boolean unwrapAsync) {
                   // do nothing.
                   return CompletableFuture.completedFuture(null);
                }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/HttpRequestParameterInjectorParamFactoryImpl.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/HttpRequestParameterInjectorParamFactoryImpl.java
@@ -12,6 +12,8 @@ import javax.servlet.http.HttpServletRequest;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public class HttpRequestParameterInjectorParamFactoryImpl extends InjectorFactoryImpl {
     @SuppressWarnings("unchecked")
@@ -24,15 +26,17 @@ public class HttpRequestParameterInjectorParamFactoryImpl extends InjectorFactor
                     genericType, annotations, factory);
         } else {
             return new ValueInjector() {
-                public Object inject(HttpRequest request, HttpResponse response) {
-                    return ResteasyProviderFactory.getContextData(HttpServletRequest.class)
-                            .getParameter(param.value());
-                }
+               @Override
+               public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                  return CompletableFuture.completedFuture(ResteasyProviderFactory.getContextData(HttpServletRequest.class)
+                        .getParameter(param.value()));
+               }
 
-                public Object inject() {
-                    // do nothing.
-                    return null;
-                }
+               @Override
+               public CompletionStage<Object> inject() {
+                  // do nothing.
+                  return CompletableFuture.completedFuture(null);
+               }
             };
         }
     }
@@ -44,15 +48,17 @@ public class HttpRequestParameterInjectorParamFactoryImpl extends InjectorFactor
             return super.createParameterExtractor(parameter, providerFactory);
         } else {
             return new ValueInjector() {
-                public Object inject(HttpRequest request, HttpResponse response) {
-                    return ResteasyProviderFactory.getContextData(HttpServletRequest.class)
-                            .getParameter(param.value());
-                }
+               @Override
+               public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                  return CompletableFuture.completedFuture(ResteasyProviderFactory.getContextData(HttpServletRequest.class)
+                        .getParameter(param.value()));
+               }
 
-                public Object inject() {
-                    // do nothing.
-                    return null;
-                }
+               @Override
+               public CompletionStage<Object> inject() {
+                  // do nothing.
+                  return CompletableFuture.completedFuture(null);
+               }
             };
         }
     }

--- a/testsuite/legacy-integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomValueInjectorInjectorFactoryImpl.java
+++ b/testsuite/legacy-integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomValueInjectorInjectorFactoryImpl.java
@@ -24,12 +24,12 @@ public class CustomValueInjectorInjectorFactoryImpl extends InjectorFactoryImpl 
         } else {
             return new ValueInjector() {
                 @Override
-                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
                     return CompletableFuture.completedFuture(hello.value());
                 }
 
                 @Override
-                public CompletionStage<Object> inject() {
+                public CompletionStage<Object> inject(boolean unwrapAsync) {
                    // do nothing.
                    return CompletableFuture.completedFuture(hello.value());
                 }
@@ -45,12 +45,12 @@ public class CustomValueInjectorInjectorFactoryImpl extends InjectorFactoryImpl 
         } else {
             return new ValueInjector() {
                 @Override
-                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
                     return CompletableFuture.completedFuture(hello.value());
                 }
 
                 @Override
-                public CompletionStage<Object> inject() {
+                public CompletionStage<Object> inject(boolean unwrapAsync) {
                    // do nothing.
                    return CompletableFuture.completedFuture(hello.value());
                 }

--- a/testsuite/legacy-integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomValueInjectorInjectorFactoryImpl.java
+++ b/testsuite/legacy-integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomValueInjectorInjectorFactoryImpl.java
@@ -11,6 +11,8 @@ import org.jboss.resteasy.util.FindAnnotation;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public class CustomValueInjectorInjectorFactoryImpl extends InjectorFactoryImpl {
     @Override
@@ -21,12 +23,15 @@ public class CustomValueInjectorInjectorFactoryImpl extends InjectorFactoryImpl 
             return super.createParameterExtractor(injectTargetClass, injectTarget, defaultName, type, genericType, annotations, factory);
         } else {
             return new ValueInjector() {
-                public Object inject(HttpRequest request, HttpResponse response) {
-                    return hello.value();
+                @Override
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                    return CompletableFuture.completedFuture(hello.value());
                 }
 
-                public Object inject() {
-                    return hello.value();
+                @Override
+                public CompletionStage<Object> inject() {
+                   // do nothing.
+                   return CompletableFuture.completedFuture(hello.value());
                 }
             };
         }
@@ -39,12 +44,15 @@ public class CustomValueInjectorInjectorFactoryImpl extends InjectorFactoryImpl 
             return super.createParameterExtractor(parameter, providerFactory);
         } else {
             return new ValueInjector() {
-                public Object inject(HttpRequest request, HttpResponse response) {
-                    return hello.value();
+                @Override
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                    return CompletableFuture.completedFuture(hello.value());
                 }
 
-                public Object inject() {
-                    return hello.value();
+                @Override
+                public CompletionStage<Object> inject() {
+                   // do nothing.
+                   return CompletableFuture.completedFuture(hello.value());
                 }
             };
         }

--- a/testsuite/legacy-integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/HttpRequestParameterInjectorParamFactoryImpl.java
+++ b/testsuite/legacy-integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/HttpRequestParameterInjectorParamFactoryImpl.java
@@ -12,6 +12,8 @@ import javax.servlet.http.HttpServletRequest;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public class HttpRequestParameterInjectorParamFactoryImpl extends InjectorFactoryImpl {
     @SuppressWarnings("unchecked")
@@ -24,14 +26,16 @@ public class HttpRequestParameterInjectorParamFactoryImpl extends InjectorFactor
                     genericType, annotations, factory);
         } else {
             return new ValueInjector() {
-                public Object inject(HttpRequest request, HttpResponse response) {
-                    return ResteasyProviderFactory.getContextData(HttpServletRequest.class)
-                            .getParameter(param.value());
+                @Override
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                   return CompletableFuture.completedFuture(ResteasyProviderFactory.getContextData(HttpServletRequest.class)
+                         .getParameter(param.value()));
                 }
 
-                public Object inject() {
-                    // do nothing.
-                    return null;
+                @Override
+                public CompletionStage<Object> inject() {
+                   // do nothing.
+                   return CompletableFuture.completedFuture(null);
                 }
             };
         }
@@ -44,14 +48,16 @@ public class HttpRequestParameterInjectorParamFactoryImpl extends InjectorFactor
             return super.createParameterExtractor(parameter, providerFactory);
         } else {
             return new ValueInjector() {
-                public Object inject(HttpRequest request, HttpResponse response) {
-                    return ResteasyProviderFactory.getContextData(HttpServletRequest.class)
-                            .getParameter(param.value());
+                @Override
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                   return CompletableFuture.completedFuture(ResteasyProviderFactory.getContextData(HttpServletRequest.class)
+                         .getParameter(param.value()));
                 }
 
-                public Object inject() {
-                    // do nothing.
-                    return null;
+                @Override
+                public CompletionStage<Object> inject() {
+                   // do nothing.
+                   return CompletableFuture.completedFuture(null);
                 }
             };
         }

--- a/testsuite/legacy-integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/HttpRequestParameterInjectorParamFactoryImpl.java
+++ b/testsuite/legacy-integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/HttpRequestParameterInjectorParamFactoryImpl.java
@@ -27,13 +27,13 @@ public class HttpRequestParameterInjectorParamFactoryImpl extends InjectorFactor
         } else {
             return new ValueInjector() {
                 @Override
-                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
                    return CompletableFuture.completedFuture(ResteasyProviderFactory.getContextData(HttpServletRequest.class)
                          .getParameter(param.value()));
                 }
 
                 @Override
-                public CompletionStage<Object> inject() {
+                public CompletionStage<Object> inject(boolean unwrapAsync) {
                    // do nothing.
                    return CompletableFuture.completedFuture(null);
                 }
@@ -49,13 +49,13 @@ public class HttpRequestParameterInjectorParamFactoryImpl extends InjectorFactor
         } else {
             return new ValueInjector() {
                 @Override
-                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response) {
+                public CompletionStage<Object> inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
                    return CompletableFuture.completedFuture(ResteasyProviderFactory.getContextData(HttpServletRequest.class)
                          .getParameter(param.value()));
                 }
 
                 @Override
-                public CompletionStage<Object> inject() {
+                public CompletionStage<Object> inject(boolean unwrapAsync) {
                    // do nothing.
                    return CompletableFuture.completedFuture(null);
                 }


### PR DESCRIPTION
Here's a preview of the work I did for pluggable async injection, FYI. Note that I still have to test this with a real-world integration (hopefully next week), so don't merge this as-is. I also need to iron out a few things and write docs.

To give a quick example of what this allows is that it's now possible to declare an injector for `Single<Foo>` and inject it via `@Context Foo` and the response will be automatically made asynchronous and the resource method will only be invoked once the `Single<Foo>` is resolved (non-blocking) to `Foo` and we can proceed. That's very huge for async users who want injection of async types.

- New `@Provider` type `ContextInjector` which allows users to declare pluggable injectors that can be injected with `@Context`.
- These injectors can be declared to provide injection of async types, such as `CompletionStage<X>`.
- If trying to inject `@Context X` and we have an async injector for `CompletionStage<X>` we properly wait for its resolution before injecting the resolved `X` (non blocking).
- Async injection supports pluggable async types using existing (unmodified) `AsyncResponseProvider` system to wrap pluggable async types into `CompletionStage`. We may have to rename it, though?
- Injection had to be rewritten to use `CompletionStage` everywhere. I initially wrote this using callbacks in order to avoid using `CompletionStage` but the API was not at all cleaner, and the implementation was just terribly fragile and error-prone. Using `CompletionStage` is invasive, but clean and trustworthy. I did verify that performance would not suffer, crudely, by measuring difference of running all Maven tests, and there's zero difference. Obviously that's not a real benchmark, but if you can point me to one, I'll measure it.
- Async injection is only attempted at points where async injection is permitted, such as for resource creation and resource method invocation. It is not enabled at points where the API does not allow for suspending the request (via `ResourceContext.getResource` for example).