### PR TITLE
[RESTEASY-2166] Review elytron testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 install:
- - mvn clean
+ - mvn -B clean
 script:
- - travis_wait 60 mvn -B -Ptravis -fae -Dserver.version=$SERVER_VERSION install
+ - travis_wait 60 mvn -B -Ptravis -fae -Dserver.version=$SERVER_VERSION ${ELYTRON:+-Delytron} install
 
 language: java
 jdk:
@@ -11,10 +11,13 @@ env:
   - SERVER_VERSION=13.0.0.Final
   - SERVER_VERSION=14.0.0.Final
   - SERVER_VERSION=15.0.0.Final
+  - SERVER_VERSION=15.0.0.Final ELYTRON=true
 jobs:
   exclude:
     - jdk: oraclejdk11
       env: SERVER_VERSION=13.0.0.Final
+    - jdk: oraclejdk11
+      env: SERVER_VERSION=15.0.0.Final ELYTRON=true
   include:
     - stage: "javadoc"
       script: mvn -B -DskipTests install && mvn -B -Dmaven.javadoc.skip=false javadoc:javadoc

--- a/testsuite/README.MD
+++ b/testsuite/README.MD
@@ -96,24 +96,18 @@ To redirect to standard output (console) use ``-Dmaven.test.redirectTestOutputTo
 > mvn clean verify -Dserver.home=PATH_TO_WIDLFLY_HOME -Dmaven.test.redirectTestOutputToFile=false
 
 ### Set security subsystem for the tests (PicketBox/Elytron)
-The testsuite can run in **three modes**, which differ by security subsystem configuration and by subsystem used in the tests,
+The testsuite can run in **two modes**, which differ by security subsystem configuration and by subsystem used in the tests,
 which require security domain defined.
 
 The tests which require security domain configuration are extending ``org.jboss.resteasy.setup.AbstractUsersRolesSecurityDomainSetup``
 which implements ServerSetupTask.
 
-#### PicketBox is enabled, Elytron is not enabled
+#### Default (PicketBox) security configuration is used, Elytron is not enabled
 Tests run with PicketBox security domain. This is the default.
   
-#### Both PicketBox and Elytron security subsystems are enabled
-  * Tests run with PicketBox security domain. Activate this mode by:
-    > mvn clean verify -Dserver.home=PATH_TO_WIDLFLY_HOME -Delytron
-  * Tests run with Elytron security domain. Activate this mode by:
-    > mvn clean verify -Dserver.home=PATH_TO_WIDLFLY_HOME -Delytron -Dsecurity.domain=elytron
-    
-    If property '-Dsecurity.domain=elytron' is defined in the maven run, then '-Delytron' property is enforced to be defined too,
-     because tests need this property to trigger correct server configuration.
-
+#### Elytron security subsystems are enabled
+Tests run with Elytron security domain. Activate this mode by:
+> mvn clean verify -Dserver.home=PATH_TO_WIDLFLY_HOME -Delytron
 
 ## Jacoco test coverage
 You can generate Jacoco test coverage report with the following steps.

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/setup/AbstractUsersRolesSecurityDomainSetup.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/setup/AbstractUsersRolesSecurityDomainSetup.java
@@ -35,7 +35,7 @@ public abstract class AbstractUsersRolesSecurityDomainSetup implements ServerSet
    private File ROLES_FILE;
 
    // This property decides under which security subsystem will be used for the tests
-   private String subsystem = System.getProperty("security.domain", "picketbox");
+   private String subsystem = "elytron".equals(System.getProperty("security.provider")) ? "elytron" : "picketbox";
 
    // Security domain name shared by elytron and picketBox configuration
    private String securityDomainName = "jaxrsSecDomain";

--- a/testsuite/config/enable-elytron-full.cli
+++ b/testsuite/config/enable-elytron-full.cli
@@ -1,4 +1,9 @@
 embed-server --server-config=standalone-full-elytron.xml
+
+if (outcome != success) of /subsystem=elytron/http-authentication-factory=application-http-authentication:read-resource
+    /subsystem=elytron/http-authentication-factory=application-http-authentication:add(http-server-mechanism-factory=global, security-domain=ApplicationDomain,mechanism-configurations=[{mechanism-name=BASIC},{mechanism-name=FORM}])
+end-if
+
 /subsystem=undertow/application-security-domain=other:add(http-authentication-factory=application-http-authentication)
 /subsystem=ejb3/application-security-domain=other:add(security-domain=ApplicationDomain)
 /subsystem=batch-jberet:write-attribute(name=security-domain, value=ApplicationDomain)

--- a/testsuite/config/enable-elytron-full.cli
+++ b/testsuite/config/enable-elytron-full.cli
@@ -16,11 +16,9 @@ end-if
 /core-service=management/management-interface=http-interface:write-attribute(name=http-authentication-factory,value=management-http-authentication)
 /core-service=management/management-interface=http-interface:undefine-attribute(name=security-realm)
 
