### PR TITLE
 [RESTEASY-2128] JDK-8212233 workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ jobs:
       script: mvn -B -DskipTests install && mvn -B -Dmaven.javadoc.skip=false javadoc:javadoc
       jdk: openjdk8
       env: SERVER_VERSION=15.0.0.Final
-#    - stage: "javadoc"
-#      script: mvn -B -DskipTests install && mvn -B -Dmaven.javadoc.skip=false javadoc:javadoc
-#      jdk: oraclejdk11
-#      env: SERVER_VERSION=15.0.0.Final
+    - stage: "javadoc"
+      script: mvn -B -DskipTests install && mvn -B -Dmaven.javadoc.skip=false javadoc:javadoc
+      jdk: oraclejdk11
+      env: SERVER_VERSION=15.0.0.Final
 ##cache:
 # directories:
 #  - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <!-- Plugins versions -->
         <version.org.jacoco.plugin>0.7.9</version.org.jacoco.plugin>
         <version.surefire.plugin>2.19.1</version.surefire.plugin>
+        <version.javadoc.plugin>3.0.1</version.javadoc.plugin>
     </properties>
 
     <url>http://rest-easy.org</url>
@@ -257,6 +258,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${version.javadoc.plugin}</version>
                     <configuration>
+                        <source>8</source>
                         <minmemory>128m</minmemory>
                         <maxmemory>1024m</maxmemory>
                         <quiet>false</quiet>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/RESTEASY-2128

Re-enabling javadoc for JDK 11 by reverting commit f97ba8cce.
Thanks @rsvoboda for the found workaround.
