### PR TITLE
[RESTEASY-1912] Update naming and BeforeClass method in JMS tests

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/AbstractInjectionTestBase.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/AbstractInjectionTestBase.java
@@ -11,7 +11,6 @@ import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
  */
 public class AbstractInjectionTestBase {
 
-    @BeforeClass
     public static void initQueue() throws Exception {
         OnlineManagementClient client = TestUtil.clientInit();
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionTest.java
@@ -109,7 +109,8 @@ public class InjectionTest extends AbstractInjectionTestBase {
 
     @SuppressWarnings(value = "unchecked")
     @Deployment
-    public static Archive<?> createTestArchive() {
+    public static Archive<?> createTestArchive() throws Exception {
+        initQueue();
         WebArchive war = TestUtil.prepareArchive(InjectionTest.class.getSimpleName());
         war.addClass(AbstractInjectionTestBase.class)
                 .addClasses(CDIInjectionBook.class, CDIInjectionBookResource.class, Constants.class, UtilityProducer.class, BookCollectionType.getClass())

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/MDBInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/MDBInjectionTest.java
@@ -70,7 +70,8 @@ public class MDBInjectionTest extends AbstractInjectionTestBase {
 
     @SuppressWarnings(value = "unchecked")
     @Deployment
-    public static Archive<?> createTestArchive() {
+    public static Archive<?> createTestArchive() throws Exception {
+        initQueue();
         WebArchive war = TestUtil.prepareArchive(MDBInjectionTest.class.getSimpleName());
         war.addClass(AbstractInjectionTestBase.class)
                 .addClasses(CDIInjectionBook.class, CDIInjectionBookResource.class, Constants.class, UtilityProducer.class)

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/ReverseInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/ReverseInjectionTest.java
@@ -130,7 +130,8 @@ public class ReverseInjectionTest extends AbstractInjectionTestBase {
     };
 
     @Deployment
-    public static Archive<?> createTestArchive() {
+    public static Archive<?> createTestArchive() throws Exception {
+        initQueue();
         WebArchive war = TestUtil.prepareArchive("resteasy-reverse-injection-test")
                 .addClasses(AbstractInjectionTestBase.class, ReverseInjectionTest.class, PortProviderUtil.class)
                 .addClasses(Constants.class, PersistenceUnitProducer.class, UtilityProducer.class, Utilities.class)

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/resource/CDIInjectionResourceProducer.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/resource/CDIInjectionResourceProducer.java
@@ -14,12 +14,12 @@ import javax.jms.Queue;
 import javax.jms.Session;
 
 @ApplicationScoped
-@Resource(name = "queue/test")
+@Resource(name = "java:/jms/queue/test")
 public class CDIInjectionResourceProducer {
     private static Connection connection;
     private static Session session;
     private static boolean disposed;
-    @Resource(mappedName = "jms/queue/test")
+    @Resource(mappedName = "java:/jms/queue/test")
     Queue bookQueue;
     @Resource(mappedName = "java:jboss/exported/jms/RemoteConnectionFactory")
     ConnectionFactory connectionFactory;


### PR DESCRIPTION
Update naming and BeforeClass method in JMS tests. It is necessary for WF13

See the details in WFLY-10432

Jira: https://issues.jboss.org/browse/RESTEASY-1912
Master PR: coming 