### PR TITLE
[RESTEASY-1865] SynchronousDispatcher #getResource not returning Resource Instance

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodRegistry.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodRegistry.java
@@ -366,6 +366,10 @@ public class ResourceMethodRegistry implements Registry
             rootNode.addInvoker(fullpath, locator);
          else root.addInvoker(classExpression, fullpath, locator);
       }
+
+      if (rf instanceof SingletonResource) {
+         providerFactory.registerSingletonResource((SingletonResource) rf);
+      }
    }
 
    /**

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/core/DispatcherTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/core/DispatcherTest.java
@@ -1,0 +1,87 @@
+package org.jboss.resteasy.test.core;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.util.Date;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.ResourceContext;
+import javax.ws.rs.core.Context;
+
+import org.jboss.resteasy.core.Dispatcher;
+import org.jboss.resteasy.mock.MockDispatcherFactory;
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.jboss.resteasy.mock.MockHttpResponse;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DispatcherTest {
+
+    private Dispatcher dispatcher;
+
+
+    @Before
+    public void before() {
+        dispatcher = MockDispatcherFactory.createDispatcher();
+    }
+
+    // @see https://issues.jboss.org/browse/RESTEASY-1865
+    @Test
+    public void testSingletonResource() throws URISyntaxException, UnsupportedEncodingException {
+        dispatcher.getRegistry().addSingletonResource(new ParentResource());
+        dispatcher.getRegistry().addSingletonResource(new ChildResource("I'm singleton child"));
+
+        MockHttpRequest request = MockHttpRequest.get("/parent");
+        MockHttpResponse response = new MockHttpResponse();
+
+        dispatcher.invoke(request, response);
+
+        assertEquals(200, response.getStatus());
+        assertEquals("I'm singleton child", response.getContentAsString());
+    }
+
+
+
+
+    @Path("/parent")
+    public static class ParentResource {
+
+        @Context
+        public ResourceContext resourceCtx;
+
+
+        @GET
+        public String get() {
+            ChildResource child = resourceCtx.getResource(ChildResource.class);
+            return child.get();
+        }
+
+    }
+
+    @Path("child")
+    public static class ChildResource {
+
+        private final String name;
+
+
+        @SuppressWarnings("unused")     // Not used if RESTEASY-1865 is fixed
+        public ChildResource() {
+            this.name = "I'm new child created on " + new Date();
+        }
+
+        public ChildResource(String name) {
+            this.name = name;
+        }
+
+
+        @GET
+        public String get() {
+            return name;
+        }
+
+    }
+
+}


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RESTEASY-1865

dispatcher.getRegistry().addSingletonResource(...) works for ResourceMethodInvoker (returned object is the proper singleton), but not for resourceContext.getResource(...). Here, the object being returned is simply constructed one by ResteasyProviderFactory using a constructor.
