### PR TITLE
[RESTEASY-1884] Use custom manually started container for GZIP tests instead of surefire execution

### DIFF
--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -402,12 +402,7 @@
                                 <excludes>
                                      <!-- Tests requires excluding JsonBindingProvider-->
                                     <exclude>**/JsonBindingAnnotationsJacksonTest.java</exclude>
-                                    <exclude>**/AllowGzipOnServerAllowGzipOnClientTest.java</exclude>
-                                    <exclude>**/AllowGzipOnServerNotAllowGzipOnClientTest.java</exclude>
                                 </excludes>
-                                <systemPropertyVariables combine.children="append">
-                                    <allow.gzip.server.jvm.arg>-Dplaceholder=placeholder</allow.gzip.server.jvm.arg>
-                                </systemPropertyVariables>
                             </configuration>
                         </execution>
 
@@ -425,29 +420,6 @@
                                 <classpathDependencyExcludes>
                                     <classpathDependencyExclude>org.jboss.resteasy:resteasy-json-binding-provider</classpathDependencyExclude>
                                 </classpathDependencyExcludes>
-                                <systemPropertyVariables combine.children="append">
-                                    <allow.gzip.server.jvm.arg>-Dplaceholder=placeholder</allow.gzip.server.jvm.arg>
-                                </systemPropertyVariables>
-                            </configuration>
-                        </execution>
-
-                        <!-- execution allows gzip interceptors on server by -Dallow.gzip property -->
-                        <execution>
-                            <id>allowGzip_on_server.allowGzip_on_client</id>
-                            <phase>test</phase>
-                            <goals>
-                                <goal>test</goal>
-                            </goals>
-                            <configuration>
-                                <trimStackTrace>false</trimStackTrace>
-                                <skip>false</skip>
-                                <systemPropertyVariables combine.children="append">
-                                    <allow.gzip.server.jvm.arg>-Dresteasy.allowGzip=true</allow.gzip.server.jvm.arg>
-                                </systemPropertyVariables>
-                                <includes>
-                                    <include>**/AllowGzipOnServerAllowGzipOnClientTest.java</include>
-                                    <include>**/AllowGzipOnServerNotAllowGzipOnClientTest.java</include>
-                                </includes>
                             </configuration>
                         </execution>
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/AllowGzipOnServerAbstractTestBase.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/AllowGzipOnServerAbstractTestBase.java
@@ -1,0 +1,74 @@
+package org.jboss.resteasy.test.interceptor.gzip;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * Abstract base class for tests with gzip enabled on server side.
+ *
+ * This abstract class provides deployments and starts and stops custom server.
+ *
+ * This abstract class is extended by:
+ *      AllowGzipOnServerAllowGzipOnClientTest
+ *      AllowGzipOnServerNotAllowGzipOnClientTest
+ */
+public class AllowGzipOnServerAbstractTestBase extends GzipAbstractTestBase {
+
+   /**
+    * Name of server with allowed gzip
+    */
+   protected static final String GZIP_SERVER_NAME = "jbossas-manual-gzip";
+
+   //keep in sync with offset in arquillian.xml
+   protected static String gzipServerBaseUrl = "http://" + PortProviderUtil.getHost() + ":" + (PortProviderUtil.getPort() + 1000);
+
+   @ArquillianResource
+   protected ContainerController containerController;
+
+   @ArquillianResource
+   protected Deployer deployer;
+
+   @Before
+   public void startContainerWithGzipEnabledAndDeploy() {
+      if (!containerController.isStarted(GZIP_SERVER_NAME)) {
+         containerController.start(GZIP_SERVER_NAME);
+      }
+
+      deployer.deploy(WAR_WITH_PROVIDERS_FILE);
+      deployer.deploy(WAR_WITHOUT_PROVIDERS_FILE);
+   }
+
+   @After
+   public void undeployAndStopContainerWithGzipEnabled() {
+      if (containerController.isStarted(GZIP_SERVER_NAME)) {
+         deployer.undeploy(WAR_WITH_PROVIDERS_FILE);
+         deployer.undeploy(WAR_WITHOUT_PROVIDERS_FILE);
+         containerController.stop(GZIP_SERVER_NAME);
+      }
+   }
+
+   /**
+    * Deployment with javax.ws.rs.ext.Providers file, that contains gzip interceptor definition
+    */
+   @Deployment(name = WAR_WITH_PROVIDERS_FILE, managed = false, testable = false)
+   @TargetsContainer(GZIP_SERVER_NAME)
+   public static Archive<?> createWebDeploymentWithGzipProvidersFile() {
+      return createWebArchive(WAR_WITH_PROVIDERS_FILE, true);
+   }
+
+   /**
+    * Deployment without any javax.ws.rs.ext.Providers file
+    */
+   @Deployment(name = WAR_WITHOUT_PROVIDERS_FILE, managed = false, testable = false)
+   @TargetsContainer(GZIP_SERVER_NAME)
+   public static Archive<?> createWebDeploymentWithoutGzipProvidersFile() {
+      return createWebArchive(WAR_WITHOUT_PROVIDERS_FILE, false);
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/AllowGzipOnServerAllowGzipOnClientTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/AllowGzipOnServerAllowGzipOnClientTest.java
@@ -5,13 +5,15 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.net.URL;
+
 /**
  * @tpSubChapter Gzip
  * @tpChapter Integration tests
  * @tpTestCaseDetails Regression test for RESTEASY-1735
  * @tpSince RESTEasy 3.6
  */
-public class AllowGzipOnServerAllowGzipOnClientTest extends GzipAbstractTest {
+public class AllowGzipOnServerAllowGzipOnClientTest extends AllowGzipOnServerAbstractTestBase {
 
     @BeforeClass
     public static void init() {
@@ -28,9 +30,9 @@ public class AllowGzipOnServerAllowGzipOnClientTest extends GzipAbstractTest {
      * @tpSince RESTEasy 3.6
      */
     @Test
-    @OperateOnDeployment("war_without_providers_file")
+    @OperateOnDeployment(WAR_WITHOUT_PROVIDERS_FILE)
     public void allowGzipOnServerAllowGzipOnClientTest() throws Exception {
-        testNormalClient(false, "true", true, true);
+        testNormalClient(new URL(gzipServerBaseUrl + "/" + WAR_WITHOUT_PROVIDERS_FILE), false, "true", true, true);
     }
 
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/AllowGzipOnServerNotAllowGzipOnClientTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/AllowGzipOnServerNotAllowGzipOnClientTest.java
@@ -3,13 +3,15 @@ package org.jboss.resteasy.test.interceptor.gzip;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.junit.Test;
 
+import java.net.URL;
+
 /**
  * @tpSubChapter Gzip
  * @tpChapter Integration tests
  * @tpTestCaseDetails Regression test for RESTEASY-1735
  * @tpSince RESTEasy 3.6
  */
-public class AllowGzipOnServerNotAllowGzipOnClientTest extends GzipAbstractTest {
+public class AllowGzipOnServerNotAllowGzipOnClientTest extends AllowGzipOnServerAbstractTestBase {
 
     /**
      * @tpTestDetails gzip is allowed on server by resteasy.allowGzip system property,
@@ -17,9 +19,9 @@ public class AllowGzipOnServerNotAllowGzipOnClientTest extends GzipAbstractTest 
      * @tpSince RESTEasy 3.6
      */
     @Test
-    @OperateOnDeployment("war_without_providers_file")
+    @OperateOnDeployment(WAR_WITHOUT_PROVIDERS_FILE)
     public void manuallyImportOnClient() throws Exception {
-        testNormalClient(true, "true", true, true);
+        testNormalClient(new URL(gzipServerBaseUrl + "/" + WAR_WITHOUT_PROVIDERS_FILE), true, "true", true, true);
     }
 
     /**
@@ -28,9 +30,9 @@ public class AllowGzipOnServerNotAllowGzipOnClientTest extends GzipAbstractTest 
      * @tpSince RESTEasy 3.6
      */
     @Test
-    @OperateOnDeployment("war_with_providers_file")
+    @OperateOnDeployment(WAR_WITH_PROVIDERS_FILE)
     public void noGzipOnClient() throws Exception {
-        testNormalClient(false, "true", false, false);
+        testNormalClient(new URL(gzipServerBaseUrl + "/" + WAR_WITH_PROVIDERS_FILE), false, "true", false, false);
     }
 
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/NotAllowGzipOnServerAbstractTestBase.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/NotAllowGzipOnServerAbstractTestBase.java
@@ -1,0 +1,32 @@
+package org.jboss.resteasy.test.interceptor.gzip;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+
+/**
+ * Abstract base class for tests with gzip disabled on server side.
+ *
+ * This abstract class provides deployments.
+ *
+ * This abstract class is extended by:
+ *      NotAllowGzipOnServerAllowGzipOnClientTest
+ *      NotAllowGzipOnServerNotAllowGzipOnClientTest
+ */
+public class NotAllowGzipOnServerAbstractTestBase extends GzipAbstractTestBase {
+
+   /**
+    * Deployment with javax.ws.rs.ext.Providers file, that contains gzip interceptor definition
+    */
+   @Deployment(name = WAR_WITH_PROVIDERS_FILE, testable = false)
+   public static Archive<?> createWebDeploymentWithGzipProvidersFile() {
+      return createWebArchive(WAR_WITH_PROVIDERS_FILE, true);
+   }
+
+   /**
+    * Deployment without any javax.ws.rs.ext.Providers file
+    */
+   @Deployment(name = WAR_WITHOUT_PROVIDERS_FILE, testable = false)
+   public static Archive<?> createWebDeploymentWithoutGzipProvidersFile() {
+      return createWebArchive(WAR_WITHOUT_PROVIDERS_FILE, false);
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/NotAllowGzipOnServerAllowGzipOnClientTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/NotAllowGzipOnServerAllowGzipOnClientTest.java
@@ -1,9 +1,12 @@
 package org.jboss.resteasy.test.interceptor.gzip;
 
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.net.URL;
 
 /**
  * @tpSubChapter Gzip
@@ -11,7 +14,7 @@ import org.junit.Test;
  * @tpTestCaseDetails Regression test for RESTEASY-1735
  * @tpSince RESTEasy 3.6
  */
-public class NotAllowGzipOnServerAllowGzipOnClientTest extends GzipAbstractTest {
+public class NotAllowGzipOnServerAllowGzipOnClientTest extends NotAllowGzipOnServerAbstractTestBase {
 
     @BeforeClass
     public static void init() {
@@ -23,15 +26,18 @@ public class NotAllowGzipOnServerAllowGzipOnClientTest extends GzipAbstractTest 
         System.clearProperty(PROPERTY_NAME);
     }
 
-    /**
+    @ArquillianResource
+    private URL deploymentBaseUrl;
+
+   /**
      * @tpTestDetails gzip is disabled on server
      *                gzip is allowed on client by resteasy.allowGzip system property
      * @tpSince RESTEasy 3.6
      */
     @Test
-    @OperateOnDeployment("war_without_providers_file")
+    @OperateOnDeployment(WAR_WITHOUT_PROVIDERS_FILE)
     public void noProvidersFileOnServer() throws Exception {
-        testNormalClient(false, "null", true, false);
+        testNormalClient(deploymentBaseUrl, false, "null", true, false);
     }
 
     /**
@@ -40,9 +46,9 @@ public class NotAllowGzipOnServerAllowGzipOnClientTest extends GzipAbstractTest 
      * @tpSince RESTEasy 3.6
      */
     @Test
-    @OperateOnDeployment("war_with_providers_file")
+    @OperateOnDeployment(WAR_WITH_PROVIDERS_FILE)
     public void providersFileOnServer() throws Exception {
-        testNormalClient(false, "null", true, true);
+        testNormalClient(deploymentBaseUrl, false, "null", true, true);
     }
 
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/NotAllowGzipOnServerNotAllowGzipOnClientTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/NotAllowGzipOnServerNotAllowGzipOnClientTest.java
@@ -1,7 +1,10 @@
 package org.jboss.resteasy.test.interceptor.gzip;
 
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
+
+import java.net.URL;
 
 /**
  * @tpSubChapter Gzip
@@ -9,17 +12,20 @@ import org.junit.Test;
  * @tpTestCaseDetails Regression test for RESTEASY-1735
  * @tpSince RESTEasy 3.6
  */
-public class NotAllowGzipOnServerNotAllowGzipOnClientTest extends GzipAbstractTest {
+public class NotAllowGzipOnServerNotAllowGzipOnClientTest extends NotAllowGzipOnServerAbstractTestBase {
 
-    /**
+   @ArquillianResource
+   private URL deploymentBaseUrl;
+
+   /**
      * @tpTestDetails gzip is disabled on server
      *                gzip is disabled on client
      * @tpSince RESTEasy 3.6
      */
     @Test
-    @OperateOnDeployment("war_without_providers_file")
+    @OperateOnDeployment(WAR_WITHOUT_PROVIDERS_FILE)
     public void noProvidersFileNoManualImportOnClient() throws Exception {
-        testNormalClient(false, "null", false, false);
+        testNormalClient(deploymentBaseUrl, false, "null", false, false);
     }
 
     /**
@@ -28,9 +34,9 @@ public class NotAllowGzipOnServerNotAllowGzipOnClientTest extends GzipAbstractTe
      * @tpSince RESTEasy 3.6
      */
     @Test
-    @OperateOnDeployment("war_with_providers_file")
+    @OperateOnDeployment(WAR_WITH_PROVIDERS_FILE)
     public void providersFileManualImportOnClient() throws Exception {
-        testNormalClient(true, "null", true, true);
+        testNormalClient(deploymentBaseUrl, true, "null", true, true);
     }
 
 
@@ -40,9 +46,9 @@ public class NotAllowGzipOnServerNotAllowGzipOnClientTest extends GzipAbstractTe
      * @tpSince RESTEasy 3.6
      */
     @Test
-    @OperateOnDeployment("war_with_providers_file")
+    @OperateOnDeployment(WAR_WITH_PROVIDERS_FILE)
     public void providersFileNoManualImportOnClient() throws Exception {
-        testNormalClient(false, "null", false, false);
+        testNormalClient(deploymentBaseUrl, false, "null", false, false);
     }
 
 
@@ -52,9 +58,9 @@ public class NotAllowGzipOnServerNotAllowGzipOnClientTest extends GzipAbstractTe
      * @tpSince RESTEasy 3.6
      */
     @Test
-    @OperateOnDeployment("war_without_providers_file")
+    @OperateOnDeployment(WAR_WITHOUT_PROVIDERS_FILE)
     public void noProvidersFileManualImportOnClient() throws Exception {
-        testNormalClient(true, "null", true, false);
+        testNormalClient(deploymentBaseUrl, true, "null", true, false);
     }
 
 }

--- a/testsuite/integration-tests/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests/src/test/resources/arquillian.xml
@@ -4,19 +4,29 @@
         http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
     <defaultProtocol type="Servlet 3.0" />
-    <container qualifier="jbossas-managed" default="true">
-        <configuration>
-            <property name="jbossHome">${jboss.home}</property>
-            <property name="jbossArguments">${securityManagerArg}</property>
-            <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
-            <!--<property name="javaVmArguments">-Xmx512m -XX:MaxPermSize=128m
-                -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y
-            </property>-->
-            <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${allow.gzip.server.jvm.arg} ${ipv6ArquillianSettings} ${jacoco.agent}</property>
-            <!--<property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent}</property>-->
-            <property name="managementAddress">${node}</property>
-        </configuration>
-    </container>
+    <group qualifier="integration-tests" default="true">
+        <container qualifier="jbossas-managed" default="true">
+            <configuration>
+                <property name="jbossHome">${jboss.home}</property>
+                <property name="jbossArguments">${securityManagerArg}</property>
+                <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
+
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=0</property>
+                <property name="managementAddress">${node}</property>
+                <property name="managementPort">9990</property>
+            </configuration>
+        </container>
+        <container qualifier="jbossas-manual-gzip" mode="manual">
+            <configuration>
+                <property name="jbossHome">${jboss.home}</property>
+                <property name="jbossArguments">${securityManagerArg}</property>
+                <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Dee8.preview.mode=${ee8.preview.mode} -Djboss.socket.binding.port-offset=1000 -Dresteasy.allowGzip=true</property>
+                <property name="managementAddress">${node}</property>
+                <property name="managementPort">10990</property><!-- keep in sync with port-offset -->
+            </configuration>
+        </container>
+    </group>
     <extension qualifier="systemproperties">
         <property name="prefix">org.jboss.resteasy.</property>
     </extension>


### PR DESCRIPTION
https://issues.jboss.org/browse/RESTEASY-1884
Removal of extra surefire execution just for two testcases, instead new container with needed settings is manually started for these tests.