### PR TITLE
[RESTEASY-1927] ClientResponseContextImpl: getEntityStream returns possibly exhausted inputStream

### DIFF
--- a/resteasy-client-jetty/src/main/java/org/jboss/resteasy/client/jaxrs/engines/jetty/JettyClientResponse.java
+++ b/resteasy-client-jetty/src/main/java/org/jboss/resteasy/client/jaxrs/engines/jetty/JettyClientResponse.java
@@ -24,6 +24,7 @@ class JettyClientResponse extends ClientResponse {
     @Override
     protected void setInputStream(InputStream is) {
         stream = is;
+        resetEntity();
     }
 
     @Override

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpAsyncClient4Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpAsyncClient4Engine.java
@@ -641,6 +641,7 @@ public class ApacheHttpAsyncClient4Engine implements AsyncClientHttpEngine, Clos
       protected synchronized void setInputStream(InputStream is)
       {
          stream = is;
+         resetEntity();
       }
 
       @Override

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpClient4Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpClient4Engine.java
@@ -331,6 +331,7 @@ public class ApacheHttpClient4Engine implements ClientHttpEngine
          protected void setInputStream(InputStream is)
          {
             stream = is;
+            resetEntity();
          }
 
          public InputStream getInputStream()

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/URLConnectionEngine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/URLConnectionEngine.java
@@ -79,6 +79,7 @@ public class URLConnectionEngine implements ClientHttpEngine
             protected void setInputStream(InputStream is)
             {
                 stream = is;
+                resetEntity();
             }
 
             @Override

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientResponse.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientResponse.java
@@ -397,6 +397,13 @@ public abstract class ClientResponse extends BuiltResponse
       return true;
    }
 
+   protected void resetEntity()
+   {
+       entity = null;
+       bufferedEntity = null;
+       streamFullyRead = false;
+   }
+
    @Override
    public void abortIfClosed()
    {

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientResponseContextImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientResponseContextImpl.java
@@ -146,7 +146,7 @@ public class ClientResponseContextImpl implements ClientResponseContext
    @Override
    public InputStream getEntityStream()
    {
-      return response.getInputStream();
+      return response.getEntityStream();
    }
 
    @Override


### PR DESCRIPTION
Currently, a response filter that chooses to read the response context's `getEntityStream` is returning the `inputStream`.
This is fine if the stream has not been read already.  But if it ends up being buffered, either internally or via `bufferEntity()`, the input stream is exhausted.

Returning the entity stream from the response fixes this issue.