### PR TITLE
[RESTEASY-1142] ExceptionHandler: catch IllegalStateException from ClientResponse

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
@@ -165,13 +165,14 @@ public class ExceptionHandler
 
       if (unwrappedException instanceof WebApplicationException) {
          WebApplicationException wae = (WebApplicationException) unwrappedException;
-         if (wae.getResponse() != null) {
+         Response response = wae.getResponse();
+         if (response != null) {
             try {
-               if (wae.getResponse().getEntity() != null) return wae.getResponse();
+               if (response.getEntity() != null) return response;
             }
             catch(IllegalStateException ise) {
-               // ignore
                // IllegalStateException from ClientResponse.getEntity() means the response is closed and got no entity
+               return response;
             }
          }
       }

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
@@ -165,7 +165,15 @@ public class ExceptionHandler
 
       if (unwrappedException instanceof WebApplicationException) {
          WebApplicationException wae = (WebApplicationException) unwrappedException;
-         if (wae.getResponse() != null && wae.getResponse().getEntity() != null) return wae.getResponse();
+         if (wae.getResponse() != null) {
+            try {
+               if (wae.getResponse().getEntity() != null) return wae.getResponse();
+            }
+            catch(IllegalStateException ise) {
+               // ignore
+               // IllegalStateException from ClientResponse.getEntity() means the response is closed and got no entity
+            }
+         }
       }
 
       jaxrsResponse = executeExceptionMapper(unwrappedException, logger);

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
@@ -172,7 +172,6 @@ public class ExceptionHandler
             }
             catch(IllegalStateException ise) {
                // IllegalStateException from ClientResponse.getEntity() means the response is closed and got no entity
-               return response;
             }
          }
       }

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ContainerResponseContextImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ContainerResponseContextImpl.java
@@ -235,13 +235,13 @@ public class ContainerResponseContextImpl implements SuspendableContainerRespons
    @Override
    public boolean hasEntity()
    {
-      return jaxrsResponse.hasEntity();
+      return !jaxrsResponse.isClosed() && jaxrsResponse.hasEntity();
    }
 
    @Override
    public Object getEntity()
    {
-      return jaxrsResponse.getEntity();
+      return !jaxrsResponse.isClosed() ? jaxrsResponse.getEntity() : null;
    }
 
    @Override

--- a/resteasy-core/src/main/java/org/jboss/resteasy/tracing/RESTEasyTracingLoggerImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/tracing/RESTEasyTracingLoggerImpl.java
@@ -146,17 +146,17 @@ class RESTEasyTracingLoggerImpl extends RESTEasyTracing implements RESTEasyTraci
 
       Object entity;
       try {
-          entity = response.getEntity();
+         entity = response.getEntity();
       }
       catch(IllegalStateException ise) {
-          // [RESTEASY-1142] IllegalStateException from ClientResponse.getEntity() means the response is closed and got no entity
-          entity = null;
+         // [RESTEASY-1142] IllegalStateException from ClientResponse.getEntity() means the response is closed and got no entity
+         entity = null;
       }
 
       if (entity != null) {
-          formatInstance(entity, text);
+         formatInstance(entity, text);
       } else {
-          text.append("-no-entity-");
+         text.append("-no-entity-");
       }
 
       text.append('>');

