### PR TITLE
[RESTEASY-1959] Removal of unused imports in JaxrsWithSpringMVCTest

### DIFF
--- a/testsuite/integration-tests-spring/deployment/src/test/java/org/jboss/resteasy/test/spring/deployment/JaxrsWithSpringMVCTest.java
+++ b/testsuite/integration-tests-spring/deployment/src/test/java/org/jboss/resteasy/test/spring/deployment/JaxrsWithSpringMVCTest.java
@@ -1,11 +1,7 @@
 package org.jboss.resteasy.test.spring.deployment;
 
-import java.security.AllPermission;
 import javax.json.JsonArray;
 
-import javax.xml.ws.WebServicePermission;
-import org.apache.http.HttpEntity;
-import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -28,14 +24,10 @@ import org.junit.runner.RunWith;
 import javax.management.MBeanPermission;
 import javax.management.MBeanServerPermission;
 import javax.management.MBeanTrustPermission;
-import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import java.io.FilePermission;
 import java.lang.reflect.ReflectPermission;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.PropertyPermission;
 import java.util.logging.LoggingPermission;
 


### PR DESCRIPTION
Unused imports in JaxrsWithSpringMVCTest prevent compilation success on **Java 11 ea+22**
Import of `javax.xml.ws.WebServicePermission` is the main problem.

https://issues.jboss.org/browse/RESTEASY-1959