### PR TITLE
[RESTEASY-2072] Update TypesBuiltInTest to use ParamConverter

### DIFF
--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/TypesBuiltInTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/TypesBuiltInTest.java
@@ -1,12 +1,16 @@
 package org.jboss.resteasy.test.util;
 
 import org.jboss.resteasy.spi.StringConverter;
+import org.jboss.resteasy.test.util.resource.TypesParamConverterPOJO;
+import org.jboss.resteasy.test.util.resource.TypesTestParamConverterProvider;
+import org.jboss.resteasy.test.util.resource.TypesTestParamConverterProviderSubclass;
 import org.jboss.resteasy.test.util.resource.TypesTestProvider;
 import org.jboss.resteasy.test.util.resource.TypesTestProviderSubclass;
 import org.jboss.resteasy.util.Types;
 import org.junit.Test;
 
 import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.ParamConverter;
 import java.lang.reflect.Type;
 
 import static org.junit.Assert.assertEquals;
@@ -32,6 +36,10 @@ public class TypesBuiltInTest {
       parameters = Types.getActualTypeArgumentsOfAnInterface(TypesTestProvider.class, StringConverter.class);
       assertEquals("Wrong count of parameters", 1, parameters.length);
       assertEquals("Wrong type of parameter", Integer.class, (Class<?>) parameters[0]);
+
+      parameters = Types.getActualTypeArgumentsOfAnInterface(TypesTestParamConverterProvider.class, ParamConverter.class);
+      assertEquals("Wrong count of parameters", 1, parameters.length);
+      assertEquals("Wrong type of parameter", TypesParamConverterPOJO.class, (Class<?>) parameters[0]);
    }
 
    /**
@@ -48,5 +56,9 @@ public class TypesBuiltInTest {
       parameters = Types.getActualTypeArgumentsOfAnInterface(TypesTestProviderSubclass.class, StringConverter.class);
       assertEquals("Wrong count of parameters", 1, parameters.length);
       assertEquals("Wrong type of parameter", Integer.class, (Class<?>) parameters[0]);
+
+      parameters = Types.getActualTypeArgumentsOfAnInterface(TypesTestParamConverterProviderSubclass.class, ParamConverter.class);
+      assertEquals("Wrong count of parameters", 1, parameters.length);
+      assertEquals("Wrong type of parameter", TypesParamConverterPOJO.class, (Class<?>) parameters[0]);
    }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/resource/TypesParamConverterPOJO.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/resource/TypesParamConverterPOJO.java
@@ -1,0 +1,14 @@
+package org.jboss.resteasy.test.util.resource;
+
+public class TypesParamConverterPOJO {
+
+   private String name;
+
+   public String getName() {
+      return name;
+   }
+
+   public void setName(String name) {
+      this.name = name;
+   }
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/resource/TypesTestParamConverterProvider.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/resource/TypesTestParamConverterProvider.java
@@ -1,0 +1,18 @@
+package org.jboss.resteasy.test.util.resource;
+
+import javax.ws.rs.ext.ParamConverter;
+
+public class TypesTestParamConverterProvider implements ParamConverter<TypesParamConverterPOJO> {
+
+   @Override
+   public TypesParamConverterPOJO fromString(String str) {
+      TypesParamConverterPOJO pojo = new TypesParamConverterPOJO();
+      pojo.setName(str);
+      return pojo;
+   }
+
+   @Override
+   public String toString(TypesParamConverterPOJO value) {
+      return value.getName();
+   }
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/resource/TypesTestParamConverterProviderSubclass.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/resource/TypesTestParamConverterProviderSubclass.java
@@ -1,0 +1,4 @@
+package org.jboss.resteasy.test.util.resource;
+
+public class TypesTestParamConverterProviderSubclass extends TypesTestParamConverterProvider {
+}


### PR DESCRIPTION
Update TypesBuiltInTest to use ParamConverter

Jira: https://issues.jboss.org/browse/RESTEASY-2072
Master: https://github.com/resteasy/Resteasy/pull/1784