--- a/resteasy-core/src/main/java/org/jboss/resteasy/tracing/RESTEasyTracingLoggerImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/tracing/RESTEasyTracingLoggerImpl.java
@@ -143,11 +143,22 @@ class RESTEasyTracingLoggerImpl extends RESTEasyTracing implements RESTEasyTraci
 
    private static void formatResponse(final Response response, final StringBuilder text) {
       text.append(" <").append(formatStatusInfo(response.getStatusInfo())).append('|');
-      if (response.hasEntity()) {
-         formatInstance(response.getEntity(), text);
-      } else {
-         text.append("-no-entity-");
+
+      Object entity;
+      try {
+          entity = response.getEntity();
       }
+      catch(IllegalStateException ise) {
+          // [RESTEASY-1142] IllegalStateException from ClientResponse.getEntity() means the response is closed and got no entity
+          entity = null;
+      }
+
+      if (entity != null) {
+          formatInstance(entity, text);
+      } else {
+          text.append("-no-entity-");
+      }
+
       text.append('>');
    }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/ClosedResponseHandling.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/ClosedResponseHandling.java
@@ -1,0 +1,165 @@
+package org.jboss.resteasy.test.exception;
+
+import java.io.IOException;
+import java.lang.reflect.ReflectPermission;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.NotAcceptableException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.NotSupportedException;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
+import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
+import org.jboss.resteasy.test.UndertowTestRunner;
+import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
+import org.jboss.resteasy.tracing.api.RESTEasyTracing;
+import org.jboss.resteasy.tracing.api.RESTEasyTracingLevel;
+import org.jboss.resteasy.utils.PermissionUtil;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
+import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
+
+
+/**
+ * @tpSubChapter Resteasy-client
+ * @tpChapter Integration tests
+ * @tpSince RESTEasy 4.0.0.CR1
+ * @tpTestCaseDetails Regression test for RESTEASY-1142
+ * @author <a href="ron.sigal@jboss.com">Ron Sigal</a>
+ * @author <a href="jonas.zeiger@talpidae.net">Jonas Zeiger</a>
+ * @version $Revision: 1.0 $
+ */
+@RunWith(Arquillian.class)
+//@RunWith(UndertowTestRunner.class)
+@RunAsClient
+public class ClosedResponseHandling
+{
+	@Deployment
+	public static Archive<?> deploy() {
+		WebArchive war = TestUtil.prepareArchive(ClosedResponseHandling.class.getSimpleName());
+		war.addClass(ClosedResponseHandling.class);
+		war.addClass(PortProviderUtil.class);
+		war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
+				new ReflectPermission("suppressAccessChecks")
+		), "permissions.xml");
+
+		Map<String, String> params = new HashMap<>();
+		params.put(ResteasyContextParameters.RESTEASY_TRACING_TYPE, ResteasyContextParameters.RESTEASY_TRACING_TYPE_ALL);
+		params.put(ResteasyContextParameters.RESTEASY_TRACING_THRESHOLD, ResteasyContextParameters.RESTEASY_TRACING_LEVEL_VERBOSE);
+
+		return TestUtil.finishContainerPrepare(war, params, TestResource.class,
+				PleaseMapExceptionMapper.class,
+				TestEnableVerboseTracingRequestFilter.class);
+	}
+
+	/**
+	 * @tpTestDetails Request is sent to an endpoint that issues a Resteasy client request triggering a 404 error.
+	 * @tpPassCrit A NotFoundException is returned
+	 * @tpSince RESTEasy 4.0.0.CR1
+	 */
+	@Test(expected = NotAcceptableException.class)
+	public void testNotAcceptable() {
+		new ResteasyClientBuilderImpl().build().target(generateURL("/testNotAcceptable")).request().get(String.class);
+	}
+
+	/**
+	 * @tpTestDetails Request is sent to an exception mapping and tracing endpoint that issues a Resteasy client request triggering a 404 error.
+	 * @tpPassCrit A NotFoundException is returned
+	 * @tpSince RESTEasy 4.0.0.CR1
+	 */
+	@Test(expected = NotSupportedException.class)
+	public void testNotSupportedTraced() {
+		new ResteasyClientBuilderImpl().build().target(generateURL("/testNotSupportedTraced")).request().get(String.class);
+	}
+
+	@Path("")
+	public static class TestResource {
+
+		@Path("/testNotAcceptable/406")
+		@GET
+		public Response errorNotAcceptable() {
+			return Response.status(NOT_ACCEPTABLE).build();
+		}
+
+		@Path("/testNotAcceptable")
+		@GET
+		public String getNotAcceptable(@Context UriInfo uriInfo) {
+			URI endpoint406 = UriBuilder.fromUri(uriInfo.getRequestUri()).path("406").build();
+			return ClientBuilder.newClient().target(endpoint406).request().get(String.class);
+		}
+
+		@Path("/testNotSupportedTraced/415")
+		@GET
+		public Response errorNotFound() {
+			return Response.status(UNSUPPORTED_MEDIA_TYPE).build();
+		}
+
+		@Path("/testNotSupportedTraced")
+		@GET
+		public String getNotSupportedTraced(@Context UriInfo uriInfo) {
+			URI endpoint415 = UriBuilder.fromUri(uriInfo.getRequestUri()).path("415").build();
+			try {
+				return ClientBuilder.newClient().target(endpoint415).request().get(String.class);
+			} catch(NotSupportedException e) {
+				throw new PleaseMapException(e.getResponse());
+			}
+		}
+	}
+
+
+	private static class PleaseMapException extends RuntimeException {
+		private final Response response;
+
+		private PleaseMapException(Response response) {
+			this.response = response;
+		}
+	}
+
+	/** ExceptionHandler only uses the logger for tracing exception mapping, so we need to map something.
+	 */
+	@Provider
+	public static class PleaseMapExceptionMapper implements ExceptionMapper<PleaseMapException> {
+		@Override
+		public Response toResponse(PleaseMapException e) {
+			return e.response;
+		}
+	}
+
+	@Provider
+	@PreMatching
+	public static class TestEnableVerboseTracingRequestFilter implements ContainerRequestFilter {
+		@Override
+		public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+			// force verbose tracing, enabling via finishContainerPrepare()'s contextParams didn't work
+			containerRequestContext.setProperty(RESTEasyTracing.PROPERTY_NAME,
+					RESTEasyTracingLogger.create(RESTEasyTracingLevel.VERBOSE.name(), ClosedResponseHandling.class.getSimpleName()));
+		}
+	}
+
+	private static String generateURL(String path) {
+		return PortProviderUtil.generateURL(path, ClosedResponseHandling.class.getSimpleName());
+	}
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/ClosedResponseHandlingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/ClosedResponseHandlingTest.java
@@ -40,7 +40,6 @@ import org.junit.runner.RunWith;
 import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
 import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 