-reload
-
 /core-service=management/security-realm=ManagementRealm:remove
 /core-service=management/security-realm=ApplicationRealm/authentication=local:remove
 /core-service=management/security-realm=ApplicationRealm/authentication=properties:remove
 /core-service=management/security-realm=ApplicationRealm/authorization=properties:remove
-reload
+
 stop-embedded-server

--- a/testsuite/integration-tests-spring/deployment/pom.xml
+++ b/testsuite/integration-tests-spring/deployment/pom.xml
@@ -84,7 +84,70 @@
             <jboss.home>${project.build.directory}/test-server/wildfly-${server.version}</jboss.home>
           </properties>
         </profile>
-
+        <!-- This profile creates custom server configuration file with configured Elytron subsystem -->
+        <profile>
+            <id>elytron</id>
+            <activation>
+                <property>
+                    <name>elytron</name>
+                </property>
+            </activation>
+            <properties>
+                <jboss.server.config.file.name>standalone-full-elytron.xml</jboss.server.config.file.name>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-elytron-server-config</id>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <target>
+                                        <copy file="${jboss.home}/standalone/configuration/standalone-full.xml"
+                                              tofile="${jboss.home}/standalone/configuration/${jboss.server.config.file.name}"
+                                              overwrite="true" failonerror="true"/>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <id>enable-elytron-full-cli</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${java.home}/bin/java</executable>
+                                    <arguments>
+                                        <argument>-jar</argument>
+                                        <argument>${jboss.home}/jboss-modules.jar</argument>
+                                        <argument>-mp</argument>
+                                        <argument>${jboss.home}/modules</argument>
+                                        <argument>org.jboss.as.cli</argument>
+                                        <argument>--file=${basedir}/../../config/enable-elytron-full.cli</argument>
+                                    </arguments>
+                                    <environmentVariables>
+                                        <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                                    </environmentVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>

--- a/testsuite/integration-tests-spring/deployment/pom.xml
+++ b/testsuite/integration-tests-spring/deployment/pom.xml
@@ -131,14 +131,12 @@
                                 </goals>
                                 <configuration>
                                     <executable>${java.home}/bin/java</executable>
-                                    <arguments>
-                                        <argument>-jar</argument>
-                                        <argument>${jboss.home}/jboss-modules.jar</argument>
-                                        <argument>-mp</argument>
-                                        <argument>${jboss.home}/modules</argument>
-                                        <argument>org.jboss.as.cli</argument>
-                                        <argument>--file=${basedir}/../../config/enable-elytron-full.cli</argument>
-                                    </arguments>
+                                    <commandlineArgs>
+                                        ${modular.jdk.args} -jar ${jboss.home}/jboss-modules.jar
+                                        -mp ${jboss.home}/modules
+                                        org.jboss.as.cli
+                                        --file=${basedir}/../../config/enable-elytron-full.cli
+                                    </commandlineArgs>
                                     <environmentVariables>
                                         <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
                                     </environmentVariables>

--- a/testsuite/integration-tests-spring/deployment/pom.xml
+++ b/testsuite/integration-tests-spring/deployment/pom.xml
@@ -93,6 +93,7 @@
                 </property>
             </activation>
             <properties>
+                <security.provider>elytron</security.provider>
                 <jboss.server.config.file.name>standalone-full-elytron.xml</jboss.server.config.file.name>
             </properties>
             <build>

--- a/testsuite/integration-tests-spring/inmodule/pom.xml
+++ b/testsuite/integration-tests-spring/inmodule/pom.xml
@@ -90,6 +90,70 @@
             <jboss.home>${project.build.directory}/test-server/wildfly-${server.version}</jboss.home>
           </properties>
         </profile>
+        <!-- This profile creates custom server configuration file with configured Elytron subsystem -->
+        <profile>
+            <id>elytron</id>
+            <activation>
+                <property>
+                    <name>elytron</name>
+                </property>
+            </activation>
+            <properties>
+                <jboss.server.config.file.name>standalone-full-elytron.xml</jboss.server.config.file.name>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-elytron-server-config</id>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <target>
+                                        <copy file="${jboss.home}/standalone/configuration/standalone-full.xml"
+                                              tofile="${jboss.home}/standalone/configuration/${jboss.server.config.file.name}"
+                                              overwrite="true" failonerror="true"/>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <id>enable-elytron-full-cli</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${java.home}/bin/java</executable>
+                                    <arguments>
+                                        <argument>-jar</argument>
+                                        <argument>${jboss.home}/jboss-modules.jar</argument>
+                                        <argument>-mp</argument>
+                                        <argument>${jboss.home}/modules</argument>
+                                        <argument>org.jboss.as.cli</argument>
+                                        <argument>--file=${basedir}/../../config/enable-elytron-full.cli</argument>
+                                    </arguments>
+                                    <environmentVariables>
+                                        <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                                    </environmentVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>

