### PR TITLE
[RESTEASY-2123] wiremock update, commons-logging removal

### DIFF
--- a/arquillian/RESTEASY-1056-jetty-bv11/pom.xml
+++ b/arquillian/RESTEASY-1056-jetty-bv11/pom.xml
@@ -89,12 +89,6 @@
           <scope>test</scope>
       </dependency>
       <dependency>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-          <version>1.1.1</version>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
           <groupId>javax.validation</groupId>
           <artifactId>validation-api</artifactId>
       </dependency>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -50,7 +50,7 @@
         <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
         <version.org.eclipse.jetty>9.4.14.v20181114</version.org.eclipse.jetty>
         <version.org.eclipse.yasson>1.0.2</version.org.eclipse.yasson>
-        <version.com.github.tomakehurst.wiremock>2.10.1</version.com.github.tomakehurst.wiremock>
+        <version.com.github.tomakehurst.wiremock>2.20.0</version.com.github.tomakehurst.wiremock>
         <version.org.glassfish.javax.el>3.0.1-b08</version.org.glassfish.javax.el>
         <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
         <version.org.hibernate.hibernate-validator>5.2.4.Final</version.org.hibernate.hibernate-validator>


### PR DESCRIPTION
wiremock update, commons-logging removal

https://issues.jboss.org/browse/RESTEASY-2123

json-patch will be covered in separate PR
Issue which proposes 3 possible solutions for json-patch is https://issues.jboss.org/browse/RESTEASY-2126