### PR TITLE
RESTEASY_3.6-1983: Instances built from org.jboss.resteasy.client.jaxrs.internal.ClientWebTarget must inherit of a detached snaphot of the parent configuration

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/LocalResteasyProviderFactory.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/LocalResteasyProviderFactory.java
@@ -1,12 +1,6 @@
 package org.jboss.resteasy.client.jaxrs.internal;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import javax.ws.rs.RuntimeType;
-import javax.ws.rs.core.Feature;
 
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
@@ -25,65 +19,7 @@ public class LocalResteasyProviderFactory extends ResteasyProviderFactory
    {
       super(factory, true);
    }
-   
-   @Override
-   public boolean isEnabled(Feature feature)
-   {
-      for (Feature f : enabledFeatures)
-      {
-         if (f == feature)
-         {
-            return true;
-         }
-      }
-      return false;
-   }
 
-   @Override
-   public boolean isEnabled(Class<? extends Feature> featureClass)
-   {
-      if (enabledFeatures == null) return false;
-      for (Feature feature : enabledFeatures)
-      {
-         if (featureClass.equals(feature.getClass()))
-         {
-            return true;
-         }
-      }
-      return false;
-   }
-
-   @Override
-   public boolean isRegistered(Class<?> componentClass)
-   {
-      if (providerClasses.contains(componentClass)) return true;
-      for (Object obj : providerInstances)
-      {
-         if (obj.getClass().equals(componentClass)) return true;
-      }
-      return false;
-   }
-   
-   @Override
-   public Map<Class<?>, Integer> getContracts(Class<?> componentClass)
-   {
-      Map<Class<?>, Integer> classIntegerMap = classContracts.get(componentClass);
-      if (classIntegerMap == null) return Collections.emptyMap();
-      return classIntegerMap;
-   }
-
-   @Override
-   public Set<Class<?>> getProviderClasses()
-   {
-      return new HashSet<Class<?>>(providerClasses);
-   }
-   
-   @Override
-   public Set<Object> getProviderInstances()
-   {
-      return new HashSet<Object>(providerInstances);
-   }
-   
    @Override
    public RuntimeType getRuntimeType()
    {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/InterceptorRegistry.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/InterceptorRegistry.java
@@ -161,7 +161,7 @@ public class InterceptorRegistry<T>
       InterceptorRegistry<T> clone = new InterceptorRegistry<T>(intf, factory);
       clone.interceptors.addAll(interceptors);
       clone.precedenceOrder.putAll(precedenceOrder);
-      precedenceList.addAll(precedenceList);
+      clone.precedenceList.addAll(precedenceList);
       return clone;
    }
 

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -370,15 +370,15 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
       headerDelegates = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getHeaderDelegates());
 
       precedence = new LegacyPrecedence();
-      serverReaderInterceptorRegistry = parent == null ? new ReaderInterceptorRegistry(this, precedence) : parent.serverReaderInterceptorRegistry.clone(this);
-      serverWriterInterceptorRegistry = parent == null ? new WriterInterceptorRegistry(this, precedence) : parent.serverWriterInterceptorRegistry.clone(this);
-      containerRequestFilterRegistry = parent == null ? new ContainerRequestFilterRegistry(this, precedence) : parent.containerRequestFilterRegistry.clone(this);
+      serverReaderInterceptorRegistry = parent == null ? new ReaderInterceptorRegistry(this, precedence) : parent.getServerReaderInterceptorRegistry().clone(this);
+      serverWriterInterceptorRegistry = parent == null ? new WriterInterceptorRegistry(this, precedence) : parent.getServerWriterInterceptorRegistry().clone(this);
+      containerRequestFilterRegistry = parent == null ? new ContainerRequestFilterRegistry(this, precedence) : parent.getContainerRequestFilterRegistry().clone(this);
 
