### PR TITLE
[RESTEASY-1142] ExceptionHandler: catch IllegalStateException from ClientResponse

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
@@ -125,7 +125,15 @@ public class ExceptionHandler
 
       if (unwrappedException instanceof WebApplicationException) {
          WebApplicationException wae = (WebApplicationException) unwrappedException;
-         if (wae.getResponse() != null && wae.getResponse().getEntity() != null) return wae.getResponse();
+         Response response = wae.getResponse();
+         if (response != null) {
+            try {
+               if (response.getEntity() != null) return response;
+            } catch(IllegalStateException ise) {
+               // IllegalStateException from ClientResponse.getEntity() means the response is closed and got no entity
+               return response;
+            }
+         }
       }
 
       if ((jaxrsResponse = executeExceptionMapper(unwrappedException)) != null) {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ServerResponseWriter.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ServerResponseWriter.java
@@ -80,8 +80,10 @@ public class ServerResponseWriter
       setResponseMediaType(jaxrsResponse, request, response, providerFactory, method);
 
       executeFilters(jaxrsResponse, request, response, providerFactory, method, onComplete, () -> {
+         Object entity = jaxrsResponse.isClosed() ? null : jaxrsResponse.getEntity();
+
          //[RESTEASY-1627] check on response.getOutputStream() to avoid resteasy-netty4 trying building a chunked response body for HEAD requests
-         if (jaxrsResponse.getEntity() == null || response.getOutputStream() == null)
+         if (entity == null || response.getOutputStream() == null)
          {
             response.setStatus(jaxrsResponse.getStatus());
             commitHeaders(jaxrsResponse, response);
@@ -89,7 +91,6 @@ public class ServerResponseWriter
          }
 
          Class type = jaxrsResponse.getEntityClass();
-         Object ent = jaxrsResponse.getEntity();
          Type generic = jaxrsResponse.getGenericType();
          Annotation[] annotations = jaxrsResponse.getAnnotations();
          @SuppressWarnings(value = "unchecked")
@@ -132,7 +133,7 @@ public class ServerResponseWriter
          }
 
          AbstractWriterInterceptorContext writerContext =  new ServerWriterInterceptorContext(writerInterceptors,
-               providerFactory, ent, type, generic, annotations, mt,
+               providerFactory, entity, type, generic, annotations, mt,
                jaxrsResponse.getMetadata(), os, request);
          writerContext.proceed();
          if(sendHeaders) {
@@ -154,7 +155,7 @@ public class ServerResponseWriter
    public static MediaType getResponseMediaType(BuiltResponse jaxrsResponse, HttpRequest request, HttpResponse response, ResteasyProviderFactory providerFactory, ResourceMethodInvoker method)
    {
       MediaType mt = null;
-      if (jaxrsResponse.getEntity() != null)
+      if (!jaxrsResponse.isClosed() && jaxrsResponse.getEntity() != null)
       {
          if ((mt = jaxrsResponse.getMediaType()) == null)
          {

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/ContainerResponseContextImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/interception/ContainerResponseContextImpl.java
@@ -235,13 +235,13 @@ public class ContainerResponseContextImpl implements SuspendableContainerRespons
    @Override
    public boolean hasEntity()
    {
-      return jaxrsResponse.hasEntity();
+      return !jaxrsResponse.isClosed() && jaxrsResponse.hasEntity();
    }
 
    @Override
    public Object getEntity()
    {
-      return jaxrsResponse.getEntity();
+      return !jaxrsResponse.isClosed() ? jaxrsResponse.getEntity() : null;
    }
 
    @Override

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/ClosedResponseHandlingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/ClosedResponseHandlingTest.java
@@ -1,0 +1,71 @@
+package org.jboss.resteasy.test.exception;
+
+import java.lang.reflect.ReflectPermission;
+
+import javax.ws.rs.NotAcceptableException;
+import javax.ws.rs.NotSupportedException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.test.exception.resource.ClosedResponseHandlingPleaseMapExceptionMapper;
+import org.jboss.resteasy.test.exception.resource.ClosedResponseHandlingResource;
+import org.jboss.resteasy.utils.PermissionUtil;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @tpSubChapter Resteasy-client
+ * @tpChapter Integration tests
+ * @tpSince RESTEasy 3.6.3
+ * @tpTestCaseDetails Regression test for RESTEASY-1142
+ * @author <a href="ron.sigal@jboss.com">Ron Sigal</a>
+ * @author <a href="jonas.zeiger@talpidae.net">Jonas Zeiger</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ClosedResponseHandlingTest {
+
+   @Deployment
+   public static Archive<?> deploy() {
+      WebArchive war = TestUtil.prepareArchive(ClosedResponseHandlingTest.class.getSimpleName());
+      war.addClass(ClosedResponseHandlingTest.class);
+      war.addPackage(ClosedResponseHandlingResource.class.getPackage());
+      war.addClass(PortProviderUtil.class);
+      war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
+           new ReflectPermission("suppressAccessChecks")
+      ), "permissions.xml");
+
+      return TestUtil.finishContainerPrepare(war, null, ClosedResponseHandlingResource.class,
+            ClosedResponseHandlingPleaseMapExceptionMapper.class);
+   }
+
+   /**
+    * @tpTestDetails RESTEasy client errors that result in a closed Response are correctly handled.
+    * @tpPassCrit A NotAcceptableException is returned
+    * @tpSince RESTEasy 3.6.3
+    */
+   @Test(expected = NotAcceptableException.class)
+   public void testNotAcceptable() {
+      new ResteasyClientBuilder().build().target(generateURL("/testNotAcceptable")).request().get(String.class);
+   }
+
+   /**
+    * @tpTestDetails Closed Response instances should be handled correctly with full tracing enabled.
+    * @tpPassCrit A NotSupportedException is returned
+    * @tpSince RESTEasy 3.6.3
+    */
+   @Test(expected = NotSupportedException.class)
+   public void testNotSupportedTraced() {
+      new ResteasyClientBuilder().build().target(generateURL("/testNotSupportedTraced")).request().get(String.class);
+   }
+
+   private static String generateURL(String path) {
+      return PortProviderUtil.generateURL(path, ClosedResponseHandlingTest.class.getSimpleName());
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingPleaseMapException.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingPleaseMapException.java
@@ -1,0 +1,12 @@
+package org.jboss.resteasy.test.exception.resource;
+
+import javax.ws.rs.core.Response;
+
+public class ClosedResponseHandlingPleaseMapException extends RuntimeException {
+
+   final Response response;
+
+   public ClosedResponseHandlingPleaseMapException(Response response) {
+      this.response = response;
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingPleaseMapException.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingPleaseMapException.java
@@ -6,7 +6,7 @@ public class ClosedResponseHandlingPleaseMapException extends RuntimeException {
 
    final Response response;
 
-   public ClosedResponseHandlingPleaseMapException(Response response) {
+   public ClosedResponseHandlingPleaseMapException(final Response response) {
       this.response = response;
    }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingPleaseMapExceptionMapper.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingPleaseMapExceptionMapper.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.test.exception.resource;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/** ExceptionHandler only uses the logger for tracing exception mapping, so we need to map something.
+ */
+@Provider
+public class ClosedResponseHandlingPleaseMapExceptionMapper implements ExceptionMapper<ClosedResponseHandlingPleaseMapException> {
+
+   @Override
+   public Response toResponse(ClosedResponseHandlingPleaseMapException e) {
+      return e.response;
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingResource.java
@@ -1,0 +1,48 @@
+package org.jboss.resteasy.test.exception.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.NotSupportedException;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+
+import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
+import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
+
+@Path("")
+public class ClosedResponseHandlingResource {
+
+   @Path("/testNotAcceptable/406")
+   @GET
+   public Response errorNotAcceptable() {
+      return Response.status(NOT_ACCEPTABLE).build();
+   }
+
+   @Path("/testNotAcceptable")
+   @GET
+   public String getNotAcceptable(@Context UriInfo uriInfo) {
+      URI endpoint406 = UriBuilder.fromUri(uriInfo.getRequestUri()).path("406").build();
+      return ClientBuilder.newClient().target(endpoint406).request().get(String.class);
+   }
+
+   @Path("/testNotSupportedTraced/415")
+   @GET
+   public Response errorNotFound() {
+      return Response.status(UNSUPPORTED_MEDIA_TYPE).build();
+   }
+
+   @Path("/testNotSupportedTraced")
+   @GET
+   public String getNotSupportedTraced(@Context UriInfo uriInfo) {
+      URI endpoint415 = UriBuilder.fromUri(uriInfo.getRequestUri()).path("415").build();
+      try {
+         return ClientBuilder.newClient().target(endpoint415).request().get(String.class);
+      } catch(NotSupportedException e) {
+         throw new ClosedResponseHandlingPleaseMapException(e.getResponse());
+      }
+   }
+}


### PR DESCRIPTION
Backport of #1716 for 3.6 branch.

@ronsigal This does not include the tracing logger fix, as that feature doesn't exist on 3.6.
