### PR TITLE
[RESTEASY-2083] Fix issue when SseBroadcasterImpl.notifyOnCloseListeners removes wrong sink from the outputQueue

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
@@ -315,4 +315,13 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
       return false;
    }
 
+   @Override
+   public boolean equals(Object o) {
+      return this == o;
+   }
+
+   @Override
+   public int hashCode() {
+      return ((Object)this).hashCode();
+   }
 }

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -105,6 +105,19 @@
     </profiles>
 
     <dependencies>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.9.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+
         <!-- TODO Workaround dependency for arquillian to work with container using Remoting 5. Remove when updated version of
         wildfly-arquillian-container-managed is available -->
         <dependency>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcasterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcasterTest.java
@@ -1,18 +1,26 @@
 package org.jboss.resteasy.test.providers.sse;
 
-import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import org.jboss.resteasy.core.ResteasyContext;
+import org.jboss.resteasy.plugins.providers.sse.OutboundSseEventImpl;
+import org.jboss.resteasy.plugins.providers.sse.SseBroadcasterImpl;
+import org.jboss.resteasy.plugins.providers.sse.SseEventOutputImpl;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.ResteasyAsynchronousContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 import javax.ws.rs.sse.OutboundSseEvent;
 import javax.ws.rs.sse.SseEventSink;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.concurrent.*;
 
-import org.jboss.resteasy.plugins.providers.sse.OutboundSseEventImpl;
-import org.jboss.resteasy.plugins.providers.sse.SseBroadcasterImpl;
-import org.junit.Assert;
-import org.junit.Test;
+import static junit.framework.TestCase.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 /***
  *
@@ -94,8 +102,8 @@ public class SseBroadcasterTest
       {
          Assert.fail("All close listeners should have been notified");
       }
-      Assert.assertTrue(sseEventSink1.isClosed());
-      Assert.assertTrue(sseEventSink2.isClosed());
+      assertTrue(sseEventSink1.isClosed());
+      assertTrue(sseEventSink2.isClosed());
    }
 
    // We are expecting this test to invoke both close and error listeners when
@@ -108,7 +116,7 @@ public class SseBroadcasterTest
       SseEventSink sseEventSink = newSseEventSink();
       sseBroadcasterImpl.register(sseEventSink);
       sseEventSink.close();
-      Assert.assertTrue(sseEventSink.isClosed());
+      assertTrue(sseEventSink.isClosed());
 
       CountDownLatch countDownLatch = new CountDownLatch(3);
       sseBroadcasterImpl.onClose(ses -> {
@@ -184,6 +192,66 @@ public class SseBroadcasterTest
       {
          Assert.fail("All error listeners should have been notified");
       }
+   }
+
+   @Before
+   public void before(){
+      HttpRequest request = mock(HttpRequest.class);
+      ResteasyAsynchronousContext resteasyAsynchronousContext = mock(ResteasyAsynchronousContext.class);
+      doReturn(resteasyAsynchronousContext).when(request).getAsyncContext();
+
+      //prevent NPE in SseEventOutputImpl ctr
+      ResteasyContext.pushContext(org.jboss.resteasy.spi.HttpRequest.class, request);
+   }
+
+   @Test
+   public void testRemoveDisconnectedEventSink() throws Exception {
+      SseBroadcasterImpl sseBroadcasterImpl = new SseBroadcasterImpl();
+
+      final ConcurrentLinkedQueue<SseEventSink> outputQueue = getOutputQueue(sseBroadcasterImpl);
+      CountDownLatch countDownLatch = new CountDownLatch(2);
+
+      //we want to test against actual SseEventOutputImpl
+      final SseEventSink sseEventSink1 = new SseEventOutputImpl(null);
+      final SseEventSink sseEventSink2 = new SseEventOutputImpl(null);
+
+
+      sseBroadcasterImpl.register(sseEventSink1);
+      sseBroadcasterImpl.register(sseEventSink2);
+
+
+      sseBroadcasterImpl.onClose(ses -> {
+         countDownLatch.countDown();
+      });
+
+      sseBroadcasterImpl.onError((ses, error) -> {
+         //error is an NPE thrown by SseEventOutputImpl#send
+         countDownLatch.countDown();
+      });
+
+      sseEventSink2.close();
+
+      sseBroadcasterImpl.broadcast(new OutboundSseEventImpl.BuilderImpl().data("Test").build());
+
+      if (!countDownLatch.await(5, TimeUnit.SECONDS))
+      {
+         fail("All close listeners should have been notified");
+      } else {
+         assertTrue(outputQueue.size() == 1);
+         assertSame(outputQueue.peek(), sseEventSink1);
+      }
+   }
+
+   private ConcurrentLinkedQueue<SseEventSink> getOutputQueue(SseBroadcasterImpl sseBroadcasterImpl) throws NoSuchFieldException, IllegalAccessException {
+      Field fld = SseBroadcasterImpl.class.getDeclaredField("outputQueue");
+      fld.setAccessible(true);
+      return (ConcurrentLinkedQueue<SseEventSink>) fld.get(sseBroadcasterImpl);
+   }
+
+   @org.junit.After
+   public void after(){
+      //revert contextual data
+      ResteasyContext.pushContext(org.jboss.resteasy.spi.HttpRequest.class, null);
    }
 
    private SseEventSink newSseEventSink()

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcasterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcasterTest.java
@@ -20,7 +20,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcasterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcasterTest.java
@@ -14,9 +14,12 @@ import javax.ws.rs.sse.OutboundSseEvent;
 import javax.ws.rs.sse.SseEventSink;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.concurrent.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
-import static junit.framework.TestCase.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
@@ -102,8 +105,8 @@ public class SseBroadcasterTest
       {
          Assert.fail("All close listeners should have been notified");
       }
-      assertTrue(sseEventSink1.isClosed());
-      assertTrue(sseEventSink2.isClosed());
+      Assert.assertTrue(sseEventSink1.isClosed());
+      Assert.assertTrue(sseEventSink2.isClosed());
    }
 
    // We are expecting this test to invoke both close and error listeners when
@@ -116,7 +119,7 @@ public class SseBroadcasterTest
       SseEventSink sseEventSink = newSseEventSink();
       sseBroadcasterImpl.register(sseEventSink);
       sseEventSink.close();
-      assertTrue(sseEventSink.isClosed());
+      Assert.assertTrue(sseEventSink.isClosed());
 
       CountDownLatch countDownLatch = new CountDownLatch(3);
       sseBroadcasterImpl.onClose(ses -> {
@@ -237,8 +240,8 @@ public class SseBroadcasterTest
       {
          fail("All close listeners should have been notified");
       } else {
-         assertTrue(outputQueue.size() == 1);
-         assertSame(outputQueue.peek(), sseEventSink1);
+         Assert.assertTrue(outputQueue.size() == 1);
+         Assert.assertSame(outputQueue.peek(), sseEventSink1);
       }
    }
 


### PR DESCRIPTION
Due to GenericType.equals implementation currently (as per 3.6.2.Final) SseBroadcasterImpl always removes first item from the outputQueue in notifyOnCloseListeners method when client closes connection. Resulting in other clients stop receive events.

Test project that reproduces the issue and suggest workaround: [link](https://github.com/Ingvord/resteasy-sse-bug-report)