-
 /**
  * @tpSubChapter Resteasy-client
  * @tpChapter Integration tests
@@ -51,113 +50,111 @@ import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
  * @version $Revision: 1.0 $
  */
 @RunWith(Arquillian.class)
-//@RunWith(UndertowTestRunner.class)
 @RunAsClient
-public class ClosedResponseHandlingTest
-{
-	@Deployment
-	public static Archive<?> deploy() {
-		WebArchive war = TestUtil.prepareArchive(ClosedResponseHandlingTest.class.getSimpleName());
-		war.addClass(ClosedResponseHandlingTest.class);
-		war.addClass(PortProviderUtil.class);
-		war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
-				new ReflectPermission("suppressAccessChecks")
-		), "permissions.xml");
+public class ClosedResponseHandlingTest {
 
-		Map<String, String> params = new HashMap<>();
-		params.put(ResteasyContextParameters.RESTEASY_TRACING_TYPE, ResteasyContextParameters.RESTEASY_TRACING_TYPE_ALL);
-		params.put(ResteasyContextParameters.RESTEASY_TRACING_THRESHOLD, ResteasyContextParameters.RESTEASY_TRACING_LEVEL_VERBOSE);
+   @Deployment
+   public static Archive<?> deploy() {
+       WebArchive war = TestUtil.prepareArchive(ClosedResponseHandlingTest.class.getSimpleName());
+       war.addClass(ClosedResponseHandlingTest.class);
+       war.addClass(PortProviderUtil.class);
+       war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
+             new ReflectPermission("suppressAccessChecks")
+       ), "permissions.xml");
 
-		return TestUtil.finishContainerPrepare(war, params, TestResource.class,
-				PleaseMapExceptionMapper.class,
-				TestEnableVerboseTracingRequestFilter.class);
-	}
+       Map<String, String> params = new HashMap<>();
+       params.put(ResteasyContextParameters.RESTEASY_TRACING_TYPE, ResteasyContextParameters.RESTEASY_TRACING_TYPE_ALL);
+       params.put(ResteasyContextParameters.RESTEASY_TRACING_THRESHOLD, ResteasyContextParameters.RESTEASY_TRACING_LEVEL_VERBOSE);
 
