### PR TITLE
[RESTEASY-2096] Remove all usage of removed ExpectedFailingOnWildFly12 class

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/DuplicitePathTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/DuplicitePathTest.java
@@ -3,7 +3,6 @@ package org.jboss.resteasy.test.response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.resteasy.category.ExpectedFailingOnWildFly12;
 import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
@@ -101,7 +100,7 @@ public class DuplicitePathTest {
     * @tpSince RESTEasy 3.0.17
     */
    @Test
-   @Category({NotForForwardCompatibility.class, ExpectedFailingOnWildFly12.class, ExpectedFailingOnWildFly13.class})
+   @Category({NotForForwardCompatibility.class, ExpectedFailingOnWildFly13.class})
    public void testDuplicationTwoAppTwoResourceSameMethodPath() throws Exception {
       WebTarget base = client.target(generateURL("/a/b/c"));
       Response response = null;


### PR DESCRIPTION
jira: https://issues.jboss.org/browse/RESTEASY-2096
This issue is valid for master branch only

---

Remove all usage of removed ExpectedFailingOnWildFly12 class

ExpectedFailingOnWildFly12 was removed by https://github.com/resteasy/Resteasy/pull/1798, but it was introduced again by un-rebased https://github.com/resteasy/Resteasy/pull/1790