### PR TITLE
PriorityTest: improve robustness (FakeHttpServer)

### DIFF
--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/interception/PriorityTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/interception/PriorityTest.java
@@ -37,6 +37,7 @@ import org.jboss.resteasy.core.interception.jaxrs.ContainerResponseFilterRegistr
 import org.jboss.resteasy.core.interception.jaxrs.JaxrsInterceptorRegistryImpl;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.spi.interception.JaxrsInterceptorRegistry;
+import org.jboss.resteasy.test.interception.resource.FakeHttpServer;
 import org.jboss.resteasy.test.interception.resource.PriorityClientRequestFilter1;
 import org.jboss.resteasy.test.interception.resource.PriorityClientRequestFilter2;
 import org.jboss.resteasy.test.interception.resource.PriorityClientRequestFilter3;
@@ -47,6 +48,7 @@ import org.jboss.resteasy.test.interception.resource.PriorityContainerResponseFi
 import org.jboss.resteasy.test.interception.resource.PriorityContainerResponseFilter2;
 import org.jboss.resteasy.test.interception.resource.PriorityContainerResponseFilter3;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 
 
@@ -59,6 +61,10 @@ import org.junit.Test;
 public class PriorityTest {
 
    private static final String ERROR_MESSAGE = "RESTEasy uses filter in wrong older";
+
+   @Rule
+   public FakeHttpServer fakeHttpServer = new FakeHttpServer();
+
    /**
     * @tpTestDetails Test for classes implements ContainerResponseFilter.
     * @tpSince RESTEasy 3.0.16
@@ -122,7 +128,9 @@ public class PriorityTest {
       Client client = ClientBuilder.newClient();
       try
       {
-         WebTarget webTarget = client.target("http://www.test.com");
+         fakeHttpServer.start();
+
+         WebTarget webTarget = client.target("http://" + fakeHttpServer.getHostAndPort());
          StringBuilder result = new StringBuilder();
          webTarget.register(new ClientRequestFilter()
          {
@@ -155,7 +163,9 @@ public class PriorityTest {
       Client client = ClientBuilder.newClient();
       try
       {
-         WebTarget webTarget = client.target("http://www.test.com");
+         fakeHttpServer.start();
+
+         WebTarget webTarget = client.target("http://" + fakeHttpServer.getHostAndPort());
          StringBuilder result = new StringBuilder();
          webTarget.register(new ClientResponseFilter()
          {
@@ -190,7 +200,9 @@ public class PriorityTest {
       Client client = ClientBuilder.newClient();
       try
       {
-         WebTarget webTarget = client.target("http://www.test.com");
+         fakeHttpServer.start();
+
+         WebTarget webTarget = client.target("http://" + fakeHttpServer.getHostAndPort());
          webTarget.register((ClientResponseFilter) (containerRequestContext, containerResponseContext) -> {
             containerResponseContext.getHeaders().putSingle(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN);
             containerResponseContext.setEntityStream(new ByteArrayInputStream("hello".getBytes()));
@@ -230,7 +242,9 @@ public class PriorityTest {
       Client client = ClientBuilder.newClient();
       try
       {
-         WebTarget webTarget = client.target("http://www.test.com");
+         fakeHttpServer.start();
+
+         WebTarget webTarget = client.target("http://" + fakeHttpServer.getHostAndPort());
          StringBuilder result = new StringBuilder();
          webTarget.register(new WriterInterceptor()
          {
@@ -265,7 +279,9 @@ public class PriorityTest {
       Client client = ClientBuilder.newClient();
       try
       {
-         WebTarget webTarget = client.target("http://www.test.com");
+         fakeHttpServer.start();
+
+         WebTarget webTarget = client.target("http://" + fakeHttpServer.getHostAndPort());
          webTarget.register((ClientResponseFilter) (containerRequestContext, containerResponseContext) -> {
             containerResponseContext.getHeaders().putSingle(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN);
             containerResponseContext.setEntityStream(new ByteArrayInputStream("hello".getBytes()));
@@ -320,7 +336,9 @@ public class PriorityTest {
       Client client = ClientBuilder.newClient();
       try
       {
-         WebTarget webTarget = client.target("http://www.test.com");
+         fakeHttpServer.start();
+
+         WebTarget webTarget = client.target("http://" + fakeHttpServer.getHostAndPort());
          StringBuilder result = new StringBuilder();
          webTarget.register(new MessageBodyWriter<String>()
          {
@@ -369,7 +387,9 @@ public class PriorityTest {
       Client client = ClientBuilder.newClient();
       try
       {
-         WebTarget webTarget = client.target("http://www.test.com");
+         fakeHttpServer.start();
+
+         WebTarget webTarget = client.target("http://" + fakeHttpServer.getHostAndPort());
          webTarget.register(new ClientRequestFilter()
          {
             @Context
@@ -408,5 +428,4 @@ public class PriorityTest {
          client.close();
       }
    }
-
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/interception/resource/FakeHttpServer.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/interception/resource/FakeHttpServer.java
@@ -1,0 +1,100 @@
+package org.jboss.resteasy.test.interception.resource;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.rules.ExternalResource;
+import org.xnio.streams.Streams;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+/** Tiny fake HTTP server providing a target for testing the RESTEasy client. */
+public class FakeHttpServer extends ExternalResource {
+
+   private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+
+   private HttpServer server;
+
+   /**
+    * Get the servers listen address.
+    *
+    * @return The address the server is listening on.
+    */
+   public InetSocketAddress getAddress()
+   {
+      return server.getAddress();
+   }
+
+   /**
+    * Get the servers listen address in host:port format.
+    *
+    * @return The host and port the server is listening on.
+    */
+   public String getHostAndPort()
+   {
+      return server.getAddress().getHostString() + ":" + server.getAddress().getPort();
+   }
+
+   /**
+    * Start the server.
+    */
+   public void start()
+   {
+      server.start();
+   }
+
+   @Override
+   protected void before() throws Throwable {
+      HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+
+      server.createContext("/path", exchange -> {
+         final byte[] response;
+         final int length;
+         final int status;
+         switch (exchange.getRequestMethod().toUpperCase())
+         {
+            case "HEAD":
+               response = EMPTY_BYTE_ARRAY;
+               length = exchange.getRequestURI().toString().getBytes(StandardCharsets.UTF_8).length;
+               status = 200;
+               break;
+
+            case "GET":
+               response = exchange.getRequestURI().toString().getBytes(StandardCharsets.UTF_8);
+               length = response.length;
+               status = 200;
+               break;
+
+            case "POST": {
+               ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+               Streams.copyStream(exchange.getRequestBody(), buffer);
+               response = buffer.toByteArray();
+               length = response.length;
+               status = 200;
+               break;
+            }
+
+            default:
+               response = "Method Not Allowed".getBytes(StandardCharsets.UTF_8);
+               length = response.length;
+               status = 405;
+               break;
+         }
+
+         exchange.sendResponseHeaders(status, length);
+         OutputStream os = exchange.getResponseBody();
+         os.write(response);
+         os.close();
+      });
+
+      server.setExecutor(null);  // handle on dispatcher thread
+
+      this.server = server;
+   }
+
+   @Override
+   protected void after() {
+      server.stop(0);
+   }
+}


### PR DESCRIPTION
This is a follow up on https://github.com/resteasy/Resteasy/pull/1765

Tests in `org.jboss.resteasy.test.interception.PriorityTest` also use the RESTEasy client, targetting the real internet site `www.test.com`. This leads to spurious test failures.

The commit replaces use of `www.test.com` with the URL of a fake HTTP server listening on the IPv4 loopback address on a dynamically allocated port.

@asoldano Sorry for not committing in time to catch the previous PR's merge. I duplicated the `FakeHttpServer` class in `../interception/resource` to conform to the projects test layout. In theory I would prefer to mock the client for these tests, but using the fake server is too easy and apparently fast enough.