### PR TITLE
[RESTEASY-2063] Add missing provider annotations

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/ByteArrayProvider.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/ByteArrayProvider.java
@@ -10,6 +10,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -20,6 +21,7 @@ import java.lang.reflect.Type;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
+@Provider
 @Produces("*/*")
 @Consumes("*/*")
 public class ByteArrayProvider implements MessageBodyReader<byte[]>, MessageBodyWriter<byte[]>

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/FileRangeWriter.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/FileRangeWriter.java
@@ -4,6 +4,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -14,6 +15,7 @@ import java.lang.reflect.Type;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
+@Provider
 public class FileRangeWriter implements MessageBodyWriter<FileRange>
 {
    @Override

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/StreamingOutputProvider.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/StreamingOutputProvider.java
@@ -5,6 +5,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
@@ -15,6 +16,7 @@ import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
+@Provider
 @Produces("*/*")
 public class StreamingOutputProvider implements MessageBodyWriter<StreamingOutput>
 {


### PR DESCRIPTION
Add missing `@Provider` annotation to `StreamingOutputProvider`, `ByteArrayProvider` and `FileRangeWriter`.

Fix for minor Issue [RESTEASY-2063](https://issues.jboss.org/browse/RESTEASY-2063).
