### PR TITLE
[RESTEASY-2100] - The byte[] type of input parameter in proxy/MP-rest-client will cause large JVM stack used.

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientWebTarget.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientWebTarget.java
@@ -309,6 +309,12 @@ public class ClientWebTarget implements ResteasyWebTarget
    {
       client.abortIfClosed();
       if (name == null) throw new NullPointerException(Messages.MESSAGES.nameWasNull());
+
+      //The whole array can be represented as one object, so we need to cast it to array of objects
+      if (values.length == 1 && values[0].getClass().isArray() && !values[0].getClass().getComponentType().isPrimitive()) {
+         values = (Object[]) values[0];
+      }
+
       String[] stringValues = toStringValues(values);
       ResteasyUriBuilder copy;
       if (uriBuilder instanceof ResteasyUriBuilder) {
@@ -316,10 +322,8 @@ public class ClientWebTarget implements ResteasyWebTarget
       } else {
          copy = (ResteasyUriBuilder)ResteasyUriBuilder.fromTemplate(uriBuilder.toTemplate());
       }
-      for (String obj : stringValues)
-      {
-         copy.clientQueryParam(name, obj);
-      }
+
+      copy.clientQueryParam(name, stringValues);
       return  newInstance(client, copy, configuration);
    }
 

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/AbstractCollectionProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/AbstractCollectionProcessor.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.client.jaxrs.internal.proxy.processors;
 
 import java.util.Collection;
+import java.lang.reflect.Array;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -17,64 +18,38 @@ public abstract class AbstractCollectionProcessor<T>
 
    protected abstract T apply(T target, Object object);
 
+   protected abstract T apply(T target, Object[] objects);
+
    public T buildIt(T target, Object object)
    {
       if (object == null) return target;
       if (object instanceof Collection)
       {
-         for (Object obj : (Collection<?>) object)
-         {
-            target = apply(target, obj);
-         }
+         target = apply(target,  ((Collection<?>) object).toArray());
       }
       else if (object.getClass().isArray())
       {
-         if (object.getClass().getComponentType().isPrimitive())
-         {
-            Class<?> componentType = object.getClass().getComponentType();
-            if (componentType.equals(boolean.class))
-            {
-               for (boolean bool : (boolean[]) object) target = apply(target, bool);
-            }
-            else if (componentType.equals(byte.class))
-            {
-               for (byte val : (byte[]) object) target = apply(target, val);
-            }
-            else if (componentType.equals(short.class))
-            {
-               for (short val : (short[]) object) target = apply(target, val);
-            }
-            else if (componentType.equals(int.class))
-            {
-               for (int val : (int[]) object) target = apply(target, val);
-            }
-            else if (componentType.equals(long.class))
-            {
-               for (long val : (long[]) object) target = apply(target, val);
-            }
-            else if (componentType.equals(float.class))
-            {
-               for (float val : (float[]) object) target = apply(target, val);
-            }
-            else if (componentType.equals(double.class))
-            {
-               for (double val : (double[]) object) target = apply(target, val);
-            }
-         }
-         else
-         {
-            Object[] objs = (Object[]) object;
-            for (Object obj : objs)
-            {
-               target = apply(target, obj);
-
-            }
-         }
+         Object[] arr = convertToObjectsArray(object);
+         target = apply(target, arr);
       }
       else
       {
          target = apply(target, object);
       }
       return target;
+   }
+
+   private static Object[] convertToObjectsArray(Object array) {
+      if(array instanceof Object[])
+         return (Object[]) array;
+
+      int length = Array.getLength(array);
+
+      Object[] objects = new Object[length];
+      for (int i = 0; i < length; i++) {
+          objects[i] = Array.get(array, i);
+      }
+
+      return objects;
    }
 }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/FormParamProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/FormParamProcessor.java