-	/**
-	 * @tpTestDetails Request is sent to an endpoint that issues a Resteasy client request triggering a 404 error.
-	 * @tpPassCrit A NotAcceptableException is returned
-	 * @tpSince RESTEasy 4.0.0.CR1
-	 */
-	@Test(expected = NotAcceptableException.class)
-	public void testNotAcceptable() {
-		new ResteasyClientBuilderImpl().build().target(generateURL("/testNotAcceptable")).request().get(String.class);
-	}
+       return TestUtil.finishContainerPrepare(war, params, TestResource.class,
+             PleaseMapExceptionMapper.class,
+             TestEnableVerboseTracingRequestFilter.class);
+    }
 
-	/**
-	 * @tpTestDetails Request is sent to an exception mapping and tracing endpoint that issues a Resteasy client request triggering a 404 error.
-	 * @tpPassCrit A NotSupportedException is returned
-	 * @tpSince RESTEasy 4.0.0.CR1
-	 */
-	@Test(expected = NotSupportedException.class)
-	public void testNotSupportedTraced() {
-		new ResteasyClientBuilderImpl().build().target(generateURL("/testNotSupportedTraced")).request().get(String.class);
-	}
+   /**
+    * @tpTestDetails Request is sent to an endpoint that issues a Resteasy client request triggering a 404 error.
+    * @tpPassCrit A NotAcceptableException is returned
+    * @tpSince RESTEasy 4.0.0.CR1
+    */
+   @Test(expected = NotAcceptableException.class)
+   public void testNotAcceptable() {
+      new ResteasyClientBuilderImpl().build().target(generateURL("/testNotAcceptable")).request().get(String.class);
+   }
 
-	@Path("")
-	public static class TestResource {
+   /**
+    * @tpTestDetails Request is sent to an exception mapping and tracing endpoint that issues a Resteasy client request triggering a 404 error.
+    * @tpPassCrit A NotSupportedException is returned
+    * @tpSince RESTEasy 4.0.0.CR1
+    */
+   @Test(expected = NotSupportedException.class)
+   public void testNotSupportedTraced() {
+      new ResteasyClientBuilderImpl().build().target(generateURL("/testNotSupportedTraced")).request().get(String.class);
+   }
 
-		@Path("/testNotAcceptable/406")
-		@GET
-		public Response errorNotAcceptable() {
-			return Response.status(NOT_ACCEPTABLE).build();
-		}
+   @Path("")
+   public static class TestResource {
 
-		@Path("/testNotAcceptable")
-		@GET
-		public String getNotAcceptable(@Context UriInfo uriInfo) {
-			URI endpoint406 = UriBuilder.fromUri(uriInfo.getRequestUri()).path("406").build();
-			return ClientBuilder.newClient().target(endpoint406).request().get(String.class);
-		}
+      @Path("/testNotAcceptable/406")
+      @GET
+      public Response errorNotAcceptable() {
+         return Response.status(NOT_ACCEPTABLE).build();
+      }
 
-		@Path("/testNotSupportedTraced/415")
-		@GET
-		public Response errorNotFound() {
-			return Response.status(UNSUPPORTED_MEDIA_TYPE).build();
-		}
+      @Path("/testNotAcceptable")
+      @GET
+      public String getNotAcceptable(@Context UriInfo uriInfo) {
+         URI endpoint406 = UriBuilder.fromUri(uriInfo.getRequestUri()).path("406").build();
+         return ClientBuilder.newClient().target(endpoint406).request().get(String.class);
+      }
 
-		@Path("/testNotSupportedTraced")
-		@GET
-		public String getNotSupportedTraced(@Context UriInfo uriInfo) {
-			URI endpoint415 = UriBuilder.fromUri(uriInfo.getRequestUri()).path("415").build();
-			try {
-				return ClientBuilder.newClient().target(endpoint415).request().get(String.class);
-			} catch(NotSupportedException e) {
-				throw new PleaseMapException(e.getResponse());
-			}
-		}
-	}
+      @Path("/testNotSupportedTraced/415")
+      @GET
+      public Response errorNotFound() {
+         return Response.status(UNSUPPORTED_MEDIA_TYPE).build();
+      }
 
+      @Path("/testNotSupportedTraced")
+      @GET
+      public String getNotSupportedTraced(@Context UriInfo uriInfo) {
+         URI endpoint415 = UriBuilder.fromUri(uriInfo.getRequestUri()).path("415").build();
+         try {
+            return ClientBuilder.newClient().target(endpoint415).request().get(String.class);
+         } catch(NotSupportedException e) {
+            throw new PleaseMapException(e.getResponse());
+         }
+      }
+   }
 
