### PR TITLE
[RESTEASY-2004] Add java.se module to JDK11 testsuite runs

### DIFF
--- a/arquillian/RESTEASY-1056-jetty-bv11/src/test/resources/arquillian.xml
+++ b/arquillian/RESTEASY-1056-jetty-bv11/src/test/resources/arquillian.xml
@@ -24,8 +24,8 @@
     <container qualifier="jetty" default="true">
        <configuration>
            <property name="bindHttpPort">0</property>
-           <property name="javaVmArguments">${additionalJvmArgs}</property>
-           <!--property name="javaVmArguments">${additionalJvmArgs} -Xdebug -Xrunjdwp:transport=dt_socket,address=8585,server=y, suspend=y</property-->
+           <property name="javaVmArguments">${additionalJvmArgs} ${modular.jdk.args}</property>
+           <!--property name="javaVmArguments">${additionalJvmArgs} ${modular.jdk.args} -Xdebug -Xrunjdwp:transport=dt_socket,address=8585,server=y, suspend=y</property-->
        </configuration>
     </container>
 </arquillian>

--- a/arquillian/RESTEASY-1630-jetty-resteasy-servlet-initializer/src/test/resources/arquillian.xml
+++ b/arquillian/RESTEASY-1630-jetty-resteasy-servlet-initializer/src/test/resources/arquillian.xml
@@ -24,9 +24,9 @@
     <container qualifier="jetty" default="true">
        <configuration>
            <property name="bindHttpPort">0</property>
-           <property name="javaVmArguments">${additionalJvmArgs}</property>
+           <property name="javaVmArguments">${additionalJvmArgs} ${modular.jdk.args}</property>
          <!--
-           <property name="javaVmArguments">${additionalJvmArgs} -Xdebug -Xrunjdwp:transport=dt_socket,address=8585,server=y, suspend=n</property>
+           <property name="javaVmArguments">${additionalJvmArgs} ${modular.jdk.args} -Xdebug -Xrunjdwp:transport=dt_socket,address=8585,server=y, suspend=n</property>
          -->
        </configuration>
     </container>

--- a/arquillian/pom.xml
+++ b/arquillian/pom.xml
@@ -39,7 +39,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
-                        <additionalJvmArgs>${modular.jdk.props}</additionalJvmArgs>
+                        <additionalJvmArgs>${additionalJvmArgs}</additionalJvmArgs>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,11 @@
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
         <!-- Modularized JDK support (various workarounds) - activated via profile -->
         <modular.jdk.args/>
-        <modular.jdk.props/>
         <!-- maven-enforcer-plugin -->
         <maven.min.version>3.2.5</maven.min.version>
         <jdk.min.version>${maven.compiler.source}</jdk.min.version>
         <!-- maven-surefire-plugin -->
-        <surefire.system.args>-Xms512m -Xmx512m ${modular.jdk.args} ${modular.jdk.props}</surefire.system.args>
+        <surefire.system.args>-Xms512m -Xmx512m ${modular.jdk.args}</surefire.system.args>
         <!-- Plugins versions -->
         <version.org.jacoco.plugin>0.7.9</version.org.jacoco.plugin>
         <version.surefire.plugin>2.19.1</version.surefire.plugin>

--- a/testsuite/integration-tests-spring/deployment/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests-spring/deployment/src/test/resources/arquillian.xml
@@ -13,7 +13,7 @@
                 -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y
             </property>-->
             <property name="javaVmArguments">-server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node}
-                -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent}
+                -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent}
             </property>
             <property name="managementAddress">${node}</property>
         </configuration>

--- a/testsuite/integration-tests-spring/inmodule/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests-spring/inmodule/src/test/resources/arquillian.xml
@@ -12,7 +12,7 @@
             <!--<property name="javaVmArguments">-Xmx512m -XX:MaxPermSize=128m
                 -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y
             </property>-->
-            <property name="javaVmArguments">-server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent}</property>
+            <property name="javaVmArguments">-server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent}</property>
             <property name="managementAddress">${node}</property>
         </configuration>
     </container>

--- a/testsuite/integration-tests/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests/src/test/resources/arquillian.xml
@@ -10,7 +10,7 @@
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
-                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.managed} -Djboss.server.base.dir=${container.base.dir.managed}
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.managed} -Djboss.server.base.dir=${container.base.dir.managed}
                 </property>
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.managed}</property>
@@ -21,7 +21,7 @@
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
-                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.gzip} -Dresteasy.allowGzip=true -Djboss.server.base.dir=${container.base.dir.manual.gzip}
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.gzip} -Dresteasy.allowGzip=true -Djboss.server.base.dir=${container.base.dir.manual.gzip}
                 </property>
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.manual.gzip}</property>
@@ -32,7 +32,7 @@
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">standalone-tracing.xml</property>
-                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Dee8.preview.mode=${ee8.preview.mode} -Djboss.socket.binding.port-offset=${container.offset.manual.tracing} -Djboss.server.base.dir=${container.base.dir.manual.tracing}</property>
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent} -Dee8.preview.mode=${ee8.preview.mode} -Djboss.socket.binding.port-offset=${container.offset.manual.tracing} -Djboss.server.base.dir=${container.base.dir.manual.tracing}</property>
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.manual.tracing}</property>
             </configuration>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -32,7 +32,7 @@
                     <failIfNoTests>false</failIfNoTests>
                     <systemPropertyVariables>
                         <securityManagerArg>${securityManagerArg}</securityManagerArg>
-                        <additionalJvmArgs>${additionalJvmArgs} ${modular.jdk.props}</additionalJvmArgs>
+                        <additionalJvmArgs>${additionalJvmArgs}</additionalJvmArgs>
                         <ipv6>false</ipv6>
                         <ipv6ArquillianSettings></ipv6ArquillianSettings>
                         <node>127.0.0.1</node>
@@ -141,6 +141,21 @@
                 <version.resteasy.testsuite>${version.resteasy.testsuite}</version.resteasy.testsuite>
             </properties>
         </profile>
+
+        <!-- https://issues.jboss.org/browse/MODULES-372 - JDK 11 - module not found java.se -->
+        <profile>
+            <id>modular-jdk</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <modular.jdk.args>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+                    --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
+                    --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED
+                    --add-modules=java.se</modular.jdk.args>
+            </properties>
+        </profile>
+
         <profile>
             <id>ipv6</id>
             <activation>
@@ -265,7 +280,7 @@
                                 <securityManagerArg>${securityManagerArg}</securityManagerArg>
                                 <additionalJvmArgs>${additionalJvmArgs}</additionalJvmArgs>
                                 <jboss.server.config.file.name>standalone-full-elytron.xml</jboss.server.config.file.name>
-                                <additionalJvmArgs>${modular.jdk.props}</additionalJvmArgs>
+                                <additionalJvmArgs>${additionalJvmArgs}</additionalJvmArgs>
                                 <ipv6>false</ipv6>
                                 <ipv6ArquillianSettings></ipv6ArquillianSettings>
                                 <node>127.0.0.1</node>


### PR DESCRIPTION
Add java.se module to JDK11 testsuite runs

I add the same jdk11 args as common.sh script: https://github.com/wildfly/wildfly-core/blob/master/core-feature-pack/src/main/resources/content/bin/common.sh#L9-L12

This PR remove modular.jdk.props, this property is currently not used in WF: https://github.com/wildfly/wildfly/blob/master/pom.xml#L6985-L6997

upstream PR: https://github.com/resteasy/Resteasy/pull/1690

jira: https://issues.jboss.org/browse/RESTEASY-2004