--- a/testsuite/integration-tests-spring/inmodule/pom.xml
+++ b/testsuite/integration-tests-spring/inmodule/pom.xml
@@ -137,14 +137,12 @@
                                 </goals>
                                 <configuration>
                                     <executable>${java.home}/bin/java</executable>
-                                    <arguments>
-                                        <argument>-jar</argument>
-                                        <argument>${jboss.home}/jboss-modules.jar</argument>
-                                        <argument>-mp</argument>
-                                        <argument>${jboss.home}/modules</argument>
-                                        <argument>org.jboss.as.cli</argument>
-                                        <argument>--file=${basedir}/../../config/enable-elytron-full.cli</argument>
-                                    </arguments>
+                                    <commandlineArgs>
+                                        ${modular.jdk.args} -jar ${jboss.home}/jboss-modules.jar
+                                        -mp ${jboss.home}/modules
+                                        org.jboss.as.cli
+                                        --file=${basedir}/../../config/enable-elytron-full.cli
+                                    </commandlineArgs>
                                     <environmentVariables>
                                         <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
                                     </environmentVariables>

--- a/testsuite/integration-tests-spring/inmodule/pom.xml
+++ b/testsuite/integration-tests-spring/inmodule/pom.xml
@@ -181,7 +181,7 @@
                 <executions>
                     <execution>
                         <id>install-as-module-spring-3.2.x-resources</id>
-                        <phase>process-resources</phase>
+                        <phase>process-test-resources</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
@@ -205,7 +205,7 @@
                 <executions>
                     <execution>
                         <id>install-as-module-spring-3.2.x-dependencies</id>
-                        <phase>process-resources</phase>
+                        <phase>process-test-resources</phase>
                         <goals>
                             <goal>copy</goal>
                         </goals>

--- a/testsuite/integration-tests-spring/inmodule/pom.xml
+++ b/testsuite/integration-tests-spring/inmodule/pom.xml
@@ -99,6 +99,7 @@
                 </property>
             </activation>
             <properties>
+                <security.provider>elytron</security.provider>
                 <jboss.server.config.file.name>standalone-full-elytron.xml</jboss.server.config.file.name>
             </properties>
             <build>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -96,6 +96,70 @@
             <jboss.home>${project.build.directory}/test-server/wildfly-${server.version}</jboss.home>
           </properties>
         </profile>
+        <!-- This profile creates custom server configuration file with configured Elytron subsystem -->
+        <profile>
+            <id>elytron</id>
+            <activation>
+                <property>
+                    <name>elytron</name>
+                </property>
+            </activation>
+            <properties>
+                <jboss.server.config.file.name>standalone-full-elytron.xml</jboss.server.config.file.name>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-elytron-server-config</id>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <target>
+                                        <copy file="${jboss.home}/standalone/configuration/standalone-full.xml"
+                                              tofile="${jboss.home}/standalone/configuration/${jboss.server.config.file.name}"
+                                              overwrite="true" failonerror="true"/>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <id>enable-elytron-full-cli</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${java.home}/bin/java</executable>
+                                    <arguments>
+                                        <argument>-jar</argument>
+                                        <argument>${jboss.home}/jboss-modules.jar</argument>
+                                        <argument>-mp</argument>
+                                        <argument>${jboss.home}/modules</argument>
+                                        <argument>org.jboss.as.cli</argument>
+                                        <argument>--file=${basedir}/../config/enable-elytron-full.cli</argument>
+                                    </arguments>
+                                    <environmentVariables>
+                                        <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                                    </environmentVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <dependencies>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -143,14 +143,12 @@
                                 </goals>
                                 <configuration>
                                     <executable>${java.home}/bin/java</executable>
-                                    <arguments>
-                                        <argument>-jar</argument>
-                                        <argument>${jboss.home}/jboss-modules.jar</argument>
-                                        <argument>-mp</argument>
-                                        <argument>${jboss.home}/modules</argument>
-                                        <argument>org.jboss.as.cli</argument>
-                                        <argument>--file=${basedir}/../config/enable-elytron-full.cli</argument>
-                                    </arguments>
+                                    <commandlineArgs>
+                                        ${modular.jdk.args} -jar ${jboss.home}/jboss-modules.jar
+                                        -mp ${jboss.home}/modules
+                                        org.jboss.as.cli
+                                        --file=${basedir}/../config/enable-elytron-full.cli
+                                    </commandlineArgs>
                                     <environmentVariables>
                                         <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
                                     </environmentVariables>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -105,6 +105,7 @@
                 </property>
             </activation>
             <properties>