@@ -21,26 +21,34 @@ public class FormParamProcessor extends AbstractInvocationCollectionProcessor
    @Override
    protected ClientInvocationBuilder apply(ClientInvocationBuilder target, Object object)
    {
-      Form form = null;
-      Object entity = target.getInvocation().getEntity();
-      if (entity != null)
-      {
-         if (entity instanceof Form)
+      return apply(target, new Object[]{object});
+   }
+
+   @Override
+   protected ClientInvocationBuilder apply(ClientInvocationBuilder target, Object[] objects)
+   {
+      for (Object object : objects) {
+         Form form = null;
+         Object entity = target.getInvocation().getEntity();
+         if (entity != null)
          {
-            form = (Form) entity;
+            if (entity instanceof Form)
+            {
+               form = (Form) entity;
+            }
+            else
+            {
+               throw new RuntimeException(Messages.MESSAGES.cannotSetFormParameter());
+            }
          }
          else
          {
-            throw new RuntimeException(Messages.MESSAGES.cannotSetFormParameter());
+            form = new Form();
+            target.getInvocation().setEntity(Entity.form(form));
          }
+         String value = target.getInvocation().getClientConfiguration().toString(object);
+         form.param(paramName, value);
       }
-      else
-      {
-         form = new Form();
-         target.getInvocation().setEntity(Entity.form(form));
-      }
-      String value = target.getInvocation().getClientConfiguration().toString(object);
-      form.param(paramName, value);
       return target;
    }
 

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/HeaderParamProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/HeaderParamProcessor.java
@@ -17,7 +17,16 @@ public class HeaderParamProcessor extends AbstractInvocationCollectionProcessor
    @Override
    protected ClientInvocationBuilder apply(ClientInvocationBuilder target, Object object)
    {
-      return (ClientInvocationBuilder)target.header(paramName, object);
+      return apply(target, new Object[]{object});
+   }
+
+   @Override
+   protected ClientInvocationBuilder apply(ClientInvocationBuilder target, Object[] objects)
+   {
+      for (Object object : objects) {
+         target = (ClientInvocationBuilder)target.header(paramName, object);
+      }
+      return target;
    }
 
 }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/webtarget/MatrixParamProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/webtarget/MatrixParamProcessor.java
@@ -17,7 +17,13 @@ public class MatrixParamProcessor extends AbstractWebTargetCollectionProcessor
    @Override
    protected WebTarget apply(WebTarget target, Object object)
    {
-      return target.matrixParam(paramName, object);
+      return apply(target, new Object[]{object});
+   }
+
+   @Override
+   protected WebTarget apply(WebTarget target, Object[] objects)
+   {
+      return target.matrixParam(paramName, objects);
    }
 
 }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/webtarget/QueryParamProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/webtarget/QueryParamProcessor.java
@@ -18,9 +18,14 @@ public class QueryParamProcessor extends AbstractWebTargetCollectionProcessor
    @Override
    protected WebTarget apply(WebTarget target, Object object)
    {
-      ResteasyWebTarget t = (ResteasyWebTarget)target;
-      return t.queryParamNoTemplate(paramName, object);
+      return apply(target, new Object[]{object});
    }
 
+   @Override
+   protected WebTarget apply(WebTarget target, Object[] objects)
+   {
+      ResteasyWebTarget t = (ResteasyWebTarget)target;
+      return t.queryParamNoTemplate(paramName, objects);
+   }
 
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResteasyUriBuilder.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/specimpl/ResteasyUriBuilder.java
@@ -946,26 +946,53 @@ public class ResteasyUriBuilder extends UriBuilder
     */
    public UriBuilder clientQueryParam(String name, Object value) throws IllegalArgumentException
    {
-      if (name == null) throw new IllegalArgumentException(Messages.MESSAGES.nameParameterNull());
-      if (value == null) throw new IllegalArgumentException(Messages.MESSAGES.passedInValueNull());
+      return clientQueryParam(name, new Object[]{value});
+   }
+
+   public UriBuilder clientQueryParam(String name, Object[] values) throws IllegalArgumentException
+   {
+      StringBuilder sb = new StringBuilder();
+      String prefix = "";
       if (query == null) query = "";
-      else query += "&";
-      query += Encode.encodeQueryParamAsIs(name) + "=" + Encode.encodeQueryParamAsIs(value.toString());
+      else {
+         sb.append(query).append("&");
+      }
+
+      if (name == null) throw new IllegalArgumentException(Messages.MESSAGES.nameParameterNull());
+      if (values == null) throw new IllegalArgumentException(Messages.MESSAGES.valuesParameterNull());
+      for (Object value : values)
+      {
+         if (value == null) throw new IllegalArgumentException(Messages.MESSAGES.passedInValueNull());
+         sb.append(prefix);
+         prefix = "&";
+         sb.append(Encode.encodeQueryParamAsIs(name)).append("=").append(Encode.encodeQueryParamAsIs(value.toString()));
+      }
+
+      query = sb.toString();
       return this;
    }
 
    @Override
    public UriBuilder queryParam(String name, Object... values) throws IllegalArgumentException
    {
+      StringBuilder sb = new StringBuilder();
+      String prefix = "";
+      if (query == null) query = "";
+      else {
+         sb.append(query).append("&");
+      }
+
       if (name == null) throw new IllegalArgumentException(Messages.MESSAGES.nameParameterNull());
       if (values == null) throw new IllegalArgumentException(Messages.MESSAGES.valuesParameterNull());
       for (Object value : values)
       {
          if (value == null) throw new IllegalArgumentException(Messages.MESSAGES.passedInValueNull());
-         if (query == null) query = "";
-         else query += "&";
-         query += Encode.encodeQueryParam(name) + "=" + Encode.encodeQueryParam(value.toString());
+         sb.append(prefix);
+         prefix = "&";
+         sb.append(Encode.encodeQueryParam(name)).append("=").append(Encode.encodeQueryParam(value.toString()));
       }
+
+      query = sb.toString();
       return this;
    }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/QueryParamAsPrimitiveTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/QueryParamAsPrimitiveTest.java
