### PR TITLE
[RESTEASY-1878] UriBuilder.fromPath() fails on regexp template parameter

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResteasyUriBuilder.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResteasyUriBuilder.java
@@ -86,8 +86,8 @@ public class ResteasyUriBuilder extends UriBuilder
       return impl;
    }
 
-   public static final Pattern opaqueUri = Pattern.compile("^([^:/?#]+):([^/].*)");
-   public static final Pattern hierarchicalUri = Pattern.compile("^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?");
+   public static final Pattern opaqueUri = Pattern.compile("^([^:/?#{]+):([^/].*)");
+   public static final Pattern hierarchicalUri = Pattern.compile("^(([^:/?#{]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?");
    private static final Pattern hostPortPattern = Pattern.compile("([^/:]+):(\\d+)");
    private static final Pattern squareHostBrackets = Pattern.compile( "(\\[(([0-9A-Fa-f]{0,4}:){2,7})([0-9A-Fa-f]{0,4})%?.*\\]):(\\d+)" );
 

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/UriBuilderTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/UriBuilderTest.java
@@ -101,6 +101,18 @@ public class UriBuilderTest {
             builder = builder.resolveTemplates(values);
             template = builder.toTemplate();
             Assert.assertEquals(ERROR_MSG, template, "http://localhost/x/y/z?name=42");
+
+            // RESTEASY-1878 - test if regex templates work
+            // see javax.ws.rs.core.UriBuilder class description for info about regex template parameters
+            builder = UriBuilder.fromUri("{id: [0-9]+}");
+            Assert.assertEquals(new URI("123"), builder.build("123"));
+
+            builder = UriBuilder.fromUri("{id: [0-9]+}");
+            Assert.assertEquals(new URI("abcd"), builder.build("abcd"));
+
+            builder = UriBuilder.fromUri("/resources/{id: [0-9]+}");
+            Assert.assertEquals(new URI("/resources/123"), builder.build("123"));
+            // end of RESTEASY-1878
         }
 
         // test587


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/RESTEASY-1878

There is a problem when building URI starting with template parameter regex expression (for example "{path: .+}"), ResteasyUriBuilder mistakes it for URI scheme.