### PR TITLE
[RESTEASY-1910] Fix ValidationComplexTest custom bean validation constraint

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ValidationComplexTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ValidationComplexTest.java
@@ -36,6 +36,7 @@ import org.jboss.resteasy.test.validation.resource.ValidationComplexClassValidat
 import org.jboss.resteasy.test.validation.resource.ValidationComplexClassValidator2;
 import org.jboss.resteasy.test.validation.resource.ValidationComplexClassValidatorSubInheritance;
 import org.jboss.resteasy.test.validation.resource.ValidationComplexClassValidatorSuperInheritance;
+import org.jboss.resteasy.test.validation.resource.ValidationComplexOtherGroupValidator;
 import org.jboss.resteasy.test.validation.resource.ValidationComplexProxyInterface;
 import org.jboss.resteasy.test.validation.resource.ValidationComplexProxyResource;
 import org.jboss.resteasy.test.validation.resource.ValidationComplexResourceWithAllFivePotentialViolations;
@@ -128,7 +129,8 @@ public class ValidationComplexTest {
                 ValidationComplexFoo.class, ValidationComplexClassConstraint.class,
                 ValidationComplexInterfaceSub.class, ValidationComplexClassInheritanceSuperConstraint.class,
                 ValidationComplexClassValidatorSuperInheritance.class,
-                ValidationComplexClassConstraint2.class, ValidationComplexClassValidator2.class);
+                ValidationComplexClassConstraint2.class, ValidationComplexClassValidator2.class,
+                ValidationComplexOtherGroupValidator.class);
         // Arquillian in the deployment
         war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
                 new LoggingPermission("control", ""),

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/resource/ValidationComplexOtherGroupConstraint.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/resource/ValidationComplexOtherGroupConstraint.java
@@ -10,7 +10,7 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Documented
-@Constraint(validatedBy = ValidationComplexClassValidator.class)
+@Constraint(validatedBy = ValidationComplexOtherGroupValidator.class)
 @Target({TYPE})
 @Retention(RUNTIME)
 public @interface ValidationComplexOtherGroupConstraint {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/resource/ValidationComplexOtherGroupValidator.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/resource/ValidationComplexOtherGroupValidator.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.test.validation.resource;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ValidationComplexOtherGroupValidator implements ConstraintValidator<ValidationComplexOtherGroupConstraint, ValidationComplexResourceWithOtherGroups> {
+    public void initialize(ValidationComplexOtherGroupConstraint constraintAnnotation) {
+        // nothing to do
+    }
+
+    public boolean isValid(ValidationComplexResourceWithOtherGroups value, ConstraintValidatorContext context) {
+        // we need to just ensure, that RESTEasy && Bean-Validation integration can handle Bean-Validation-Groups
+        return true;
+    }
+
+}


### PR DESCRIPTION
Fix ValidationComplexTest custom bean validation constraint

Jira: https://issues.jboss.org/browse/RESTEASY-1910
Master PR: https://github.com/resteasy/Resteasy/pull/1515

ValidationComplexTest uses ValidationComplexOtherGroupConstraint. This constraint uses ValidationComplexClassValidator. But ValidationComplexClassValidator can be used only for ValidationComplexClassConstraint.

WF used hibernate-validator-6.0.9.Final in the past and this old validator ignores this constraint bug. But now, WF uses hibernate-validator-cdi-6.0.10.Final. And test ValidationComplexTest#testOtherGroups fails with new hibernate-validator-cdi-6.0.10.Final:
```
javax.validation.ConstraintDefinitionException: HV000243: Constraint org.jboss.resteasy.test.validation.resource.ValidationComplexOtherGroupConstraint references constraint validator type org.jboss.resteasy.test.validation.resource.ValidationComplexClassValidator, but this validator is defined for constraint type org.jboss.resteasy.test.validation.resource.ValidationComplexClassConstraint
```