-      clientRequestFilterRegistry = parent == null ? new ClientRequestFilterRegistry(this) : parent.clientRequestFilterRegistry.clone(this);
-      clientRequestFilters = parent == null ? new JaxrsInterceptorRegistry<ClientRequestFilter>(this, ClientRequestFilter.class) : parent.clientRequestFilters.clone(this);
-      clientResponseFilters = parent == null ? new ClientResponseFilterRegistry(this) : parent.clientResponseFilters.clone(this);
-      clientReaderInterceptorRegistry = parent == null ? new ReaderInterceptorRegistry(this, precedence) : parent.clientReaderInterceptorRegistry.clone(this);
-      clientWriterInterceptorRegistry = parent == null ? new WriterInterceptorRegistry(this, precedence) : parent.clientWriterInterceptorRegistry.clone(this);
+      clientRequestFilterRegistry = parent == null ? new ClientRequestFilterRegistry(this) : parent.getClientRequestFilterRegistry().clone(this);
+      clientRequestFilters = parent == null ? new JaxrsInterceptorRegistry<ClientRequestFilter>(this, ClientRequestFilter.class) : parent.getClientRequestFilters().clone(this);
+      clientResponseFilters = parent == null ? new ClientResponseFilterRegistry(this) : parent.getClientResponseFilters().clone(this);
+      clientReaderInterceptorRegistry = parent == null ? new ReaderInterceptorRegistry(this, precedence) : parent.getClientReaderInterceptorRegistry().clone(this);
+      clientWriterInterceptorRegistry = parent == null ? new WriterInterceptorRegistry(this, precedence) : parent.getClientWriterInterceptorRegistry().clone(this);
       clientExecutionInterceptorRegistry = parent == null ? new InterceptorRegistry<ClientExecutionInterceptor>(ClientExecutionInterceptor.class, this) : parent.getClientExecutionInterceptorRegistry().cloneTo(this);
 
       clientErrorInterceptors = parent == null ? new CopyOnWriteArrayList<>() : new CopyOnWriteArrayList<>(parent.getClientErrorInterceptors());

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -341,14 +341,7 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
       clientMessageBodyReaders = parent == null ? new MediaTypeMap<>() : parent.getClientMessageBodyReaders().clone();
       clientMessageBodyWriters = parent == null ? new MediaTypeMap<>() : parent.getClientMessageBodyWriters().clone();
       sortedExceptionMappers = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getSortedExceptionMappers());
-      exceptionMappers = new ConcurrentHashMap<>();
-      if (parent != null)
-      {
-         for (Entry<Class<?>, SortedKey<ExceptionMapper>> entry : getSortedExceptionMappers().entrySet())
-         {
-            exceptionMappers.put(entry.getKey(), entry.getValue().getObj());
-         }
-      }
+      exceptionMappers = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getExceptionMappers());
       clientExceptionMappers = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getClientExceptionMappers());
       asyncResponseProviders = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getAsyncResponseProviders());
       asyncClientResponseProviders = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getAsyncClientResponseProviders());
@@ -373,6 +366,7 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
       serverReaderInterceptorRegistry = parent == null ? new ReaderInterceptorRegistry(this, precedence) : parent.getServerReaderInterceptorRegistry().clone(this);
       serverWriterInterceptorRegistry = parent == null ? new WriterInterceptorRegistry(this, precedence) : parent.getServerWriterInterceptorRegistry().clone(this);
       containerRequestFilterRegistry = parent == null ? new ContainerRequestFilterRegistry(this, precedence) : parent.getContainerRequestFilterRegistry().clone(this);
+      containerResponseFilterRegistry = parent == null ? new ContainerResponseFilterRegistry(this, precedence) : parent.getContainerResponseFilterRegistry().clone(this);
 
       clientRequestFilterRegistry = parent == null ? new ClientRequestFilterRegistry(this) : parent.getClientRequestFilterRegistry().clone(this);
       clientRequestFilters = parent == null ? new JaxrsInterceptorRegistry<ClientRequestFilter>(this, ClientRequestFilter.class) : parent.getClientRequestFilters().clone(this);

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -340,6 +340,7 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
       serverMessageBodyWriters = parent == null ? new MediaTypeMap<>() : parent.getServerMessageBodyWriters().clone();
       clientMessageBodyReaders = parent == null ? new MediaTypeMap<>() : parent.getClientMessageBodyReaders().clone();
       clientMessageBodyWriters = parent == null ? new MediaTypeMap<>() : parent.getClientMessageBodyWriters().clone();
+      sortedExceptionMappers = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getSortedExceptionMappers());
       exceptionMappers = new ConcurrentHashMap<>();
       if (parent != null)
       {
@@ -348,7 +349,6 @@ public class ResteasyProviderFactory extends RuntimeDelegate implements Provider
             exceptionMappers.put(entry.getKey(), entry.getValue().getObj());
          }
       }
-      sortedExceptionMappers = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getSortedExceptionMappers());
       clientExceptionMappers = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getClientExceptionMappers());
       asyncResponseProviders = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getAsyncResponseProviders());
       asyncClientResponseProviders = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getAsyncClientResponseProviders());

--- a/security-legacy/keystone/keystone-core/src/test/java/org/jboss/resteasy/test/keystone/TokenTest.java
+++ b/security-legacy/keystone/keystone-core/src/test/java/org/jboss/resteasy/test/keystone/TokenTest.java
@@ -261,8 +261,8 @@ public class TokenTest
    {
       Authentication auth = new SkeletonKeyClientBuilder().username("wburke").password("geheim").authentication("Skeleton Key");
       ResteasyClient client = new ResteasyClientBuilder().build();
-      WebTarget target = client.target(generateBaseUrl());
       Mappers.registerContextResolver(client);
+      WebTarget target = client.target(generateBaseUrl());
       String tiny = target.path("tokens").path("url").request().post(Entity.json(auth), String.class);
       System.out.println(tiny);
       System.out.println("tiny.size: " + tiny.length());


### PR DESCRIPTION
This pull request is for JIRA https://issues.jboss.org/browse/RESTEASY-1983.
Branch: 3.6
Master PR:  https://github.com/resteasy/Resteasy/pull/1648 