### PR TITLE
[RESTEASY-1861] RESTEasy ignores @ConstrainedTo in some situations

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -2010,15 +2010,17 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
       }
       if (isA(provider, Feature.class, contracts))
       {
+         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getAnnotation(ConstrainedTo.class);
          int priority = getPriority(priorityOverride, contracts, Feature.class, provider);
          Feature feature = injectedInstance((Class<? extends Feature>) provider);
-         if (feature.configure(new FeatureContextDelegate(this)))
-         {
-            enabledFeatures.add(feature);
+         if (constrainedTo == null || constrainedTo.value() == getRuntimeType()) {
+            if (feature.configure(new FeatureContextDelegate(this)))
+            {
+               enabledFeatures.add(feature);
+            }
          }
          featureClasses.add(provider);
          newContracts.put(Feature.class, priority);
-
       }
       if (isA(provider, RxInvokerProvider.class, contracts))
       {
@@ -2375,12 +2377,15 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
       {
          Feature feature = (Feature) provider;
          injectProperties(provider.getClass(), provider);
-         if (feature.configure(new FeatureContextDelegate(this)))
-         {
-            enabledFeatures.add(feature);
+         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getClass().getAnnotation(ConstrainedTo.class);
+         if (constrainedTo == null || constrainedTo.value() == getRuntimeType()) {
+            if (feature.configure(new FeatureContextDelegate(this)))
+            {
+               enabledFeatures.add(feature);
+            }
          }
-         featureInstances.add(provider);
          int priority = getPriority(priorityOverride, contracts, Feature.class, provider.getClass());
+         featureInstances.add(provider);
          newContracts.put(Feature.class, priority);
 
       }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/CustomConstrainedFeatureTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/CustomConstrainedFeatureTest.java
@@ -1,0 +1,76 @@
+package org.jboss.resteasy.test.providers.custom;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.test.providers.custom.resource.CustomClientConstrainedFeature;
+import org.jboss.resteasy.test.providers.custom.resource.CustomConstrainedFeatureResource;
+import org.jboss.resteasy.test.providers.custom.resource.CustomServerConstrainedFeature;
+import org.jboss.resteasy.util.HttpResponseCodes;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @tpSubChapter Core
+ * @tpChapter Integration tests
+ * @tpSince RESTEasy 3.6.1
+ * @tpTestCaseDetails Regression test for RESTEASY-1861
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class CustomConstrainedFeatureTest {
+
+    private static final String TEST_URI = generateURL("/test-custom-feature");
+    private static final Logger LOGGER = LogManager.getLogger(CustomConstrainedFeatureTest.class.getName());
+    private static final String CUSTOM_PROVIDERS_FILENAME = "CustomConstrainedFeature.Providers";
+    
+    @Deployment
+    public static Archive<?> createTestArchive() {
+        WebArchive war = TestUtil.prepareArchive(CustomConstrainedFeatureTest.class.getSimpleName());
+        war.addAsResource(CustomConstrainedFeatureTest.class.getPackage(), CUSTOM_PROVIDERS_FILENAME, "META-INF/services/javax.ws.rs.ext.Providers");
+        return TestUtil.finishContainerPrepare(war, null, CustomConstrainedFeatureResource.class, CustomServerConstrainedFeature.class, CustomClientConstrainedFeature.class);
+    }
+
+    private static String generateURL(String path) {
+           return PortProviderUtil.generateURL(path, CustomConstrainedFeatureTest.class.getSimpleName());
+    }
+
+    /**
+     * @tpTestDetails Call client with restricted feature for server runtime.
+     * @tpSince RESTEasy 3.6.1
+     */
+    @Test
+    public void testClientCall() {
+       CustomServerConstrainedFeature.reset();
+       CustomClientConstrainedFeature.reset();
+       // This will register always in SERVER runtime
+       // ResteasyProviderFactory providerFactory = ResteasyProviderFactory.getInstance();
+       // providerFactory.register(CustomClientConstrainedFeature.class);
+       // providerFactory.register(CustomServerConstrainedFeature.class);
+       // ResteasyClient client = new ResteasyClientBuilder().build();
+       // the line below does the same as if there is providers file in META-INF/services/javax.ws.rs.ext.Providers
+       ResteasyClient client = new ResteasyClientBuilder().register(CustomClientConstrainedFeature.class).register(CustomServerConstrainedFeature.class).build();
+       assertTrue(CustomConstrainedFeatureResource.ERROR_CLIENT_FEATURE, CustomClientConstrainedFeature.wasInvoked());
+       assertFalse(CustomConstrainedFeatureResource.ERROR_SERVER_FEATURE, CustomServerConstrainedFeature.wasInvoked());
+       Response response = client.target(TEST_URI).request().get();
+       LOGGER.info("Response from server: {}", response.readEntity(String.class));
+       // server must return 200 if only registered feature was for server runtime
+       assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+       client.close();
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomClientConstrainedFeature.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomClientConstrainedFeature.java
@@ -1,0 +1,37 @@
+package org.jboss.resteasy.test.providers.custom.resource;
+
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.logging.Logger;
+
+/**
+ * A feature constrained to the client runtime.
+ * 
+ * @author pjurak
+ */
+@Provider
+@ConstrainedTo(RuntimeType.CLIENT)
+public class CustomClientConstrainedFeature implements Feature {
+   private static volatile boolean invoked = false;
+   private Logger logger = Logger.getLogger(CustomClientConstrainedFeature.class);
+   
+   @Override
+   public boolean configure(FeatureContext context)
+   {      
+      logger.info("Configuring CustomClientConstrainedFeature");
+      invoked = true;
+      return true;
+   }
+
+   public static boolean wasInvoked() {
+      return invoked;
+  }
+
+  public static void reset() {
+      invoked = false;
+  }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomConstrainedFeatureResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomConstrainedFeatureResource.java
@@ -1,0 +1,34 @@
+package org.jboss.resteasy.test.providers.custom.resource;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import org.jboss.logging.Logger;
+
+@Path("")
+public class CustomConstrainedFeatureResource {
+
+    public static final String ERROR_SERVER_FEATURE = "CustomServerConstrainedFeature must be invoked on the server runtime";
+    public static final String ERROR_CLIENT_FEATURE = "CustomClientConstrainedFeature must be invoked on the client runtime";
+    private Logger logger = Logger.getLogger(CustomConstrainedFeatureResource.class);
+
+    @GET
+    @Path("test-custom-feature")
+    @Produces("text/plain")
+    public Response test() {
+       try {
+          // only server runtime feature must be invoked
+          assertTrue(ERROR_SERVER_FEATURE, CustomServerConstrainedFeature.wasInvoked());
+          assertFalse(ERROR_CLIENT_FEATURE, CustomClientConstrainedFeature.wasInvoked());
+       } catch (AssertionError e) {
+          logger.error(e);
+          return Response.status(500).entity(e.getLocalizedMessage()).build();
+       }
+       return Response.status(200).build();
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomServerConstrainedFeature.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/resource/CustomServerConstrainedFeature.java
@@ -1,0 +1,37 @@
+package org.jboss.resteasy.test.providers.custom.resource;
+
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.logging.Logger;
+
+/**
+ * A feature constrained to the server runtime.
+ * 
+ * @author pjurak
+ */
+@Provider
+@ConstrainedTo(RuntimeType.SERVER)
+public class CustomServerConstrainedFeature implements Feature {
+   private static volatile boolean invoked = false;
+   private Logger logger = Logger.getLogger(CustomServerConstrainedFeature.class);
+
+   @Override
+   public boolean configure(FeatureContext context)
+   {
+      logger.info("Configuring CustomServerConstrainedFeature");
+      invoked = true;
+      return true;
+   }
+
+   public static boolean wasInvoked() {
+      return invoked;
+  }
+
+  public static void reset() {
+      invoked = false;
+  }
+}

--- a/testsuite/integration-tests/src/test/resources/org/jboss/resteasy/test/providers/custom/CustomConstrainedFeature.Providers
+++ b/testsuite/integration-tests/src/test/resources/org/jboss/resteasy/test/providers/custom/CustomConstrainedFeature.Providers
@@ -1,0 +1,2 @@
+org.jboss.resteasy.test.providers.custom.resource.CustomServerConstrainedFeature
+org.jboss.resteasy.test.providers.custom.resource.CustomClientConstrainedFeature


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/RESTEASY-1861

The approach is to not call configure method if the runtime environment does not match the one mentioned in javax.ws.rs.ConstrainedTo annotation (similar to dynamic features).