### PR TITLE
[RESTEASY-2169] AsyncResponse resume omits GenericEntity type

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AbstractAsynchronousResponse.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/AbstractAsynchronousResponse.java
@@ -10,6 +10,7 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import javax.ws.rs.container.CompletionCallback;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.container.TimeoutHandler;
+import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.WriterInterceptor;
@@ -185,7 +186,10 @@ public abstract class AbstractAsynchronousResponse implements ResteasyAsynchrono
          if (method == null) throw new IllegalStateException(Messages.MESSAGES.unknownMediaTypeResponseEntity());
          MediaType type = method.resolveContentType(request, entity);
          BuiltResponse jaxrsResponse = (BuiltResponse)Response.ok(entity, type).build();
-         jaxrsResponse.setGenericType(method.getGenericReturnType());
+         if (!(entity instanceof GenericEntity))
+         {
+             jaxrsResponse.setGenericType(method.getGenericReturnType());
+         }
          jaxrsResponse.addMethodAnnotations(method.getMethodAnnotations());
          response = jaxrsResponse;
       }


### PR DESCRIPTION
When GenericEntity is given then methods generic return type isn't used