-	private static class PleaseMapException extends RuntimeException {
-		private final Response response;
+   private static class PleaseMapException extends RuntimeException {
+      private final Response response;
 
-		private PleaseMapException(Response response) {
-			this.response = response;
-		}
-	}
+      private PleaseMapException(Response response) {
+         this.response = response;
+      }
+   }
 
-	/** ExceptionHandler only uses the logger for tracing exception mapping, so we need to map something.
-	 */
-	@Provider
-	public static class PleaseMapExceptionMapper implements ExceptionMapper<PleaseMapException> {
-		@Override
-		public Response toResponse(PleaseMapException e) {
-			return e.response;
-		}
-	}
+   /** ExceptionHandler only uses the logger for tracing exception mapping, so we need to map something.
+    */
+   @Provider
+   public static class PleaseMapExceptionMapper implements ExceptionMapper<PleaseMapException> {
+      @Override
+      public Response toResponse(PleaseMapException e) {
+         return e.response;
+      }
+   }
 
-	@Provider
-	@PreMatching
-	public static class TestEnableVerboseTracingRequestFilter implements ContainerRequestFilter {
-		@Override
-		public void filter(ContainerRequestContext containerRequestContext) throws IOException {
-			// force verbose tracing, enabling via finishContainerPrepare()'s contextParams didn't work
-			containerRequestContext.setProperty(RESTEasyTracing.PROPERTY_NAME,
-					RESTEasyTracingLogger.create(RESTEasyTracingLevel.VERBOSE.name(), ClosedResponseHandlingTest.class.getSimpleName()));
-		}
-	}
+   @Provider
+   @PreMatching
+   public static class TestEnableVerboseTracingRequestFilter implements ContainerRequestFilter {
+      @Override
+      public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+         // force verbose tracing, enabling via finishContainerPrepare()'s contextParams didn't work
+         containerRequestContext.setProperty(RESTEasyTracing.PROPERTY_NAME,
+               RESTEasyTracingLogger.create(RESTEasyTracingLevel.VERBOSE.name(), ClosedResponseHandlingTest.class.getSimpleName()));
+      }
+   }
 
-	private static String generateURL(String path) {
-		return PortProviderUtil.generateURL(path, ClosedResponseHandlingTest.class.getSimpleName());
-	}
+   private static String generateURL(String path) {
+      return PortProviderUtil.generateURL(path, ClosedResponseHandlingTest.class.getSimpleName());
+   }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/ClosedResponseHandlingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/ClosedResponseHandlingTest.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.NotAcceptableException;
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.Path;
 import javax.ws.rs.client.ClientBuilder;
@@ -27,7 +26,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
-import org.jboss.resteasy.test.UndertowTestRunner;
 import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
 import org.jboss.resteasy.tracing.api.RESTEasyTracing;
 import org.jboss.resteasy.tracing.api.RESTEasyTracingLevel;
@@ -55,12 +53,12 @@ import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 @RunWith(Arquillian.class)
 //@RunWith(UndertowTestRunner.class)
 @RunAsClient
