### PR TITLE
[RESTEASY-2111] Expose client invocation from ClientRequestContextImpl

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientRequestContextImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientRequestContextImpl.java
@@ -235,4 +235,13 @@ public class ClientRequestContextImpl implements ClientRequestContext
    {
       return invocation.getHeaders().getHeader(name);
    }
+
+   /**
+    * exposes the client invocation for easier integration with other libraries
+    * @return the underlying client invocation
+    */
+   public ClientInvocation getInvocation()
+   {
+      return invocation;
+   }
 }


### PR DESCRIPTION
The reason for this change is to be able to better implement MicroProfile Rest Client 1.2 in SmallRye,
see:
https://github.com/michalszynkiewicz/smallrye-rest-client/commit/99e05e97932e5b53bb4161594950c3ef7dba9a2d#diff-7b1121516d3f6222abe697292542ecf2R35