### PR TITLE
[RESTEASY-2105] - org.jboss.resteasy.annotations.jaxrs.*Param annotations don't work with both proxy and MP REST client

### DIFF
--- a/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/client/microprofile/MicroprofileClientBuilder.java
+++ b/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/client/microprofile/MicroprofileClientBuilder.java
@@ -207,8 +207,12 @@ class MicroprofileClientBuilder implements RestClientBuilder {
          Map<String, Object> paramMap = new HashMap<>();
          for (Parameter p : method.getParameters()) {
             PathParam pathParam = p.getAnnotation(PathParam.class);
+            org.jboss.resteasy.annotations.jaxrs.PathParam pathParam2 = p.getAnnotation(org.jboss.resteasy.annotations.jaxrs.PathParam.class);
             if (pathParam != null) {
                paramMap.put(pathParam.value(), "foobar");
+            } else if (pathParam2 != null) {
+               paramMap.put((pathParam2.value() != null && pathParam2.value().length() > 0) ?
+                               pathParam2.value() : p.getName(), "foobar");
             }
          }
 

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/FormProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/FormProcessor.java
@@ -44,11 +44,11 @@ public class FormProcessor implements InvocationProcessor, WebTargetProcessor
    protected HashMap<Long, Method> getterHashes = new HashMap<Long, Method>();
    protected Class clazz;
 
-   public FormProcessor(final Class clazz, final ClientConfiguration configuration)
+   public FormProcessor(final Class clazz, final ClientConfiguration configuration, final String defaultFormName)
    {
       this.clazz = clazz;
 
-      populateMap(clazz, configuration);
+      populateMap(clazz, configuration, defaultFormName);
    }
 
    public static long methodHash(Method method)
@@ -128,7 +128,7 @@ public class FormProcessor implements InvocationProcessor, WebTargetProcessor
       }
    }
 
-   protected void populateMap(Class clazz, ClientConfiguration configuration)
+   protected void populateMap(Class clazz, ClientConfiguration configuration, String defaultFormName)
    {
       for (Field field : clazz.getDeclaredFields())
       {
@@ -138,7 +138,7 @@ public class FormProcessor implements InvocationProcessor, WebTargetProcessor
          Type genericType = field.getGenericType();
 
          Object processor = ProcessorFactory.createProcessor(
-                 clazz, configuration, type, annotations, genericType, field, true);
+                 clazz, defaultFormName, configuration, type, annotations, genericType, field, true);
          if (processor != null)
          {
             if (!Modifier.isPublic(field.getModifiers())) field.setAccessible(true);
@@ -158,7 +158,7 @@ public class FormProcessor implements InvocationProcessor, WebTargetProcessor
          Type genericType = method.getGenericReturnType();
 
          Object processor = ProcessorFactory
-                 .createProcessor(clazz, configuration, type, annotations,
+                 .createProcessor(clazz, defaultFormName, configuration, type, annotations,
                          genericType, method, true);
          if (processor != null)
          {
@@ -184,7 +184,7 @@ public class FormProcessor implements InvocationProcessor, WebTargetProcessor
 
       }
       if (clazz.getSuperclass() != null && !clazz.getSuperclass().equals(Object.class))
-         populateMap(clazz.getSuperclass(), configuration);
+         populateMap(clazz.getSuperclass(), configuration, defaultFormName);
 
 
    }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/ProcessorFactory.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/ProcessorFactory.java
@@ -49,6 +49,7 @@ public class ProcessorFactory
       Object[] params = new Object[method.getParameterTypes().length];
       for (int i = 0; i < method.getParameterTypes().length; i++)
       {
+         String parameterName = method.getParameters()[i].getName();
          Class<?> type = method.getParameterTypes()[i];
          Annotation[] annotations = method.getParameterAnnotations()[i];
          Type genericType = method.getGenericParameterTypes()[i];
@@ -56,20 +57,20 @@ public class ProcessorFactory
             genericType = getTypeArgument((TypeVariable)genericType, declaringClass, method.getDeclaringClass());
          }
          AccessibleObject target = method;
-         params[i] = ProcessorFactory.createProcessor(declaringClass, configuration, type, annotations, genericType, target, defaultConsumes, false);
+         params[i] = ProcessorFactory.createProcessor(declaringClass, parameterName, configuration, type, annotations, genericType, target, defaultConsumes, false);
       }
       return params;
    }
 
