### PR TITLE
[RESTEASY-2046] Space Improperly Encoded in Content-Disposition Filename

### DIFF
--- a/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/AbstractMultipartFormDataWriter.java
+++ b/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/AbstractMultipartFormDataWriter.java
@@ -48,7 +48,7 @@ public class AbstractMultipartFormDataWriter extends AbstractMultipartWriter {
             // append encoding charset into the value if and only if encoding was needed
             if (!encodedFilename.equals(filename)) {
             // encoding was needed, so per rfc5987 we have to prepend charset
-               return "; filename*=utf-8''" + encodedFilename;
+               return "; filename*=utf-8''" + encodedFilename.replaceAll("\\+", "%20");
             }
          } catch (UnsupportedEncodingException e) {
             // should not happen

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/resource/EncodingMimeMultipartFormProviderResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/resource/EncodingMimeMultipartFormProviderResource.java
@@ -23,7 +23,7 @@ public class EncodingMimeMultipartFormProviderResource {
    /**
     * Non-ASCII file name
     */
-   public static final String FILENAME_NON_ASCII = "Döner.png";
+   public static final String FILENAME_NON_ASCII = "Döner 1 + 2.png";
 
    @POST
    @Path("file")


### PR DESCRIPTION
Fixed by replacing to correct chars. Enhanced test to cover this case.
Jira: https://issues.jboss.org/browse/RESTEASY-2046