### PR TITLE
[RESTEASY-2119] Upgrade Java Servlet API from 3.1 to 4.0

### DIFF
--- a/arquillian/RESTEASY-736-jetty/pom.xml
+++ b/arquillian/RESTEASY-736-jetty/pom.xml
@@ -98,7 +98,7 @@
       </dependency>
       <dependency>
           <groupId>org.jboss.spec.javax.servlet</groupId>
-          <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+          <artifactId>jboss-servlet-api_4.0_spec</artifactId>
       </dependency>
   </dependencies>
 

--- a/profiling-tests/pom.xml
+++ b/profiling-tests/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
     </dependencies>
 

--- a/providers/jackson2/pom.xml
+++ b/providers/jackson2/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.fge</groupId>

--- a/providers/jaxb/pom.xml
+++ b/providers/jaxb/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.annotation</groupId>

--- a/providers/json-binding/pom.xml
+++ b/providers/json-binding/pom.xml
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/providers/json-p-ee7/pom.xml
+++ b/providers/json-p-ee7/pom.xml
@@ -27,7 +27,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/providers/multipart/pom.xml
+++ b/providers/multipart/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/providers/resteasy-html/pom.xml
+++ b/providers/resteasy-html/pom.xml
@@ -24,7 +24,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/providers/resteasy-validator-provider-11/pom.xml
+++ b/providers/resteasy-validator-provider-11/pom.xml
@@ -64,7 +64,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/resteasy-cache/resteasy-cache-core/pom.xml
+++ b/resteasy-cache/resteasy-cache-core/pom.xml
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/resteasy-cdi/pom.xml
+++ b/resteasy-cdi/pom.xml
@@ -23,7 +23,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/resteasy-core-spi/pom.xml
+++ b/resteasy-core-spi/pom.xml
@@ -25,7 +25,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/resteasy-core/pom.xml
+++ b/resteasy-core/pom.xml
@@ -25,7 +25,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -70,7 +70,7 @@
         <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.0.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
         <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
         <version.org.jboss.spec.javax.xml.bind-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.bind-api_2.3_spec>
-        <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>1.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>
+        <version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>1.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>
         <version.org.jboss.shrinkwrap.resolver>2.2.4</version.org.jboss.shrinkwrap.resolver>
         <version.microprofile.restclient>1.0.1</version.microprofile.restclient>
         <version.microprofile.config>1.3</version.microprofile.config>
@@ -388,8 +388,8 @@
             </dependency>
             <dependency>
                 <groupId>org.jboss.spec.javax.servlet</groupId>
-                <artifactId>jboss-servlet-api_3.1_spec</artifactId>
-                <version>${version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec}</version>
+                <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+                <version>${version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/resteasy-guice/pom.xml
+++ b/resteasy-guice/pom.xml
@@ -36,7 +36,7 @@
         <!-- test -->
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/resteasy-jsapi/pom.xml
+++ b/resteasy-jsapi/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/resteasy-links/pom.xml
+++ b/resteasy-links/pom.xml
@@ -35,7 +35,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.el</groupId>

--- a/resteasy-servlet-initializer/pom.xml
+++ b/resteasy-servlet-initializer/pom.xml
@@ -28,7 +28,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         
         

--- a/resteasy-spring/pom.xml
+++ b/resteasy-spring/pom.xml
@@ -90,7 +90,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/resteasy-stats/pom.xml
+++ b/resteasy-stats/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.annotation</groupId>

--- a/resteasy-wadl-undertow-connector/pom.xml
+++ b/resteasy-wadl-undertow-connector/pom.xml
@@ -57,7 +57,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/resteasy-wadl/pom.xml
+++ b/resteasy-wadl/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
         

--- a/security/resteasy-crypto/pom.xml
+++ b/security/resteasy-crypto/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/server-adapters/resteasy-jdk-http/pom.xml
+++ b/server-adapters/resteasy-jdk-http/pom.xml
@@ -31,7 +31,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/server-adapters/resteasy-netty4-cdi/pom.xml
+++ b/server-adapters/resteasy-netty4-cdi/pom.xml
@@ -93,7 +93,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/server-adapters/resteasy-netty4/pom.xml
+++ b/server-adapters/resteasy-netty4/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>test</scope>
         </dependency>
         

--- a/server-adapters/resteasy-vertx/pom.xml
+++ b/server-adapters/resteasy-vertx/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>test</scope>
         </dependency>
         

--- a/testsuite/integration-tests-spring/pom.xml
+++ b/testsuite/integration-tests-spring/pom.xml
@@ -53,7 +53,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -306,7 +306,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Upgrade Java Servlet API from 3.1 to 4.0

https://issues.jboss.org/browse/RESTEASY-2119