### PR TITLE
RESTEASY-2107 2nd proposal

### DIFF
--- a/providers/json-binding/src/main/java/org/jboss/resteasy/plugins/providers/jsonb/JsonBindingProvider.java
+++ b/providers/json-binding/src/main/java/org/jboss/resteasy/plugins/providers/jsonb/JsonBindingProvider.java
@@ -23,7 +23,6 @@ import org.jboss.resteasy.core.ResteasyContext;
 import org.jboss.resteasy.plugins.providers.jsonb.i18n.Messages;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.spi.ResteasyConfiguration;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.util.DelegatingOutputStream;
 
 /**
@@ -41,18 +40,8 @@ public class JsonBindingProvider extends AbstractJsonBindingProvider
    public JsonBindingProvider() {
       super();
       ResteasyConfiguration context = ResteasyContext.getContextData(ResteasyConfiguration.class);
-      boolean disabled = (context != null && (Boolean.parseBoolean(context.getParameter(ResteasyContextParameters.RESTEASY_PREFER_JACKSON_OVER_JSONB))
+      disabled = (context != null && (Boolean.parseBoolean(context.getParameter(ResteasyContextParameters.RESTEASY_PREFER_JACKSON_OVER_JSONB))
             || Boolean.parseBoolean(context.getParameter("resteasy.jsonp.enable"))));
-      ResteasyProviderFactory providerFactory = ResteasyContext.getContextData(ResteasyProviderFactory.class);
-      if (context == null && providerFactory != null)
-      {
-         Object config = providerFactory.getProperty(ResteasyContextParameters.RESTEASY_PREFER_JACKSON_OVER_JSONB);
-         if (config != null)
-         {
-            disabled = Boolean.parseBoolean(config.toString());
-         }
-      }
-      this.disabled = disabled;
    }
 
    @Override

--- a/providers/json-binding/src/main/java/org/jboss/resteasy/plugins/providers/jsonb/JsonBindingProvider.java
+++ b/providers/json-binding/src/main/java/org/jboss/resteasy/plugins/providers/jsonb/JsonBindingProvider.java
@@ -24,6 +24,7 @@ import org.jboss.resteasy.core.ResteasyContext;
 import org.jboss.resteasy.plugins.providers.jsonb.i18n.Messages;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.spi.ResteasyConfiguration;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.util.DelegatingOutputStream;
 
 /**
@@ -36,13 +37,22 @@ import org.jboss.resteasy.util.DelegatingOutputStream;
 public class JsonBindingProvider extends AbstractJsonBindingProvider
       implements MessageBodyReader<Object>, MessageBodyWriter<Object> {
 
-   private final boolean disabled;
+   private boolean disabled;
 
    public JsonBindingProvider() {
       super();
       ResteasyConfiguration context = ResteasyContext.getContextData(ResteasyConfiguration.class);
       disabled = (context != null && (Boolean.parseBoolean(context.getParameter(ResteasyContextParameters.RESTEASY_PREFER_JACKSON_OVER_JSONB))
             || Boolean.parseBoolean(context.getParameter("resteasy.jsonp.enable"))));
+      ResteasyProviderFactory providerFactory = ResteasyContext.getContextData(ResteasyProviderFactory.class);
+      if (context == null && providerFactory != null)
+      {
+         Object config = providerFactory.getProperty(ResteasyContextParameters.RESTEASY_PREFER_JACKSON_OVER_JSONB);
+         if (config != null)
+         {
+            disabled = Boolean.parseBoolean(config.toString());
+         }
+      }
    }
 
    @Override

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.java
@@ -8,6 +8,7 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpAsyncClient4Engine;
 import org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43;
 import org.jboss.resteasy.client.jaxrs.i18n.Messages;
+import org.jboss.resteasy.core.ResteasyContext;
 import org.jboss.resteasy.core.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
@@ -15,6 +16,7 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.ws.rs.core.Configuration;
+
 import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -315,7 +317,7 @@ public class ResteasyClientBuilderImpl extends ResteasyClientBuilder
       {
          // create a new one
          providerFactory = new LocalResteasyProviderFactory(ResteasyProviderFactory.newInstance());
-         RegisterBuiltin.register(providerFactory);
+         ResteasyContext.pushContext(ResteasyProviderFactory.class, providerFactory);
       }
       return providerFactory;
    }
@@ -323,12 +325,12 @@ public class ResteasyClientBuilderImpl extends ResteasyClientBuilder
    @Override
    public ResteasyClient build()
    {
+      RegisterBuiltin.register(getProviderFactory());
       ClientConfiguration config = new ClientConfiguration(getProviderFactory());
       for (Map.Entry<String, Object> entry : properties.entrySet())
       {
          config.property(entry.getKey(), entry.getValue());
       }
-
       ExecutorService executor = asyncExecutor;
 
       if (executor == null)

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.java
@@ -8,7 +8,6 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpAsyncClient4Engine;
 import org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43;
 import org.jboss.resteasy.client.jaxrs.i18n.Messages;
-import org.jboss.resteasy.core.ResteasyContext;
 import org.jboss.resteasy.core.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
@@ -317,7 +316,7 @@ public class ResteasyClientBuilderImpl extends ResteasyClientBuilder
       {
          // create a new one
          providerFactory = new LocalResteasyProviderFactory(ResteasyProviderFactory.newInstance());
-         ResteasyContext.pushContext(ResteasyProviderFactory.class, providerFactory);
+         RegisterBuiltin.register(providerFactory);
       }
       return providerFactory;
    }
@@ -325,12 +324,12 @@ public class ResteasyClientBuilderImpl extends ResteasyClientBuilder
    @Override
    public ResteasyClient build()
    {
-      RegisterBuiltin.register(getProviderFactory());
       ClientConfiguration config = new ClientConfiguration(getProviderFactory());
       for (Map.Entry<String, Object> entry : properties.entrySet())
       {
          config.property(entry.getKey(), entry.getValue());
       }
+
       ExecutorService executor = asyncExecutor;
 
       if (executor == null)

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/api/validation/ResteasyConstraintViolation.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/api/validation/ResteasyConstraintViolation.java
@@ -6,6 +6,8 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.jboss.resteasy.api.validation.ConstraintType.Type;
+
 /**
 *
 * @author <a href="ron.sigal@jboss.com">Ron Sigal</a>
@@ -19,7 +21,7 @@ public class ResteasyConstraintViolation implements Serializable
 {
    private static final long serialVersionUID = -5441628046215135260L;
 
-   private ConstraintType.Type constraintType;
+   private Type constraintType;
 
    private String path;
 
@@ -27,7 +29,7 @@ public class ResteasyConstraintViolation implements Serializable
 
    private String value;
 
-   public ResteasyConstraintViolation(final ConstraintType.Type constraintType, final String path, final String message, final String value)
+   public ResteasyConstraintViolation(final Type constraintType, final String path, final String message, final String value)
    {
       this.constraintType = constraintType;
       this.path = path;
@@ -42,7 +44,7 @@ public class ResteasyConstraintViolation implements Serializable
    /**
     * @return type of constraint
     */
