### PR TITLE
OnComplete callback registered via SseEventSource.register() must be called only once

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/plugins/providers/sse/client/SseEventSourceImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/plugins/providers/sse/client/SseEventSourceImpl.java
@@ -252,24 +252,7 @@ public class SseEventSourceImpl implements SseEventSource
    @Override
    public boolean close(final long timeout, final TimeUnit unit)
    {
-      if (state.getAndSet(State.CLOSED) != State.CLOSED)
-      {
-         if (response != null)
-         {
-            try
-            {
-               response.releaseConnection(false);
-            }
-            catch (IOException e)
-            {
-               onErrorConsumers.forEach(consumer -> {
-                  consumer.accept(e);
-               });
-            }
-         }
-         executor.shutdownNow();
-         onCompleteConsumers.forEach(Runnable::run);
-      }
+      internalClose();
       try
       {
          if (!executor.awaitTermination(timeout, unit))
@@ -287,6 +270,29 @@ public class SseEventSourceImpl implements SseEventSource
       }
 
       return true;
+   }
+   
+   private void internalClose()
+   {
+      if (state.getAndSet(State.CLOSED) == State.CLOSED)
+      {
+         return;
+      }
+      if (response != null)
+      {
+         try
+         {
+            response.releaseConnection(false);
+         }
+         catch (IOException e)
+         {
+            onErrorConsumers.forEach(consumer -> {
+               consumer.accept(e);
+            });
+         }
+      }
+      executor.shutdownNow();
+      onCompleteConsumers.forEach(Runnable::run);
    }
 
    public void setAlwasyReconnect(boolean always)
@@ -332,7 +338,6 @@ public class SseEventSourceImpl implements SseEventSource
       {
          if (state.get() != State.OPEN)
          {
-            onCompleteConsumers.forEach(Runnable::run);
             return;
          }
          
@@ -358,7 +363,7 @@ public class SseEventSourceImpl implements SseEventSource
                //if 200<= response code <300 and response contentType is null, fail the connection. 
                if (eventInput == null && !alwaysReconnect)
                {
-                  state.set(State.CLOSED);
+                  internalClose();
                }
             }
             else
@@ -417,8 +422,10 @@ public class SseEventSourceImpl implements SseEventSource
                   else
                   {
                      //event sink closed
-                     if (!alwaysReconnect)
+                     if (!alwaysReconnect){
+                        internalClose();
                         break;
+                     }
                   }
                }
                catch (IOException e)
@@ -428,7 +435,6 @@ public class SseEventSourceImpl implements SseEventSource
                }
             }
          }
-         onCompleteConsumers.forEach(Runnable::run);
       }
 
       public void awaitConnected()
@@ -451,11 +457,11 @@ public class SseEventSourceImpl implements SseEventSource
 
       private void onUnrecoverableError(Throwable throwable)
       {
-         state.set(State.CLOSED);
          connectedLatch.countDown();
          onErrorConsumers.forEach(consumer -> {
             consumer.accept(throwable);
          });
+         internalClose();
       }
 
       private void onEvent(final InboundSseEvent event)

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSourceTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSourceTest.java
@@ -115,7 +115,6 @@ public class SseEventSourceTest {
      * @tpSince RESTEasy 3.5.0
      */
     @Test
-    @Category(ExpectedFailing.class) // See RESTEASY-1816
     public void testSseEventSourceOnEventOnErrorOnCompleteCallback() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
         final List<InboundSseEvent> results = new ArrayList<InboundSseEvent>();


### PR DESCRIPTION
This pull request is to remove multiple invocation of SseEventSource completion handlers and enable test about it.

@ronsigal You might be interested by this PR since it seem's that the regression has been introduced by https://github.com/resteasy/Resteasy/pull/1478 

@rnetuka and @kanovotn You also might be interested by this PR as an enrichment to what have been done in https://github.com/resteasy/Resteasy/pull/1435/files