### PR TITLE
[RESTEASY-2053] JDK11 illegal reflective access testsuite warnings

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -81,7 +81,7 @@
         <version.org.wildfly.wildfly-arquillian-container-managed>2.1.0.Final</version.org.wildfly.wildfly-arquillian-container-managed>
         <version.org.wildfly.wildfly-arquillian-container-remote>2.1.0.Final</version.org.wildfly.wildfly-arquillian-container-remote>
         <version.org.wildfly-security>10.0.0.Final</version.org.wildfly-security>
-        <version.org.wildfly.security.wildfly-elytron>1.1.5.Final</version.org.wildfly.security.wildfly-elytron>
+        <version.org.wildfly.security.wildfly-elytron>1.6.1.Final</version.org.wildfly.security.wildfly-elytron>
         <version.javax.validation-api>1.1.0.Final</version.javax.validation-api>
         <version.weld.api>3.0.SP3</version.weld.api>
         <version.weld>3.0.4.Final</version.weld>
@@ -92,6 +92,7 @@
         <version.io.reactivex.rxjava2-rxjava>2.2.2</version.io.reactivex.rxjava2-rxjava>
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.hibernate.validator>6.0.10.Final</version.org.hibernate.validator>
+        <version.org.jboss.marshalling.jboss-marshalling>2.0.6.Final</version.org.jboss.marshalling.jboss-marshalling>
     </properties>
 
     <distributionManagement>
@@ -790,6 +791,16 @@
                 <groupId>io.reactivex.rxjava2</groupId>
                 <artifactId>rxjava</artifactId>
                 <version>${version.io.reactivex.rxjava2-rxjava}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.marshalling</groupId>
+                <artifactId>jboss-marshalling</artifactId>
+                <version>${version.org.jboss.marshalling.jboss-marshalling}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.marshalling</groupId>
+                <artifactId>jboss-marshalling-river</artifactId>
+                <version>${version.org.jboss.marshalling.jboss-marshalling}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
jira: https://issues.jboss.org/browse/RESTEASY-2053
3.6 PR: https://github.com/resteasy/Resteasy/pull/1760

---- 

RESTEasy currently prints with JDK11 these warnings:
1. WARNING: Illegal reflective access by org.wildfly.security.manager.GetAccessibleDeclaredFieldAction (file:/home/mkopecky/.m2/repository/org/wildfly/security/wildfly-elytron/1.1.5.Final/wildfly-elytron-1.1.5.Final.jar) to field java.security.AccessControlContext.context
2. WARNING: Illegal reflective access by org.jboss.as.server.deployment.reflect.ClassReflectionIndex (jar:file:/home/mkopecky/playground/wf/modules/system/layers/base/org/jboss/as/server/main/wildfly-server-7.0.0.Alpha4.jar!/) to method java.lang.Object.finalize()

Second one is caused by WFCORE-4116 (not yet used in WF). First one is cause by wrong elytron version used in RESTEasy TS. After new (correct) Elytron is used, new warning occurs:

* WARNING: Illegal reflective access by org.jboss.marshalling.Marshalling$OptionalDataExceptionCreateAction$1 (file:/home/mkopecky/.m2/repository/org/jboss/marshalling/jboss-marshalling/2.0.0.Final/jboss-marshalling-2.0.0.Final.jar) to constructor java.io.OptionalDataException(boolean)

This warning is caused by wrong (old) jboss-marshaling version.

----

* jboss-marshaling is aligned with wf-core: https://github.com/wildfly/wildfly-core/blob/7.0.0.Alpha4/pom.xml#L178
* last final elytron is 3.6.1.Final
  * https://github.com/wildfly-security/wildfly-elytron/releases
  * https://github.com/wildfly/wildfly-core/blob/7.0.0.Alpha4/pom.xml#L213 
