### PR TITLE
Async filter bugfix

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
@@ -446,6 +446,7 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
          if(method.isAsynchronous())
             return null;
          // resume a sync request that got turned async by filters
+         initializeAsync(request.getAsyncContext().getAsyncResponse());
          request.getAsyncContext().getAsyncResponse().resume(rtn);
          return null;
       }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncRequestFilterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncRequestFilterTest.java
@@ -457,4 +457,24 @@ public class AsyncRequestFilterTest {
 
         client.close();
     }
+
+    /**
+     * @tpTestDetails Interceptors work with non-Response resource methods
+     * @tpSince RESTEasy 4.0.0
+     */
+    @Test
+    public void testRequestFiltersGuessReturnType() throws Exception {
+        Client client = ClientBuilder.newClient();
+
+        // Create book.
+        WebTarget base = client.target(generateURL("/non-response"));
+
+        Response response = base.request()
+           .header("Filter1", "async-pass")
+           .header("Filter2", "sync-pass")
+           .header("Filter3", "sync-pass")
+           .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("resource", response.readEntity(String.class));
+    }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilterResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilterResource.java
@@ -9,6 +9,7 @@ import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
@@ -34,6 +35,26 @@ public class AsyncRequestFilterResource {
        if(async != request.getAsyncContext().isSuspended())
           return Response.serverError().entity("Request suspention is wrong").build();
        return Response.ok("resource").build();
+    }
+
+    @Path("non-response")
+    @GET
+    public String threeSyncRequestFiltersNonResponse(@Context HttpRequest request,
+          @HeaderParam("Filter1") @DefaultValue("") String filter1,
+          @HeaderParam("Filter2") @DefaultValue("") String filter2,
+          @HeaderParam("Filter3") @DefaultValue("") String filter3,
+          @HeaderParam("PreMatchFilter1") @DefaultValue("") String preMatchFilter1,
+          @HeaderParam("PreMatchFilter2") @DefaultValue("") String preMatchFilter2,
+          @HeaderParam("PreMatchFilter3") @DefaultValue("") String preMatchFilter3) {
+       boolean async = isAsync(filter1)
+             || isAsync(filter2)
+             || isAsync(filter3)
+             || isAsync(preMatchFilter1)
+             || isAsync(preMatchFilter2)
+             || isAsync(preMatchFilter3);
+       if(async != request.getAsyncContext().isSuspended())
+          throw new WebApplicationException(Response.serverError().entity("Request suspention is wrong").build());
+       return "resource";
     }
 
     @Path("async")


### PR DESCRIPTION
This fixes a bug when the resource method return type is neither `void` nor `Response` and a filter turns the request async.