### PR TITLE
[RESTEASY-1999] Do not use specific rxjava dependency in TS

### DIFF
--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/TestUtilRxJava.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/TestUtilRxJava.java
@@ -42,7 +42,7 @@ public class TestUtilRxJava {
         
         try {
             runtimeDependencies.add(mavenUtil.createMavenGavFile("org.jboss.resteasy:resteasy-reactive-context:" + System.getProperty("version.resteasy.testsuite")));
-            runtimeDependencies.add(mavenUtil.createMavenGavFile("org.jboss.resteasy:resteasy-rxjava:" + System.getProperty("version.resteasy.testsuite")));
+            runtimeDependencies.add(mavenUtil.createMavenGavFile("org.jboss.resteasy:resteasy-rxjava:" + System.getProperty("project.version")));
             runtimeDependencies.add(mavenUtil.createMavenGavFile("io.reactiverse:reactive-contexts-core:" + getReactiveContextsVersion()));
             runtimeDependencies.add(mavenUtil.createMavenGavFile("io.reactiverse:reactive-contexts-propagators-rxjava1:" + getReactiveContextsVersion()));
             runtimeDependencies.add(mavenUtil.createMavenGavFile("io.reactivex:rxjava:" + getRxJavaVersion()));

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -375,7 +375,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-rxjava</artifactId>
-            <version>${version.resteasy.testsuite}</version>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Do not use specific rxjava dependency in TS, because rxjava is not used in WF, so no need to change this version

Jira: https://issues.jboss.org/browse/RESTEASY-1999
3.6 PR: https://github.com/resteasy/Resteasy/pull/1669
3.6.1 PR: https://github.com/resteasy/Resteasy/pull/1670