### PR TITLE
RESTEASY-2113 Fix testELWorksWithoutPackageJSON

### DIFF
--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/el/TestLinksInvalidEL.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/el/TestLinksInvalidEL.java
@@ -25,7 +25,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -107,7 +106,6 @@ public class TestLinksInvalidEL
       }
    }
    @Test
-   @Ignore
    public void testELWorksWithoutPackageJSON() throws Exception
    {
       try{


### PR DESCRIPTION
This test is automatically fixed, because we have uniformed the `@AddLink` annotation to work for both JAXB and Jackson provider.