### PR TITLE
[RESTEASY-1943] Async filter resume with exception issues

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AbstractAsynchronousResponse.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AbstractAsynchronousResponse.java
@@ -38,6 +38,7 @@ public abstract class AbstractAsynchronousResponse implements ResteasyAsynchrono
    protected TimeoutHandler timeoutHandler;
    protected List<CompletionCallback> completionCallbacks = new ArrayList<CompletionCallback>();
    protected Map<Class<?>, Object> contextDataMap;
+   private boolean callbacksCalled;
 
    protected AbstractAsynchronousResponse(SynchronousDispatcher dispatcher, HttpRequest request, HttpResponse response)
    {
@@ -151,6 +152,10 @@ public abstract class AbstractAsynchronousResponse implements ResteasyAsynchrono
    @Override
    public void completionCallbacks(Throwable throwable)
    {
+      // make sure we only call them once
+      if(callbacksCalled)
+         return;
+      callbacksCalled = true;
       for (CompletionCallback callback : completionCallbacks)
       {
          callback.onComplete(throwable);

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/PreMatchContainerRequestContext.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/PreMatchContainerRequestContext.java
@@ -287,14 +287,11 @@ public class PreMatchContainerRequestContext implements SuspendableContainerRequ
    
    private void writeException(Throwable t)
    {
-      HttpRequest httpRequest = (HttpRequest) contextDataMap.get(HttpRequest.class);
-      HttpResponse httpResponse = (HttpResponse) contextDataMap.get(HttpResponse.class);
-      SynchronousDispatcher dispatcher = (SynchronousDispatcher) contextDataMap.get(Dispatcher.class);
-      try {
-         dispatcher.writeException(httpRequest, httpResponse, t, t2 -> {});
-      }catch(Throwable x) {
-         dispatcher.unhandledAsynchronousException(httpResponse, x);
-      }
+      /*
+       * Here, contrary to ContainerResponseContextImpl.writeException, we can use the async response
+       * to write the exception, because it calls the right response filters, complete() and callbacks
+       */
+      httpRequest.getAsyncContext().getAsyncResponse().resume(t);
    }
 
    public synchronized BuiltResponse filter()

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/SuspendableContainerRequestContext.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/SuspendableContainerRequestContext.java
@@ -28,7 +28,9 @@ public interface SuspendableContainerRequestContext extends ContainerRequestCont
    
    /**
     * Aborts the current request with the given exception. This behaves as if the request
-    * filter threw this exception synchronously.
+    * filter threw this exception synchronously, which means exceptions may be mapped via
+    * exception mappers, response filters will run and async response callbacks will be
+    * called with this exception.
     * 
     * @param t the exception to send back to the client, as mapped by the application.
     */

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/SuspendableContainerResponseContext.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/jaxrs/SuspendableContainerResponseContext.java
@@ -28,9 +28,11 @@ public interface SuspendableContainerResponseContext extends ContainerResponseCo
    
    /**
     * Aborts the current response with the given exception. This behaves as if the request
-    * filter threw this exception synchronously.
+    * filter threw this exception synchronously, which means that the exception will not
+    * be mapped by exception mappers, the response filters will stop running, and the
+    * async response callbacks will be called with this exception.
     * 
-    * @param t the exception to send back to the client, as mapped by the application.
+    * @param t the exception to send back to the client, as an internal server error.
     */
    public void resume(Throwable t);
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/servlet/Servlet3AsyncHttpRequest.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/servlet/Servlet3AsyncHttpRequest.java
@@ -115,16 +115,7 @@ public class Servlet3AsyncHttpRequest extends HttpServletInputMessage
                if (cancelled) return false;
                AsyncContext asyncContext = getAsyncContext();
                done = true;
-               return internalResume(exc, t -> {
-                  if(t instanceof UnhandledException)
-                  {
-                     internalResume(Response.status(500).build(), t2 -> asyncContext.complete());
-                  }
-                  else
-                  {
-                     asyncContext.complete();
-                  }
-               });
+               return internalResume(exc, t -> asyncContext.complete());
             }
          }
 

--- a/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpRequest.java
+++ b/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpRequest.java
@@ -292,16 +292,7 @@ public class NettyHttpRequest extends BaseHttpRequest
                     if (done) return false;
                     if (cancelled) return false;
                     done = true;
-                    return internalResume(ex, t -> {
-                    		if(t instanceof UnhandledException)
-                    		{
-                    			internalResume(Response.status(500).build(), t2 -> nettyFlush());
-                    		}
-                    		else
-                    		{
-                    		   nettyFlush();
-                    		}
-                    });
+                    return internalResume(ex, t -> nettyFlush());
                 }
             }
 

--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpRequest.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpRequest.java
@@ -280,15 +280,7 @@ public class VertxHttpRequest extends BaseHttpRequest
                if (done) return false;
                if (cancelled) return false;
                done = true;
-               return internalResume(ex, t -> {
-                  if(t instanceof UnhandledException) {
-                     internalResume(Response.status(500).build(), t2 -> vertxFlush());
-                  }
-                  else 
-                  {
-                     vertxFlush();
-                  }
-               });
+               return internalResume(ex, t -> vertxFlush());
             }
          }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncRequestFilterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncRequestFilterTest.java
