### PR TITLE
Improve ChunkedTransferEncodingUnitTest robustness

### DIFF
--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ChunkedTransferEncodingUnitTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ChunkedTransferEncodingUnitTest.java
@@ -1,25 +1,18 @@
 package org.jboss.resteasy.test.client;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.Inet4Address;
-import java.net.ServerSocket;
-import java.net.Socket;
 
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 
-import org.jboss.logging.Logger;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.jboss.resteasy.client.jaxrs.internal.ClientInvocationBuilder;
+import org.jboss.resteasy.test.client.resource.FakeHttpServer;
 import org.jboss.resteasy.utils.TestUtil;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -32,112 +25,22 @@ import org.junit.Test;
  */
 public class ChunkedTransferEncodingUnitTest
 {
-   private static Thread t;
-   private static ServerSocket ss;
-   private static Socket s;
-   private static final Logger logger = Logger.getLogger(ChunkedTransferEncodingUnitTest.class);
-
-   private static String RESPONSE_200 =
-         "HTTP/1.1 200 OK\r\n" +
-         "Content-Type: text/plain;charset=UTF-8\r\n" +
-         "Content-Length: 2\r\n" +
-         "\r\n" +
-         "ok";
-
-   private static String RESPONSE_400 =
-         "HTTP/1.1 400 OK\r\n" +
-         "Content-Type: text/plain;charset=UTF-8\r\n" +
-         "Content-Length: 6\r\n" +
-         "\r\n" +
-         "not ok";
-
-   static final String testFilePath;
+   private static final String testFilePath;
 
    static {
       testFilePath = TestUtil.getResourcePath(ChunkedTransferEncodingUnitTest.class, "ChunkedTransferEncodingUnitTestFile");
    }
 
-   private String fakeServerHostAndPort;
-   //////////////////////////////////////////////////////////////////////////////
+   @Rule
+   public FakeHttpServer fakeHttpServer = new FakeHttpServer();
 
-   @Before
-   public void before() throws Exception
-   {
-      int[] chars = new int[1024];
-
-      t = new Thread() {
-         public void run() {
-            try {
-               ss = new ServerSocket(0, 0, Inet4Address.getLocalHost());
-               fakeServerHostAndPort = ss.getInetAddress().getHostAddress() + ":" + ss.getLocalPort();
-               s = ss.accept();
-               InputStream is = s.getInputStream();
-               int j = 0;
-               while (!endOfHeaders(chars, j)) {
-                  chars[j++] = is.read();
-               }
-               String headers = new String(chars, 0, j);
-               int length = getLength(chars, j, is);
-               for (int k = 0; k < length; k++) {
-                  chars[k] = is.read();
-               }
-               String entity = new String(chars, 0, length);
-               OutputStream os = s.getOutputStream();
-               if (headers.contains("Transfer-Encoding: chunked") && entity.contains("file entity")) {
-                  os.write(RESPONSE_200.getBytes());
-               }
-               else {
-                  os.write(RESPONSE_400.getBytes());
-               }
-               return;
-            } catch (IOException e) {
-               logger.error(e.getMessage(), e);
-            }
-         }
-      };
-      t.setDaemon(true);
-      t.start();
-   }
-
-   private static boolean endOfHeaders(int[] chars, int length) {
-      if (length < 4) {
-         return false;
-      }
-      return chars[length - 4] == '\r' && chars[length - 3] == '\n' && chars[length - 2] == '\r' && chars[length - 1] == '\n';
-   }
-
-   private static int getLength(int[] chars, int start, InputStream is) throws IOException {
-      int i = start;
-      while (true) {
-         chars[i] = is.read();
-         while (chars[i++] != '\r') {
-            chars[i] = is.read();
-         }
-         chars[i] = is.read();
-         if (chars[i++] == '\n') {
-            String s = new String(chars, start, i - start - 2);
-            return Integer.valueOf(s, 16);
-         }
-      }
-   }
-
-   @After
-   public void after() throws Exception
-   {
-      if (s != null) {
-         s.close();
-      }
-      if (ss != null) {
-         ss.close();
-      }
-   }
-
-   //////////////////////////////////////////////////////////////////////////////
 
    @Test
    public void testChunkedTarget() throws Exception {
+      fakeHttpServer.start();
+
       ResteasyClient client = (ResteasyClient)ClientBuilder.newClient();
-      ResteasyWebTarget target = client.target("http://" + fakeServerHostAndPort + "/test");
+      ResteasyWebTarget target = client.target("http://" + fakeHttpServer.getHostAndPort() + "/chunked");
       target.setChunked(true);
       ClientInvocationBuilder request = (ClientInvocationBuilder) target.request();
       File file = new File(testFilePath);
@@ -151,8 +54,10 @@ public class ChunkedTransferEncodingUnitTest
 
    @Test
    public void testChunkedRequest() throws Exception {
+      fakeHttpServer.start();
+
       ResteasyClient client = (ResteasyClient)ClientBuilder.newClient();
-      ResteasyWebTarget target = client.target("http://" + fakeServerHostAndPort + "/test");
+      ResteasyWebTarget target = client.target("http://" + fakeHttpServer.getHostAndPort() + "/chunked");
       ClientInvocationBuilder request = (ClientInvocationBuilder) target.request();
       request.setChunked(true);
       File file = new File(testFilePath);


### PR DESCRIPTION
I encountered the following, spurious Travis errors:

```
Running org.jboss.resteasy.test.client.ChunkedTransferEncodingUnitTest
Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.044 sec <<< FAILURE! - in org.jboss.resteasy.test.client.ChunkedTransferEncodingUnitTest
testChunkedRequest(org.jboss.resteasy.test.client.ChunkedTransferEncodingUnitTest)  Time elapsed: 0.028 sec  <<< ERROR!
javax.ws.rs.ProcessingException: RESTEASY004655: Unable to invoke request
    at org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient43Engine.invoke(ApacheHttpClient43Engine.java:272)
    at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.invoke(ClientInvocation.java:484)
    at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.invoke(ClientInvocation.java:63)
    at org.jboss.resteasy.client.jaxrs.internal.ClientInvocationBuilder.post(ClientInvocationBuilder.java:218)
    at org.jboss.resteasy.test.client.ChunkedTransferEncodingUnitTest.testChunkedRequest(ChunkedTransferEncodingUnitTest.java:159)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
    at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
    at org.junit.runners.Suite.runChild(Suite.java:128)
    at org.junit.runners.Suite.runChild(Suite.java:27)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
    at org.apache.maven.surefire.junitcore.JUnitCore.run(JUnitCore.java:55)
    at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.createRequestAndRun(JUnitCoreWrapper.java:137)
    at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.executeEager(JUnitCoreWrapper.java:107)
    at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:83)
    at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:75)
    at org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:161)
    at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:290)
    at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:242)
    at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:121)
Caused by: java.net.UnknownHostException: null: Name or service not known
    at java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method)
    at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:929)
    at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1324)
    at java.net.InetAddress.getAllByName0(InetAddress.java:1277)
    at java.net.InetAddress.getAllByName(InetAddress.java:1193)
    at java.net.InetAddress.getAllByName(InetAddress.java:1127)
    at org.apache.http.impl.conn.SystemDefaultDnsResolver.resolve(SystemDefaultDnsResolver.java:45)
    at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:112)
    at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:373)
    at org.apache.http.impl.execchain.MainClientExec.establishRoute(MainClientExec.java:381)
    at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:237)
    at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:185)
    at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)
    at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:111)
    at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
    at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
    at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:56)
    at org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient43Engine.invoke(ApacheHttpClient43Engine.java:268)
    ... 40 more
Results :
Tests in error:
  ChunkedTransferEncodingUnitTest.testChunkedRequest:159 » Processing RESTEASY00...
Tests run: 261, Failures: 0, Errors: 1, Skipped: 2
```


This PR replaces the "custom HTTP server implementation" in `ChunkedTransferEncodingUnitTest` with the `FakeHttpServer` added in #1765 .