### PR TITLE
[RESTEASY-2105] - org.jboss.resteasy.annotations.jaxrs.*Param annotations don't work with both proxy and MP REST client

### DIFF
--- a/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/client/microprofile/MicroprofileClientBuilder.java
+++ b/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/client/microprofile/MicroprofileClientBuilder.java
@@ -206,8 +206,12 @@ class MicroprofileClientBuilder implements RestClientBuilder {
          Map<String, Object> paramMap = new HashMap<>();
          for (Parameter p : method.getParameters()) {
             PathParam pathParam = p.getAnnotation(PathParam.class);
+            org.jboss.resteasy.annotations.jaxrs.PathParam pathParam2 = p.getAnnotation(org.jboss.resteasy.annotations.jaxrs.PathParam.class);
             if (pathParam != null) {
                paramMap.put(pathParam.value(), "foobar");
+            } else if (pathParam2 != null) {
+               paramMap.put((pathParam2.value() != null && pathParam2.value().length() > 0) ?
+                               pathParam2.value() : p.getName(), "foobar");
             }
          }
 

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/FormProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/FormProcessor.java
@@ -44,11 +44,11 @@ public class FormProcessor implements InvocationProcessor, WebTargetProcessor
    protected HashMap<Long, Method> getterHashes = new HashMap<Long, Method>();
    protected Class clazz;
 
-   public FormProcessor(final Class clazz, final ClientConfiguration configuration)
+   public FormProcessor(final Class clazz, final ClientConfiguration configuration, final String defaultFormName)
    {
       this.clazz = clazz;
 
-      populateMap(clazz, configuration);
+      populateMap(clazz, configuration, defaultFormName);
    }
 
    public static long methodHash(Method method)
@@ -128,7 +128,7 @@ public class FormProcessor implements InvocationProcessor, WebTargetProcessor
       }
    }
 
