### PR TITLE
[RESTEASY-2070] wadl - Useless control flow - if ends with semi-colon

### DIFF
--- a/resteasy-wadl/src/main/java/org/jboss/resteasy/wadl/ResteasyWadlWriter.java
+++ b/resteasy-wadl/src/main/java/org/jboss/resteasy/wadl/ResteasyWadlWriter.java
@@ -395,10 +395,10 @@ public class ResteasyWadlWriter {
                    Iterator<Include> iter = grammars.getInclude().iterator();
                    while (iter.hasNext()) {
                        for (Doc doc : iter.next().getDoc()) {
-                           // CHECKSTYLE.OFF: EmptyStatement
-                           if ("Generated".equals(doc.getTitle()));
-                           // CHECKSTYLE.ON: EmptyStatement
-                           iter.remove();
+                           if ("Generated".equals(doc.getTitle())) {
+                               iter.remove();
+                               break;
+                           }
                        }
                    }
                }


### PR DESCRIPTION
https://issues.jboss.org/browse/RESTEASY-2070
wadl - Useless control flow - if ends with semi-colon

`iter.remove()` is performed every time