### PR TITLE
[RESTEASY-2040] disable stream flush with jsonb provider to avoid per…

### DIFF
--- a/providers/json-binding/src/main/java/org/jboss/resteasy/plugins/providers/jsonb/JsonBindingProvider.java
+++ b/providers/json-binding/src/main/java/org/jboss/resteasy/plugins/providers/jsonb/JsonBindingProvider.java
@@ -33,6 +33,7 @@ import org.jboss.resteasy.spi.ResteasyConfiguration;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.util.FindAnnotation;
 import org.jboss.resteasy.util.Types;
+import org.jboss.resteasy.util.DelegatingOutputStream;
 
 /**
  * Created by rsearls on 6/26/17.
@@ -142,6 +143,13 @@ public class JsonBindingProvider extends AbstractJsonBindingProvider
       Jsonb jsonb = getJsonb(type);
       try
       {
+         entityStream = new DelegatingOutputStream(entityStream) {
+            @Override
+            public void flush() throws IOException {
+               // don't flush as this is a performance hit on Undertow.
+               // and causes chunked encoding to happen.
+            }
+         };
          entityStream.write(jsonb.toJson(t).getBytes(getCharset(mediaType)));
          entityStream.flush();
       } catch (Throwable e)


### PR DESCRIPTION
…formance issues in undertow

Backport for EAP 7.2.z.

https://issues.jboss.org/browse/RESTEASY-2040

Upstream PRs:
https://github.com/resteasy/Resteasy/pull/1754
https://github.com/resteasy/Resteasy/pull/1745