### PR TITLE
Ignore charset when checking the content type

### DIFF
--- a/resteasy-jsapi/src/main/resources/resteasy-client.js
+++ b/resteasy-jsapi/src/main/resources/resteasy-client.js
@@ -277,6 +277,7 @@ REST._complete = function(request, callback){
 }
 
 REST._isXMLMIME = function(contentType){
+	contentType = contentType.split(";", 1)[0];
 	return contentType == "text/xml"
 			|| contentType == "application/xml"
 			|| (contentType.indexOf("application/") == 0
@@ -284,6 +285,7 @@ REST._isXMLMIME = function(contentType){
 }
 
 REST._isJSONMIME = function(contentType){
+	contentType = contentType.split(";", 1)[0];
 	return contentType == "application/json"
 			|| (contentType.indexOf("application/") == 0
 				&& contentType.lastIndexOf("+json") == (contentType.length - 5));


### PR DESCRIPTION
Some reverse proxies add a charset specification after the content-type: e.g. `application/json;charset=utf-8`. More details here: https://www.npmjs.com/advisories/8 .

This needs to be recognized as application/json as well.