### PR TITLE
[RESTEASY-1995] remove unused imports from JaxrsWithSpringMVCTest

### DIFF
--- a/testsuite/integration-tests-spring/deployment/src/test/java/org/jboss/resteasy/test/spring/deployment/JaxrsWithSpringMVCTest.java
+++ b/testsuite/integration-tests-spring/deployment/src/test/java/org/jboss/resteasy/test/spring/deployment/JaxrsWithSpringMVCTest.java
@@ -1,11 +1,7 @@
 package org.jboss.resteasy.test.spring.deployment;
 
-import java.security.AllPermission;
 import javax.json.JsonArray;
 
-import javax.xml.ws.WebServicePermission;
-import org.apache.http.HttpEntity;
-import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -28,14 +24,10 @@ import org.junit.runner.RunWith;
 import javax.management.MBeanPermission;
 import javax.management.MBeanServerPermission;
 import javax.management.MBeanTrustPermission;
-import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import java.io.FilePermission;
 import java.lang.reflect.ReflectPermission;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.PropertyPermission;
 import java.util.logging.LoggingPermission;
 


### PR DESCRIPTION
testsuite/integration-tests-spring/deployment module can't be built with unused import of `javax.xml.ws.WebServicePermission` on JDK11:

```
11:32:52 [ERROR] COMPILATION ERROR : 
11:32:52 [INFO] -------------------------------------------------------------
11:32:52 [ERROR] /home/hudson/hudson_workspace/workspace/eap-7.x-resteasy-functional-ts-rhel/64f1522b/resteasy/testsuite/integration-tests-spring/deployment/src/test/java/org/jboss/resteasy/test/spring/deployment/JaxrsWithSpringMVCTest.java:[6,20] package javax.xml.ws does not exist
```

JDK11 test run with this fix is linked on [jira](https://issues.jboss.org/browse/RESTEASY-1995)

Jira: https://issues.jboss.org/browse/RESTEASY-1995
3.6.1.SPx PR: https://github.com/resteasy/Resteasy/pull/1662
master PR: merged a few time ago: https://github.com/resteasy/Resteasy/pull/1611