@@ -5,6 +5,8 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.client.jaxrs.ProxyBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ProcessingException;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.resource.param.resource.QueryParamAsPrimitiveResource;
 import org.jboss.resteasy.test.resource.param.resource.QueryParamAsPrimitiveResourceArray;
@@ -299,6 +301,24 @@ public class QueryParamAsPrimitiveTest {
       byte[] array =
             {(byte) 127, (byte) 127, (byte) 127};
       resourceQueryPrimitiveArray.doGetByte(array);
+   }
+
+   @Test(timeout = 5000)
+   public void testProxyClientGetByte() {
+      final int size = 30000;
+      byte[] array = new byte[size];
+      //Test bigger sizes
+      for (int i = 0; i < size; i++) {
+         array[i] = (byte) 127;
+      }
+
+      for (int i = 0; i < 5; i++) {
+         try {
+            resourceQueryPrimitiveArray.doPostByte(array);
+         } catch (BadRequestException | ProcessingException e) {
+            // expected
+         }
+      }
    }
 
    /**

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/resource/QueryParamAsPrimitiveResourceArray.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/resource/QueryParamAsPrimitiveResourceArray.java
@@ -4,6 +4,7 @@ import org.jboss.resteasy.test.resource.param.QueryParamAsPrimitiveTest;
 import org.junit.Assert;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
@@ -22,6 +23,15 @@ public class QueryParamAsPrimitiveResourceArray implements QueryParamAsPrimitive
    @GET
    @Produces("application/byte")
    public String doGetByte(@QueryParam("byte") byte[] v) {
+      Assert.assertTrue(QueryParamAsPrimitiveTest.ERROR_MESSAGE, (byte) 127 == v[0]);
+      Assert.assertTrue(QueryParamAsPrimitiveTest.ERROR_MESSAGE, (byte) 127 == v[1]);
+      Assert.assertTrue(QueryParamAsPrimitiveTest.ERROR_MESSAGE, (byte) 127 == v[2]);
+      return "content";
+   }
+
+   @POST
+   @Produces("application/byte")
+   public String doPostByte(@QueryParam("byte") byte[] v) {
       Assert.assertTrue(QueryParamAsPrimitiveTest.ERROR_MESSAGE, (byte) 127 == v[0]);
       Assert.assertTrue(QueryParamAsPrimitiveTest.ERROR_MESSAGE, (byte) 127 == v[1]);
       Assert.assertTrue(QueryParamAsPrimitiveTest.ERROR_MESSAGE, (byte) 127 == v[2]);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/resource/QueryParamAsPrimitiveResourceResourceArray.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/resource/QueryParamAsPrimitiveResourceResourceArray.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.test.resource.param.resource;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
@@ -14,6 +15,11 @@ public interface QueryParamAsPrimitiveResourceResourceArray {
    @GET
    @Produces("application/byte")
    String doGetByte(@QueryParam("byte") byte[] v);
+
+   @POST
+   @Path("/non/existing/end/point")
+   @Produces("application/byte")
+   String doPostByte(@QueryParam("byte") byte[] v);
 
    @GET
    @Produces("application/short")


### PR DESCRIPTION
RESTEASY issue: https://issues.jboss.org/browse/RESTEASY-2100

Enhanced speed of the QueryParam processing in the proxy client. It is achieved by using StringBuilder and passing the data as array to the ResteasyUriBuilderImpl.java.

I have edited the fix, in order to preserve signatures of the public and protected methods.