### PR TITLE
[RESTEASY-1999] Do not use specific rxjava dependency in TS

### DIFF
--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/TestUtilRxJava.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/TestUtilRxJava.java
@@ -36,7 +36,7 @@ public class TestUtilRxJava {
         List<File> runtimeDependencies = new ArrayList<>();
         
         try {
-            runtimeDependencies.add(mavenUtil.createMavenGavFile("org.jboss.resteasy:resteasy-rxjava:" + System.getProperty("version.resteasy.testsuite")));
+            runtimeDependencies.add(mavenUtil.createMavenGavFile("org.jboss.resteasy:resteasy-rxjava:" + System.getProperty("project.version")));
             runtimeDependencies.add(mavenUtil.createMavenGavFile("io.reactivex:rxjava:" + getRxJavaVersion()));
             runtimeDependencies.add(mavenUtil.createMavenGavFile("io.reactivex:rxjava-reactive-streams:" + getRxJavaReactiveStreamsVersion()));
         } catch (Exception e) {

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -371,7 +371,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-rxjava</artifactId>
-            <version>${version.resteasy.testsuite}</version>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Do not use specific rxjava dependency in TS, because rxjava is not used in WF, so no need to change this version

Jira: https://issues.jboss.org/browse/RESTEASY-1999
3.6 PR: https://github.com/resteasy/Resteasy/pull/1669
master PR: https://github.com/resteasy/Resteasy/pull/1671