### PR TITLE
[RESTEASY-2029] Java 11 on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language: java
 jdk:
   - oraclejdk8
   - oraclejdk10
+  - openjdk11
 env:
   - SERVER_VERSION=12.0.0.Final
   - SERVER_VERSION=13.0.0.Final


### PR DESCRIPTION
[RESTEASY-2029] Java 11 on travis-ci
https://issues.jboss.org/browse/RESTEASY-2029