+                <security.provider>elytron</security.provider>
                 <jboss.server.config.file.name>standalone-full-elytron.xml</jboss.server.config.file.name>
             </properties>
             <build>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -24,6 +24,7 @@
         <additionalJvmArgs></additionalJvmArgs>
         <ipv6ArquillianSettings></ipv6ArquillianSettings>
         <jboss.server.config.file.name>standalone-full.xml</jboss.server.config.file.name>
+        <security.provider>picketbox</security.provider>
     </properties>
 
     <build>
@@ -43,6 +44,7 @@
                         <project.version>${project.version}</project.version>
                         <version.resteasy.testsuite>${version.resteasy.testsuite}</version.resteasy.testsuite>
                         <jboss.server.config.file.name>${jboss.server.config.file.name}</jboss.server.config.file.name>
+                        <security.provider>${security.provider}</security.provider>
                     </systemPropertyVariables>
                     <excludedGroups>org.jboss.resteasy.category.ExpectedFailing,${additional.surefire.excluded.groups}</excludedGroups>
                 </configuration>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -23,11 +23,13 @@
         <jacoco.agent></jacoco.agent>
         <additionalJvmArgs></additionalJvmArgs>
         <ipv6ArquillianSettings></ipv6ArquillianSettings>
+        <jboss.server.config.file.name>standalone-full.xml</jboss.server.config.file.name>
     </properties>
 
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <failIfNoTests>false</failIfNoTests>
@@ -40,6 +42,7 @@
                         <jboss.home>${jboss.home}</jboss.home>
                         <project.version>${project.version}</project.version>
                         <version.resteasy.testsuite>${version.resteasy.testsuite}</version.resteasy.testsuite>
+                        <jboss.server.config.file.name>${jboss.server.config.file.name}</jboss.server.config.file.name>
                     </systemPropertyVariables>
                     <excludedGroups>org.jboss.resteasy.category.ExpectedFailing,${additional.surefire.excluded.groups}</excludedGroups>
                 </configuration>
@@ -215,115 +218,6 @@
             <properties>
                 <securityManagerArg>-secmgr</securityManagerArg>
             </properties>
-        </profile>
-        <!-- This profile creates custom server configuration file with configured Elytron subsystem -->
-        <profile>
-            <id>elytron</id>
-            <activation>
-                <property>
-                    <name>elytron</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>copy</id>
-                                <phase>process-test-resources</phase>
-                                <configuration>
-                                    <target>
-                                        <copy file="${server.home}/standalone/configuration/standalone-full.xml"
-                                              tofile="${server.home}/standalone/configuration/standalone-full-elytron.xml"
-                                              overwrite="true" failonerror="true"/>
-                                    </target>
-                                </configuration>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <inherited>false</inherited>
-                        <executions>
-                            <execution>
-                                <id>enable-elytron-full-cli</id>
-                                <phase>process-test-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${java.home}/bin/java</executable>
-                                    <arguments>
-                                        <argument>-jar</argument>
-                                        <argument>${server.home}/jboss-modules.jar</argument>
-                                        <argument>-mp</argument>
-                                        <argument>${server.home}/modules</argument>
-                                        <argument>org.jboss.as.cli</argument>
-                                        <argument>--file=${basedir}/config/enable-elytron-full.cli</argument>
-                                    </arguments>
-                                    <environmentVariables>
-                                        <JBOSS_HOME>${server.home}</JBOSS_HOME>
-                                    </environmentVariables>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <securityManagerArg>${securityManagerArg}</securityManagerArg>
-                                <additionalJvmArgs>${additionalJvmArgs}</additionalJvmArgs>
-                                <jboss.server.config.file.name>standalone-full-elytron.xml</jboss.server.config.file.name>
-                                <ipv6>false</ipv6>
-                                <ipv6ArquillianSettings></ipv6ArquillianSettings>
-                                <node>127.0.0.1</node>
-                                <jboss.home>${jboss.home}</jboss.home>
-                                <project.version>${project.version}</project.version>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <!-- This profile enforces to define -Delytron property when -Dsecurity.domain=elytron is triggered -->
-        <profile>
-            <id>security.domain</id>
-            <activation>
-                <property>
-                    <name>security.domain</name>
-                    <value>elytron</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>enforce-property</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <requireProperty>
-                                            <property>elytron</property>
-                                            <message>You must set property '-Delytron' to the build in order to have all components for Elytron configured!</message>
-                                        </requireProperty>
-                                    </rules>
-                                    <fail>true</fail>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
         <!-- This profile generates jacoco coverage files. To generate html report use "-Djacoco.generate.report" -->
         <profile>


### PR DESCRIPTION
https://issues.jboss.org/browse/RESTEASY-2166

These commits allow for testing with Elytron security domains against recent WildFly builds and running this configuration with JDK11.

The change of configuration of travis testing is just for a verification of the changes and serves as an example, I don't think we need to double the testing execution time this way.