### PR TITLE
Async filter exception bug

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AsyncResponseConsumer.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AsyncResponseConsumer.java
@@ -152,7 +152,13 @@ public abstract class AsyncResponseConsumer
       ResteasyProviderFactory.pushContextDataMap(contextDataMap);
       HttpRequest httpRequest = (HttpRequest) contextDataMap.get(HttpRequest.class);
       HttpResponse httpResponse = (HttpResponse) contextDataMap.get(HttpResponse.class);
-      dispatcher.writeException(httpRequest, httpResponse, t, onComplete);
+      try {
+         dispatcher.writeException(httpRequest, httpResponse, t, onComplete);
+      }catch(Throwable t2) {
+         // ignore t2 and report the original exception without going through filters
+         dispatcher.unhandledAsynchronousException(httpResponse, t);
+         onComplete.accept(t);
+      }
    }
 
    protected BuiltResponse createResponse(Object entity, HttpRequest httpRequest)

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AsyncResponseConsumer.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AsyncResponseConsumer.java
@@ -117,10 +117,10 @@ public abstract class AsyncResponseConsumer
             onComplete.accept(e);
          });
       }
-      catch (IOException e)
+      catch (Throwable e)
       {
-         onComplete.accept(e);
          exceptionWhileResuming(e);
+         onComplete.accept(e);
       }
    }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/UndertowTestRunner.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/UndertowTestRunner.java
@@ -7,7 +7,9 @@ import java.util.HashSet;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
+import javax.ws.rs.ext.Provider;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
@@ -51,8 +53,13 @@ public class UndertowTestRunner extends BlockJUnit4ClassRunner
                for (Entry<ArchivePath, Node> entry : archive.getContent().entrySet())
                {
                   Asset asset = entry.getValue().getAsset();
-                  if(asset instanceof ClassAsset)
-                     classes.add(((ClassAsset)asset).getSource());
+                  if(asset instanceof ClassAsset) {
+                     Class<?> classAsset = ((ClassAsset)asset).getSource();
+                     if((classAsset.isAnnotationPresent(Path.class)
+                           || classAsset.isAnnotationPresent(Provider.class))
+                           && !classAsset.isInterface())
+                        classes.add(classAsset);
+                  }
                }
                return;
             } 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/CompletionStageResponseTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/CompletionStageResponseTest.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.test.response;
 
 import java.net.InetAddress;
+import java.util.concurrent.Future;
 
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Response;
@@ -8,7 +9,6 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.resteasy.category.ExpectedFailing;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.response.resource.AsyncResponseCallback;
@@ -25,10 +25,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import java.util.concurrent.Future;
 
 /**
  * @tpSubChapter CompletionStage response type
@@ -199,9 +196,8 @@ public class CompletionStageResponseTest {
       Response response = request.get();
       String entity = response.readEntity(String.class);
       Assert.assertEquals(500, response.getStatus());
-      if (serverIsLocal) {
-    	  Assert.assertTrue(entity.contains(CompletionStageResponseResource.EXCEPTION));
-      }
+      response.close();
+
       // make sure the completion callback was called with with an error
       request = client.target(generateURL("/callback-called-with-error")).request();
       response = request.get();
@@ -221,9 +217,6 @@ public class CompletionStageResponseTest {
       Response response = request.get();
       String entity = response.readEntity(String.class);
       Assert.assertEquals(500, response.getStatus());
-      if (serverIsLocal) {
-         Assert.assertTrue(entity.contains(CompletionStageResponseResource.EXCEPTION));
-      }
       response.close();
       
       // make sure the completion callback was called with with an error

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/rx/resource/ExceptionThrowingFilter.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/rx/resource/ExceptionThrowingFilter.java
@@ -1,0 +1,25 @@
+package org.jboss.resteasy.test.rx.resource;
+
+import java.io.IOException;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+@FilterException
+@Provider
+public class ExceptionThrowingFilter implements ContainerResponseFilter
+{
+
+   @Override
+   public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+         throws IOException
+   {
+      throw new WebApplicationException(Response.ok("exception", MediaType.TEXT_PLAIN).build());
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/rx/resource/FilterException.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/rx/resource/FilterException.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.test.rx.resource;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.ws.rs.NameBinding;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(value = RetentionPolicy.RUNTIME)
+@NameBinding
+public @interface FilterException
+{
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/rx/resource/RxCompletionStageResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/rx/resource/RxCompletionStageResource.java
@@ -125,4 +125,9 @@ public interface RxCompletionStageResource {
    @GET
    @Path("exception/handled")
    public CompletionStage<Thing> exceptionHandled() throws Exception;
+
+   @GET
+   @Path("exception/filter")
+   @Produces(MediaType.TEXT_PLAIN)
+   public CompletionStage<String> exceptionInFilter();
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/rx/resource/RxCompletionStageResourceImpl.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/rx/resource/RxCompletionStageResourceImpl.java
@@ -167,4 +167,20 @@ public class RxCompletionStageResourceImpl {
    public CompletionStage<Thing> exceptionHandled() throws Exception {
       throw new TestException("handled");
    }
+
+   @FilterException
+   @GET
+   @Path("exception/filter")
+   @Produces(MediaType.TEXT_PLAIN)
+   public CompletionStage<String> exceptionInFilter() {
+      return (CompletionStage<String>) singleProvider.toCompletionStage(Single.just("x"));
+   }
+
+   @FilterException
+   @GET
+   @Path("exception/filter-sync")
+   @Produces(MediaType.TEXT_PLAIN)
+   public String exceptionInFilterSync() {
+      return "x";
+   }
 }


### PR DESCRIPTION
If we have an async response (returning `CompletionStage` for example, and a filter throws an exception while writing the response, the exception used to be silently ignored by `CompletionStage`, which meant that the client would hang waiting for the response, and nothing would be logged.

I fixed this, but it also means I don't throw `UnhandledException` to the container anymore in such cases, because it's very hard (if not impossible) to know at that point if the container is still in our call stack, or if we're in another thread entirely, in which case the container would never get the exception, and the exception would be caught by whatever happened to complete the async response, which is just wrong.

So I had to adapt a test which used to assume we'd get a stack trace from the container in the response, while now we get a 500 response with no stack trace. I would have changed the RESTEasy error response to include the stack trace, but I think that's a security risk unless we have a setting to turn this on/off. WDYT @asoldano @ronsigal ?