-   protected void populateMap(Class clazz, ClientConfiguration configuration)
+   protected void populateMap(Class clazz, ClientConfiguration configuration, String defaultFormName)
    {
       for (Field field : clazz.getDeclaredFields())
       {
@@ -138,7 +138,7 @@ public class FormProcessor implements InvocationProcessor, WebTargetProcessor
          Type genericType = field.getGenericType();
 
          Object processor = ProcessorFactory.createProcessor(
-                 clazz, configuration, type, annotations, genericType, field, true);
+                 clazz, defaultFormName, configuration, type, annotations, genericType, field, true);
          if (processor != null)
          {
             if (!Modifier.isPublic(field.getModifiers())) field.setAccessible(true);
@@ -158,7 +158,7 @@ public class FormProcessor implements InvocationProcessor, WebTargetProcessor
          Type genericType = method.getGenericReturnType();
 
          Object processor = ProcessorFactory
-                 .createProcessor(clazz, configuration, type, annotations,
+                 .createProcessor(clazz, defaultFormName, configuration, type, annotations,
                          genericType, method, true);
          if (processor != null)
          {
@@ -184,7 +184,7 @@ public class FormProcessor implements InvocationProcessor, WebTargetProcessor
 
       }
       if (clazz.getSuperclass() != null && !clazz.getSuperclass().equals(Object.class))
-         populateMap(clazz.getSuperclass(), configuration);
+         populateMap(clazz.getSuperclass(), configuration, defaultFormName);
 
 
    }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProxyParameterAnotations.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProxyParameterAnotations.java
@@ -1,0 +1,51 @@
+package org.jboss.resteasy.test.client.proxy.resource;
+
+import org.jboss.resteasy.annotations.jaxrs.CookieParam;
+import org.jboss.resteasy.annotations.jaxrs.FormParam;
+import org.jboss.resteasy.annotations.jaxrs.HeaderParam;
+import org.jboss.resteasy.annotations.jaxrs.MatrixParam;
+import org.jboss.resteasy.annotations.jaxrs.QueryParam;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * Created by Marek Marusic <mmarusic@redhat.com> on 1/16/19.
+ */
+@Path("/")
+public interface ProxyParameterAnotations {
+    @Path("QueryParam")
+    @GET
+    String executeQueryParam(@QueryParam String queryParam);
+
+    @Path("HeaderParam")
+    @GET
+    String executeHeaderParam(@HeaderParam String headerParam);
+
+    @Path("CookieParam")
+    @GET
+    String executeCookieParam(@CookieParam String cookieParam);
+
+    @Path("PathParam/{pathParam}")
+    @GET
+    String executePathParam(@PathParam String pathParam);
+
+    @Path("FormParam")
+    @POST
+    String executeFormParam(@FormParam String formParam);
+
+    @Path("MatrixParam")
+    @GET
+    String executeMatrixParam(@MatrixParam String matrixParam);
+
+    @Path("AllParams/{pathParam}")
+    @POST
+    String executeAllParams(@QueryParam String queryParam,
+                            @HeaderParam String headerParam,
+                            @CookieParam String cookieParam,
+                            @PathParam String pathParam,
+                            @FormParam String formParam,
+                            @MatrixParam String matrixParam);
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProxyParameterAnotationsResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProxyParameterAnotationsResource.java
@@ -1,0 +1,65 @@
+package org.jboss.resteasy.test.client.proxy.resource;
+
+import org.jboss.resteasy.annotations.jaxrs.CookieParam;
+import org.jboss.resteasy.annotations.jaxrs.FormParam;
+import org.jboss.resteasy.annotations.jaxrs.HeaderParam;
+import org.jboss.resteasy.annotations.jaxrs.MatrixParam;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+import org.jboss.resteasy.annotations.jaxrs.QueryParam;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * Created by Marek Marusic <mmarusic@redhat.com> on 1/16/19.
+ */
+@Path("/")
+public class ProxyParameterAnotationsResource {
+    @Path("QueryParam")
+    @GET
+    public String getQueryParam(@QueryParam("queryParam") String queryParam) {
+        return "QueryParam = " + queryParam;
+    }
+
+    @Path("HeaderParam")
+    @GET
+    public String getHeaderParam(@HeaderParam("headerParam") String headerParam) {
+        return "HeaderParam = " + headerParam;
+    }
+
+    @Path("CookieParam")
+    @GET
+    public String getCookieParam(@CookieParam("cookieParam") String cookieParam) {
+        return "CookieParam = " + cookieParam;
+    }
+
+    @Path("PathParam/{pathParam}")
+    @GET
+    public String getPathParam(@PathParam("pathParam") String pathParam) {
+        return "PathParam = " + pathParam;
+    }
+
+    @Path("FormParam")
+    @POST
+    public String  getFormParam(@FormParam("formParam") String formParam) {
+        return "FormParam = " + formParam;
+    }
+
+    @Path("MatrixParam")
+    @GET
+    public String  getMatrixParam(@MatrixParam("matrixParam") String matrixParam) {
+        return "MatrixParam = " + matrixParam;
+    }
+
+    @Path("AllParams/{pathParam}")
+    @POST
+    public String getAllParams(@QueryParam String queryParam,
+                               @HeaderParam String headerParam,
+                               @CookieParam String cookieParam,
+                               @PathParam String pathParam,
+                               @FormParam String formParam,
+                               @MatrixParam String matrixParam) {
+        return queryParam+" "+headerParam+" "+cookieParam+" "+pathParam+" "+formParam+" "+matrixParam;
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/RESTEasyParamBasicTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/RESTEasyParamBasicTest.java
@@ -4,11 +4,14 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.Response;
 
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.test.client.proxy.resource.ProxyParameterAnotations;
+import org.jboss.resteasy.test.client.proxy.resource.ProxyParameterAnotationsResource;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.resource.param.resource.RESTEasyParamBasicCustomValuesResource;
 import org.jboss.resteasy.test.resource.param.resource.RESTEasyParamBasicJaxRsParamDifferentResource;
@@ -26,6 +29,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 
 /**
  * @tpSubChapter Parameters
@@ -47,6 +53,7 @@ public class RESTEasyParamBasicTest {
       war.addClass(RESTEasyParamBasicProxy.class);
       return TestUtil.finishContainerPrepare(war, null,
             RESTEasyParamBasicResource.class,
+            ProxyParameterAnotationsResource.class,
             RESTEasyParamBasicJaxRsParamDifferentResource.class,
             RESTEasyParamBasicJaxRsParamSameResource.class,
             RESTEasyParamBasicCustomValuesResource.class,
@@ -66,6 +73,59 @@ public class RESTEasyParamBasicTest {
    private String generateURL(String path) {
       return PortProviderUtil.generateURL(path, RESTEasyParamBasicTest.class.getSimpleName());
    }
+
+   /**
+    * @tpTestDetails Basic check of new query parameters, matrix parameters, header parameters, cookie parameters and form parameters in proxy clients
+    *                Test checks that RESTEasy can inject correct values to method attributes in proxy clients
+    *                This test uses new annotations without any annotation value in the proxy, however the annotation values are used in the server side resource.
+    * @tpSince RESTEasy 4.0
+    */
+   @Test
+   public void proxyClientAllParamsTest() throws MalformedURLException {
+      final String url = generateURL("");
+      final String parameterValue = "parameterValue";
+      ProxyParameterAnotations proxy = new ResteasyClientBuilder().build().target(url).proxy(ProxyParameterAnotations.class);
+
+      String response = proxy.executeQueryParam(parameterValue);
+      Assert.assertEquals("QueryParam = "+parameterValue, response);
+
+      response = proxy.executeHeaderParam(parameterValue);
+      Assert.assertEquals("HeaderParam = "+parameterValue, response);
+
+      response = proxy.executeCookieParam(parameterValue);
+      Assert.assertEquals("CookieParam = "+parameterValue, response);
+
+      response = proxy.executePathParam(parameterValue);
+      Assert.assertEquals("PathParam = "+parameterValue, response);
+
+      response = proxy.executeFormParam(parameterValue);
+      Assert.assertEquals("FormParam = "+parameterValue, response);
+
+      response = proxy.executeMatrixParam(parameterValue);
+      Assert.assertEquals("MatrixParam = "+parameterValue, response);
+
+      //AllAtOnce with RestEasy client
+      response = proxy.executeAllParams(
+              "queryParam0",
+              "headerParam0",
+              "cookieParam0",
+              "pathParam0",
+              "formParam0",
+              "matrixParam0");
+      Assert.assertEquals("queryParam0 headerParam0 cookieParam0 pathParam0 formParam0 matrixParam0", response);
+
+      //AllAtOnce with MicroProfile client
+      ProxyParameterAnotations mpRestClient = RestClientBuilder.newBuilder().baseUrl(new URL(url)).build(ProxyParameterAnotations.class);
+      response = mpRestClient.executeAllParams(
+              "queryParam0",
+              "headerParam0",
+              "cookieParam0",
+              "pathParam0",
+              "formParam0",
+              "matrixParam0");
+      Assert.assertEquals("queryParam0 headerParam0 cookieParam0 pathParam0 formParam0 matrixParam0", response);
+   }
+
 
    /**
     * @tpTestDetails Basic check of new query parameters, matrix parameters, header parameters, cookie parameters and form parameters


### PR DESCRIPTION
RESTEASY issue: https://issues.jboss.org/browse/RESTEASY-2105

It is now possible to use any of the org.jboss.resteasy.annotations.jaxrs.*Param annotations in proxy and MP REST client.