### PR TITLE
[RESTEASY-1936] Testsuite elytron module misconfiguration

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -261,7 +261,7 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration combine.children="append">
+                        <configuration>
                             <systemPropertyVariables>
                                 <securityManagerArg>${securityManagerArg}</securityManagerArg>
                                 <additionalJvmArgs>${additionalJvmArgs}</additionalJvmArgs>


### PR DESCRIPTION

Testsuite elytron module misconfiguration

Elytron module sets surefire system properties in testsuite/pom.xml. But these properties are replaced/removed by system properties from surefire execution definitions from testsuite/integration-tests/pom.xml

Elytron profile definition needs to be updated

Jira: https://issues.jboss.org/browse/RESTEASY-1936
Master PR: https://github.com/resteasy/Resteasy/pull/1591