### PR TITLE
[RESTEASY-2003] Isolate container standalone dir in tests

### DIFF
--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/LogCounter.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/LogCounter.java
@@ -20,16 +20,27 @@ public class LogCounter {
     private boolean onServer;
 
 
-    public LogCounter(String message, boolean onServer) {
+    /**
+     * Container qualifier when arquillian starts multiple instance, null otherwise.
+     */
+    private String containerQualifier;
+
+
+    public LogCounter(String message, boolean onServer, String containerQualifier) {
         this.message = message;
         this.onServer = onServer;
-        initCount = TestUtil.getWarningCount(message, onServer);
+        this.containerQualifier = containerQualifier;
+        this.initCount = TestUtil.getWarningCount(message, onServer, containerQualifier);
+    }
+
+    public LogCounter(String message, boolean onServer) {
+        this(message, onServer, null);
     }
 
     /**
      * Get count of examined log message, logged after creation of this LogCounter
      */
     public int count() {
-        return TestUtil.getWarningCount(message, onServer) - initCount;
+        return TestUtil.getWarningCount(message, onServer, containerQualifier) - initCount;
     }
 }

--- a/testsuite/integration-tests-spring/deployment/pom.xml
+++ b/testsuite/integration-tests-spring/deployment/pom.xml
@@ -33,7 +33,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>process-test-classes</phase>
+                        <phase>generate-test-resources</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>
@@ -57,8 +57,8 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>unpack resteasy</id>
-                        <phase>process-test-classes</phase>
+                        <id>unpack-resteasy</id>
+                        <phase>generate-test-resources</phase>
                         <configuration>
                             <target>
                                 <!-- Explicitly remove resteasy-spring contents as the module.xml does not reference resource jars in this case

--- a/testsuite/integration-tests-spring/inmodule/pom.xml
+++ b/testsuite/integration-tests-spring/inmodule/pom.xml
@@ -39,7 +39,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>process-test-classes</phase>
+                        <phase>generate-test-resources</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>
@@ -63,8 +63,8 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>unpack resteasy</id>
-                        <phase>process-test-classes</phase>
+                        <id>unpack-resteasy</id>
+                        <phase>generate-test-resources</phase>
                         <configuration>
                             <target>
                                 <!-- Explicitly remove resteasy-spring contents as the module.xml does not reference resource jars in this case

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>process-test-classes</phase>
+                        <phase>generate-test-resources</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>
@@ -61,8 +61,8 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>unpack resteasy</id>
-                        <phase>process-test-classes</phase>
+                        <id>unpack-resteasy</id>
+                        <phase>generate-test-resources</phase>
                         <configuration>
                             <target>
                                 <!-- Explicitly remove resteasy-spring contents as the module.xml does not reference resource jars in this case

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -13,6 +13,14 @@
 
     <properties>
         <maven.compiler.parameters>true</maven.compiler.parameters>
+        <container.base.dir.managed>${project.build.directory}${file.separator}${container.qualifier.managed}</container.base.dir.managed>
+        <container.base.dir.manual.gzip>${project.build.directory}${file.separator}${container.qualifier.manual.gzip}</container.base.dir.manual.gzip>
+        <container.offset.managed>0</container.offset.managed>
+        <container.offset.manual.gzip>1000</container.offset.manual.gzip>
+        <container.management.port.managed>9990</container.management.port.managed><!-- keep in sync with port offset -->
+        <container.management.port.manual.gzip>10990</container.management.port.manual.gzip><!-- keep in sync with port offset -->
+        <container.qualifier.managed>jbossas-managed</container.qualifier.managed>
+        <container.qualifier.manual.gzip>jbossas-manual-gzip</container.qualifier.manual.gzip>
     </properties>
 
     <artifactId>resteasy-integration-tests</artifactId>
@@ -406,6 +414,37 @@
             </testResource>
         </testResources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>initialize-basedirs</id>
+                        <phase>process-test-classes</phase>
+                        <configuration>
+                            <target>
+                                <!-- Initialize basedir for tested container by copying
+                                     the original into new place.
+                                     This helps to isolate the multiple running instances.
+                                     One copy per each container in arquillian.xml -->
+                                
+                                <delete quiet="true" dir="${container.base.dir.managed}" />
+                                <copy todir="${container.base.dir.managed}" overwrite="true" failonerror="true">
+                                    <fileset dir="${jboss.home}/standalone"/>
+                                </copy>
+
+                                <delete quiet="true" dir="${container.base.dir.manual.gzip}" />
+                                <copy todir="${container.base.dir.manual.gzip}" overwrite="true" failonerror="true">
+                                    <fileset dir="${jboss.home}/standalone"/>
+                                </copy>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                     <executions>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/ContainerConstants.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/ContainerConstants.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.test;
+
+import java.io.File;
+
+/**
+ * Various contants for containers defined in arquillian.xml. Keep this file in sync with the values there.
+ */
+public class ContainerConstants {
+
+   public static final String DEFAULT_CONTAINER_QUALIFIER = "jbossas-managed";
+
+   public static final String GZIP_CONTAINER_QUALIFIER = "jbossas-manual-gzip";
+
+   public static final int GZIP_CONTAINER_PORT_OFFSET = 1000;
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/CDIResourceTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/CDIResourceTest.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.test.ContainerConstants;
 import org.jboss.resteasy.util.HttpResponseCodes;
 import org.jboss.resteasy.utils.PermissionUtil;
 import org.jboss.resteasy.utils.PortProviderUtil;
@@ -57,8 +58,7 @@ public class CDIResourceTest {
 
     static {
         toStr = new StringBuilder()
-                .append(TestUtil.getJbossHome()).append(File.separator)
-                .append("standalone").append(File.separator)
+                .append(TestUtil.getStandaloneDir(ContainerConstants.DEFAULT_CONTAINER_QUALIFIER)).append(File.separator)
                 .append("deployments").append(File.separator)
                 .append(WAR_NAME).toString();
         exportFile = new File(FileSystems.getDefault().getPath("target").toFile(), WAR_NAME);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
@@ -22,6 +22,8 @@ import java.lang.reflect.ReflectPermission;
 import java.util.PropertyPermission;
 import java.util.logging.LoggingPermission;
 
+import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALIFIER;
+
 /**
  * @tpSubChapter Resteasy-client
  * @tpChapter Unit tests
@@ -38,7 +40,7 @@ public class ClientBuilderTest {
         war.addClass(NotForForwardCompatibility.class);
         // Arquillian in the deployment and use of TestUtil
         war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
-                new FilePermission(TestUtil.getJbossHome() + File.separator + "standalone" + File.separator + "log" +
+                new FilePermission(TestUtil.getStandaloneDir(DEFAULT_CONTAINER_QUALIFIER) + File.separator + "log" +
                         File.separator + "server.log", "read"),
                 new LoggingPermission("control", ""),
                 new PropertyPermission("arquillian.*", "read"),
@@ -58,7 +60,7 @@ public class ClientBuilderTest {
     }
 
     private int getWarningCount() {
-        return TestUtil.getWarningCount("RESTEASY002155", true);
+        return TestUtil.getWarningCount("RESTEASY002155", true, DEFAULT_CONTAINER_QUALIFIER);
     }
 
     /**
@@ -86,16 +88,16 @@ public class ClientBuilderTest {
     @Test
     @Category({NotForForwardCompatibility.class})
     public void testDoubleRegistration() {
-        int countRESTEASY002160 = TestUtil.getWarningCount("RESTEASY002160", true);
-        int countRESTEASY002155 = TestUtil.getWarningCount("RESTEASY002155", true);
+        int countRESTEASY002160 = TestUtil.getWarningCount("RESTEASY002160", true, DEFAULT_CONTAINER_QUALIFIER);
+        int countRESTEASY002155 = TestUtil.getWarningCount("RESTEASY002155", true, DEFAULT_CONTAINER_QUALIFIER);
         Client client = ClientBuilder.newClient();
         int count = client.getConfiguration().getInstances().size();
         Object reg = new FeatureReturningFalse();
 
         client.register(reg).register(reg);
         client.register(FeatureReturningFalse.class).register(FeatureReturningFalse.class);
-        Assert.assertEquals("Expect 1 warnining messages of Provider instance is already registered", 1, TestUtil.getWarningCount("RESTEASY002160", true) - countRESTEASY002160);
-        Assert.assertEquals("Expect 1 warnining messages of Provider class is already registered", 2, TestUtil.getWarningCount("RESTEASY002155", true) - countRESTEASY002155);
+        Assert.assertEquals("Expect 1 warnining messages of Provider instance is already registered", 1, TestUtil.getWarningCount("RESTEASY002160", true, DEFAULT_CONTAINER_QUALIFIER) - countRESTEASY002160);
+        Assert.assertEquals("Expect 1 warnining messages of Provider class is already registered", 2, TestUtil.getWarningCount("RESTEASY002155", true, DEFAULT_CONTAINER_QUALIFIER) - countRESTEASY002155);
         Assert.assertEquals(count + 1, client.getConfiguration().getInstances().size());
 
         client.close();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/DuplicateDeploymentTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/DuplicateDeploymentTest.java
@@ -19,6 +19,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALIFIER;
+
 /**
  * @tpSubChapter Response
  * @tpChapter Integration tests
@@ -31,7 +33,7 @@ public class DuplicateDeploymentTest {
     private static int initWarningCount = 0;
 
     private static int getWarningCount() {
-        return TestUtil.getWarningCount("RESTEASY002172", false);
+        return TestUtil.getWarningCount("RESTEASY002172", false, DEFAULT_CONTAINER_QUALIFIER);
     }
 
     @Deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/logging/DebugLoggingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/logging/DebugLoggingTest.java
@@ -34,6 +34,7 @@ import javax.ws.rs.core.Response;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
+import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALIFIER;
 
 /**
  * @tpSubChapter Interceptors
@@ -109,10 +110,10 @@ public class DebugLoggingTest {
     @Test
     public void  testBuildIn() throws Exception {
         // count log messages before request
-        LogCounter bodyReaderStringLog = new LogCounter("MessageBodyReader: org.jboss.resteasy.plugins.providers.StringTextStar", false);
-        LogCounter bodyWriterStringLog = new LogCounter("MessageBodyWriter: org.jboss.resteasy.plugins.providers.StringTextStar", false);
-        LogCounter readerInterceptorLog = new LogCounter("ReaderInterceptor: org.jboss.resteasy.security.doseta.DigitalVerificationInterceptor", false);
-        LogCounter writerInterceptorLog = new LogCounter("WriterInterceptor: org.jboss.resteasy.security.doseta.DigitalSigningInterceptor", false);
+        LogCounter bodyReaderStringLog = new LogCounter("MessageBodyReader: org.jboss.resteasy.plugins.providers.StringTextStar", false, DEFAULT_CONTAINER_QUALIFIER);
+        LogCounter bodyWriterStringLog = new LogCounter("MessageBodyWriter: org.jboss.resteasy.plugins.providers.StringTextStar", false, DEFAULT_CONTAINER_QUALIFIER);
+        LogCounter readerInterceptorLog = new LogCounter("ReaderInterceptor: org.jboss.resteasy.security.doseta.DigitalVerificationInterceptor", false, DEFAULT_CONTAINER_QUALIFIER);
+        LogCounter writerInterceptorLog = new LogCounter("WriterInterceptor: org.jboss.resteasy.security.doseta.DigitalSigningInterceptor", false, DEFAULT_CONTAINER_QUALIFIER);
 
         // perform request
         WebTarget base = client.target(PortProviderUtil.generateURL("/build/in", BUILD_IN));
@@ -135,16 +136,16 @@ public class DebugLoggingTest {
     @Test
     public void  testCustom() throws Exception {
         // count log messages before request
-        LogCounter bodyReaderStringLog = new LogCounter("MessageBodyReader: org.jboss.resteasy.plugins.providers.StringTextStar", false);
-        LogCounter bodyWriterStringLog = new LogCounter("MessageBodyWriter: org.jboss.resteasy.plugins.providers.StringTextStar", false);
-        LogCounter readerInterceptorLog = new LogCounter("ReaderInterceptor: org.jboss.resteasy.test.core.logging.resource.DebugLoggingReaderInterceptorCustom", false);
-        LogCounter writerInterceptorLog = new LogCounter("WriterInterceptor: org.jboss.resteasy.test.core.logging.resource.DebugLoggingWriterInterceptorCustom", false);
-        LogCounter bodyReaderCustomLog = new LogCounter("MessageBodyReader: org.jboss.resteasy.test.core.logging.resource.DebugLoggingCustomReaderAndWriter", false);
-        LogCounter bodyWriterCustomLog = new LogCounter("MessageBodyWriter: org.jboss.resteasy.test.core.logging.resource.DebugLoggingCustomReaderAndWriter", false);
+        LogCounter bodyReaderStringLog = new LogCounter("MessageBodyReader: org.jboss.resteasy.plugins.providers.StringTextStar", false, DEFAULT_CONTAINER_QUALIFIER);
+        LogCounter bodyWriterStringLog = new LogCounter("MessageBodyWriter: org.jboss.resteasy.plugins.providers.StringTextStar", false, DEFAULT_CONTAINER_QUALIFIER);
+        LogCounter readerInterceptorLog = new LogCounter("ReaderInterceptor: org.jboss.resteasy.test.core.logging.resource.DebugLoggingReaderInterceptorCustom", false, DEFAULT_CONTAINER_QUALIFIER);
+        LogCounter writerInterceptorLog = new LogCounter("WriterInterceptor: org.jboss.resteasy.test.core.logging.resource.DebugLoggingWriterInterceptorCustom", false, DEFAULT_CONTAINER_QUALIFIER);
+        LogCounter bodyReaderCustomLog = new LogCounter("MessageBodyReader: org.jboss.resteasy.test.core.logging.resource.DebugLoggingCustomReaderAndWriter", false, DEFAULT_CONTAINER_QUALIFIER);
+        LogCounter bodyWriterCustomLog = new LogCounter("MessageBodyWriter: org.jboss.resteasy.test.core.logging.resource.DebugLoggingCustomReaderAndWriter", false, DEFAULT_CONTAINER_QUALIFIER);
 
         // perform request
-        TestUtil.getWarningCount("MessageBodyReader: org.jboss.resteasy.plugins.providers.StringTextStar", false);
-        TestUtil.getWarningCount("MessageBodyWriter: org.jboss.resteasy.plugins.providers.StringTextStar", false);
+        TestUtil.getWarningCount("MessageBodyReader: org.jboss.resteasy.plugins.providers.StringTextStar", false, DEFAULT_CONTAINER_QUALIFIER);
+        TestUtil.getWarningCount("MessageBodyWriter: org.jboss.resteasy.plugins.providers.StringTextStar", false, DEFAULT_CONTAINER_QUALIFIER);
         WebTarget base = client.target(PortProviderUtil.generateURL("/custom", CUSTOM));
         Response response = base.request().post(Entity.entity("data", "aaa/bbb"));
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/ResourceClassProcessorErrorTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/ResourceClassProcessorErrorTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALIFIER;
 
 /**
  * @tpSubChapter ResourceClassProcessor SPI
@@ -55,7 +56,7 @@ public class ResourceClassProcessorErrorTest {
     @Test
     public void errorTest() {
         LogCounter errorLogCounter = new LogCounter("java.lang.RuntimeException: Exception from ResourceClassProcessorErrorImplementation",
-                false);
+                false, DEFAULT_CONTAINER_QUALIFIER);
         try {
             deployer.deploy(DEPLOYMENT_NAME);
             Assert.fail("Exception from ResourceClassProcessor was not thrown");

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/AllowGzipOnServerAbstractTestBase.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/gzip/AllowGzipOnServerAbstractTestBase.java
@@ -10,6 +10,9 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.junit.After;
 import org.junit.Before;
 
+import static org.jboss.resteasy.test.ContainerConstants.GZIP_CONTAINER_PORT_OFFSET;
+import static org.jboss.resteasy.test.ContainerConstants.GZIP_CONTAINER_QUALIFIER;
+
 /**
  * Abstract base class for tests with gzip enabled on server side.
  *
@@ -21,13 +24,8 @@ import org.junit.Before;
  */
 public class AllowGzipOnServerAbstractTestBase extends GzipAbstractTestBase {
 
-   /**
-    * Name of server with allowed gzip
-    */
-   protected static final String GZIP_SERVER_NAME = "jbossas-manual-gzip";
-
    //keep in sync with offset in arquillian.xml
-   protected static String gzipServerBaseUrl = "http://" + PortProviderUtil.getHost() + ":" + (PortProviderUtil.getPort() + 1000);
+   protected static String gzipServerBaseUrl = "http://" + PortProviderUtil.getHost() + ":" + (PortProviderUtil.getPort() + GZIP_CONTAINER_PORT_OFFSET);
 
    @ArquillianResource
    protected ContainerController containerController;
@@ -37,8 +35,8 @@ public class AllowGzipOnServerAbstractTestBase extends GzipAbstractTestBase {
 
    @Before
    public void startContainerWithGzipEnabledAndDeploy() {
-      if (!containerController.isStarted(GZIP_SERVER_NAME)) {
-         containerController.start(GZIP_SERVER_NAME);
+      if (!containerController.isStarted(GZIP_CONTAINER_QUALIFIER)) {
+         containerController.start(GZIP_CONTAINER_QUALIFIER);
       }
 
       deployer.deploy(WAR_WITH_PROVIDERS_FILE);
@@ -47,10 +45,10 @@ public class AllowGzipOnServerAbstractTestBase extends GzipAbstractTestBase {
 
    @After
    public void undeployAndStopContainerWithGzipEnabled() {
-      if (containerController.isStarted(GZIP_SERVER_NAME)) {
+      if (containerController.isStarted(GZIP_CONTAINER_QUALIFIER)) {
          deployer.undeploy(WAR_WITH_PROVIDERS_FILE);
          deployer.undeploy(WAR_WITHOUT_PROVIDERS_FILE);
-         containerController.stop(GZIP_SERVER_NAME);
+         containerController.stop(GZIP_CONTAINER_QUALIFIER);
       }
    }
 
@@ -58,7 +56,7 @@ public class AllowGzipOnServerAbstractTestBase extends GzipAbstractTestBase {
     * Deployment with javax.ws.rs.ext.Providers file, that contains gzip interceptor definition
     */
    @Deployment(name = WAR_WITH_PROVIDERS_FILE, managed = false, testable = false)
-   @TargetsContainer(GZIP_SERVER_NAME)
+   @TargetsContainer(GZIP_CONTAINER_QUALIFIER)
    public static Archive<?> createWebDeploymentWithGzipProvidersFile() {
       return createWebArchive(WAR_WITH_PROVIDERS_FILE, true);
    }
@@ -67,7 +65,7 @@ public class AllowGzipOnServerAbstractTestBase extends GzipAbstractTestBase {
     * Deployment without any javax.ws.rs.ext.Providers file
     */
    @Deployment(name = WAR_WITHOUT_PROVIDERS_FILE, managed = false, testable = false)
-   @TargetsContainer(GZIP_SERVER_NAME)
+   @TargetsContainer(GZIP_CONTAINER_QUALIFIER)
    public static Archive<?> createWebDeploymentWithoutGzipProvidersFile() {
       return createWebArchive(WAR_WITHOUT_PROVIDERS_FILE, false);
    }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/DuplicateProviderRegistrationTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/DuplicateProviderRegistrationTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.providers.custom;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
+import org.jboss.resteasy.test.ContainerConstants;
 import org.jboss.resteasy.test.providers.custom.resource.DuplicateProviderRegistrationFeature;
 import org.jboss.resteasy.test.providers.custom.resource.DuplicateProviderRegistrationFilter;
 import org.jboss.resteasy.test.providers.custom.resource.DuplicateProviderRegistrationInterceptor;
@@ -26,6 +27,8 @@ import java.lang.reflect.ReflectPermission;
 import java.util.PropertyPermission;
 import java.util.logging.LoggingPermission;
 
+import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALIFIER;
+
 /**
  * @tpSubChapter Providers
  * @tpChapter Integration tests
@@ -42,12 +45,12 @@ public class DuplicateProviderRegistrationTest {
     public static Archive<?> createTestArchive() {
         WebArchive war = TestUtil.prepareArchive(DuplicateProviderRegistrationTest.class.getSimpleName());
         war.addClasses(DuplicateProviderRegistrationFeature.class, DuplicateProviderRegistrationFilter.class,
-                TestUtil.class, DuplicateProviderRegistrationInterceptor.class);
+                TestUtil.class, DuplicateProviderRegistrationInterceptor.class, ContainerConstants.class);
         war.addClass(NotForForwardCompatibility.class);
         // Arquillian in the deployment, test reads the server.log
         war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
                 new ReflectPermission("suppressAccessChecks"),
-                new FilePermission(TestUtil.getJbossHome() + File.separator + "standalone" + File.separator + "log" +
+                new FilePermission(TestUtil.getStandaloneDir(DEFAULT_CONTAINER_QUALIFIER) + File.separator + "log" +
                         File.separator + "server.log", "read"),
                 new LoggingPermission("control", ""),
                 new PropertyPermission("arquillian.*", "read"),
@@ -58,11 +61,11 @@ public class DuplicateProviderRegistrationTest {
     }
 
     private static int getRESTEASY002155WarningCount() {
-        return TestUtil.getWarningCount("RESTEASY002155", true);
+        return TestUtil.getWarningCount("RESTEASY002155", true, DEFAULT_CONTAINER_QUALIFIER);
     }
     
     private static int getRESTEASY002160WarningCount() {
-       return TestUtil.getWarningCount("RESTEASY002160", true);
+       return TestUtil.getWarningCount("RESTEASY002160", true, DEFAULT_CONTAINER_QUALIFIER);
    }
 
     /**

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/MissingProducerTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/MissingProducerTest.java
@@ -12,6 +12,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALIFIER;
+
 /**
  * @tpSubChapter Core
  * @tpChapter Integration tests
@@ -27,13 +29,13 @@ public class MissingProducerTest {
     private static int initLogMsg3Count = parseLog3();
 
     private static int parseLog1() {
-        return TestUtil.getWarningCount("RESTEASY002120: ClassNotFoundException: ", false);
+        return TestUtil.getWarningCount("RESTEASY002120: ClassNotFoundException: ", false, DEFAULT_CONTAINER_QUALIFIER);
     }
     private static int parseLog2() {
-        return TestUtil.getWarningCount("Unable to load builtin provider org.jboss.resteasy.Missing from ", false);
+        return TestUtil.getWarningCount("Unable to load builtin provider org.jboss.resteasy.Missing from ", false, DEFAULT_CONTAINER_QUALIFIER);
     }
     private static int parseLog3() {
-        return TestUtil.getWarningCount("classes/META-INF/services/javax.ws.rs.ext.Providers", false);
+        return TestUtil.getWarningCount("classes/META-INF/services/javax.ws.rs.ext.Providers", false, DEFAULT_CONTAINER_QUALIFIER);
     }
 
     @SuppressWarnings(value = "unchecked")

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jsonb/basic/JsonBindingAnnotationsJacksonTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jsonb/basic/JsonBindingAnnotationsJacksonTest.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALIFIER;
 
 /**
  * @tpSubChapter Json-binding provider.
@@ -137,7 +138,7 @@ public class JsonBindingAnnotationsJacksonTest {
     */
    @Test
    public void negativeScenarioOnServer() throws Exception {
-      LogCounter errorLogCounter = new LogCounter("ERROR", false);
+      LogCounter errorLogCounter = new LogCounter("ERROR", false, DEFAULT_CONTAINER_QUALIFIER);
       try {
          ResteasyClient client = new ResteasyClientBuilder().register(JsonBindingCustomRepeaterProvider.class).build();
          String charset = "UTF-8";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/request/NotFoundErrorMessageTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/request/NotFoundErrorMessageTest.java
@@ -22,6 +22,8 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 
+import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALIFIER;
+
 /**
  * @tpSubChapter Core
  * @tpChapter Integration tests
@@ -44,7 +46,7 @@ public class NotFoundErrorMessageTest {
     }
 
     private static int getWarningCount() {
-        return TestUtil.getWarningCount("RESTEASY002010", false);
+        return TestUtil.getWarningCount("RESTEASY002010", false, DEFAULT_CONTAINER_QUALIFIER);
     }
 
     @Deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/DuplicitePathTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/DuplicitePathTest.java
@@ -32,6 +32,7 @@ import javax.ws.rs.core.Response;
 
 import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.is;
+import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALIFIER;
 
 /**
  * @tpSubChapter Response
@@ -45,7 +46,7 @@ public class DuplicitePathTest {
     static ResteasyClient client;
 
     private static int getWarningCount() {
-        return TestUtil.getWarningCount("RESTEASY002142", false);
+        return TestUtil.getWarningCount("RESTEASY002142", false, DEFAULT_CONTAINER_QUALIFIER);
     }
 
     @Deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/warning/SubResourceWarningTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/warning/SubResourceWarningTest.java
@@ -17,6 +17,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 
+import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALIFIER;
+
 /**
  * @tpSubChapter Miscellaneous
  * @tpChapter Integration tests
@@ -28,7 +30,7 @@ import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 public class SubResourceWarningTest {
 
    // check server.log msg count before app is deployed.  Deploying causes messages to be logged.
-   private static int preTestCnt = TestUtil.getWarningCount("have the same path, [test", false);
+   private static int preTestCnt = TestUtil.getWarningCount("have the same path, [test", false, DEFAULT_CONTAINER_QUALIFIER);
 
    @Deployment
    public static Archive<?> deploySimpleResource() {
@@ -59,7 +61,7 @@ public class SubResourceWarningTest {
     */
    @Test
    public void testWarningMsg () throws Exception {
-      int cnt = TestUtil.getWarningCount("have the same path, [test", false);
+      int cnt = TestUtil.getWarningCount("have the same path, [test", false, DEFAULT_CONTAINER_QUALIFIER);
       Assert.assertEquals( "Improper log WARNING count", preTestCnt+2, cnt);
    }
 }

--- a/testsuite/integration-tests/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests/src/test/resources/arquillian.xml
@@ -5,24 +5,26 @@
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
     <defaultProtocol type="Servlet 3.0" />
     <group qualifier="integration-tests" default="true">
-        <container qualifier="jbossas-managed" default="true">
+        <container qualifier="${container.qualifier.managed}" default="true">
             <configuration>
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
-                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=0</property>
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.managed} -Djboss.server.base.dir=${container.base.dir.managed}
+                </property>
                 <property name="managementAddress">${node}</property>
-                <property name="managementPort">9990</property>
+                <property name="managementPort">${container.management.port.managed}</property>
             </configuration>
         </container>
-        <container qualifier="jbossas-manual-gzip" mode="manual">
+        <container qualifier="${container.qualifier.manual.gzip}" mode="manual">
             <configuration>
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
-                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=1000 -Dresteasy.allowGzip=true</property>
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.gzip} -Dresteasy.allowGzip=true -Djboss.server.base.dir=${container.base.dir.manual.gzip}
+                </property>
                 <property name="managementAddress">${node}</property>
-                <property name="managementPort">10990</property><!-- keep in sync with port-offset -->
+                <property name="managementPort">${container.management.port.manual.gzip}</property>
             </configuration>
         </container>
     </group>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -217,7 +217,7 @@
                         <executions>
                             <execution>
                                 <id>copy</id>
-                                <phase>generate-test-sources</phase>
+                                <phase>process-test-resources</phase>
                                 <configuration>
                                     <target>
                                         <copy file="${server.home}/standalone/configuration/standalone-full.xml"


### PR DESCRIPTION
https://issues.jboss.org/browse/RESTEASY-2003

To isolate the instance specific stuff I had to introduce few more steps for copying the standalone directory and retarget few plugin runs to different phases so that all is executed in proper order.

master branch PR https://github.com/resteasy/Resteasy/pull/1684