@@ -493,6 +493,14 @@ public class AsyncRequestFilterTest {
        // this is 500 even with exception mapper because exceptions in response filters are not mapped
        assertEquals(500, response.getStatus());
 
+       try
+       {
+          // give a chance to CI to run the callbacks
+          Thread.sleep(1000);
+       } catch (InterruptedException e)
+       {
+       }
+
        // check that callbacks were called
        response = base.request().get();
        assertEquals(200, response.getStatus());
@@ -517,6 +525,14 @@ public class AsyncRequestFilterTest {
        else 
        {
           assertEquals(500, response.getStatus());
+       }
+
+       try
+       {
+          // give a chance to CI to run the callbacks
+          Thread.sleep(1000);
+       } catch (InterruptedException e)
+       {
        }
 
        // check that callbacks were called

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncFilterException.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncFilterException.java
@@ -1,0 +1,12 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+@SuppressWarnings("serial")
+public class AsyncFilterException extends RuntimeException
+{
+
+   public AsyncFilterException(String message)
+   {
+      super(message);
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncFilterExceptionMapper.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncFilterExceptionMapper.java
@@ -1,0 +1,18 @@
+package org.jboss.resteasy.test.asynch.resource;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class AsyncFilterExceptionMapper implements ExceptionMapper<AsyncFilterException>
+{
+
+   @Override
+   public Response toResponse(AsyncFilterException exception)
+   {
+      return Response.ok("exception was mapped").status(Status.ACCEPTED).build();
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilterResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilterResource.java
@@ -10,6 +10,9 @@ import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.CompletionCallback;
+import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
@@ -74,6 +77,18 @@ public class AsyncRequestFilterResource {
           resp.complete(Response.ok("resource").build());
        });
        return resp;
+    }
+
+    @Path("callback")
+    @GET
+    public String callback() {
+       return "hello";
+    }
+
+    @Path("callback-async")
+    @GET
+    public CompletionStage<String> callbackAsync() {
+       return CompletableFuture.completedFuture("hello");
     }
 
    private boolean isAsync(String filter)

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter.java
@@ -1,19 +1,26 @@
 package org.jboss.resteasy.test.asynch.resource;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import javax.ws.rs.container.CompletionCallback;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.core.Response;
 
 import org.jboss.resteasy.core.interception.jaxrs.SuspendableContainerResponseContext;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.ResteasyAsynchronousResponse;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 public abstract class AsyncResponseFilter implements ContainerResponseFilter {
 
    private String name;
+   private String callbackException;
    
    public AsyncResponseFilter(String name)
    {
@@ -24,6 +31,16 @@ public abstract class AsyncResponseFilter implements ContainerResponseFilter {
    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
          throws IOException
    {
+      // copy request filter callback values
+      for (Entry<String, List<String>> entry : requestContext.getHeaders().entrySet())
+      {
+         if(entry.getKey().startsWith("RequestFilterCallback"))
+            // cast required to disambiguate with Object... method
+            responseContext.getHeaders().addAll(entry.getKey(), (List)entry.getValue());
+      }
+      responseContext.getHeaders().add("ResponseFilterCallback"+name, String.valueOf(callbackException));
+      callbackException = null;
+
       SuspendableContainerResponseContext ctx = (SuspendableContainerResponseContext) responseContext;
       String action = requestContext.getHeaderString(name);
       System.err.println("Filter response for "+name+" with action: "+action);
@@ -64,6 +81,33 @@ public abstract class AsyncResponseFilter implements ContainerResponseFilter {
          ctx.suspend();
          ctx.setEntity(name);
          ctx.resume();
+      }else if("sync-throw".equals(action)) {
+         throw new AsyncFilterException("ouch");
+      }else if("async-throw-late".equals(action)) {
+         ctx.suspend();
+         HttpRequest req = ResteasyProviderFactory.getContextData(HttpRequest.class);
+         ExecutorService executor = Executors.newSingleThreadExecutor();
+         executor.submit(() -> {
+            try
+            {
+               Thread.sleep(2000);
+            } catch (InterruptedException e)
+            {
+               // TODO Auto-generated catch block
+               e.printStackTrace();
+            }
+            ctx.setEntity(name);
+            ResteasyAsynchronousResponse resp = req.getAsyncContext().getAsyncResponse();
+            resp.register((CompletionCallback) (t) -> {
+               if(callbackException != null)
+                  throw new RuntimeException("Callback called twice");
+               callbackException = Objects.toString(t);
+            });
+            if("true".equals(req.getHttpHeaders().getHeaderString("UseExceptionMapper")))
+               ctx.resume(new AsyncFilterException("ouch"));
+            else
+               ctx.resume(new Throwable("ouch"));
+         });
       }
       System.err.println("Filter response for "+name+" with action: "+action+" done");
    }


### PR DESCRIPTION
This fixes the following bugs:

- `SuspendableRequestContainerContext.resume(Throwable)` and `SuspendableResponseContainerContext.resume(Throwable)` were ill-specified
- `SuspendableRequestContainerContext.resume(Throwable)` and `SuspendableResponseContainerContext.resume(Throwable)` did not call async callbacks
- `SuspendableRequestContainerContext.resume(Throwable)` did not always call exception mapper and response filters
- `SuspendableResponseContainerContext.resume(Throwable)` should not call exception mapper and response filters
