### PR TITLE
[RESTEASY-2077] Cleanup of ignored tests

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/AsyncBenchTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/AsyncBenchTest.java
@@ -24,9 +24,15 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+/**
+ * @tpChapter Client tests
+ * @tpSubChapter Asynchronous
+ * @tpTestCaseDetails https://issues.jboss.org/browse/RESTEASY-1025
+ * @tpSince RESTEasy 3.5.0
+ */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Ignore
+@Ignore("Not a functional test")
 public class AsyncBenchTest extends ClientTestBase
 {
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/ResourceClassProcessorBasicTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/ResourceClassProcessorBasicTest.java
@@ -6,7 +6,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.category.ExpectedFailing;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import javax.ws.rs.client.ClientBuilder;
 
@@ -29,11 +28,10 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.Ignore;
 
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 
@@ -234,7 +232,7 @@ public class ResourceClassProcessorBasicTest {
     * @tpSince RESTEasy 3.6
     */
    @Test
-   @Category(ExpectedFailing.class)
+   @Ignore("https://issues.jboss.org/browse/RESTEASY-2071")
    public void proxyTest() {
       ResteasyClient proxyClient= (ResteasyClient)ClientBuilder.newBuilder()
             .register(ResourceClassProcessorImplementation.class)

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/resource/SseBroadcastResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/resource/SseBroadcastResource.java
@@ -58,15 +58,14 @@ public class SseBroadcastResource {
       this.sseBroadcaster.broadcast(sse.newEvent(message));
    }
 
-   @POST
-   @Path("/startAndClose")
-   public void broadcastAndClose(String message, @Context Sse sse) throws IOException, InterruptedException {
+   @GET
+   @Path("/closeSink")
+   public void closeSink() {
       if (this.sseBroadcaster == null) {
          throw new IllegalStateException("No Sse broadcaster created.");
       }
       this.eventSink.close();
       logger.info("Sink closed: " + eventSink.isClosed());
-      this.sseBroadcaster.broadcast(sse.newEvent(message));
    }
 
    @GET

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/DefaultMediaTypeTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/DefaultMediaTypeTest.java
@@ -83,6 +83,7 @@ public class DefaultMediaTypeTest {
 
    /**
     * @tpTestDetails Test Date object without produce annotation
+    *                https://issues.jboss.org/browse/RESTEASY-1403
     * @tpSince RESTEasy 3.0.16
     */
    @Test
@@ -118,6 +119,7 @@ public class DefaultMediaTypeTest {
 
    /**
     * @tpTestDetails Test Foo object without produce annotation
+    *                https://issues.jboss.org/browse/RESTEASY-1403
     * @tpSince RESTEasy 3.0.16
     */
    @Test

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/DuplicitePathTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/DuplicitePathTest.java
@@ -3,7 +3,8 @@ package org.jboss.resteasy.test.response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.resteasy.category.ExpectedFailing;
+import org.jboss.resteasy.category.ExpectedFailingOnWildFly12;
+import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import javax.ws.rs.client.ClientBuilder;
@@ -45,12 +46,30 @@ import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALI
 public class DuplicitePathTest {
    static ResteasyClient client;
 
+   /**
+    * Init servlet warning count ( WFLYUT0101: Duplicate servlet mapping /a/* found )
+    */
+   private static int initServletWarningsCount;
+
+   /**
+    * Get RESTEasy warning count
+    */
    private static int getWarningCount() {
       return TestUtil.getWarningCount("RESTEASY002142", false, DEFAULT_CONTAINER_QUALIFIER);
    }
 
+   /**
+    * Gets servlet warning count
+    * Warning comes from server (outside of the resteasy)
+    * Example: WFLYUT0101: Duplicate servlet mapping /a/* found
+    */
+   private static int getServletMappingWarningCount() {
+      return TestUtil.getWarningCount("WFLYUT0101", false, DEFAULT_CONTAINER_QUALIFIER);
+   }
+
    @Deployment
    public static Archive<?> deploySimpleResource() {
+      initServletWarningsCount = getServletMappingWarningCount();
       WebArchive war = ShrinkWrap.create(WebArchive.class, DuplicitePathTest.class.getSimpleName() + ".war");
       war.addClass(DuplicitePathDupliciteApplicationOne.class);
       war.addClass(DuplicitePathDupliciteApplicationTwo.class);
@@ -82,9 +101,8 @@ public class DuplicitePathTest {
     * @tpSince RESTEasy 3.0.17
     */
    @Test
-   @Category({NotForForwardCompatibility.class, ExpectedFailing.class}) //[RESTEASY-1445] FIXME
+   @Category({NotForForwardCompatibility.class, ExpectedFailingOnWildFly12.class, ExpectedFailingOnWildFly13.class})
    public void testDuplicationTwoAppTwoResourceSameMethodPath() throws Exception {
-      int initWarningsCount = getWarningCount();
       WebTarget base = client.target(generateURL("/a/b/c"));
       Response response = null;
       try {
@@ -98,7 +116,7 @@ public class DuplicitePathTest {
          response.close();
       }
       Assert.assertEquals(TestUtil.getErrorMessageForKnownIssue("RESTEASY-1445", "Wrong count of warnings in server log"),
-                     1, getWarningCount() - initWarningsCount);
+                     1, getServletMappingWarningCount() - initServletWarningsCount);
    }
 
    /**


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/RESTEASY-2077
3.6 PR: https://github.com/resteasy/Resteasy/pull/1789

Cleanup of ignored tests:

* DuplicitePathTest
  * related bug is fixed
  * fix test
  * remove ignoring
* SseBroadcastTest
  * add description to ignore annotation
  * improve ignored tests (cc @jimma )
  * btw, related jira was reopened [RESTEASY-1819](https://issues.jboss.org/browse/RESTEASY-1819)
* AsyncBenchTest
  * improve javadoc
  * add description to ignore annotation
* ResourceClassProcessorBasicTest
  * add description to ignore annotation
* DefaultMediaTypeTest
  * improve javadoc