-public class ClosedResponseHandling
+public class ClosedResponseHandlingTest
 {
 	@Deployment
 	public static Archive<?> deploy() {
-		WebArchive war = TestUtil.prepareArchive(ClosedResponseHandling.class.getSimpleName());
-		war.addClass(ClosedResponseHandling.class);
+		WebArchive war = TestUtil.prepareArchive(ClosedResponseHandlingTest.class.getSimpleName());
+		war.addClass(ClosedResponseHandlingTest.class);
 		war.addClass(PortProviderUtil.class);
 		war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
 				new ReflectPermission("suppressAccessChecks")
@@ -77,7 +75,7 @@ public class ClosedResponseHandling
 
 	/**
 	 * @tpTestDetails Request is sent to an endpoint that issues a Resteasy client request triggering a 404 error.
-	 * @tpPassCrit A NotFoundException is returned
+	 * @tpPassCrit A NotAcceptableException is returned
 	 * @tpSince RESTEasy 4.0.0.CR1
 	 */
 	@Test(expected = NotAcceptableException.class)
@@ -87,7 +85,7 @@ public class ClosedResponseHandling
 
 	/**
 	 * @tpTestDetails Request is sent to an exception mapping and tracing endpoint that issues a Resteasy client request triggering a 404 error.
-	 * @tpPassCrit A NotFoundException is returned
+	 * @tpPassCrit A NotSupportedException is returned
 	 * @tpSince RESTEasy 4.0.0.CR1
 	 */
 	@Test(expected = NotSupportedException.class)
@@ -155,11 +153,11 @@ public class ClosedResponseHandling
 		public void filter(ContainerRequestContext containerRequestContext) throws IOException {
 			// force verbose tracing, enabling via finishContainerPrepare()'s contextParams didn't work
 			containerRequestContext.setProperty(RESTEasyTracing.PROPERTY_NAME,
-					RESTEasyTracingLogger.create(RESTEasyTracingLevel.VERBOSE.name(), ClosedResponseHandling.class.getSimpleName()));
+					RESTEasyTracingLogger.create(RESTEasyTracingLevel.VERBOSE.name(), ClosedResponseHandlingTest.class.getSimpleName()));
 		}
 	}
 
 	private static String generateURL(String path) {
-		return PortProviderUtil.generateURL(path, ClosedResponseHandling.class.getSimpleName());
+		return PortProviderUtil.generateURL(path, ClosedResponseHandlingTest.class.getSimpleName());
 	}
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/ClosedResponseHandlingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/ClosedResponseHandlingTest.java
@@ -1,34 +1,20 @@
 package org.jboss.resteasy.test.exception;
 
-import java.io.IOException;
 import java.lang.reflect.ReflectPermission;
-import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.ws.rs.GET;
 import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.NotSupportedException;
-import javax.ws.rs.Path;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.container.PreMatching;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
-import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
-import org.jboss.resteasy.tracing.api.RESTEasyTracing;
-import org.jboss.resteasy.tracing.api.RESTEasyTracingLevel;
+import org.jboss.resteasy.test.exception.resource.ClosedResponseHandlingEnableTracingRequestFilter;
+import org.jboss.resteasy.test.exception.resource.ClosedResponseHandlingPleaseMapExceptionMapper;
+import org.jboss.resteasy.test.exception.resource.ClosedResponseHandlingResource;
 import org.jboss.resteasy.utils.PermissionUtil;
 import org.jboss.resteasy.utils.PortProviderUtil;
 import org.jboss.resteasy.utils.TestUtil;
