### PR TITLE
JDK11 java.se module and WF14 upstream testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ jdk:
   - oraclejdk8
   - oraclejdk10
 env:
-  - SERVER_VERSION=11.0.0.Final
   - SERVER_VERSION=12.0.0.Final
   - SERVER_VERSION=13.0.0.Final
+  - SERVER_VERSION=14.0.0.Final
 cache:
  directories:
   - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,11 @@
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
         <!-- Modularized JDK support (various workarounds) - activated via profile -->
         <modular.jdk.args/>
-        <modular.jdk.props/>
         <!-- maven-enforcer-plugin -->
         <maven.min.version>3.2.5</maven.min.version>
         <jdk.min.version>${maven.compiler.source}</jdk.min.version>
         <!-- maven-surefire-plugin -->
-        <surefire.system.args>-Xms512m -Xmx512m ${modular.jdk.args} ${modular.jdk.props}</surefire.system.args>
+        <surefire.system.args>-Xms512m -Xmx512m ${modular.jdk.args}</surefire.system.args>
         <!-- Plugins versions -->
         <version.org.jacoco.plugin>0.7.9</version.org.jacoco.plugin>
         <version.surefire.plugin>2.19.1</version.surefire.plugin>

--- a/testsuite/integration-tests-spring/deployment/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests-spring/deployment/src/test/resources/arquillian.xml
@@ -13,7 +13,7 @@
                 -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y
             </property>-->
             <property name="javaVmArguments">-server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node}
-                -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent}
+                -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent}
             </property>
             <property name="managementAddress">${node}</property>
         </configuration>

--- a/testsuite/integration-tests-spring/inmodule/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests-spring/inmodule/src/test/resources/arquillian.xml
@@ -12,7 +12,7 @@
             <!--<property name="javaVmArguments">-Xmx512m -XX:MaxPermSize=128m
                 -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y
             </property>-->
-            <property name="javaVmArguments">-server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent}</property>
+            <property name="javaVmArguments">-server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent}</property>
             <property name="managementAddress">${node}</property>
         </configuration>
     </container>

--- a/testsuite/integration-tests/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests/src/test/resources/arquillian.xml
@@ -10,7 +10,7 @@
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
-                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.managed} -Djboss.server.base.dir=${container.base.dir.managed}
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.managed} -Djboss.server.base.dir=${container.base.dir.managed}
                 </property>
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.managed}</property>
@@ -21,7 +21,7 @@
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
-                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.gzip} -Dresteasy.allowGzip=true -Djboss.server.base.dir=${container.base.dir.manual.gzip}
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.gzip} -Dresteasy.allowGzip=true -Djboss.server.base.dir=${container.base.dir.manual.gzip}
                 </property>
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.manual.gzip}</property>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -115,7 +115,7 @@
               </property>
             </activation>
             <properties>
-                <server.version>12.0.0.Final</server.version>
+                <server.version>14.0.0.Final</server.version>
             </properties>
         </profile>
         <profile>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -142,6 +142,21 @@
                 <version.resteasy.testsuite>${version.resteasy.testsuite}</version.resteasy.testsuite>
             </properties>
         </profile>
+
+        <!-- https://issues.jboss.org/browse/MODULES-372 - JDK 11 - module not found java.se -->
+        <profile>
+            <id>modular-jdk</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <modular.jdk.args>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+                    --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
+                    --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED
+                    --add-modules=java.se</modular.jdk.args>
+            </properties>
+        </profile>
+
         <profile>
             <id>ipv6</id>
             <activation>


### PR DESCRIPTION
**https://issues.jboss.org/browse/RESTEASY-2004**

Add java.se module to JDK11 testsuite runs

I add the same jdk11 args as common.sh script: https://github.com/wildfly/wildfly-core/blob/master/core-feature-pack/src/main/resources/content/bin/common.sh#L9-L12

This PR remove modular.jdk.props, this property is currently not used in WF: https://github.com/wildfly/wildfly/blob/master/pom.xml#L6985-L6997

master PR: https://github.com/resteasy/Resteasy/pull/1689

----

**https://issues.jboss.org/browse/RESTEASY-2002**

Move towards WildFly 14

master PR: https://github.com/resteasy/Resteasy/pull/1683