### PR TITLE
[RESTEASY-2035] Add named web-fragments

### DIFF
--- a/resteasy-cdi/src/main/resources/META-INF/web-fragment.xml
+++ b/resteasy-cdi/src/main/resources/META-INF/web-fragment.xml
@@ -6,6 +6,7 @@
       http://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd"
 	version="3.0">
 
+	<name>resteasy_cdi</name>
 	<context-param>
 		<param-name>resteasy.injector.factory</param-name>
 		<param-value>org.jboss.resteasy.cdi.CdiInjectorFactory</param-value>

--- a/resteasy-servlet-initializer/src/main/resources/META-INF/web-fragment.xml
+++ b/resteasy-servlet-initializer/src/main/resources/META-INF/web-fragment.xml
@@ -6,4 +6,5 @@
       http://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd"
               version="3.0">
     <name>resteasy_servlet_initializer</name>
+    <distributable/>
 </web-fragment>

--- a/resteasy-servlet-initializer/src/main/resources/META-INF/web-fragment.xml
+++ b/resteasy-servlet-initializer/src/main/resources/META-INF/web-fragment.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-fragment xmlns="http://java.sun.com/xml/ns/javaee"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee
+      http://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd"
+              version="3.0">
+    <name>resteasy_servlet_initializer</name>
+</web-fragment>


### PR DESCRIPTION
## The issue

The problem I'm trying to solve is the following:

- Tomcat 9.0.10
- OpenWebBeans 2.0.4

We are using `<absolute-ordering>` in our `web.xml`. This - as far as I understood the Servlet API Spec - disable autoscanning on all JARs not explicitly mentioned in the `<absolute-ordering>` section, including scans for Annotations.

I still want to use RestEasy's autoscan feature, but in order to do that, I have to mention `resteasy-servlet-initializer` in the `<absolute-ordering>` section of my `web.xml`, but since `resteasy-servlet-initializer.jar` does not contain a `web-fragment.xml` with a `<name>` tag (actually: it does not contain any `web-fragment.xml` at all) I can't do that.

Similar applies to `resteasy-cdi`, which has a `web-fragment`, but does not set the `<name>` tag on it, so I cannot mention it in our `web.xml` either. Servlet API Spec (afaik, please correct me if I'm wrong) does not define default names for `web-fragments`.

## My solution

This pull request adds:

- a `web-fragment.xml` to `resteasy-servlet-initializer`, setting its `<name>` to `resteasy_servlet_initializer`, (I use `_` because `-` is not allowed)
- a `<name>` tag to `resteasy-cdi`, being `resteasy_cdi`

## TODOs

I do **NOT** know, if `resteasy-servlet-initializer` is supposed to be `<distributable/>`. If ~~so~~ not, please let me know, or just ~~add~~ remove it yourself.