### PR TITLE
[RESTEASY-2097]: ClientResponse.getEntity() and ClientResponse.bufferEntity() do not completely follow the spec

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientResponse.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientResponse.java
@@ -43,8 +43,8 @@ public abstract class ClientResponse extends BuiltResponse
    protected Map<String, Object> properties;
    protected ClientConfiguration configuration;
    protected byte[] bufferedEntity;
-   protected boolean streamRead;
-   protected boolean streamFullyRead;
+   protected volatile boolean streamRead;
+   protected volatile boolean streamFullyRead;
    protected RESTEasyTracingLogger tracingLogger;
 
    @Deprecated

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientResponseWithEntityTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientResponseWithEntityTest.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.test.client;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 
 import javax.ws.rs.GET;
@@ -117,6 +118,154 @@ public class ClientResponseWithEntityTest {
             }
          } while (wasRead > -1);
          response.getEntity();
+      }
+   }
+
+   /**
+    *
+    * According to {@link Response#getEntity()} java doc if the entity was previously fully consumed as an {@link InputStream input stream}
+    * an {@link IllegalStateException} MUST be thrown.
+    *
+    * @throws IOException
+    */
+   @Test
+   public void getEntity_Should_ThrowIllegalStateException_When_EntityIsInputStream_And_IsFullyConsumed() throws IOException
+   {
+      Invocation.Builder request = client.target(generateURL()).path("echo").queryParam("msg", "Hello world")
+            .request(MediaType.APPLICATION_XML_TYPE);
+
+      //entity retrieved as an input stream using response.getEntity() and then fully consumed => response.getEntity() MUST throw an IllegalStateException
+      try (Response response = request.get();)
+      {
+         Assert.assertTrue(response.hasEntity());
+         //Fully consumed the original response stream
+         while (((InputStream) response.getEntity()).read() != -1)
+         {
+         }
+         try
+         {
+            response.getEntity();
+            Assert.fail("An IllegalStateException was expected.");
+         }
+         catch (Exception e)
+         {
+            Assert.assertTrue(IllegalStateException.class.isInstance(e));
+            // Following is to be sure that previous IllegalStateException is not because of closed response
+            try
+            {
+               Assert.assertTrue(response.hasEntity());
+            }
+            catch (IllegalStateException e2)
+            {
+               Assert.fail("The response was not supposed to be closed");
+            }
+         }
+      }
+
+      //entity retrieved as an input stream using response.readEntity(InputStream.class) and then fully consumed => response.getEntity() MUST throw an IllegalStateException
+      try (Response response = request.get();)
+      {
+         Assert.assertTrue(response.hasEntity());
+         //Fully consumed the original response stream
+         while (response.readEntity(InputStream.class).read() != -1)
+         {
+         }
+         try
+         {
+            response.getEntity();
+            Assert.fail("An IllegalStateException was expected.");
+         }
+         catch (Exception e)
+         {
+            Assert.assertTrue(IllegalStateException.class.isInstance(e));
+            // Following is to be sure that previous IllegalStateException is not because of closed response
+            try
+            {
+               Assert.assertTrue(response.hasEntity());
+            }
+            catch (IllegalStateException e2)
+            {
+               Assert.fail("The response was not supposed to be closed");
+            }
+         }
+      }
+   }
+
+   @Test
+   public void getEntity_Should_ReturnEntity_When_EntityIsInputStream_And_IsNotFullyConsumed() throws IOException
+   {
+      Invocation.Builder request = client.target(generateURL()).path("echo").queryParam("msg", "Hello world")
+            .request(MediaType.APPLICATION_XML_TYPE);
+
+      //entity retrieved as an input stream using response.getEntity() and then partially consumed => response.getEntity() MUST return input stream
+      try (Response response = request.get();)
+      {
+         Assert.assertTrue(response.hasEntity());
+         InputStream entityStream = (InputStream) response.getEntity();
+         //Let consume a part of the entity stream
+         Assert.assertTrue(-1 != ((InputStream) response.getEntity()).read());
+         Assert.assertTrue(InputStream.class.isInstance(response.getEntity()));
+      }
+
+      //entity retrieved as an input stream using response.readEntity(InputStream.class) and then partially consumed => response.getEntity() MUST return input stream
+      try (Response response = request.get();)
+      {
+         Assert.assertTrue(response.hasEntity());
+         //Let consume a part of the entity stream
+         Assert.assertTrue(-1 != response.readEntity(InputStream.class).read());
+         Assert.assertTrue(InputStream.class.isInstance(response.getEntity()));
+      }
+   }
+
+   /**
+    * According to {@link Response#bufferEntity()} java doc, if the response entity instance is not backed by an unconsumed input stream, the method invocation is
+    * ignored and the method MUST returns false.
+    *
+    * @throws IOException
+    */
+   @Test
+   public void bufferEntity_Should_ReturnFalse_When_EntityInputStreamIsNotUnconsumed() throws IOException
+   {
+      Invocation.Builder request = client.target(generateURL()).path("echo").queryParam("msg", "Hello world")
+            .request(MediaType.APPLICATION_XML_TYPE);
+
+      //entity retrieved as an input stream using response.getEntity() and then consumed => response.bufferEntity() MUST return false
+      try (Response response = request.get();)
+      {
+         Assert.assertTrue(response.hasEntity());
+         Assert.assertTrue(-1 != ((InputStream) response.getEntity()).read());
+         Assert.assertFalse(response.bufferEntity());
+      }
+
+      //entity retrieved as an input stream using response.readEntity(InputStream.class) and then consumed => response.bufferEntity() MUST return false
+      try (Response response = request.get();)
+      {
+         Assert.assertTrue(response.hasEntity());
+         Assert.assertTrue(-1 != response.readEntity(InputStream.class).read());
+         Assert.assertFalse(response.bufferEntity());
+      }
+   }
+
+   @Test
+   public void bufferEntity_Should_ReturnTrue_When_EntityInputStreamIsUnconsumed()
+   {
+      Invocation.Builder request = client.target(generateURL()).path("echo").queryParam("msg", "Hello world")
+            .request(MediaType.APPLICATION_XML_TYPE);
+
+      //entity retrieved as an input stream using response.getEntity() and not consumed => response.bufferEntity() MUST return true
+      try (Response response = request.get();)
+      {
+         Assert.assertTrue(response.hasEntity());
+         Assert.assertTrue(InputStream.class.isInstance(response.getEntity()));
+         Assert.assertTrue(response.bufferEntity());
+      }
+
+      //entity retrieved as an input stream using response.readEntity(InputStream.class) and not consumed => response.bufferEntity() MUST return true
+      try (Response response = request.get();)
+      {
+         Assert.assertTrue(response.hasEntity());
+         Assert.assertTrue(InputStream.class.isInstance(response.readEntity(InputStream.class)));
+         Assert.assertTrue(response.bufferEntity());
       }
    }
 


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/RESTEASY-2097