-   public static Object createProcessor(Class<?> declaring,
+   public static Object createProcessor(Class<?> declaring, String defaultParameterName,
                                                ClientConfiguration configuration, Class<?> type,
                                                Annotation[] annotations, Type genericType, AccessibleObject target,
                                                boolean ignoreBody)
    {
-      return createProcessor(declaring, configuration, type, annotations, genericType, target, null, ignoreBody);
+      return createProcessor(declaring, defaultParameterName, configuration, type, annotations, genericType, target, null, ignoreBody);
    }
 
-   public static Object createProcessor(Class<?> declaring,
+   public static Object createProcessor(Class<?> declaring, String defaultParameterName,
                                                ClientConfiguration configuration, Class<?> type,
                                                Annotation[] annotations, Type genericType, AccessibleObject target, MediaType defaultConsumes,
                                                boolean ignoreBody)
@@ -77,11 +78,17 @@ public class ProcessorFactory
       Object processor = null;
 
       QueryParam query;
+      org.jboss.resteasy.annotations.jaxrs.QueryParam queryParam2;
       HeaderParam header;
+      org.jboss.resteasy.annotations.jaxrs.HeaderParam header2;
       MatrixParam matrix;
+      org.jboss.resteasy.annotations.jaxrs.MatrixParam matrix2;
       PathParam uriParam;
+      org.jboss.resteasy.annotations.jaxrs.PathParam uriParam2;
       CookieParam cookie;
+      org.jboss.resteasy.annotations.jaxrs.CookieParam cookie2;
       FormParam formParam;
+      org.jboss.resteasy.annotations.jaxrs.FormParam formParam2;
       // Form form;
 
       boolean isEncoded = FindAnnotation.findAnnotation(annotations,
@@ -91,40 +98,70 @@ public class ProcessorFactory
       {
          processor = new QueryParamProcessor(query.value(), genericType, annotations, configuration);
       }
+      else if ((queryParam2 = FindAnnotation.findAnnotation(annotations,
+              org.jboss.resteasy.annotations.jaxrs.QueryParam.class)) != null)
+      {
+         processor = new QueryParamProcessor(getParamName(defaultParameterName, queryParam2.value()), genericType, annotations, configuration);
+      }
       else if ((header = FindAnnotation.findAnnotation(annotations,
               HeaderParam.class)) != null)
       {
          processor = new HeaderParamProcessor(header.value(), genericType, annotations, configuration);
+      }
+      else if ((header2 = FindAnnotation.findAnnotation(annotations,
+              org.jboss.resteasy.annotations.jaxrs.HeaderParam.class)) != null)
+      {
+         processor = new HeaderParamProcessor(getParamName(defaultParameterName, header2.value()), genericType, annotations, configuration);
       }
       else if ((cookie = FindAnnotation.findAnnotation(annotations,
               CookieParam.class)) != null)
       {
          processor = new CookieParamProcessor(cookie.value(), genericType, annotations);
       }
+      else if ((cookie2 = FindAnnotation.findAnnotation(annotations,
+              org.jboss.resteasy.annotations.jaxrs.CookieParam.class)) != null)
+      {
+         processor = new CookieParamProcessor(getParamName(defaultParameterName, cookie2.value()), genericType, annotations);
+      }
       else if ((uriParam = FindAnnotation.findAnnotation(annotations,
               PathParam.class)) != null)
       {
          processor = new PathParamProcessor(uriParam.value(), isEncoded, genericType, annotations, configuration);
+      }
+      else if ((uriParam2 = FindAnnotation.findAnnotation(annotations,
+              org.jboss.resteasy.annotations.jaxrs.PathParam.class)) != null)
+      {
+         processor = new PathParamProcessor(getParamName(defaultParameterName, uriParam2.value()), isEncoded, genericType, annotations, configuration);
       }
       else if ((matrix = FindAnnotation.findAnnotation(annotations,
               MatrixParam.class)) != null)
       {
          processor = new MatrixParamProcessor(matrix.value(), genericType, annotations, configuration);
       }
+      else if ((matrix2 = FindAnnotation.findAnnotation(annotations,
+              org.jboss.resteasy.annotations.jaxrs.MatrixParam.class)) != null)
+      {
+         processor = new MatrixParamProcessor(getParamName(defaultParameterName, matrix2.value()), genericType, annotations, configuration);
+      }
       else if ((formParam = FindAnnotation.findAnnotation(annotations,
               FormParam.class)) != null)
       {
          processor = new FormParamProcessor(formParam.value(), genericType, annotations, configuration);
       }
+      else if ((formParam2 = FindAnnotation.findAnnotation(annotations,
+              org.jboss.resteasy.annotations.jaxrs.FormParam.class)) != null)
+      {
+         processor = new FormParamProcessor(getParamName(defaultParameterName, formParam2.value()), genericType, annotations, configuration);
+      }
       else if ((/* form = */FindAnnotation.findAnnotation(annotations,
               Form.class)) != null)
       {
-         processor = new FormProcessor(type, configuration);
+         processor = new FormProcessor(type, configuration, defaultParameterName);
       }
       else if ((/* form = */FindAnnotation.findAnnotation(annotations,
               BeanParam.class)) != null)
       {
-         processor = new FormProcessor(type, configuration);
+         processor = new FormProcessor(type, configuration, defaultParameterName);
       }
       else if ((FindAnnotation.findAnnotation(annotations,
               Context.class)) != null)
@@ -153,6 +190,10 @@ public class ProcessorFactory
                  genericType, annotations);
       }
       return processor;
+   }
+
+   private static String getParamName(String defaultName, String parameterValue) {
+      return (parameterValue != null && parameterValue.length() > 0) ? parameterValue : defaultName;
    }
 
    static Type getTypeArgument(TypeVariable<?> var, Class<?> clazz, Class<?> baseInterface) {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProxyParameterAnotations.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProxyParameterAnotations.java
@@ -1,0 +1,51 @@
+package org.jboss.resteasy.test.client.proxy.resource;
+
+import org.jboss.resteasy.annotations.jaxrs.CookieParam;
+import org.jboss.resteasy.annotations.jaxrs.FormParam;
+import org.jboss.resteasy.annotations.jaxrs.HeaderParam;
+import org.jboss.resteasy.annotations.jaxrs.MatrixParam;
+import org.jboss.resteasy.annotations.jaxrs.QueryParam;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * Created by Marek Marusic <mmarusic@redhat.com> on 1/16/19.
+ */
+@Path("/")
+public interface ProxyParameterAnotations {
+    @Path("QueryParam")
+    @GET
+    String executeQueryParam(@QueryParam String queryParam);
+
+    @Path("HeaderParam")
+    @GET
+    String executeHeaderParam(@HeaderParam String headerParam);
+
+    @Path("CookieParam")
+    @GET
+    String executeCookieParam(@CookieParam String cookieParam);
+
+    @Path("PathParam/{pathParam}")
+    @GET
+    String executePathParam(@PathParam String pathParam);
+
+    @Path("FormParam")
+    @POST
+    String executeFormParam(@FormParam String formParam);
+
+    @Path("MatrixParam")
+    @GET
+    String executeMatrixParam(@MatrixParam String matrixParam);
+
+    @Path("AllParams/{pathParam}")
+    @POST
+    String executeAllParams(@QueryParam String queryParam,
+                            @HeaderParam String headerParam,
+                            @CookieParam String cookieParam,
+                            @PathParam String pathParam,
+                            @FormParam String formParam,
+                            @MatrixParam String matrixParam);
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProxyParameterAnotationsResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProxyParameterAnotationsResource.java
@@ -1,0 +1,65 @@
+package org.jboss.resteasy.test.client.proxy.resource;
+
+import org.jboss.resteasy.annotations.jaxrs.CookieParam;
+import org.jboss.resteasy.annotations.jaxrs.FormParam;
+import org.jboss.resteasy.annotations.jaxrs.HeaderParam;
+import org.jboss.resteasy.annotations.jaxrs.MatrixParam;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+import org.jboss.resteasy.annotations.jaxrs.QueryParam;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * Created by Marek Marusic <mmarusic@redhat.com> on 1/16/19.
+ */
+@Path("/")
+public class ProxyParameterAnotationsResource {
+    @Path("QueryParam")
+    @GET
+    public String getQueryParam(@QueryParam("queryParam") String queryParam) {
+        return "QueryParam = " + queryParam;
+    }
+
+    @Path("HeaderParam")
+    @GET
+    public String getHeaderParam(@HeaderParam("headerParam") String headerParam) {
+        return "HeaderParam = " + headerParam;
+    }
+
+    @Path("CookieParam")
+    @GET
+    public String getCookieParam(@CookieParam("cookieParam") String cookieParam) {
+        return "CookieParam = " + cookieParam;
+    }
+
+    @Path("PathParam/{pathParam}")
+    @GET
+    public String getPathParam(@PathParam("pathParam") String pathParam) {
+        return "PathParam = " + pathParam;
+    }
+
+    @Path("FormParam")
+    @POST
+    public String  getFormParam(@FormParam("formParam") String formParam) {
+        return "FormParam = " + formParam;
+    }
+
+    @Path("MatrixParam")
+    @GET
+    public String  getMatrixParam(@MatrixParam("matrixParam") String matrixParam) {
+        return "MatrixParam = " + matrixParam;
+    }
+
+    @Path("AllParams/{pathParam}")
+    @POST
+    public String getAllParams(@QueryParam String queryParam,
+                               @HeaderParam String headerParam,
+                               @CookieParam String cookieParam,
+                               @PathParam String pathParam,
+                               @FormParam String formParam,
+                               @MatrixParam String matrixParam) {
+        return queryParam+" "+headerParam+" "+cookieParam+" "+pathParam+" "+formParam+" "+matrixParam;
+    }
+}


### PR DESCRIPTION
RESTEASY issue: https://issues.jboss.org/browse/RESTEASY-2105

It is now possible to use any of the org.jboss.resteasy.annotations.jaxrs.*Param annotations in proxy and MP REST client.