### PR TITLE
[RESTEASY-1805] Proxy tests for resource metadata SPI

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/resource/ResourceClassProcessorClass.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/resource/ResourceClassProcessorClass.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.test.core.spi.resource;
 
+import org.jboss.logging.Logger;
 import org.jboss.resteasy.spi.metadata.FieldParameter;
 import org.jboss.resteasy.spi.metadata.ResourceClass;
 import org.jboss.resteasy.spi.metadata.ResourceConstructor;
@@ -11,10 +12,13 @@ import java.util.ArrayList;
 
 public class ResourceClassProcessorClass implements ResourceClass {
 
+    protected static final Logger logger = Logger.getLogger(ResourceClassProcessorClass.class.getName());
+
     private final ResourceClass delegate;
     private final ResourceMethod[] resourceMethods;
 
     public ResourceClassProcessorClass(ResourceClass delegate) {
+        logger.info(String.format("ResourceClassProcessorClass constructor called for %s class", delegate.getClazz().getSimpleName()));
         this.delegate = delegate;
 
         ArrayList<ResourceMethod> methods = new ArrayList<>();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/resource/ResourceClassProcessorEndPoint.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/resource/ResourceClassProcessorEndPoint.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.test.core.spi.resource;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
@@ -13,7 +14,7 @@ public class ResourceClassProcessorEndPoint {
         return "<a></a>";
     }
 
-    @GET
+    @POST // should be replaced by GET in ResourceClassProcessorMethod
     @Path("custom")
     @Produces("text/plain")
     public String custom() {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/resource/ResourceClassProcessorEndPointCDI.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/resource/ResourceClassProcessorEndPointCDI.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.test.core.spi.resource;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
@@ -13,7 +14,7 @@ public class ResourceClassProcessorEndPointCDI {
         return "<a></a>";
     }
 
-    @GET
+    @POST // should be replaced by GET in ResourceClassProcessorMethod
     @Path("custom")
     @Produces("text/plain")
     public String custom() {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/resource/ResourceClassProcessorEndPointEJB.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/resource/ResourceClassProcessorEndPointEJB.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.test.core.spi.resource;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
@@ -13,7 +14,7 @@ public class ResourceClassProcessorEndPointEJB {
         return "<a></a>";
     }
 
-    @GET
+    @POST // should be replaced by GET in ResourceClassProcessorMethod
     @Path("custom")
     @Produces("text/plain")
     public String custom() {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/resource/ResourceClassProcessorImplementation.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/resource/ResourceClassProcessorImplementation.java
@@ -1,16 +1,24 @@
 package org.jboss.resteasy.test.core.spi.resource;
 
+import org.jboss.logging.Logger;
 import org.jboss.resteasy.spi.metadata.ResourceClass;
 import org.jboss.resteasy.spi.metadata.ResourceClassProcessor;
+
 import javax.ws.rs.ext.Provider;
 
 @Provider
 public class ResourceClassProcessorImplementation implements ResourceClassProcessor {
+
+    protected static final Logger logger = Logger.getLogger(ResourceClassProcessorImplementation.class.getName());
+
     @Override
     public ResourceClass process(ResourceClass clazz) {
+        logger.info(String.format("ResourceClassProcessorImplementation#process method called on class %s",
+                            clazz.getClazz().getSimpleName()));
         String clazzName = clazz.getClazz().getSimpleName();
-        if (clazzName.equals("ResourceClassProcessorEndPoint")
-                || clazzName.startsWith("ResourceClassProcessorProxy")) {
+        if (clazzName.startsWith("ResourceClassProcessorEndPoint")
+                || clazzName.equals("ResourceClassProcessorProxy")
+                || clazzName.equals("ResourceClassProcessorProxyEndPoint")) {
             return new ResourceClassProcessorClass(clazz);
         }
         return clazz;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/resource/ResourceClassProcessorMethod.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/resource/ResourceClassProcessorMethod.java
@@ -6,6 +6,7 @@ import org.jboss.resteasy.spi.metadata.ResourceMethod;
 import javax.ws.rs.core.MediaType;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.HashSet;
 import java.util.Set;
 
 public class ResourceClassProcessorMethod implements ResourceMethod {
@@ -19,7 +20,9 @@ public class ResourceClassProcessorMethod implements ResourceMethod {
 
     @Override
     public Set<String> getHttpMethods() {
-        return delegate.getHttpMethods();
+        Set<String> methods = new HashSet<>();
+        methods.add("GET");
+        return methods;
     }
 
     @Override

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/resource/ResourceClassProcessorProxy.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/resource/ResourceClassProcessorProxy.java
@@ -1,10 +1,10 @@
 package org.jboss.resteasy.test.core.spi.resource;
 
-import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
 @Path("/proxy")
 public interface ResourceClassProcessorProxy {
-    @GET
+    @POST // should be replaced by GET in ResourceClassProcessorMethod
     String custom();
 }


### PR DESCRIPTION
Proxy tests for resource metadata SPI

jira: https://issues.jboss.org/browse/RESTEASY-1805

This PR adds ResourceClassProcessorBasicTest#proxyTest. This test is in ExpectedFailing category. SPI needs to be fixed for proxy.

This PR also fixes test bug in customClassCustomMethodTestHelper and defaultClassDefaultMethodTestHelper methods.

master PR: https://github.com/resteasy/Resteasy/pull/1523