-   public ConstraintType.Type getConstraintType()
+   public Type getConstraintType()
    {
       return constraintType;
    }
@@ -85,5 +87,25 @@ public class ResteasyConstraintViolation implements Serializable
    public String type()
    {
       return constraintType.toString();
+   }
+
+   public void setConstraintType(Type constraintType)
+   {
+      this.constraintType = constraintType;
+   }
+
+   public void setPath(String path)
+   {
+      this.path = path;
+   }
+
+   public void setMessage(String message)
+   {
+      this.message = message;
+   }
+
+   public void setValue(String value)
+   {
+      this.value = value;
    }
 }

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -91,6 +91,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.hibernate.validator>6.0.14.Final</version.org.hibernate.validator>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.6.Final</version.org.jboss.marshalling.jboss-marshalling>
+        <version.rest-assured>3.3.0</version.rest-assured>
     </properties>
 
     <distributionManagement>
@@ -388,6 +389,12 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${version.junit}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.rest-assured</groupId>
+                <artifactId>rest-assured</artifactId>
+                <version>${version.rest-assured}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -502,6 +502,7 @@
                                 <includes>
                                     <include>**/JsonBindingAnnotationsJacksonTest.java</include>
                                     <include>**/SseJsonEventTest.java</include>
+                                    <include>**/ValidationJaxbTest.java</include>
                                 </includes>
                                 <classpathDependencyExcludes>
                                     <classpathDependencyExclude>org.jboss.resteasy:resteasy-json-binding-provider</classpathDependencyExclude>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -392,7 +392,10 @@
             <scope>provided</scope>
         </dependency>
 
-
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jaxb/JaxbXmlRootElementProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jaxb/JaxbXmlRootElementProviderTest.java
@@ -1,12 +1,18 @@
 package org.jboss.resteasy.test.providers.jaxb;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.client.jaxrs.ProxyBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+
 import javax.ws.rs.client.ClientBuilder;
+
+import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.test.providers.jaxb.resource.JaxbElementClient;
 import org.jboss.resteasy.test.providers.jaxb.resource.JaxbJsonXmlRootElementClient;
 import org.jboss.resteasy.test.providers.jaxb.resource.JaxbXmlRootElementClient;
@@ -58,7 +64,9 @@ public class JaxbXmlRootElementProviderTest {
       WebArchive war = TestUtil.prepareArchive(JaxbXmlRootElementProviderTest.class.getSimpleName());
       war.addClass(Parent.class);
       war.addClass(Child.class);
-      return TestUtil.finishContainerPrepare(war, null, JaxbXmlRootElementProviderResource.class);
+      Map<String, String> contextParams = new HashMap<>();
+      contextParams.put(ResteasyContextParameters.RESTEASY_PREFER_JACKSON_OVER_JSONB, "true");
+      return TestUtil.finishContainerPrepare(war, contextParams, JaxbXmlRootElementProviderResource.class);
    }
 
    @Before

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ValidationXMLTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ValidationXMLTest.java
@@ -67,10 +67,7 @@ public class ValidationXMLTest {
 
    @Before
    public void init() {
-      ClientBuilder builder = ClientBuilder.newBuilder();
-      builder.property(ResteasyContextParameters.RESTEASY_PREFER_JACKSON_OVER_JSONB, true);
-      builder.register(ValidationXMLFooReaderWriter.class);
-      client = (ResteasyClient)builder.build();
+      client = (ResteasyClient)ClientBuilder.newClient().register(ValidationXMLFooReaderWriter.class);
    }
 
    @After


### PR DESCRIPTION
Another proposal for fixing RESTEASY-2107, with minimum disruption. The idea is to avoid introducing yet another mechnism for controlling precedences in json providers on client side. The user can either build the ResteasyProviderFactory with the providers he wants or he can control the classpath deciding which provider module is available.