### PR TITLE
[RESTEASY-1725] Registering lambda context resolver results in ArrayIndexOutOfBoundsException

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
@@ -783,4 +783,7 @@ public interface Messages
 
    @Message(id = BASE + 1094, value = "Unable to instantiate ContextInjector")
    String unableToInstantiateContextInjector();
+
+   @Message(id = BASE + 1097, value = "Registering a context resolver doesn't support lambdas")
+   String registeringContextResolverAsLambda();
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -1411,6 +1411,10 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
 
    protected void addContextResolver(ContextResolver provider, Class providerClass, boolean builtin)
    {
+      // RESTEASY-1725
+      if (providerClass.getName().contains("$$Lambda$")) {
+         throw new RuntimeException(Messages.MESSAGES.registeringContextResolverAsLambda());
+      }
       Type parameter = Types.getActualTypeArgumentsOfAnInterface(providerClass, ContextResolver.class)[0];
       addContextResolver(provider, parameter, providerClass, builtin);
    }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
@@ -14,6 +14,7 @@ import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.RuntimeDelegate;
 
 import static org.jboss.resteasy.test.TestPortProvider.generateURL;
@@ -113,6 +114,48 @@ public class ClientBuilderTest {
              .type(MediaType.APPLICATION_OCTET_STREAM).build();
        Assert.assertNotNull("Build link failed", link);
     }
+
+    @Test
+    public void testRegisterContextResolverClass() {
+        ClientBuilder.newBuilder()
+                .register(new CustomContextResolver())
+                .build();
+    }
+
+    @Test
+    public void testRegisterContextResolverAnonymousClass() {
+        ClientBuilder.newBuilder()
+                .register(new ContextResolver<MyObject>() {
+
+                    @Override
+                    public MyObject getContext(Class<?> type) {
+                        return null;
+                    }
+
+                })
+                .build();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testRegisterContextResolverLambda() {
+        ClientBuilder.newBuilder()
+                .register((ContextResolver<MyObject>) type -> null)
+                .build();
+    }
+
+    public static class MyObject {
+
+    }
+
+    public static class CustomContextResolver implements ContextResolver<MyObject> {
+
+        @Override
+        public MyObject getContext(Class<?> type) {
+            return null;
+        }
+
+    }
+
     public static class FeatureReturningFalse implements Feature {
         @Override
         public boolean configure(FeatureContext context) {


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RESTEASY-1725

As stated by R Searls, Java doesn't support inspecting generic types inside lambdas. Reworking the whole ResteasyProviderFactory system for this one particular case would be very difficult. The IndexOutOfBoundsException is however highly confusing. It would be definitely better to throw some more descriptive excpetion instead.