### PR TITLE
[RESTEASY-2072] Update TypesBuiltInTest to use ParamConverter

### DIFF
--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/TypesBuiltInTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/TypesBuiltInTest.java
@@ -1,12 +1,14 @@
 package org.jboss.resteasy.test.util;
 
 import org.jboss.resteasy.spi.MarshalledEntity;
+import org.jboss.resteasy.spi.util.Types;
+import org.jboss.resteasy.test.util.resource.TypesParamConverterPOJO;
 import org.jboss.resteasy.test.util.resource.TypesTestProvider;
 import org.jboss.resteasy.test.util.resource.TypesTestProviderSubclass;
-import org.jboss.resteasy.spi.util.Types;
 import org.junit.Test;
 
 import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.ParamConverter;
 import java.lang.reflect.Type;
 
 import static org.junit.Assert.assertEquals;
@@ -32,6 +34,10 @@ public class TypesBuiltInTest {
       parameters = Types.getActualTypeArgumentsOfAnInterface(TypesTestProvider.class, MarshalledEntity.class);
       assertEquals("Wrong count of parameters", 1, parameters.length);
       assertEquals("Wrong type of parameter", Integer.class, (Class<?>) parameters[0]);
+
+      parameters = Types.getActualTypeArgumentsOfAnInterface(TypesTestProvider.class, ParamConverter.class);
+      assertEquals("Wrong count of parameters", 1, parameters.length);
+      assertEquals("Wrong type of parameter", TypesParamConverterPOJO.class, (Class<?>) parameters[0]);
    }
 
    /**
@@ -48,5 +54,9 @@ public class TypesBuiltInTest {
       parameters = Types.getActualTypeArgumentsOfAnInterface(TypesTestProviderSubclass.class, MarshalledEntity.class);
       assertEquals("Wrong count of parameters", 1, parameters.length);
       assertEquals("Wrong type of parameter", Integer.class, (Class<?>) parameters[0]);
+
+      parameters = Types.getActualTypeArgumentsOfAnInterface(TypesTestProviderSubclass.class, ParamConverter.class);
+      assertEquals("Wrong count of parameters", 1, parameters.length);
+      assertEquals("Wrong type of parameter", TypesParamConverterPOJO.class, (Class<?>) parameters[0]);
    }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/resource/TypesParamConverterPOJO.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/resource/TypesParamConverterPOJO.java
@@ -1,0 +1,14 @@
+package org.jboss.resteasy.test.util.resource;
+
+public class TypesParamConverterPOJO {
+
+   private String name;
+
+   public String getName() {
+      return name;
+   }
+
+   public void setName(String name) {
+      this.name = name;
+   }
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/resource/TypesTestProvider.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/resource/TypesTestProvider.java
@@ -4,8 +4,9 @@ import org.jboss.resteasy.spi.MarshalledEntity;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.ParamConverter;
 
-public class TypesTestProvider implements ExceptionMapper<NullPointerException>, MarshalledEntity<Integer> {
+public class TypesTestProvider implements ExceptionMapper<NullPointerException>, MarshalledEntity<Integer>, ParamConverter<TypesParamConverterPOJO> {
 
    public Response toResponse(NullPointerException exception) {
       return null;
@@ -23,4 +24,15 @@ public class TypesTestProvider implements ExceptionMapper<NullPointerException>,
       return null;
    }
 
+   @Override
+   public TypesParamConverterPOJO fromString(String str) {
+      TypesParamConverterPOJO pojo = new TypesParamConverterPOJO();
+      pojo.setName(str);
+      return pojo;
+   }
+
+   @Override
+   public String toString(TypesParamConverterPOJO value) {
+      return value.getName();
+   }
 }


### PR DESCRIPTION
Update TypesBuiltInTest to use ParamConverter

Jira: https://issues.jboss.org/browse/RESTEASY-2072
3.6: https://github.com/resteasy/Resteasy/pull/1783