### PR TITLE
[RESTEASY-1708]

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/JaxrsInterceptorRegistry.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/JaxrsInterceptorRegistry.java
@@ -76,7 +76,7 @@ public class JaxrsInterceptorRegistry<T>
 
       public AbstractInterceptorFactory(Class declaring)
       {
-         this.declaring = declaring;
+         this.declaring = getNonSyntheticClass(declaring);
       }
 
       protected void setPrecedence(Class<?> declaring)
@@ -135,7 +135,7 @@ public class JaxrsInterceptorRegistry<T>
                {
                   if (!targetClass.isAnnotationPresent(annotation) &&
                           !target.isAnnotationPresent(annotation)
-                          && (application == null || !application.getClass().isAnnotationPresent(annotation)))
+                          && (application == null || !getNonSyntheticClass(application.getClass()).isAnnotationPresent(annotation)))
                   {
                      return null;
                   }
@@ -475,5 +475,14 @@ public class JaxrsInterceptorRegistry<T>
       SingletonInterceptorFactory factory = new SingletonInterceptorFactory(interceptor.getClass(), interceptor);
       factory.setOrder(priority);
       register(factory);
+   }
+   
+   private Class<?> getNonSyntheticClass(Class<?> clazz)
+   {
+      while (clazz.isSynthetic())
+      {
+         clazz = clazz.getSuperclass();
+      }
+      return clazz;
    }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/NameBoundCDIProxiesTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/NameBoundCDIProxiesTest.java
@@ -1,0 +1,65 @@
+package org.jboss.resteasy.test.cdi.interceptors;
+
+import java.io.File;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.test.cdi.interceptors.resource.NameBoundCDIProxiesApplication;
+import org.jboss.resteasy.test.cdi.interceptors.resource.NameBoundCDIProxiesInterceptor;
+import org.jboss.resteasy.test.cdi.interceptors.resource.NameBoundCDIProxiesResource;
+import org.jboss.resteasy.test.cdi.interceptors.resource.NameBoundProxiesAnnotation;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @tpSubChapter CDI
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Name bound interceptors and Application CDI proxies
+ * @tpSince RESTEasy 3.6.1
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class NameBoundCDIProxiesTest {
+
+   @Deployment
+   public static Archive<?> deploySimpleResource() {
+      WebArchive war = prepareArchive(NameBoundCDIProxiesTest.class.getSimpleName());
+      war.addClass(NameBoundProxiesAnnotation.class);
+      war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+      return TestUtil.finishContainerPrepare(war, null, NameBoundCDIProxiesResource.class, NameBoundCDIProxiesInterceptor.class);
+   }
+
+   // Use specific Application subclass
+   private static WebArchive prepareArchive(String deploymentName) {
+      WebArchive war = ShrinkWrap.create(WebArchive.class, deploymentName + ".war");
+      war.addClass(NameBoundCDIProxiesApplication.class);
+      return war;
+   }
+   private String generateURL(String path) {
+      return PortProviderUtil.generateURL(path, NameBoundCDIProxiesTest.class.getSimpleName());
+   }
+
+   /**
+    * @tpTestDetails
+    * @tpSince RESTEasy 3.6.1
+    */
+   @Test
+   public void testNameBoundInterceptor() throws Exception {
+      Client client = ClientBuilder.newClient();
+      String answer = client.target(generateURL("/test")).request().get(String.class);
+      Assert.assertEquals("in-test-out", answer);
+      client.close();
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/resource/NameBoundCDIProxiesApplication.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/resource/NameBoundCDIProxiesApplication.java
@@ -1,0 +1,24 @@
+package org.jboss.resteasy.test.cdi.interceptors.resource;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("")
+@NameBoundProxiesAnnotation
+public class NameBoundCDIProxiesApplication extends Application {
+
+   public Set<Class<?>> getClasses() {
+      Set<Class<?>> set = new HashSet<Class<?>>();
+      set.add(NameBoundCDIProxiesResource.class);
+      return set;
+   }
+
+   public Set<Object> getSingletons() {
+      Set<Object> set = new HashSet<Object>();
+      set.add(new NameBoundCDIProxiesInterceptor());
+      return set;
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/resource/NameBoundCDIProxiesInterceptor.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/resource/NameBoundCDIProxiesInterceptor.java
@@ -1,0 +1,32 @@
+package org.jboss.resteasy.test.cdi.interceptors.resource;
+
+import java.io.IOException;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+
+@NameBoundProxiesAnnotation
+public class NameBoundCDIProxiesInterceptor implements ContainerRequestFilter, ContainerResponseFilter {
+
+   static private String in = "";
+
+   /** The application context, used for retrieving the {@link ApplicationPath} value. */
+   @Context Application application;
+
+   @Override
+   public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+      Object entity = application.getClass().isSynthetic() ? in + responseContext.getEntity() + "-out" : responseContext.getEntity();
+      responseContext.setEntity(entity); 
+   }
+
+   @Override
+   public void filter(ContainerRequestContext requestContext) throws IOException {
+      in = "in-";
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/resource/NameBoundCDIProxiesResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/resource/NameBoundCDIProxiesResource.java
@@ -1,0 +1,14 @@
+package org.jboss.resteasy.test.cdi.interceptors.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("")
+public class NameBoundCDIProxiesResource {
+
+   @Path("test")
+   @GET
+   public String test() {
+      return "test";
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/resource/NameBoundProxiesAnnotation.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/resource/NameBoundProxiesAnnotation.java
@@ -1,0 +1,13 @@
+package org.jboss.resteasy.test.cdi.interceptors.resource;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.ws.rs.NameBinding;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(value = RetentionPolicy.RUNTIME)
+@NameBinding
+public @interface NameBoundProxiesAnnotation {}


### PR DESCRIPTION
Allow matching name binding between Applications and interceptors when
the Application object is a CDI proxy.

[RESTEASY-1708]

Fix deploySimpleResource() in NameBoundCDIProxiesTest.