@@ -37,9 +23,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
-import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
-
 /**
  * @tpSubChapter Resteasy-client
  * @tpChapter Integration tests
@@ -47,7 +30,6 @@ import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
  * @tpTestCaseDetails Regression test for RESTEASY-1142
  * @author <a href="ron.sigal@jboss.com">Ron Sigal</a>
  * @author <a href="jonas.zeiger@talpidae.net">Jonas Zeiger</a>
- * @version $Revision: 1.0 $
  */
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -57,6 +39,7 @@ public class ClosedResponseHandlingTest {
    public static Archive<?> deploy() {
        WebArchive war = TestUtil.prepareArchive(ClosedResponseHandlingTest.class.getSimpleName());
        war.addClass(ClosedResponseHandlingTest.class);
+       war.addPackage(ClosedResponseHandlingResource.class.getPackage());
        war.addClass(PortProviderUtil.class);
        war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
              new ReflectPermission("suppressAccessChecks")
@@ -66,13 +49,13 @@ public class ClosedResponseHandlingTest {
        params.put(ResteasyContextParameters.RESTEASY_TRACING_TYPE, ResteasyContextParameters.RESTEASY_TRACING_TYPE_ALL);
        params.put(ResteasyContextParameters.RESTEASY_TRACING_THRESHOLD, ResteasyContextParameters.RESTEASY_TRACING_LEVEL_VERBOSE);
 
-       return TestUtil.finishContainerPrepare(war, params, TestResource.class,
-             PleaseMapExceptionMapper.class,
-             TestEnableVerboseTracingRequestFilter.class);
+       return TestUtil.finishContainerPrepare(war, params, ClosedResponseHandlingResource.class,
+             ClosedResponseHandlingPleaseMapExceptionMapper.class,
+             ClosedResponseHandlingEnableTracingRequestFilter.class);
     }
 
    /**
-    * @tpTestDetails Request is sent to an endpoint that issues a Resteasy client request triggering a 404 error.
+    * @tpTestDetails RESTEasy client errors that result in a closed Response are correctly handled.
     * @tpPassCrit A NotAcceptableException is returned
     * @tpSince RESTEasy 4.0.0.CR1
     */
@@ -82,76 +65,13 @@ public class ClosedResponseHandlingTest {
    }
 
    /**
-    * @tpTestDetails Request is sent to an exception mapping and tracing endpoint that issues a Resteasy client request triggering a 404 error.
+    * @tpTestDetails Closed Response instances should be handled correctly with full tracing enabled.
     * @tpPassCrit A NotSupportedException is returned
     * @tpSince RESTEasy 4.0.0.CR1
     */
    @Test(expected = NotSupportedException.class)
    public void testNotSupportedTraced() {
       new ResteasyClientBuilderImpl().build().target(generateURL("/testNotSupportedTraced")).request().get(String.class);
-   }
-
-   @Path("")
-   public static class TestResource {
-
-      @Path("/testNotAcceptable/406")
-      @GET
-      public Response errorNotAcceptable() {
-         return Response.status(NOT_ACCEPTABLE).build();
-      }
-
-      @Path("/testNotAcceptable")
-      @GET
-      public String getNotAcceptable(@Context UriInfo uriInfo) {
-         URI endpoint406 = UriBuilder.fromUri(uriInfo.getRequestUri()).path("406").build();
-         return ClientBuilder.newClient().target(endpoint406).request().get(String.class);
-      }
-
-      @Path("/testNotSupportedTraced/415")
-      @GET
-      public Response errorNotFound() {
-         return Response.status(UNSUPPORTED_MEDIA_TYPE).build();
-      }
-
-      @Path("/testNotSupportedTraced")
-      @GET
-      public String getNotSupportedTraced(@Context UriInfo uriInfo) {
-         URI endpoint415 = UriBuilder.fromUri(uriInfo.getRequestUri()).path("415").build();
-         try {
-            return ClientBuilder.newClient().target(endpoint415).request().get(String.class);
-         } catch(NotSupportedException e) {
-            throw new PleaseMapException(e.getResponse());
-         }
-      }
-   }
-
-   private static class PleaseMapException extends RuntimeException {
-      private final Response response;
-
-      private PleaseMapException(Response response) {
-         this.response = response;
-      }
-   }
-
-   /** ExceptionHandler only uses the logger for tracing exception mapping, so we need to map something.
-    */
-   @Provider
-   public static class PleaseMapExceptionMapper implements ExceptionMapper<PleaseMapException> {
-      @Override
-      public Response toResponse(PleaseMapException e) {
-         return e.response;
-      }
-   }
-
-   @Provider
-   @PreMatching
-   public static class TestEnableVerboseTracingRequestFilter implements ContainerRequestFilter {
-      @Override
-      public void filter(ContainerRequestContext containerRequestContext) throws IOException {
-         // force verbose tracing, enabling via finishContainerPrepare()'s contextParams didn't work
-         containerRequestContext.setProperty(RESTEasyTracing.PROPERTY_NAME,
-               RESTEasyTracingLogger.create(RESTEasyTracingLevel.VERBOSE.name(), ClosedResponseHandlingTest.class.getSimpleName()));
-      }
    }
 
    private static String generateURL(String path) {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingEnableTracingRequestFilter.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingEnableTracingRequestFilter.java
@@ -1,0 +1,23 @@
+package org.jboss.resteasy.test.exception.resource;
+
+import org.jboss.resteasy.test.exception.ClosedResponseHandlingTest;
+import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
+import org.jboss.resteasy.tracing.api.RESTEasyTracing;
+import org.jboss.resteasy.tracing.api.RESTEasyTracingLevel;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+@Provider
+@PreMatching
+public class ClosedResponseHandlingEnableTracingRequestFilter implements ContainerRequestFilter {
+   @Override
+   public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+      // force verbose tracing, enabling via finishContainerPrepare()'s contextParams didn't work
+      containerRequestContext.setProperty(RESTEasyTracing.PROPERTY_NAME,
+            RESTEasyTracingLogger.create(RESTEasyTracingLevel.VERBOSE.name(), ClosedResponseHandlingTest.class.getSimpleName()));
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingPleaseMapException.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingPleaseMapException.java
@@ -1,0 +1,12 @@
+package org.jboss.resteasy.test.exception.resource;
+
+import javax.ws.rs.core.Response;
+
+public class ClosedResponseHandlingPleaseMapException extends RuntimeException {
+
+   final Response response;
+
+   public ClosedResponseHandlingPleaseMapException(Response response) {
+      this.response = response;
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingPleaseMapExceptionMapper.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingPleaseMapExceptionMapper.java
@@ -1,0 +1,18 @@
+package org.jboss.resteasy.test.exception.resource;
+
+import org.jboss.resteasy.test.exception.ClosedResponseHandlingTest;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/** ExceptionHandler only uses the logger for tracing exception mapping, so we need to map something.
+ */
+@Provider
+public class ClosedResponseHandlingPleaseMapExceptionMapper implements ExceptionMapper<ClosedResponseHandlingPleaseMapException> {
+
+   @Override
+   public Response toResponse(ClosedResponseHandlingPleaseMapException e) {
+      return e.response;
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingResource.java
@@ -1,0 +1,48 @@
+package org.jboss.resteasy.test.exception.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.NotSupportedException;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+
+import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
+import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
+
+@Path("")
+public class ClosedResponseHandlingResource {
+
+   @Path("/testNotAcceptable/406")
+   @GET
+   public Response errorNotAcceptable() {
+      return Response.status(NOT_ACCEPTABLE).build();
+   }
+
+   @Path("/testNotAcceptable")
+   @GET
+   public String getNotAcceptable(@Context UriInfo uriInfo) {
+      URI endpoint406 = UriBuilder.fromUri(uriInfo.getRequestUri()).path("406").build();
+      return ClientBuilder.newClient().target(endpoint406).request().get(String.class);
+   }
+
+   @Path("/testNotSupportedTraced/415")
+   @GET
+   public Response errorNotFound() {
+      return Response.status(UNSUPPORTED_MEDIA_TYPE).build();
+   }
+
+   @Path("/testNotSupportedTraced")
+   @GET
+   public String getNotSupportedTraced(@Context UriInfo uriInfo) {
+      URI endpoint415 = UriBuilder.fromUri(uriInfo.getRequestUri()).path("415").build();
+      try {
+         return ClientBuilder.newClient().target(endpoint415).request().get(String.class);
+      } catch(NotSupportedException e) {
+         throw new ClosedResponseHandlingPleaseMapException(e.getResponse());
+      }
+   }
+}


### PR DESCRIPTION
Fix for the following issue: https://issues.jboss.org/browse/RESTEASY-1142

The resteasy-client's ClientResponse throws an IllegalStateException when the ExceptionMapper calls ClientResponse.getEntity().

This issue is a blocker for my use-case.
