### PR TITLE
ResteasyProviderFactory refactoring / optimization

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientConfiguration.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientConfiguration.java
@@ -57,7 +57,10 @@ public class ClientConfiguration implements Configuration, Configurable<ClientCo
 
    public void setProperties(Map<String, Object> newProps)
    {
-      providerFactory.setProperties(newProps);
+      if (newProps != null && !newProps.isEmpty())
+      {
+         providerFactory.setProperties(newProps);
+      }
    }
 
    protected ResteasyProviderFactory getProviderFactory()

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/LocalResteasyProviderFactory.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/LocalResteasyProviderFactory.java
@@ -2,7 +2,9 @@ package org.jboss.resteasy.client.jaxrs.internal;
 
 import javax.ws.rs.RuntimeType;
 
-import org.jboss.resteasy.core.ResteasyProviderFactoryImpl;
+import org.jboss.resteasy.core.providerfactory.ClientHelper;
+import org.jboss.resteasy.core.providerfactory.NOOPServerHelper;
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 /**
@@ -25,5 +27,12 @@ public class LocalResteasyProviderFactory extends ResteasyProviderFactoryImpl
    public RuntimeType getRuntimeType()
    {
       return RuntimeType.CLIENT;
+   }
+
+   @Override
+   protected void initializeUtils()
+   {
+      clientHelper = new ClientHelper(this);
+      serverHelper = NOOPServerHelper.INSTANCE;
    }
 }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.java
@@ -14,6 +14,7 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+import javax.ws.rs.RuntimeType;
 import javax.ws.rs.core.Configuration;
 
 import java.security.KeyStore;
@@ -315,8 +316,7 @@ public class ResteasyClientBuilderImpl extends ResteasyClientBuilder
       if (providerFactory == null)
       {
          // create a new one
-         providerFactory = new LocalResteasyProviderFactory(ResteasyProviderFactory.newInstance());
-         RegisterBuiltin.register(providerFactory);
+         providerFactory = new LocalResteasyProviderFactory(RegisterBuiltin.getClientInitializedResteasyProviderFactory(Thread.currentThread().getContextClassLoader()));
 
          if (ResteasyProviderFactory.peekInstance() != null)
          {
@@ -424,7 +424,13 @@ public class ResteasyClientBuilderImpl extends ResteasyClientBuilder
    @Override
    public ResteasyClientBuilderImpl withConfig(Configuration config)
    {
-      providerFactory = new LocalResteasyProviderFactory(new ResteasyProviderFactoryImpl());
+      providerFactory = new ResteasyProviderFactoryImpl() {
+         @Override
+         public RuntimeType getRuntimeType()
+         {
+            return RuntimeType.CLIENT;
+         }
+      };
       providerFactory.setProperties(config.getProperties());
       for (Class clazz : config.getClasses())
       {

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.java
@@ -8,7 +8,7 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpAsyncClient4Engine;
 import org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43;
 import org.jboss.resteasy.client.jaxrs.i18n.Messages;
-import org.jboss.resteasy.core.ResteasyProviderFactoryImpl;
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -133,9 +133,9 @@ public abstract class ResteasyProviderFactory extends RuntimeDelegate implements
       try
       {
          return (ResteasyProviderFactory) Thread.currentThread().getContextClassLoader()
-               .loadClass("org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl").newInstance();
+               .loadClass("org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl").getDeclaredConstructor().newInstance();
       }
-      catch (InstantiationException | IllegalAccessException | ClassNotFoundException e)
+      catch (Exception e)
       {
          throw new RuntimeException(e);
       }

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -133,7 +133,7 @@ public abstract class ResteasyProviderFactory extends RuntimeDelegate implements
       try
       {
          return (ResteasyProviderFactory) Thread.currentThread().getContextClassLoader()
-               .loadClass("org.jboss.resteasy.core.ResteasyProviderFactoryImpl").newInstance();
+               .loadClass("org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl").newInstance();
       }
       catch (InstantiationException | IllegalAccessException | ClassNotFoundException e)
       {

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
@@ -55,7 +55,7 @@ public class ExceptionHandler
       if (logger == null)
          logger = RESTEasyTracingLogger.empty();
 
-      ExceptionMapper mapper = providerFactory.getExceptionMappers().get(exception.getClass());
+      ExceptionMapper mapper = providerFactory.getExceptionMapperForClass(exception.getClass());
       if (mapper == null) return null;
       mapperExecuted = true;
       long timestamp = logger.timestamp("EXCEPTION_MAPPING");
@@ -75,7 +75,7 @@ public class ExceptionHandler
    {
       if (logger == null)
          logger = RESTEasyTracingLogger.empty();
-      ExceptionMapper mapper = providerFactory.getExceptionMappers().get(clazz);
+      ExceptionMapper mapper = providerFactory.getExceptionMapperForClass(clazz);
       if (mapper == null) return null;
       mapperExecuted = true;
       long timestamp = logger.timestamp("EXCEPTION_MAPPING");
@@ -123,7 +123,7 @@ public class ExceptionHandler
       Class causeClass = exception.getClass();
       while (mapper == null) {
          if (causeClass == null) break;
-         mapper = providerFactory.getExceptionMappers().get(causeClass);
+         mapper = providerFactory.getExceptionMapperForClass(causeClass);
          if (mapper == null) causeClass = causeClass.getSuperclass();
       }
 

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.core;
 
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.spi.ApplicationException;
 import org.jboss.resteasy.spi.Failure;

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/InjectorFactoryImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/InjectorFactoryImpl.java
@@ -42,6 +42,8 @@ import static org.jboss.resteasy.spi.util.FindAnnotation.findAnnotation;
 @SuppressWarnings({"unchecked", "rawtypes"})
 public class InjectorFactoryImpl implements InjectorFactory
 {
+   public static final InjectorFactoryImpl INSTANCE = new InjectorFactoryImpl();
+
    @Override
    public ConstructorInjector createConstructor(Constructor constructor, ResteasyProviderFactory providerFactory)
    {

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/MediaTypeMap.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/MediaTypeMap.java
@@ -115,14 +115,14 @@ public class MediaTypeMap<T>
       }
    }
 
-   private static Pattern COMPOSITE_PATTERN = Pattern.compile("([^\\+]+)\\+(.+)");
+   private static final Pattern COMPOSITE_PATTERN = Pattern.compile("([^\\+]+)\\+(.+)");
 
    // Composite subtypes are of the pattern *+subtype i.e. *+xml, *+json
-   public static Pattern COMPOSITE_SUBTYPE_WILDCARD_PATTERN = Pattern.compile("\\*\\+(.+)");
+   public static final Pattern COMPOSITE_SUBTYPE_WILDCARD_PATTERN = Pattern.compile("\\*\\+(.+)");
 
 
    // This composite is subtype+*  i.e. atom+* rss+*
-   public static Pattern WILD_SUBTYPE_COMPOSITE_PATTERN = Pattern.compile("([^\\+]+)\\+\\*");
+   public static final Pattern WILD_SUBTYPE_COMPOSITE_PATTERN = Pattern.compile("([^\\+]+)\\+\\*");
 
    private static class SubtypeMap<T>
    {
@@ -252,14 +252,7 @@ public class MediaTypeMap<T>
       return clone;
    }
 
-   public Map<CachedMediaTypeAndClass, List<T>> getClassCache()
-   {
-      return classCache;
-   }
-
-
-
-   public static class CachedMediaTypeAndClass
+   private static class CachedMediaTypeAndClass
    {
       // we need a weak reference because of possible hot deployment
       // Although, these reference should get cleared up with any add() invocation

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
@@ -2,6 +2,9 @@ package org.jboss.resteasy.core;
 
 import org.jboss.resteasy.annotations.Stream;
 import org.jboss.resteasy.core.interception.jaxrs.PostMatchContainerRequestContext;
+import org.jboss.resteasy.core.providerfactory.NOOPClientHelper;
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
+import org.jboss.resteasy.core.providerfactory.ServerHelper;
 import org.jboss.resteasy.core.registry.SegmentNode;
 import org.jboss.resteasy.plugins.server.resourcefactory.SingletonResource;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
@@ -108,7 +111,14 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
          }
       };
 
-      this.resourceMethodProviderFactory = new ResteasyProviderFactoryImpl(providerFactory);
+      this.resourceMethodProviderFactory = new ResteasyProviderFactoryImpl(providerFactory) {
+         @Override
+         protected void initializeUtils()
+         {
+            clientHelper = NOOPClientHelper.INSTANCE;
+            serverHelper = new ServerHelper(this);
+         }
+      };
       for (DynamicFeature feature : providerFactory.getServerDynamicFeatures())
       {
          feature.configure(resourceInfo, new DynamicFeatureContextDelegate(resourceMethodProviderFactory));
@@ -224,7 +234,14 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
 
    public void registryUpdated(JaxrsInterceptorRegistry registry)
    {
-      this.resourceMethodProviderFactory = new ResteasyProviderFactoryImpl(parentProviderFactory);
+      this.resourceMethodProviderFactory = new ResteasyProviderFactoryImpl(parentProviderFactory) {
+         @Override
+         protected void initializeUtils()
+         {
+            clientHelper = NOOPClientHelper.INSTANCE;
+            serverHelper = new ServerHelper(this);
+         }
+      };
       for (DynamicFeature feature : parentProviderFactory.getServerDynamicFeatures())
       {
          feature.configure(resourceInfo, new FeatureContextDelegate(resourceMethodProviderFactory));

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyProviderFactoryImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyProviderFactoryImpl.java
@@ -337,16 +337,16 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       stringParameterUnmarshallers = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getStringParameterUnmarshallers());
       reactiveClasses = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.reactiveClasses);
       headerDelegates = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getHeaderDelegates());
-      addHeaderDelegateIfAbsent(MediaType.class, new MediaTypeHeaderDelegate());
-      addHeaderDelegateIfAbsent(NewCookie.class, new NewCookieHeaderDelegate());
-      addHeaderDelegateIfAbsent(Cookie.class, new CookieHeaderDelegate());
-      addHeaderDelegateIfAbsent(URI.class, new UriHeaderDelegate());
-      addHeaderDelegateIfAbsent(EntityTag.class, new EntityTagDelegate());
-      addHeaderDelegateIfAbsent(CacheControl.class, new CacheControlDelegate());
-      addHeaderDelegateIfAbsent(Locale.class, new LocaleDelegate());
-      addHeaderDelegateIfAbsent(LinkHeader.class, new LinkHeaderDelegate());
-      addHeaderDelegateIfAbsent(javax.ws.rs.core.Link.class, new LinkDelegate());
-      addHeaderDelegateIfAbsent(Date.class, new DateDelegate());
+      addHeaderDelegateIfAbsent(MediaType.class, MediaTypeHeaderDelegate.INSTANCE);
+      addHeaderDelegateIfAbsent(NewCookie.class, NewCookieHeaderDelegate.INSTANCE);
+      addHeaderDelegateIfAbsent(Cookie.class, CookieHeaderDelegate.INSTANCE);
+      addHeaderDelegateIfAbsent(URI.class, UriHeaderDelegate.INSTANCE);
+      addHeaderDelegateIfAbsent(EntityTag.class, EntityTagDelegate.INSTANCE);
+      addHeaderDelegateIfAbsent(CacheControl.class, CacheControlDelegate.INSTANCE);
+      addHeaderDelegateIfAbsent(Locale.class, LocaleDelegate.INSTANCE);
+      addHeaderDelegateIfAbsent(LinkHeader.class, LinkHeaderDelegate.INSTANCE);
+      addHeaderDelegateIfAbsent(javax.ws.rs.core.Link.class, LinkDelegate.INSTANCE);
+      addHeaderDelegateIfAbsent(Date.class, DateDelegate.INSTANCE);
 
       resourceBuilder = new ResourceBuilder();
 
@@ -355,7 +355,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       builtinsRegistered = false;
       registerBuiltins = true;
 
-      injectorFactory = parent == null ? new InjectorFactoryImpl() : parent.getInjectorFactory();
+      injectorFactory = parent == null ? InjectorFactoryImpl.INSTANCE : parent.getInjectorFactory();
    }
 
    private void initializeRegistriesAndFilters(ResteasyProviderFactory parent)

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyProviderFactoryImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyProviderFactoryImpl.java
@@ -414,6 +414,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       return clientMessageBodyWriters;
    }
 
+   //TODO get rid of this method, replace it with getExceptionMapper(Class<?> c); get rid of exceptionMappers member (only use sortedExceptionMappers)
    public Map<Class<?>, ExceptionMapper> getExceptionMappers()
    {
       if (exceptionMappers != null)

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
@@ -505,12 +505,6 @@ public final class ThreadLocalResteasyProviderFactory extends ResteasyProviderFa
    }
 
    @Override
-   public Map<Class<?>, ExceptionMapper> getExceptionMappers()
-   {
-      return ((ResteasyProviderFactoryImpl)getDelegate()).getExceptionMappers();
-   }
-
-   @Override
    public <T> AsyncResponseProvider<T> getAsyncResponseProvider(Class<T> type)
    {
       return getDelegate().getAsyncResponseProvider(type);

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
@@ -29,6 +29,7 @@ import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ReaderInterceptor;
 import javax.ws.rs.ext.WriterInterceptor;
 
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.spi.AsyncResponseProvider;
 import org.jboss.resteasy.spi.AsyncStreamProvider;

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ServerReaderInterceptorContext.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ServerReaderInterceptorContext.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.core.interception.jaxrs;
 
-import org.jboss.resteasy.core.ResteasyProviderFactoryImpl;
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ServerWriterInterceptorContext.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/interception/jaxrs/ServerWriterInterceptorContext.java
@@ -1,7 +1,7 @@
 package org.jboss.resteasy.core.interception.jaxrs;
 
 import org.jboss.resteasy.core.NoMessageBodyWriterFoundFailure;
-import org.jboss.resteasy.core.ResteasyProviderFactoryImpl;
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.tracing.RESTEasyTracingLogger;

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ClientHelper.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ClientHelper.java
@@ -69,8 +69,8 @@ public class ClientHelper
       clientWriterInterceptorRegistry = parent == null ? new WriterInterceptorRegistryImpl(rpf) : parent.getClientWriterInterceptorRegistry().clone(rpf);
 
       clientDynamicFeatures = parent == null ? new CopyOnWriteArraySet<>() : new CopyOnWriteArraySet<>(parent.getClientDynamicFeatures());
-      asyncClientResponseProviders = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getAsyncClientResponseProviders());
-      reactiveClasses = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.clientHelper.reactiveClasses);
+      asyncClientResponseProviders = parent == null ? new ConcurrentHashMap<>(1) : new ConcurrentHashMap<>(parent.getAsyncClientResponseProviders());
+      reactiveClasses = parent == null ? new ConcurrentHashMap<>(8) : new ConcurrentHashMap<>(parent.clientHelper.reactiveClasses);
    }
 
    protected void initializeClientProviders(ResteasyProviderFactory factory)

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ClientHelper.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ClientHelper.java
@@ -1,0 +1,530 @@
+package org.jboss.resteasy.core.providerfactory;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.client.RxInvoker;
+import javax.ws.rs.client.RxInvokerProvider;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.ReaderInterceptor;
+import javax.ws.rs.ext.WriterInterceptor;
+
+import org.jboss.resteasy.core.MediaTypeMap;
+import org.jboss.resteasy.core.interception.jaxrs.ClientRequestFilterRegistryImpl;
+import org.jboss.resteasy.core.interception.jaxrs.ClientResponseFilterRegistryImpl;
+import org.jboss.resteasy.core.interception.jaxrs.ReaderInterceptorRegistryImpl;
+import org.jboss.resteasy.core.interception.jaxrs.WriterInterceptorRegistryImpl;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
+import org.jboss.resteasy.spi.AsyncClientResponseProvider;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.interception.JaxrsInterceptorRegistry;
+import org.jboss.resteasy.spi.util.Types;
+
+/**
+ *
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class ClientHelper
+{
+   private final ResteasyProviderFactoryImpl rpf;
+   private MediaTypeMap<SortedKey<MessageBodyReader>> clientMessageBodyReaders;
+   private MediaTypeMap<SortedKey<MessageBodyWriter>> clientMessageBodyWriters;
+   private JaxrsInterceptorRegistry<ClientRequestFilter> clientRequestFilterRegistry;
+   private JaxrsInterceptorRegistry<ClientResponseFilter> clientResponseFilters;
+   private JaxrsInterceptorRegistry<ReaderInterceptor> clientReaderInterceptorRegistry;
+   private JaxrsInterceptorRegistry<WriterInterceptor> clientWriterInterceptorRegistry;
+   private Set<DynamicFeature> clientDynamicFeatures;
+   private Map<Class<?>, AsyncClientResponseProvider> asyncClientResponseProviders;
+   private Map<Class<?>, Class<? extends RxInvokerProvider<?>>> reactiveClasses;
+
+   public ClientHelper(final ResteasyProviderFactoryImpl rpf)
+   {
+      this.rpf = rpf;
+   }
+
+   protected void initializeDefault()
+   {
+      reactiveClasses = new ConcurrentHashMap<>();
+   }
+
+   protected void initialize(ResteasyProviderFactoryImpl parent)
+   {
+      clientMessageBodyReaders = parent == null ? new MediaTypeMap<>() : parent.getClientMessageBodyReaders().clone();
+      clientMessageBodyWriters = parent == null ? new MediaTypeMap<>() : parent.getClientMessageBodyWriters().clone();
+      clientRequestFilterRegistry = parent == null ? new ClientRequestFilterRegistryImpl(rpf) : parent.getClientRequestFilterRegistry().clone(rpf);
+      clientResponseFilters = parent == null ? new ClientResponseFilterRegistryImpl(rpf) : parent.getClientResponseFilters().clone(rpf);
+      clientReaderInterceptorRegistry = parent == null ? new ReaderInterceptorRegistryImpl(rpf) : parent.getClientReaderInterceptorRegistry().clone(rpf);
+      clientWriterInterceptorRegistry = parent == null ? new WriterInterceptorRegistryImpl(rpf) : parent.getClientWriterInterceptorRegistry().clone(rpf);
+
+      clientDynamicFeatures = parent == null ? new CopyOnWriteArraySet<>() : new CopyOnWriteArraySet<>(parent.getClientDynamicFeatures());
+      asyncClientResponseProviders = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getAsyncClientResponseProviders());
+      reactiveClasses = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.clientHelper.reactiveClasses);
+   }
+
+   protected void initializeClientProviders(ResteasyProviderFactory factory)
+   {
+      clientRequestFilterRegistry = factory == null ? new ClientRequestFilterRegistryImpl(rpf) : factory.getClientRequestFilterRegistry().clone(rpf);
+      clientResponseFilters =  factory == null ? new ClientResponseFilterRegistryImpl(rpf) : factory.getClientResponseFilters().clone(rpf);
+   }
+
+   protected JaxrsInterceptorRegistry<ReaderInterceptor> getClientReaderInterceptorRegistry(ResteasyProviderFactory parent)
+   {
+      if (clientReaderInterceptorRegistry == null && parent != null)
+         return parent.getClientReaderInterceptorRegistry();
+      return clientReaderInterceptorRegistry;
+   }
+
+   protected JaxrsInterceptorRegistry<WriterInterceptor> getClientWriterInterceptorRegistry(ResteasyProviderFactory parent)
+   {
+      if (clientWriterInterceptorRegistry == null && parent != null)
+         return parent.getClientWriterInterceptorRegistry();
+      return clientWriterInterceptorRegistry;
+   }
+
+   protected JaxrsInterceptorRegistry<ClientRequestFilter> getClientRequestFilterRegistry(ResteasyProviderFactory parent)
+   {
+      if (clientRequestFilterRegistry == null && parent != null)
+         return parent.getClientRequestFilterRegistry();
+      return clientRequestFilterRegistry;
+   }
+
+   protected JaxrsInterceptorRegistry<ClientResponseFilter> getClientResponseFilters(ResteasyProviderFactory parent)
+   {
+      if (clientResponseFilters == null && parent != null)
+         return parent.getClientResponseFilters();
+      return clientResponseFilters;
+   }
+
+   protected Set<DynamicFeature> getClientDynamicFeatures(ResteasyProviderFactory parent)
+   {
+      if (clientDynamicFeatures == null && parent != null)
+         return parent.getClientDynamicFeatures();
+      return clientDynamicFeatures;
+   }
+
+   protected Map<Class<?>, AsyncClientResponseProvider> getAsyncClientResponseProviders(ResteasyProviderFactory parent)
+   {
+      if (asyncClientResponseProviders == null && parent != null)
+         return parent.getAsyncClientResponseProviders();
+      return asyncClientResponseProviders;
+   }
+
+   protected RxInvokerProvider<?> getRxInvokerProviderFromReactiveClass(Class<?> clazz)
+   {
+      Class<? extends RxInvokerProvider> rxInvokerProviderClass = reactiveClasses.get(clazz);
+      if (rxInvokerProviderClass != null)
+      {
+         return rpf.createProviderInstance(rxInvokerProviderClass);
+      }
+      return null;
+   }
+
+   protected boolean isReactive(Class<?> clazz)
+   {
+      return reactiveClasses.keySet().contains(clazz);
+   }
+
+   protected void processProviderContracts(Class provider, Integer priorityOverride, boolean isBuiltin,
+         Map<Class<?>, Integer> contracts, Map<Class<?>, Integer> newContracts, ResteasyProviderFactoryImpl parent)
+   {
+      if (Utils.isA(provider, MessageBodyReader.class, contracts))
+      {
+         try
+         {
+            int priority = Utils.getPriority(priorityOverride, contracts, MessageBodyReader.class, provider);
+            addMessageBodyReader(Utils.createProviderInstance(rpf, (Class<? extends MessageBodyReader>) provider), provider,
+                  priority, isBuiltin, parent);
+            newContracts.put(MessageBodyReader.class, priority);
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateMessageBodyReader(), e);
+         }
+      }
+      if (Utils.isA(provider, MessageBodyWriter.class, contracts))
+      {
+         try
+         {
+            int priority = Utils.getPriority(priorityOverride, contracts, MessageBodyWriter.class, provider);
+            addMessageBodyWriter(Utils.createProviderInstance(rpf, (Class<? extends MessageBodyWriter>) provider), provider,
+                  priority, isBuiltin, parent);
+            newContracts.put(MessageBodyWriter.class, priority);
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateMessageBodyWriter(), e);
+         }
+      }
+      if (Utils.isA(provider, ClientRequestFilter.class, contracts))
+      {
+         if (clientRequestFilterRegistry == null)
+         {
+            clientRequestFilterRegistry = parent.getClientRequestFilterRegistry().clone(rpf);
+         }
+         int priority = Utils.getPriority(priorityOverride, contracts, ClientRequestFilter.class, provider);
+         clientRequestFilterRegistry.registerClass(provider, priority);
+         newContracts.put(ClientRequestFilter.class, priority);
+      }
+      if (Utils.isA(provider, ClientResponseFilter.class, contracts))
+      {
+         if (clientResponseFilters == null)
+         {
+            clientResponseFilters = parent.getClientResponseFilters().clone(rpf);
+         }
+         int priority = Utils.getPriority(priorityOverride, contracts, ClientResponseFilter.class, provider);
+         clientResponseFilters.registerClass(provider, priority);
+         newContracts.put(ClientResponseFilter.class, priority);
+      }
+      if (Utils.isA(provider, ReaderInterceptor.class, contracts))
+      {
+         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getAnnotation(ConstrainedTo.class);
+         int priority = Utils.getPriority(priorityOverride, contracts, ReaderInterceptor.class, provider);
+         if (constrainedTo != null && constrainedTo.value() == RuntimeType.CLIENT)
+         {
+            if (clientReaderInterceptorRegistry == null)
+            {
+               clientReaderInterceptorRegistry = parent.getClientReaderInterceptorRegistry().clone(rpf);
+            }
+            clientReaderInterceptorRegistry.registerClass(provider, priority);
+         }
+         if (constrainedTo == null)
+         {
+            if (clientReaderInterceptorRegistry == null)
+            {
+               clientReaderInterceptorRegistry = parent.getClientReaderInterceptorRegistry().clone(rpf);
+            }
+            clientReaderInterceptorRegistry.registerClass(provider, priority);
+         }
+         newContracts.put(ReaderInterceptor.class, priority);
+      }
+      if (Utils.isA(provider, WriterInterceptor.class, contracts))
+      {
+         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getAnnotation(ConstrainedTo.class);
+         int priority = Utils.getPriority(priorityOverride, contracts, WriterInterceptor.class, provider);
+         if (constrainedTo != null && constrainedTo.value() == RuntimeType.CLIENT)
+         {
+            if (clientWriterInterceptorRegistry == null)
+            {
+               clientWriterInterceptorRegistry = parent.getClientWriterInterceptorRegistry().clone(rpf);
+            }
+            clientWriterInterceptorRegistry.registerClass(provider, priority);
+         }
+         if (constrainedTo == null)
+         {
+            if (clientWriterInterceptorRegistry == null)
+            {
+               clientWriterInterceptorRegistry = parent.getClientWriterInterceptorRegistry().clone(rpf);
+            }
+            clientWriterInterceptorRegistry.registerClass(provider, priority);
+         }
+         newContracts.put(WriterInterceptor.class, priority);
+      }
+      if (Utils.isA(provider, DynamicFeature.class, contracts))
+      {
+         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getAnnotation(ConstrainedTo.class);
+         int priority = Utils.getPriority(priorityOverride, contracts, DynamicFeature.class, provider);
+         if (constrainedTo != null && constrainedTo.value() == RuntimeType.CLIENT)
+         {
+            if (clientDynamicFeatures == null)
+            {
+               clientDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getClientDynamicFeatures());
+            }
+            clientDynamicFeatures.add((DynamicFeature) rpf.injectedInstance(provider));
+         }
+         if (constrainedTo == null)
+         {
+            if (clientDynamicFeatures == null)
+            {
+               clientDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getClientDynamicFeatures());
+            }
+            clientDynamicFeatures.add((DynamicFeature) rpf.injectedInstance(provider));
+         }
+         newContracts.put(DynamicFeature.class, priority);
+      }
+      if (Utils.isA(provider, AsyncClientResponseProvider.class, contracts))
+      {
+         try
+         {
+            addAsyncClientResponseProvider(
+                  rpf.createProviderInstance((Class<? extends AsyncClientResponseProvider>) provider), provider, parent);
+            newContracts.put(AsyncClientResponseProvider.class,
+                  Utils.getPriority(priorityOverride, contracts, AsyncClientResponseProvider.class, provider));
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateAsyncClientResponseProvider(), e);
+         }
+      }
+      if (Utils.isA(provider, RxInvokerProvider.class, contracts))
+      {
+         int priority = Utils.getPriority(priorityOverride, contracts, RxInvokerProvider.class, provider);
+         newContracts.put(RxInvokerProvider.class, priority);
+         Class<?> clazz = Types.getTemplateParameterOfInterface(provider, RxInvokerProvider.class);
+         clazz = Types.getTemplateParameterOfInterface(clazz, RxInvoker.class);
+         if (clazz != null)
+         {
+            reactiveClasses.put(clazz, provider);
+         }
+      }
+   }
+
+   protected void processProviderInstanceContracts(Object provider, Map<Class<?>, Integer> contracts,
+         Integer priorityOverride, boolean builtIn, Map<Class<?>, Integer> newContracts, ResteasyProviderFactoryImpl parent)
+   {
+      if (Utils.isA(provider, MessageBodyReader.class, contracts))
+      {
+         try
+         {
+            int priority = Utils.getPriority(priorityOverride, contracts, MessageBodyReader.class, provider.getClass());
+            addMessageBodyReader((MessageBodyReader) provider, provider.getClass(), priority, builtIn, parent);
+            newContracts.put(MessageBodyReader.class, priority);
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateMessageBodyReader(), e);
+         }
+      }
+      if (Utils.isA(provider, MessageBodyWriter.class, contracts))
+      {
+         try
+         {
+            int priority = Utils.getPriority(priorityOverride, contracts, MessageBodyWriter.class, provider.getClass());
+            addMessageBodyWriter((MessageBodyWriter) provider, provider.getClass(), priority, builtIn, parent);
+            newContracts.put(MessageBodyWriter.class, priority);
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateMessageBodyWriter(), e);
+         }
+      }
+      if (Utils.isA(provider, ClientRequestFilter.class, contracts))
+      {
+         if (clientRequestFilterRegistry == null)
+         {
+            clientRequestFilterRegistry = parent.getClientRequestFilterRegistry().clone(rpf);
+         }
+         int priority = Utils.getPriority(priorityOverride, contracts, ClientRequestFilter.class, provider.getClass());
+         clientRequestFilterRegistry.registerSingleton((ClientRequestFilter) provider, priority);
+         newContracts.put(ClientRequestFilter.class, priority);
+      }
+      if (Utils.isA(provider, ClientResponseFilter.class, contracts))
+      {
+         if (clientResponseFilters == null)
+         {
+            clientResponseFilters = parent.getClientResponseFilters().clone(rpf);
+         }
+         int priority = Utils.getPriority(priorityOverride, contracts, ClientResponseFilter.class, provider.getClass());
+         clientResponseFilters.registerSingleton((ClientResponseFilter) provider, priority);
+         newContracts.put(ClientResponseFilter.class, priority);
+      }
+      if (Utils.isA(provider, ReaderInterceptor.class, contracts))
+      {
+         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getClass().getAnnotation(ConstrainedTo.class);
+         int priority = Utils.getPriority(priorityOverride, contracts, ReaderInterceptor.class, provider.getClass());
+         if (constrainedTo != null && constrainedTo.value() == RuntimeType.CLIENT)
+         {
+            if (clientReaderInterceptorRegistry == null)
+            {
+               clientReaderInterceptorRegistry = parent.getClientReaderInterceptorRegistry().clone(rpf);
+            }
+            clientReaderInterceptorRegistry.registerSingleton((ReaderInterceptor) provider, priority);
+         }
+         if (constrainedTo == null)
+         {
+            if (clientReaderInterceptorRegistry == null)
+            {
+               clientReaderInterceptorRegistry = parent.getClientReaderInterceptorRegistry().clone(rpf);
+            }
+            clientReaderInterceptorRegistry.registerSingleton((ReaderInterceptor) provider, priority);
+         }
+         newContracts.put(ReaderInterceptor.class, priority);
+      }
+      if (Utils.isA(provider, WriterInterceptor.class, contracts))
+      {
+         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getClass().getAnnotation(ConstrainedTo.class);
+         int priority = Utils.getPriority(priorityOverride, contracts, WriterInterceptor.class, provider.getClass());
+         if (constrainedTo != null && constrainedTo.value() == RuntimeType.CLIENT)
+         {
+            if (clientWriterInterceptorRegistry == null)
+            {
+               clientWriterInterceptorRegistry = parent.getClientWriterInterceptorRegistry().clone(rpf);
+            }
+            clientWriterInterceptorRegistry.registerSingleton((WriterInterceptor) provider, priority);
+         }
+         if (constrainedTo == null)
+         {
+            if (clientWriterInterceptorRegistry == null)
+            {
+               clientWriterInterceptorRegistry = parent.getClientWriterInterceptorRegistry().clone(rpf);
+            }
+            clientWriterInterceptorRegistry.registerSingleton((WriterInterceptor) provider, priority);
+         }
+         newContracts.put(WriterInterceptor.class, priority);
+      }
+      if (Utils.isA(provider, DynamicFeature.class, contracts))
+      {
+         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getClass().getAnnotation(ConstrainedTo.class);
+         int priority = Utils.getPriority(priorityOverride, contracts, DynamicFeature.class, provider.getClass());
+         if (constrainedTo != null && constrainedTo.value() == RuntimeType.CLIENT)
+         {
+            if (clientDynamicFeatures == null)
+            {
+               clientDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getClientDynamicFeatures());
+            }
+            clientDynamicFeatures.add((DynamicFeature) provider);
+         }
+         if (constrainedTo == null)
+         {
+            if (clientDynamicFeatures == null)
+            {
+               clientDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getClientDynamicFeatures());
+            }
+            clientDynamicFeatures.add((DynamicFeature) provider);
+         }
+         newContracts.put(DynamicFeature.class, priority);
+      }
+      if (Utils.isA(provider, AsyncClientResponseProvider.class, contracts))
+      {
+         try
+         {
+            addAsyncClientResponseProvider((AsyncClientResponseProvider) provider, provider.getClass(), parent);
+            int priority = Utils.getPriority(priorityOverride, contracts, AsyncClientResponseProvider.class,
+                  provider.getClass());
+            newContracts.put(AsyncClientResponseProvider.class, priority);
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateAsyncClientResponseProvider(), e);
+         }
+      }
+   }
+
+   protected MediaTypeMap<SortedKey<MessageBodyReader>> getClientMessageBodyReaders(ResteasyProviderFactoryImpl parent)
+   {
+      if (clientMessageBodyReaders == null && parent != null)
+         return parent.getClientMessageBodyReaders();
+      return clientMessageBodyReaders;
+   }
+
+   protected MediaTypeMap<SortedKey<MessageBodyWriter>> getClientMessageBodyWriters(ResteasyProviderFactoryImpl parent)
+   {
+      if (clientMessageBodyWriters == null && parent != null)
+         return parent.getClientMessageBodyWriters();
+      return clientMessageBodyWriters;
+   }
+
+   protected void addMessageBodyReader(MessageBodyReader provider, Class<?> providerClass, int priority,
+         boolean isBuiltin, ResteasyProviderFactoryImpl parent)
+   {
+      SortedKey<MessageBodyReader> key = new SortedKey<MessageBodyReader>(MessageBodyReader.class, provider,
+            providerClass, priority, isBuiltin);
+      Utils.injectProperties(rpf, providerClass, provider);
+      Consumes consumeMime = provider.getClass().getAnnotation(Consumes.class);
+      RuntimeType type = null;
+      ConstrainedTo constrainedTo = providerClass.getAnnotation(ConstrainedTo.class);
+      if (constrainedTo != null)
+         type = constrainedTo.value();
+
+      if ((type == null || type == RuntimeType.CLIENT) && clientMessageBodyReaders == null)
+      {
+         clientMessageBodyReaders = parent.getClientMessageBodyReaders().clone();
+      }
+      if (consumeMime != null)
+      {
+         for (String consume : consumeMime.value())
+         {
+            if (type == null)
+            {
+               clientMessageBodyReaders.add(MediaType.valueOf(consume), key);
+            }
+            else if (type == RuntimeType.CLIENT)
+            {
+               clientMessageBodyReaders.add(MediaType.valueOf(consume), key);
+            }
+         }
+      }
+      else
+      {
+         if (type == null)
+         {
+            clientMessageBodyReaders.add(new MediaType("*", "*"), key);
+         }
+         else if (type == RuntimeType.CLIENT)
+         {
+            clientMessageBodyReaders.add(new MediaType("*", "*"), key);
+         }
+      }
+   }
+
+   protected void addMessageBodyWriter(MessageBodyWriter provider, Class<?> providerClass, int priority,
+         boolean isBuiltin, ResteasyProviderFactoryImpl parent)
+   {
+      Utils.injectProperties(rpf, providerClass, provider);
+      Produces consumeMime = provider.getClass().getAnnotation(Produces.class);
+      SortedKey<MessageBodyWriter> key = new SortedKey<MessageBodyWriter>(MessageBodyWriter.class, provider,
+            providerClass, priority, isBuiltin);
+      RuntimeType type = null;
+      ConstrainedTo constrainedTo = providerClass.getAnnotation(ConstrainedTo.class);
+      if (constrainedTo != null)
+         type = constrainedTo.value();
+
+      if ((type == null || type == RuntimeType.CLIENT) && clientMessageBodyWriters == null)
+      {
+         clientMessageBodyWriters = parent.getClientMessageBodyWriters().clone();
+      }
+      if (consumeMime != null)
+      {
+         for (String consume : consumeMime.value())
+         {
+            //logger.info(">>> Adding provider: " + provider.getClass().getName() + " with mime type of: " + mime);
+            if (type == null)
+            {
+               clientMessageBodyWriters.add(MediaType.valueOf(consume), key);
+            }
+            else if (type == RuntimeType.CLIENT)
+            {
+               clientMessageBodyWriters.add(MediaType.valueOf(consume), key);
+            }
+         }
+      }
+      else
+      {
+         //logger.info(">>> Adding provider: " + provider.getClass().getName() + " with mime type of: default */*");
+         if (type == null)
+         {
+            clientMessageBodyWriters.add(new MediaType("*", "*"), key);
+         }
+         else if (type == RuntimeType.CLIENT)
+         {
+            clientMessageBodyWriters.add(new MediaType("*", "*"), key);
+         }
+      }
+   }
+
+   private void addAsyncClientResponseProvider(AsyncClientResponseProvider provider, Class providerClass, ResteasyProviderFactory parent)
+   {
+      Type asyncType = Types.getActualTypeArgumentsOfAnInterface(providerClass, AsyncClientResponseProvider.class)[0];
+      Utils.injectProperties(rpf, provider.getClass(), provider);
+
+      Class<?> asyncClass = Types.getRawType(asyncType);
+      if (asyncClientResponseProviders == null)
+      {
+         asyncClientResponseProviders = new ConcurrentHashMap<Class<?>, AsyncClientResponseProvider>();
+         asyncClientResponseProviders.putAll(parent.getAsyncClientResponseProviders());
+      }
+      asyncClientResponseProviders.put(asyncClass, provider);
+   }
+
+}

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ExtSortedKey.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ExtSortedKey.java
@@ -1,0 +1,34 @@
+package org.jboss.resteasy.core.providerfactory;
+
+public final class ExtSortedKey<T> extends SortedKey<T>
+{
+   public ExtSortedKey(final Class<?> intf, final T reader, final Class<?> readerClass, final int priority, final boolean isBuiltin)
+   {
+      super(intf, reader, readerClass, priority, isBuiltin);
+   }
+
+   public ExtSortedKey(final Class<?> intf, final T reader, final Class<?> readerClass, final boolean isBuiltin)
+   {
+      super(intf, reader, readerClass, isBuiltin);
+   }
+
+   public ExtSortedKey(final Class<?> intf, final T reader, final Class<?> readerClass)
+   {
+      super(intf, reader, readerClass);
+   }
+
+   @Override
+   public int compareTo(SortedKey<T> tMessageBodyKey)
+   {
+      int c = super.compareTo(tMessageBodyKey);
+      if (c != 0)
+      {
+         return c;
+      }
+      if (this.getObj() == tMessageBodyKey.getObj())
+      {
+         return 0;
+      }
+      return -1;
+   }
+}

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/NOOPClientHelper.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/NOOPClientHelper.java
@@ -1,0 +1,138 @@
+package org.jboss.resteasy.core.providerfactory;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.client.RxInvokerProvider;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.ReaderInterceptor;
+import javax.ws.rs.ext.WriterInterceptor;
+
+import org.jboss.resteasy.core.MediaTypeMap;
+import org.jboss.resteasy.spi.AsyncClientResponseProvider;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.interception.JaxrsInterceptorRegistry;
+
+/**
+ * A ClientHelper that does nothing, useful to save memory when creating a ResteasyProviderFactory for server side only
+ */
+@SuppressWarnings("rawtypes")
+public final class NOOPClientHelper extends ClientHelper
+{
+   public static final NOOPClientHelper INSTANCE = new NOOPClientHelper(null);
+
+   public NOOPClientHelper(final ResteasyProviderFactoryImpl rpf)
+   {
+      super(rpf);
+   }
+
+   @Override
+   protected void initializeDefault()
+   {
+      //NOOP
+   }
+
+   @Override
+   protected void initialize(ResteasyProviderFactoryImpl parent)
+   {
+      //NOOP
+   }
+
+   @Override
+   protected void initializeClientProviders(ResteasyProviderFactory factory)
+   {
+      //NOOP
+   }
+
+   @Override
+   protected JaxrsInterceptorRegistry<ReaderInterceptor> getClientReaderInterceptorRegistry(ResteasyProviderFactory parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected JaxrsInterceptorRegistry<WriterInterceptor> getClientWriterInterceptorRegistry(ResteasyProviderFactory parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected JaxrsInterceptorRegistry<ClientRequestFilter> getClientRequestFilterRegistry(ResteasyProviderFactory parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected JaxrsInterceptorRegistry<ClientResponseFilter> getClientResponseFilters(ResteasyProviderFactory parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected Set<DynamicFeature> getClientDynamicFeatures(ResteasyProviderFactory parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected Map<Class<?>, AsyncClientResponseProvider> getAsyncClientResponseProviders(ResteasyProviderFactory parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected RxInvokerProvider<?> getRxInvokerProviderFromReactiveClass(Class<?> clazz)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected boolean isReactive(Class<?> clazz)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected void processProviderContracts(Class provider, Integer priorityOverride, boolean isBuiltin,
+         Map<Class<?>, Integer> contracts, Map<Class<?>, Integer> newContracts, ResteasyProviderFactoryImpl parent)
+   {
+      //NOOP
+   }
+
+   @Override
+   protected void processProviderInstanceContracts(Object provider, Map<Class<?>, Integer> contracts,
+         Integer priorityOverride, boolean builtIn, Map<Class<?>, Integer> newContracts, ResteasyProviderFactoryImpl parent)
+   {
+      //NOOP
+   }
+
+   @Override
+   protected MediaTypeMap<SortedKey<MessageBodyReader>> getClientMessageBodyReaders(ResteasyProviderFactoryImpl parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected MediaTypeMap<SortedKey<MessageBodyWriter>> getClientMessageBodyWriters(ResteasyProviderFactoryImpl parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected void addMessageBodyReader(MessageBodyReader provider, Class<?> providerClass, int priority,
+         boolean isBuiltin, ResteasyProviderFactoryImpl parent)
+   {
+      //NOOP
+   }
+
+   @Override
+   protected void addMessageBodyWriter(MessageBodyWriter provider, Class<?> providerClass, int priority,
+         boolean isBuiltin, ResteasyProviderFactoryImpl parent)
+   {
+      //NOOP
+   }
+}

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/NOOPServerHelper.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/NOOPServerHelper.java
@@ -1,0 +1,120 @@
+package org.jboss.resteasy.core.providerfactory;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.ReaderInterceptor;
+import javax.ws.rs.ext.WriterInterceptor;
+
+import org.jboss.resteasy.core.MediaTypeMap;
+import org.jboss.resteasy.spi.AsyncResponseProvider;
+import org.jboss.resteasy.spi.AsyncStreamProvider;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.interception.JaxrsInterceptorRegistry;
+
+/**
+ * A ServerHelper that does nothing, useful to save memory when creating a ResteasyProviderFactory for client side only
+ */
+@SuppressWarnings("rawtypes")
+public final class NOOPServerHelper extends ServerHelper
+{
+   public static final NOOPServerHelper INSTANCE = new NOOPServerHelper(null);
+
+   private NOOPServerHelper(final ResteasyProviderFactoryImpl rpf)
+   {
+      super(rpf);
+   }
+
+   @Override
+   protected void initialize(ResteasyProviderFactoryImpl parent)
+   {
+      //NOOP
+   }
+
+   @Override
+   protected JaxrsInterceptorRegistry<ReaderInterceptor> getServerReaderInterceptorRegistry(ResteasyProviderFactory parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected JaxrsInterceptorRegistry<WriterInterceptor> getServerWriterInterceptorRegistry(ResteasyProviderFactory parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected JaxrsInterceptorRegistry<ContainerRequestFilter> getContainerRequestFilterRegistry(ResteasyProviderFactory parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected JaxrsInterceptorRegistry<ContainerResponseFilter> getContainerResponseFilterRegistry(ResteasyProviderFactory parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected Set<DynamicFeature> getServerDynamicFeatures(ResteasyProviderFactory parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected Map<Class<?>, AsyncResponseProvider> getAsyncResponseProviders(ResteasyProviderFactory parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected Map<Class<?>, AsyncStreamProvider> getAsyncStreamProviders(ResteasyProviderFactory parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected void processProviderContracts(Class provider, Integer priorityOverride, boolean isBuiltin,
+         Map<Class<?>, Integer> contracts, Map<Class<?>, Integer> newContracts, ResteasyProviderFactoryImpl parent)
+   {
+      //NOOP
+   }
+
+   @Override
+   protected void processProviderInstanceContracts(Object provider, Map<Class<?>, Integer> contracts,
+         Integer priorityOverride, boolean builtIn, Map<Class<?>, Integer> newContracts, ResteasyProviderFactoryImpl parent)
+   {
+      //NOOP
+   }
+
+   @Override
+   protected MediaTypeMap<SortedKey<MessageBodyReader>> getServerMessageBodyReaders(ResteasyProviderFactoryImpl parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected MediaTypeMap<SortedKey<MessageBodyWriter>> getServerMessageBodyWriters(ResteasyProviderFactoryImpl parent)
+   {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   protected void addMessageBodyReader(MessageBodyReader provider, Class<?> providerClass, int priority,
+         boolean isBuiltin, ResteasyProviderFactoryImpl parent)
+   {
+      //NOOP
+   }
+
+   @Override
+   protected void addMessageBodyWriter(MessageBodyWriter provider, Class<?> providerClass, int priority,
+         boolean isBuiltin, ResteasyProviderFactoryImpl parent)
+   {
+      //NOOP
+   }
+}

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ResteasyProviderFactoryImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ResteasyProviderFactoryImpl.java
@@ -1,52 +1,28 @@
-package org.jboss.resteasy.core;
+package org.jboss.resteasy.core.providerfactory;
 
-import org.jboss.resteasy.core.interception.jaxrs.ClientRequestFilterRegistryImpl;
-import org.jboss.resteasy.core.interception.jaxrs.ClientResponseFilterRegistryImpl;
-import org.jboss.resteasy.core.interception.jaxrs.ContainerRequestFilterRegistryImpl;
-import org.jboss.resteasy.core.interception.jaxrs.ContainerResponseFilterRegistryImpl;
-import org.jboss.resteasy.core.interception.jaxrs.ReaderInterceptorRegistryImpl;
-import org.jboss.resteasy.core.interception.jaxrs.WriterInterceptorRegistryImpl;
-import org.jboss.resteasy.plugins.delegates.CacheControlDelegate;
-import org.jboss.resteasy.plugins.delegates.CookieHeaderDelegate;
-import org.jboss.resteasy.plugins.delegates.DateDelegate;
-import org.jboss.resteasy.plugins.delegates.EntityTagDelegate;
-import org.jboss.resteasy.plugins.delegates.LinkDelegate;
-import org.jboss.resteasy.plugins.delegates.LinkHeaderDelegate;
-import org.jboss.resteasy.plugins.delegates.LocaleDelegate;
-import org.jboss.resteasy.plugins.delegates.MediaTypeHeaderDelegate;
-import org.jboss.resteasy.plugins.delegates.NewCookieHeaderDelegate;
-import org.jboss.resteasy.plugins.delegates.UriHeaderDelegate;
-import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
-import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
-import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
-import org.jboss.resteasy.specimpl.LinkBuilderImpl;
-import org.jboss.resteasy.specimpl.ResponseBuilderImpl;
-import org.jboss.resteasy.specimpl.ResteasyUriBuilderImpl;
-import org.jboss.resteasy.specimpl.VariantListBuilderImpl;
-import org.jboss.resteasy.spi.AsyncClientResponseProvider;
-import org.jboss.resteasy.spi.AsyncResponseProvider;
-import org.jboss.resteasy.spi.AsyncStreamProvider;
-import org.jboss.resteasy.spi.ConstructorInjector;
-import org.jboss.resteasy.spi.ContextInjector;
-import org.jboss.resteasy.spi.HeaderValueProcessor;
-import org.jboss.resteasy.spi.HttpRequest;
-import org.jboss.resteasy.spi.HttpResponse;
-import org.jboss.resteasy.spi.InjectorFactory;
-import org.jboss.resteasy.spi.LinkHeader;
-import org.jboss.resteasy.spi.PropertyInjector;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.jboss.resteasy.spi.StringParameterUnmarshaller;
-import org.jboss.resteasy.spi.interception.JaxrsInterceptorRegistry;
-import org.jboss.resteasy.spi.metadata.ResourceBuilder;
-import org.jboss.resteasy.spi.metadata.ResourceClassProcessor;
-import org.jboss.resteasy.spi.util.PickConstructor;
-import org.jboss.resteasy.spi.util.Types;
-import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
-import org.jboss.resteasy.util.FeatureContextDelegate;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 
-import javax.annotation.Priority;
 import javax.ws.rs.ConstrainedTo;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.Produces;
 import javax.ws.rs.RuntimeType;
@@ -81,28 +57,42 @@ import javax.ws.rs.ext.ReaderInterceptor;
 import javax.ws.rs.ext.RuntimeDelegate;
 import javax.ws.rs.ext.WriterInterceptor;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import java.util.Objects;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArraySet;
+import org.jboss.resteasy.core.InjectorFactoryImpl;
+import org.jboss.resteasy.core.MediaTypeMap;
+import org.jboss.resteasy.core.ResteasyContext;
+import org.jboss.resteasy.plugins.delegates.CacheControlDelegate;
+import org.jboss.resteasy.plugins.delegates.CookieHeaderDelegate;
+import org.jboss.resteasy.plugins.delegates.DateDelegate;
+import org.jboss.resteasy.plugins.delegates.EntityTagDelegate;
+import org.jboss.resteasy.plugins.delegates.LinkDelegate;
+import org.jboss.resteasy.plugins.delegates.LinkHeaderDelegate;
+import org.jboss.resteasy.plugins.delegates.LocaleDelegate;
+import org.jboss.resteasy.plugins.delegates.MediaTypeHeaderDelegate;
+import org.jboss.resteasy.plugins.delegates.NewCookieHeaderDelegate;
+import org.jboss.resteasy.plugins.delegates.UriHeaderDelegate;
+import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
+import org.jboss.resteasy.spi.AsyncClientResponseProvider;
+import org.jboss.resteasy.spi.AsyncResponseProvider;
+import org.jboss.resteasy.spi.AsyncStreamProvider;
+import org.jboss.resteasy.spi.ConstructorInjector;
+import org.jboss.resteasy.spi.ContextInjector;
+import org.jboss.resteasy.spi.HeaderValueProcessor;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.InjectorFactory;
+import org.jboss.resteasy.spi.LinkHeader;
+import org.jboss.resteasy.spi.PropertyInjector;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.StringParameterUnmarshaller;
+import org.jboss.resteasy.spi.interception.JaxrsInterceptorRegistry;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
+import org.jboss.resteasy.spi.metadata.ResourceClassProcessor;
+import org.jboss.resteasy.spi.util.PickConstructor;
+import org.jboss.resteasy.spi.util.Types;
+import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
+import org.jboss.resteasy.util.FeatureContextDelegate;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -111,148 +101,29 @@ import java.util.concurrent.CopyOnWriteArraySet;
 @SuppressWarnings({"unchecked", "rawtypes"})
 public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory implements Providers, HeaderValueProcessor, Configurable<ResteasyProviderFactory>, Configuration
 {
-   /**
-    * Allow us to sort message body implementations that are more specific for their types
-    * i.e. MessageBodyWriter&#x3C;Object&#x3E; is less specific than MessageBodyWriter&#x3C;String&#x3E;.
-    * <p>
-    * This helps out a lot when the desired media type is a wildcard and to weed out all the possible
-    * default mappings.
-    */
-   private static class SortedKey<T> implements Comparable<SortedKey<T>>, MediaTypeMap.Typed
-   {
-      private final T obj;
-      private final boolean isBuiltin;
-      private final Class<?> template;
-      private final int priority;
-
-      protected SortedKey(final Class<?> intf, final T reader, final Class<?> readerClass, final int priority, final boolean isBuiltin)
-      {
-         this.obj = reader;
-         // check the super class for the generic type 1st
-         Class<?> t = Types.getTemplateParameterOfInterface(readerClass, intf);
-         template = (t != null) ? t : Object.class;
-         this.priority = priority;
-         this.isBuiltin = isBuiltin;
-      }
-
-      protected SortedKey(final Class<?> intf, final T reader, final Class<?> readerClass, final boolean isBuiltin)
-      {
-         this(intf, reader, readerClass, Priorities.USER, isBuiltin);
-      }
-
-      protected SortedKey(final Class<?> intf, final T reader, final Class<?> readerClass)
-      {
-         this(intf, reader, readerClass, Priorities.USER, false);
-      }
-
-      public int compareTo(SortedKey<T> tMessageBodyKey)
-      {
-         // Sort user provider before builtins
-         if (this == tMessageBodyKey)
-            return 0;
-         if (isBuiltin == tMessageBodyKey.isBuiltin)
-         {
-            if (this.priority < tMessageBodyKey.priority)
-            {
-               return -1;
-            }
-            if (this.priority == tMessageBodyKey.priority)
-            {
-               return 0;
-            }
-            if (this.priority > tMessageBodyKey.priority)
-            {
-               return 1;
-            }
-         }
-         if (isBuiltin)
-            return 1;
-         else
-            return -1;
-      }
-
-      public Class<?> getType()
-      {
-         return template;
-      }
-
-      public T getObj()
-      {
-         return obj;
-      }
-   }
-
-   private static class ExtSortedKey<T> extends SortedKey<T>
-   {
-      protected ExtSortedKey(final Class<?> intf, final T reader, final Class<?> readerClass, final int priority, final boolean isBuiltin)
-      {
-         super(intf, reader, readerClass, priority, isBuiltin);
-      }
-
-      protected ExtSortedKey(final Class<?> intf, final T reader, final Class<?> readerClass, final boolean isBuiltin)
-      {
-         super(intf, reader, readerClass, isBuiltin);
-      }
-
-      protected ExtSortedKey(final Class<?> intf, final T reader, final Class<?> readerClass)
-      {
-         super(intf, reader, readerClass);
-      }
-
-      @Override
-      public int compareTo(SortedKey<T> tMessageBodyKey)
-      {
-         int c = super.compareTo(tMessageBodyKey);
-         if (c != 0)
-         {
-            return c;
-         }
-         if (this.getObj() == tMessageBodyKey.getObj())
-         {
-            return 0;
-         }
-         return -1;
-      }
-   }
-
-   private MediaTypeMap<SortedKey<MessageBodyReader>> serverMessageBodyReaders;
-   private MediaTypeMap<SortedKey<MessageBodyWriter>> serverMessageBodyWriters;
-   private MediaTypeMap<SortedKey<MessageBodyReader>> clientMessageBodyReaders;
-   private MediaTypeMap<SortedKey<MessageBodyWriter>> clientMessageBodyWriters;
+   protected ClientHelper clientHelper;
+   protected ServerHelper serverHelper;
+   private Map<Class<?>, HeaderDelegate> headerDelegates;
    private Map<Class<?>, SortedKey<ExceptionMapper>> sortedExceptionMappers;
-   private Map<Class<?>, AsyncResponseProvider> asyncResponseProviders;
-   private Map<Class<?>, AsyncClientResponseProvider> asyncClientResponseProviders;
-   private Map<Class<?>, AsyncStreamProvider> asyncStreamProviders;
    private Map<Class<?>, MediaTypeMap<SortedKey<ContextResolver>>> contextResolvers;
    private Map<Type, ContextInjector> contextInjectors;
    private Map<Type, ContextInjector> asyncContextInjectors;
    private Set<ExtSortedKey<ParamConverterProvider>> sortedParamConverterProviders;
    private Map<Class<?>, Class<? extends StringParameterUnmarshaller>> stringParameterUnmarshallers;
-   protected Map<Class<?>, Map<Class<?>, Integer>> classContracts;
-   private Map<Class<?>, HeaderDelegate> headerDelegates;
-   private JaxrsInterceptorRegistry<ReaderInterceptor> serverReaderInterceptorRegistry;
-   private JaxrsInterceptorRegistry<WriterInterceptor> serverWriterInterceptorRegistry;
-   private JaxrsInterceptorRegistry<ContainerRequestFilter> containerRequestFilterRegistry;
-   private JaxrsInterceptorRegistry<ContainerResponseFilter> containerResponseFilterRegistry;
-   private JaxrsInterceptorRegistry<ClientRequestFilter> clientRequestFilterRegistry;
-   private JaxrsInterceptorRegistry<ClientResponseFilter> clientResponseFilters;
-   private JaxrsInterceptorRegistry<ReaderInterceptor> clientReaderInterceptorRegistry;
-   private JaxrsInterceptorRegistry<WriterInterceptor> clientWriterInterceptorRegistry;
+   private Map<Class<?>, Map<Class<?>, Integer>> classContracts;
    private boolean builtinsRegistered = false;
    private boolean registerBuiltins = true;
    private InjectorFactory injectorFactory;
    private ResteasyProviderFactoryImpl parent;
-   private Set<DynamicFeature> serverDynamicFeatures;
-   private Set<DynamicFeature> clientDynamicFeatures;
    private Map<String, Object> properties;
-   private Map<Class<?>, Class<? extends RxInvokerProvider<?>>> reactiveClasses;
    private ResourceBuilder resourceBuilder;
-   protected Set<Feature> enabledFeatures;
-   protected Set<Class<?>> providerClasses;
-   protected Set<Object> providerInstances;
+   private Set<Feature> enabledFeatures;
+   private Set<Class<?>> providerClasses;
+   private Set<Object> providerInstances;
 
    public ResteasyProviderFactoryImpl()
    {
+      initializeUtils();
       // NOTE!!! It is important to put all initialization into initialize() as ThreadLocalResteasyProviderFactory
       // subclasses and delegates to this class.
       initialize();
@@ -277,6 +148,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
     */
    public ResteasyProviderFactoryImpl(final ResteasyProviderFactory parent, final boolean local)
    {
+      initializeUtils();
       if (local || parent == null)
       {
          // Parent MUST not be referenced after current object is created
@@ -286,12 +158,12 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       else
       {
          this.parent = (ResteasyProviderFactoryImpl) parent;
+         clientHelper.initializeDefault();
          providerClasses = new CopyOnWriteArraySet<>();
          providerInstances = new CopyOnWriteArraySet<>();
          properties = new ConcurrentHashMap<>();
          properties.putAll(parent.getProperties());
          enabledFeatures = new CopyOnWriteArraySet<>();
-         reactiveClasses = new ConcurrentHashMap<>();
          resourceBuilder = new ResourceBuilder();
       }
    }
@@ -306,23 +178,20 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       initialize(null);
    }
 
+   protected void initializeUtils()
+   {
+      clientHelper = new ClientHelper(this);
+      serverHelper = new ServerHelper(this);
+   }
+
    protected void initialize(ResteasyProviderFactoryImpl parent)
    {
-      serverDynamicFeatures = parent == null ? new CopyOnWriteArraySet<>() : new CopyOnWriteArraySet<>(parent.getServerDynamicFeatures());
-      clientDynamicFeatures = parent == null ? new CopyOnWriteArraySet<>() : new CopyOnWriteArraySet<>(parent.getClientDynamicFeatures());
       enabledFeatures = parent == null ? new CopyOnWriteArraySet<>() : new CopyOnWriteArraySet<>(parent.getEnabledFeatures());
       properties = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getProperties());
       providerClasses = parent == null ? new CopyOnWriteArraySet<>() : new CopyOnWriteArraySet<>(parent.getProviderClasses());
       providerInstances = parent == null ? new CopyOnWriteArraySet<>() : new CopyOnWriteArraySet<>(parent.getProviderInstances());
       classContracts = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getClassContracts());
-      serverMessageBodyReaders = parent == null ? new MediaTypeMap<>() : parent.getServerMessageBodyReaders().clone();
-      serverMessageBodyWriters = parent == null ? new MediaTypeMap<>() : parent.getServerMessageBodyWriters().clone();
-      clientMessageBodyReaders = parent == null ? new MediaTypeMap<>() : parent.getClientMessageBodyReaders().clone();
-      clientMessageBodyWriters = parent == null ? new MediaTypeMap<>() : parent.getClientMessageBodyWriters().clone();
       sortedExceptionMappers = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getSortedExceptionMappers());
-      asyncResponseProviders = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getAsyncResponseProviders());
-      asyncClientResponseProviders = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getAsyncClientResponseProviders());
-      asyncStreamProviders = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getAsyncStreamProviders());
       contextResolvers = new ConcurrentHashMap<>();
       if (parent != null)
       {
@@ -335,7 +204,9 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       asyncContextInjectors = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getAsyncContextInjectors());
       sortedParamConverterProviders = Collections.synchronizedSortedSet(parent == null ? new TreeSet<>() : new TreeSet<>(parent.getSortedParamConverterProviders()));
       stringParameterUnmarshallers = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getStringParameterUnmarshallers());
-      reactiveClasses = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.reactiveClasses);
+
+      resourceBuilder = new ResourceBuilder();
+
       headerDelegates = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getHeaderDelegates());
       addHeaderDelegateIfAbsent(MediaType.class, MediaTypeHeaderDelegate.INSTANCE);
       addHeaderDelegateIfAbsent(NewCookie.class, NewCookieHeaderDelegate.INSTANCE);
@@ -348,9 +219,8 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       addHeaderDelegateIfAbsent(javax.ws.rs.core.Link.class, LinkDelegate.INSTANCE);
       addHeaderDelegateIfAbsent(Date.class, DateDelegate.INSTANCE);
 
-      resourceBuilder = new ResourceBuilder();
-
-      initializeRegistriesAndFilters(parent);
+      serverHelper.initialize(parent);
+      clientHelper.initialize(parent);
 
       builtinsRegistered = false;
       registerBuiltins = true;
@@ -358,59 +228,34 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       injectorFactory = parent == null ? InjectorFactoryImpl.INSTANCE : parent.getInjectorFactory();
    }
 
-   private void initializeRegistriesAndFilters(ResteasyProviderFactory parent)
-   {
-      serverReaderInterceptorRegistry = parent == null ? new ReaderInterceptorRegistryImpl(this) : parent.getServerReaderInterceptorRegistry().clone(this);
-      serverWriterInterceptorRegistry = parent == null ? new WriterInterceptorRegistryImpl(this) : parent.getServerWriterInterceptorRegistry().clone(this);
-      containerRequestFilterRegistry = parent == null ? new ContainerRequestFilterRegistryImpl(this) : parent.getContainerRequestFilterRegistry().clone(this);
-      containerResponseFilterRegistry = parent == null ? new ContainerResponseFilterRegistryImpl(this) : parent.getContainerResponseFilterRegistry().clone(this);
-
-      clientRequestFilterRegistry = parent == null ? new ClientRequestFilterRegistryImpl(this) : parent.getClientRequestFilterRegistry().clone(this);
-      clientResponseFilters = parent == null ? new ClientResponseFilterRegistryImpl(this) : parent.getClientResponseFilters().clone(this);
-      clientReaderInterceptorRegistry = parent == null ? new ReaderInterceptorRegistryImpl(this) : parent.getClientReaderInterceptorRegistry().clone(this);
-      clientWriterInterceptorRegistry = parent == null ? new WriterInterceptorRegistryImpl(this) : parent.getClientWriterInterceptorRegistry().clone(this);
-   }
-
    public Set<DynamicFeature> getServerDynamicFeatures()
    {
-      if (serverDynamicFeatures == null && parent != null)
-         return parent.getServerDynamicFeatures();
-      return serverDynamicFeatures;
+      return serverHelper.getServerDynamicFeatures(parent);
    }
 
    public Set<DynamicFeature> getClientDynamicFeatures()
    {
-      if (clientDynamicFeatures == null && parent != null)
-         return parent.getClientDynamicFeatures();
-      return clientDynamicFeatures;
+      return clientHelper.getClientDynamicFeatures(parent);
    }
 
-   private MediaTypeMap<SortedKey<MessageBodyReader>> getServerMessageBodyReaders()
+   protected MediaTypeMap<SortedKey<MessageBodyReader>> getServerMessageBodyReaders()
    {
-      if (serverMessageBodyReaders == null && parent != null)
-         return parent.getServerMessageBodyReaders();
-      return serverMessageBodyReaders;
+      return serverHelper.getServerMessageBodyReaders(parent);
    }
 
-   private MediaTypeMap<SortedKey<MessageBodyWriter>> getServerMessageBodyWriters()
+   protected MediaTypeMap<SortedKey<MessageBodyWriter>> getServerMessageBodyWriters()
    {
-      if (serverMessageBodyWriters == null && parent != null)
-         return parent.getServerMessageBodyWriters();
-      return serverMessageBodyWriters;
+      return serverHelper.getServerMessageBodyWriters(parent);
    }
 
-   private MediaTypeMap<SortedKey<MessageBodyReader>> getClientMessageBodyReaders()
+   protected MediaTypeMap<SortedKey<MessageBodyReader>> getClientMessageBodyReaders()
    {
-      if (clientMessageBodyReaders == null && parent != null)
-         return parent.getClientMessageBodyReaders();
-      return clientMessageBodyReaders;
+      return clientHelper.getClientMessageBodyReaders(parent);
    }
 
-   private MediaTypeMap<SortedKey<MessageBodyWriter>> getClientMessageBodyWriters()
+   protected MediaTypeMap<SortedKey<MessageBodyWriter>> getClientMessageBodyWriters()
    {
-      if (clientMessageBodyWriters == null && parent != null)
-         return parent.getClientMessageBodyWriters();
-      return clientMessageBodyWriters;
+      return clientHelper.getClientMessageBodyWriters(parent);
    }
 
    private Map<Class<?>, SortedKey<ExceptionMapper>> getSortedExceptionMappers()
@@ -422,23 +267,17 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
 
    public Map<Class<?>, AsyncResponseProvider> getAsyncResponseProviders()
    {
-      if (asyncResponseProviders == null && parent != null)
-         return parent.getAsyncResponseProviders();
-      return asyncResponseProviders;
-   }
-
-   public Map<Class<?>, AsyncClientResponseProvider> getAsyncClientResponseProviders()
-   {
-      if (asyncClientResponseProviders == null && parent != null)
-         return parent.getAsyncClientResponseProviders();
-      return asyncClientResponseProviders;
+      return serverHelper.getAsyncResponseProviders(parent);
    }
 
    public Map<Class<?>, AsyncStreamProvider> getAsyncStreamProviders()
    {
-      if (asyncStreamProviders == null && parent != null)
-         return parent.getAsyncStreamProviders();
-      return asyncStreamProviders;
+      return serverHelper.getAsyncStreamProviders(parent);
+   }
+
+   public Map<Class<?>, AsyncClientResponseProvider> getAsyncClientResponseProviders()
+   {
+      return clientHelper.getAsyncClientResponseProviders(parent);
    }
 
    public Map<Type, ContextInjector> getContextInjectors()
@@ -579,58 +418,42 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
 
    public JaxrsInterceptorRegistry<ReaderInterceptor> getServerReaderInterceptorRegistry()
    {
-      if (serverReaderInterceptorRegistry == null && parent != null)
-         return parent.getServerReaderInterceptorRegistry();
-      return serverReaderInterceptorRegistry;
+      return serverHelper.getServerReaderInterceptorRegistry(parent);
    }
 
    public JaxrsInterceptorRegistry<WriterInterceptor> getServerWriterInterceptorRegistry()
    {
-      if (serverWriterInterceptorRegistry == null && parent != null)
-         return parent.getServerWriterInterceptorRegistry();
-      return serverWriterInterceptorRegistry;
+      return serverHelper.getServerWriterInterceptorRegistry(parent);
    }
 
    public JaxrsInterceptorRegistry<ContainerRequestFilter> getContainerRequestFilterRegistry()
    {
-      if (containerRequestFilterRegistry == null && parent != null)
-         return parent.getContainerRequestFilterRegistry();
-      return containerRequestFilterRegistry;
+      return serverHelper.getContainerRequestFilterRegistry(parent);
    }
 
    public JaxrsInterceptorRegistry<ContainerResponseFilter> getContainerResponseFilterRegistry()
    {
-      if (containerResponseFilterRegistry == null && parent != null)
-         return parent.getContainerResponseFilterRegistry();
-      return containerResponseFilterRegistry;
+      return serverHelper.getContainerResponseFilterRegistry(parent);
    }
 
    public JaxrsInterceptorRegistry<ReaderInterceptor> getClientReaderInterceptorRegistry()
    {
-      if (clientReaderInterceptorRegistry == null && parent != null)
-         return parent.getClientReaderInterceptorRegistry();
-      return clientReaderInterceptorRegistry;
+      return clientHelper.getClientReaderInterceptorRegistry(parent);
    }
 
    public JaxrsInterceptorRegistry<WriterInterceptor> getClientWriterInterceptorRegistry()
    {
-      if (clientWriterInterceptorRegistry == null && parent != null)
-         return parent.getClientWriterInterceptorRegistry();
-      return clientWriterInterceptorRegistry;
+      return clientHelper.getClientWriterInterceptorRegistry(parent);
    }
 
    public JaxrsInterceptorRegistry<ClientRequestFilter> getClientRequestFilterRegistry()
    {
-      if (clientRequestFilterRegistry == null && parent != null)
-         return parent.getClientRequestFilterRegistry();
-      return clientRequestFilterRegistry;
+      return clientHelper.getClientRequestFilterRegistry(parent);
    }
 
    public JaxrsInterceptorRegistry<ClientResponseFilter> getClientResponseFilters()
    {
-      if (clientResponseFilters == null && parent != null)
-         return parent.getClientResponseFilters();
-      return clientResponseFilters;
+      return clientHelper.getClientResponseFilters(parent);
    }
 
    public boolean isBuiltinsRegistered()
@@ -645,17 +468,17 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
 
    public UriBuilder createUriBuilder()
    {
-      return new ResteasyUriBuilderImpl();
+      return Utils.createUriBuilder();
    }
 
    public Response.ResponseBuilder createResponseBuilder()
    {
-      return new ResponseBuilderImpl();
+      return Utils.createResponseBuilder();
    }
 
    public Variant.VariantListBuilder createVariantListBuilder()
    {
-      return new VariantListBuilderImpl();
+      return Utils.createVariantListBuilder();
    }
 
    public <T> HeaderDelegate<T> createHeaderDelegate(Class<T> tClass)
@@ -665,49 +488,24 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       if (headerDelegates == null && parent != null)
          return parent.createHeaderDelegate(tClass);
 
-      Class<?> clazz = tClass;
-      while (clazz != null)
-      {
-         HeaderDelegate<T> delegate = headerDelegates.get(clazz);
-         if (delegate != null)
-         {
-            return delegate;
-         }
-         delegate = createHeaderDelegateFromInterfaces(clazz.getInterfaces());
-         if (delegate != null)
-         {
-            return delegate;
-         }
-         clazz = clazz.getSuperclass();
-      }
-
-      return createHeaderDelegateFromInterfaces(tClass.getInterfaces());
-   }
-
-   private <T> HeaderDelegate<T> createHeaderDelegateFromInterfaces(Class<?>[] interfaces)
-   {
-      HeaderDelegate<T> delegate = null;
-      for (int i = 0; i < interfaces.length; i++)
-      {
-         delegate = headerDelegates.get(interfaces[i]);
-         if (delegate != null)
-         {
-            return delegate;
-         }
-         delegate = createHeaderDelegateFromInterfaces(interfaces[i].getInterfaces());
-         if (delegate != null)
-         {
-            return delegate;
-         }
-      }
-      return null;
+      return Utils.createHeaderDelegate(headerDelegates, tClass);
    }
 
    private Map<Class<?>, HeaderDelegate> getHeaderDelegates()
    {
       if (headerDelegates == null && parent != null)
          return parent.getHeaderDelegates();
-      return headerDelegates;
+      return headerDelegates != null ? headerDelegates : Collections.emptyMap();
+   }
+
+   public void addHeaderDelegate(Class clazz, HeaderDelegate header)
+   {
+      if (headerDelegates == null)
+       {
+          headerDelegates = new ConcurrentHashMap<Class<?>, HeaderDelegate>();
+          headerDelegates.putAll(parent.getHeaderDelegates());
+       }
+       headerDelegates.put(clazz, header);
    }
 
    private void addHeaderDelegateIfAbsent(Class clazz, HeaderDelegate header)
@@ -715,151 +513,6 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       if (headerDelegates == null || !headerDelegates.containsKey(clazz))
       {
          addHeaderDelegate(clazz, header);
-      }
-   }
-
-   public void addHeaderDelegate(Class clazz, HeaderDelegate header)
-   {
-      if (headerDelegates == null)
-      {
-         headerDelegates = new ConcurrentHashMap<Class<?>, HeaderDelegate>();
-         headerDelegates.putAll(parent.getHeaderDelegates());
-      }
-      headerDelegates.put(clazz, header);
-   }
-
-   /**
-    * Specify the provider class.  This is there jsut in case the provider instance is a proxy.  Proxies tend
-    * to lose generic type information.
-    *
-    * @param provider message reader
-    * @param providerClass provider class
-    * @param priority priority
-    * @param isBuiltin built-in
-    */
-
-   private void addMessageBodyReader(MessageBodyReader provider, Class<?> providerClass, int priority,
-         boolean isBuiltin)
-   {
-      SortedKey<MessageBodyReader> key = new SortedKey<MessageBodyReader>(MessageBodyReader.class, provider,
-            providerClass, priority, isBuiltin);
-      injectProperties(providerClass, provider);
-      Consumes consumeMime = provider.getClass().getAnnotation(Consumes.class);
-      RuntimeType type = null;
-      ConstrainedTo constrainedTo = providerClass.getAnnotation(ConstrainedTo.class);
-      if (constrainedTo != null)
-         type = constrainedTo.value();
-
-      if ((type == null || type == RuntimeType.CLIENT) && clientMessageBodyReaders == null)
-      {
-         clientMessageBodyReaders = parent.getClientMessageBodyReaders().clone();
-      }
-      if ((type == null || type == RuntimeType.SERVER) && serverMessageBodyReaders == null)
-      {
-         serverMessageBodyReaders = parent.getServerMessageBodyReaders().clone();
-      }
-      if (consumeMime != null)
-      {
-         for (String consume : consumeMime.value())
-         {
-            if (type == null)
-            {
-               clientMessageBodyReaders.add(MediaType.valueOf(consume), key);
-               serverMessageBodyReaders.add(MediaType.valueOf(consume), key);
-            }
-            else if (type == RuntimeType.CLIENT)
-            {
-               clientMessageBodyReaders.add(MediaType.valueOf(consume), key);
-            }
-            else
-            {
-               serverMessageBodyReaders.add(MediaType.valueOf(consume), key);
-            }
-         }
-      }
-      else
-      {
-         if (type == null)
-         {
-            clientMessageBodyReaders.add(new MediaType("*", "*"), key);
-            serverMessageBodyReaders.add(new MediaType("*", "*"), key);
-         }
-         else if (type == RuntimeType.CLIENT)
-         {
-            clientMessageBodyReaders.add(new MediaType("*", "*"), key);
-         }
-         else
-         {
-            serverMessageBodyReaders.add(new MediaType("*", "*"), key);
-         }
-      }
-   }
-
-   /**
-    * Specify the provider class.  This is there jsut in case the provider instance is a proxy.  Proxies tend
-    * to lose generic type information
-    *
-    * @param provider message reader
-    * @param providerClass provider class
-    * @param priority priority
-    * @param isBuiltin built-in
-    */
-   private void addMessageBodyWriter(MessageBodyWriter provider, Class<?> providerClass, int priority,
-         boolean isBuiltin)
-   {
-      injectProperties(providerClass, provider);
-      Produces consumeMime = provider.getClass().getAnnotation(Produces.class);
-      SortedKey<MessageBodyWriter> key = new SortedKey<MessageBodyWriter>(MessageBodyWriter.class, provider,
-            providerClass, priority, isBuiltin);
-      RuntimeType type = null;
-      ConstrainedTo constrainedTo = providerClass.getAnnotation(ConstrainedTo.class);
-      if (constrainedTo != null)
-         type = constrainedTo.value();
-
-      if ((type == null || type == RuntimeType.CLIENT) && clientMessageBodyWriters == null)
-      {
-         clientMessageBodyWriters = parent.getClientMessageBodyWriters().clone();
-      }
-      if ((type == null || type == RuntimeType.SERVER) && serverMessageBodyWriters == null)
-      {
-         serverMessageBodyWriters = parent.getServerMessageBodyWriters().clone();
-      }
-      if (consumeMime != null)
-      {
-         for (String consume : consumeMime.value())
-         {
-            //logger.info(">>> Adding provider: " + provider.getClass().getName() + " with mime type of: " + mime);
-            if (type == null)
-            {
-               clientMessageBodyWriters.add(MediaType.valueOf(consume), key);
-               serverMessageBodyWriters.add(MediaType.valueOf(consume), key);
-            }
-            else if (type == RuntimeType.CLIENT)
-            {
-               clientMessageBodyWriters.add(MediaType.valueOf(consume), key);
-            }
-            else
-            {
-               serverMessageBodyWriters.add(MediaType.valueOf(consume), key);
-            }
-         }
-      }
-      else
-      {
-         //logger.info(">>> Adding provider: " + provider.getClass().getName() + " with mime type of: default */*");
-         if (type == null)
-         {
-            clientMessageBodyWriters.add(new MediaType("*", "*"), key);
-            serverMessageBodyWriters.add(new MediaType("*", "*"), key);
-         }
-         else if (type == RuntimeType.CLIENT)
-         {
-            clientMessageBodyWriters.add(new MediaType("*", "*"), key);
-         }
-         else
-         {
-            serverMessageBodyWriters.add(new MediaType("*", "*"), key);
-         }
       }
    }
 
@@ -923,16 +576,16 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       for (SortedKey<MessageBodyReader> reader : readers)
       {
          //logger.info("     matching reader: " + reader.getClass().getName());
-         if (reader.obj.isReadable(type, genericType, annotations, mediaType))
+         if (reader.getObj().isReadable(type, genericType, annotations, mediaType))
          {
             LogMessages.LOGGER.debugf("MessageBodyReader: %s", reader.getClass().getName());
-            return (MessageBodyReader<T>) reader.obj;
+            return (MessageBodyReader<T>) reader.getObj();
          }
       }
       return null;
    }
 
-   protected <T> MessageBodyReader<T> resolveMessageBodyReader(Class<T> type, Type genericType,
+   private <T> MessageBodyReader<T> resolveMessageBodyReader(Class<T> type, Type genericType,
          Annotation[] annotations, MediaType mediaType, MediaTypeMap<SortedKey<MessageBodyReader>> availableReaders,
          RESTEasyTracingLogger tracingLogger)
    {
@@ -953,10 +606,10 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       {
          final SortedKey<MessageBodyReader> reader = iterator.next();
 
-         if (reader.obj.isReadable(type, genericType, annotations, mediaType))
+         if (reader.getObj().isReadable(type, genericType, annotations, mediaType))
          {
             LogMessages.LOGGER.debugf("MessageBodyReader: %s", reader.getClass().getName());
-            result = (MessageBodyReader<T>) reader.obj;
+            result = (MessageBodyReader<T>) reader.getObj();
             tracingLogger.log("MBR_SELECTED", reader);
             break;
          }
@@ -968,7 +621,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
          while (iterator.hasNext())
          {
             final SortedKey<MessageBodyReader> reader = iterator.next();
-            tracingLogger.log("MBR_SKIPPED", reader.obj);
+            tracingLogger.log("MBR_SKIPPED", reader.getObj());
          }
       }
       return result;
@@ -983,7 +636,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       }
       Type exceptionType = Types.getActualTypeArgumentsOfAnInterface(providerClass, ExceptionMapper.class)[0];
 
-      injectProperties(providerClass, provider);
+      Utils.injectProperties(this, providerClass, provider);
 
       Class<?> exceptionClass = Types.getRawType(exceptionType);
       if (!Throwable.class.isAssignableFrom(exceptionClass))
@@ -995,7 +648,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
          sortedExceptionMappers = new ConcurrentHashMap<Class<?>, SortedKey<ExceptionMapper>>();
          sortedExceptionMappers.putAll(parent.getSortedExceptionMappers());
       }
-      int priority = getPriority(null, null, ExceptionMapper.class, providerClass);
+      int priority = Utils.getPriority(null, null, ExceptionMapper.class, providerClass);
       SortedKey<ExceptionMapper> candidateExceptionMapper = new SortedKey<>(null, provider, providerClass, priority,
             isBuiltin);
       SortedKey<ExceptionMapper> registeredExceptionMapper;
@@ -1007,50 +660,10 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       sortedExceptionMappers.put(exceptionClass, candidateExceptionMapper);
    }
 
-   private void addAsyncResponseProvider(AsyncResponseProvider provider, Class providerClass)
-   {
-      Type asyncType = Types.getActualTypeArgumentsOfAnInterface(providerClass, AsyncResponseProvider.class)[0];
-      injectProperties(provider.getClass(), provider);
-      Class<?> asyncClass = Types.getRawType(asyncType);
-      if (asyncResponseProviders == null)
-      {
-         asyncResponseProviders = new ConcurrentHashMap<Class<?>, AsyncResponseProvider>();
-         asyncResponseProviders.putAll(parent.getAsyncResponseProviders());
-      }
-      asyncResponseProviders.put(asyncClass, provider);
-   }
-
-   private void addAsyncClientResponseProvider(AsyncClientResponseProvider provider, Class providerClass)
-   {
-      Type asyncType = Types.getActualTypeArgumentsOfAnInterface(providerClass, AsyncClientResponseProvider.class)[0];
-      injectProperties(provider.getClass(), provider);
-
-      Class<?> asyncClass = Types.getRawType(asyncType);
-      if (asyncClientResponseProviders == null)
-      {
-         asyncClientResponseProviders = new ConcurrentHashMap<Class<?>, AsyncClientResponseProvider>();
-         asyncClientResponseProviders.putAll(parent.getAsyncClientResponseProviders());
-      }
-      asyncClientResponseProviders.put(asyncClass, provider);
-   }
-
-   private void addAsyncStreamProvider(AsyncStreamProvider provider, Class providerClass)
-   {
-      Type asyncType = Types.getActualTypeArgumentsOfAnInterface(providerClass, AsyncStreamProvider.class)[0];
-      injectProperties(provider.getClass(), provider);
-      Class<?> asyncClass = Types.getRawType(asyncType);
-      if (asyncStreamProviders == null)
-      {
-         asyncStreamProviders = new ConcurrentHashMap<Class<?>, AsyncStreamProvider>();
-         asyncStreamProviders.putAll(parent.getAsyncStreamProviders());
-      }
-      asyncStreamProviders.put(asyncClass, provider);
-   }
-
    private void addContextInjector(ContextInjector provider, Class providerClass)
    {
       Type[] typeArgs = Types.getActualTypeArgumentsOfAnInterface(providerClass, ContextInjector.class);
-      injectProperties(provider.getClass(), provider);
+      Utils.injectProperties(this, provider.getClass(), provider);
 
       if (contextInjectors == null)
       {
@@ -1078,7 +691,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
          throw new RuntimeException(Messages.MESSAGES.registeringContextResolverAsLambda());
       }
       Type typeParameter = Types.getActualTypeArgumentsOfAnInterface(providerClass, ContextResolver.class)[0];
-      injectProperties(providerClass, provider);
+      Utils.injectProperties(this, providerClass, provider);
       Class<?> parameterClass = Types.getRawType(typeParameter);
       if (contextResolvers == null)
       {
@@ -1140,7 +753,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
          return null;
       List<ContextResolver> rtn = new ArrayList<ContextResolver>();
       List<SortedKey<ContextResolver>> list = resolvers.getPossible(type);
-      list.forEach(resolver -> rtn.add(resolver.obj));
+      list.forEach(resolver -> rtn.add(resolver.getObj()));
       return rtn;
    }
 
@@ -1254,34 +867,6 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       registerProvider(provider, null, isBuiltin, null);
    }
 
-   protected boolean isA(Class target, Class type, Map<Class<?>, Integer> contracts)
-   {
-      return isA(target, type, contracts == null ? null : contracts.keySet());
-   }
-
-   protected boolean isA(Object target, Class type, Map<Class<?>, Integer> contracts)
-   {
-      return isA(target.getClass(), type, contracts);
-   }
-
-   private static int getPriority(Integer override, Map<Class<?>, Integer> contracts, Class type, Class<?> component)
-   {
-      if (override != null)
-         return override;
-      if (contracts != null)
-      {
-         Integer p = contracts.get(type);
-         if (p != null)
-            return p;
-      }
-      // Check for weld proxy.
-      component = component.isSynthetic() ? component.getSuperclass() : component;
-      Priority priority = component.getAnnotation(Priority.class);
-      if (priority == null)
-         return Priorities.USER;
-      return priority.value();
-   }
-
    public void registerProvider(Class provider, Integer priorityOverride, boolean isBuiltin,
          Map<Class<?>, Integer> contracts)
    {
@@ -1297,10 +882,13 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       classContracts.put(provider, newContracts);
    }
 
-   protected void processProviderContracts(Class provider, Integer priorityOverride, boolean isBuiltin,
+   private void processProviderContracts(Class provider, Integer priorityOverride, boolean isBuiltin,
          Map<Class<?>, Integer> contracts, Map<Class<?>, Integer> newContracts)
    {
-      if (isA(provider, ParamConverterProvider.class, contracts))
+      clientHelper.processProviderContracts(provider, priorityOverride, isBuiltin, contracts, newContracts, parent);
+      serverHelper.processProviderContracts(provider, priorityOverride, isBuiltin, contracts, newContracts, parent);
+
+      if (Utils.isA(provider, ParamConverterProvider.class, contracts))
       {
          ParamConverterProvider paramConverterProvider = (ParamConverterProvider) injectedInstance(provider);
          injectProperties(provider);
@@ -1309,209 +897,30 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
             sortedParamConverterProviders = Collections
                   .synchronizedSortedSet(new TreeSet<>(parent.getSortedParamConverterProviders()));
          }
-         int priority = getPriority(priorityOverride, contracts, ParamConverterProvider.class, provider);
+         int priority = Utils.getPriority(priorityOverride, contracts, ParamConverterProvider.class, provider);
          sortedParamConverterProviders
                .add(new ExtSortedKey<>(null, paramConverterProvider, provider, priority, isBuiltin));
          newContracts.put(ParamConverterProvider.class, priority);
       }
-      if (isA(provider, MessageBodyReader.class, contracts))
-      {
-         try
-         {
-            int priority = getPriority(priorityOverride, contracts, MessageBodyReader.class, provider);
-            addMessageBodyReader(createProviderInstance((Class<? extends MessageBodyReader>) provider), provider,
-                  priority, isBuiltin);
-            newContracts.put(MessageBodyReader.class, priority);
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateMessageBodyReader(), e);
-         }
-      }
-      if (isA(provider, MessageBodyWriter.class, contracts))
-      {
-         try
-         {
-            int priority = getPriority(priorityOverride, contracts, MessageBodyWriter.class, provider);
-            addMessageBodyWriter(createProviderInstance((Class<? extends MessageBodyWriter>) provider), provider,
-                  priority, isBuiltin);
-            newContracts.put(MessageBodyWriter.class, priority);
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateMessageBodyWriter(), e);
-         }
-      }
-      if (isA(provider, ExceptionMapper.class, contracts))
+      if (Utils.isA(provider, ExceptionMapper.class, contracts))
       {
          try
          {
             addExceptionMapper(createProviderInstance((Class<? extends ExceptionMapper>) provider), provider,
                   isBuiltin);
             newContracts.put(ExceptionMapper.class,
-                  getPriority(priorityOverride, contracts, ExceptionMapper.class, provider));
+                  Utils.getPriority(priorityOverride, contracts, ExceptionMapper.class, provider));
          }
          catch (Exception e)
          {
             throw new RuntimeException(Messages.MESSAGES.unableToInstantiateExceptionMapper(), e);
          }
       }
-      if (isA(provider, AsyncResponseProvider.class, contracts))
+      if (Utils.isA(provider, ContextResolver.class, contracts))
       {
          try
          {
-            addAsyncResponseProvider(createProviderInstance((Class<? extends AsyncResponseProvider>) provider),
-                  provider);
-            newContracts.put(AsyncResponseProvider.class,
-                  getPriority(priorityOverride, contracts, AsyncResponseProvider.class, provider));
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateAsyncResponseProvider(), e);
-         }
-      }
-      if (isA(provider, AsyncClientResponseProvider.class, contracts))
-      {
-         try
-         {
-            addAsyncClientResponseProvider(
-                  createProviderInstance((Class<? extends AsyncClientResponseProvider>) provider), provider);
-            newContracts.put(AsyncClientResponseProvider.class,
-                  getPriority(priorityOverride, contracts, AsyncClientResponseProvider.class, provider));
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateAsyncClientResponseProvider(), e);
-         }
-      }
-      if (isA(provider, AsyncStreamProvider.class, contracts))
-      {
-         try
-         {
-            addAsyncStreamProvider(createProviderInstance((Class<? extends AsyncStreamProvider>) provider), provider);
-            newContracts.put(AsyncStreamProvider.class,
-                  getPriority(priorityOverride, contracts, AsyncStreamProvider.class, provider));
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateAsyncStreamProvider(), e);
-         }
-      }
-      if (isA(provider, ClientRequestFilter.class, contracts))
-      {
-         if (clientRequestFilterRegistry == null)
-         {
-            clientRequestFilterRegistry = parent.getClientRequestFilterRegistry().clone(this);
-         }
-         int priority = getPriority(priorityOverride, contracts, ClientRequestFilter.class, provider);
-         clientRequestFilterRegistry.registerClass(provider, priority);
-         newContracts.put(ClientRequestFilter.class, priority);
-      }
-      if (isA(provider, ClientResponseFilter.class, contracts))
-      {
-         if (clientResponseFilters == null)
-         {
-            clientResponseFilters = parent.getClientResponseFilters().clone(this);
-         }
-         int priority = getPriority(priorityOverride, contracts, ClientResponseFilter.class, provider);
-         clientResponseFilters.registerClass(provider, priority);
-         newContracts.put(ClientResponseFilter.class, priority);
-      }
-      if (isA(provider, ContainerRequestFilter.class, contracts))
-      {
-         if (containerRequestFilterRegistry == null)
-         {
-            containerRequestFilterRegistry = parent.getContainerRequestFilterRegistry().clone(this);
-         }
-         int priority = getPriority(priorityOverride, contracts, ContainerRequestFilter.class, provider);
-         containerRequestFilterRegistry.registerClass(provider, priority);
-         newContracts.put(ContainerRequestFilter.class, priority);
-      }
-      if (isA(provider, ContainerResponseFilter.class, contracts))
-      {
-         if (containerResponseFilterRegistry == null)
-         {
-            containerResponseFilterRegistry = parent.getContainerResponseFilterRegistry().clone(this);
-         }
-         int priority = getPriority(priorityOverride, contracts, ContainerResponseFilter.class, provider);
-         containerResponseFilterRegistry.registerClass(provider, priority);
-         newContracts.put(ContainerResponseFilter.class, priority);
-      }
-      if (isA(provider, ReaderInterceptor.class, contracts))
-      {
-         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getAnnotation(ConstrainedTo.class);
-         int priority = getPriority(priorityOverride, contracts, ReaderInterceptor.class, provider);
-         if (constrainedTo != null && constrainedTo.value() == RuntimeType.SERVER)
-         {
-            if (serverReaderInterceptorRegistry == null)
-            {
-               serverReaderInterceptorRegistry = parent.getServerReaderInterceptorRegistry().clone(this);
-            }
-            serverReaderInterceptorRegistry.registerClass(provider, priority);
-         }
-         if (constrainedTo != null && constrainedTo.value() == RuntimeType.CLIENT)
-         {
-            if (clientReaderInterceptorRegistry == null)
-            {
-               clientReaderInterceptorRegistry = parent.getClientReaderInterceptorRegistry().clone(this);
-            }
-            clientReaderInterceptorRegistry.registerClass(provider, priority);
-         }
-         if (constrainedTo == null)
-         {
-            if (serverReaderInterceptorRegistry == null)
-            {
-               serverReaderInterceptorRegistry = parent.getServerReaderInterceptorRegistry().clone(this);
-            }
-            serverReaderInterceptorRegistry.registerClass(provider, priority);
-            if (clientReaderInterceptorRegistry == null)
-            {
-               clientReaderInterceptorRegistry = parent.getClientReaderInterceptorRegistry().clone(this);
-            }
-            clientReaderInterceptorRegistry.registerClass(provider, priority);
-         }
-         newContracts.put(ReaderInterceptor.class, priority);
-      }
-      if (isA(provider, WriterInterceptor.class, contracts))
-      {
-         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getAnnotation(ConstrainedTo.class);
-         int priority = getPriority(priorityOverride, contracts, WriterInterceptor.class, provider);
-         if (constrainedTo != null && constrainedTo.value() == RuntimeType.SERVER)
-         {
-            if (serverWriterInterceptorRegistry == null)
-            {
-               serverWriterInterceptorRegistry = parent.getServerWriterInterceptorRegistry().clone(this);
-            }
-            serverWriterInterceptorRegistry.registerClass(provider, priority);
-         }
-         if (constrainedTo != null && constrainedTo.value() == RuntimeType.CLIENT)
-         {
-            if (clientWriterInterceptorRegistry == null)
-            {
-               clientWriterInterceptorRegistry = parent.getClientWriterInterceptorRegistry().clone(this);
-            }
-            clientWriterInterceptorRegistry.registerClass(provider, priority);
-         }
-         if (constrainedTo == null)
-         {
-            if (serverWriterInterceptorRegistry == null)
-            {
-               serverWriterInterceptorRegistry = parent.getServerWriterInterceptorRegistry().clone(this);
-            }
-            serverWriterInterceptorRegistry.registerClass(provider, priority);
-            if (clientWriterInterceptorRegistry == null)
-            {
-               clientWriterInterceptorRegistry = parent.getClientWriterInterceptorRegistry().clone(this);
-            }
-            clientWriterInterceptorRegistry.registerClass(provider, priority);
-         }
-         newContracts.put(WriterInterceptor.class, priority);
-      }
-      if (isA(provider, ContextResolver.class, contracts))
-      {
-         try
-         {
-            int priority = getPriority(priorityOverride, contracts, ContextResolver.class, provider);
+            int priority = Utils.getPriority(priorityOverride, contracts, ContextResolver.class, provider);
             addContextResolver(createProviderInstance((Class<? extends ContextResolver>)provider), priority, provider, isBuiltin);
             newContracts.put(ContextResolver.class, priority);
          }
@@ -1520,12 +929,12 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
             throw new RuntimeException(Messages.MESSAGES.unableToInstantiateContextResolver(), e);
          }
       }
-      if (isA(provider, ContextInjector.class, contracts))
+      if (Utils.isA(provider, ContextInjector.class, contracts))
       {
          try
          {
             addContextInjector(createProviderInstance((Class<? extends ContextInjector>) provider), provider);
-            int priority = getPriority(priorityOverride, contracts, ContextInjector.class, provider);
+            int priority = Utils.getPriority(priorityOverride, contracts, ContextInjector.class, provider);
             newContracts.put(ContextInjector.class, priority);
          }
          catch (Exception e)
@@ -1533,13 +942,13 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
             throw new RuntimeException(Messages.MESSAGES.unableToInstantiateContextInjector(), e);
          }
       }
-      if (isA(provider, StringParameterUnmarshaller.class, contracts))
+      if (Utils.isA(provider, StringParameterUnmarshaller.class, contracts))
       {
          addStringParameterUnmarshaller(provider);
-         int priority = getPriority(priorityOverride, contracts, StringParameterUnmarshaller.class, provider);
+         int priority = Utils.getPriority(priorityOverride, contracts, StringParameterUnmarshaller.class, provider);
          newContracts.put(StringParameterUnmarshaller.class, priority);
       }
-      if (isA(provider, InjectorFactory.class, contracts))
+      if (Utils.isA(provider, InjectorFactory.class, contracts))
       {
          try
          {
@@ -1551,45 +960,10 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
             throw new RuntimeException(e);
          }
       }
-      if (isA(provider, DynamicFeature.class, contracts))
+      if (Utils.isA(provider, Feature.class, contracts))
       {
          ConstrainedTo constrainedTo = (ConstrainedTo) provider.getAnnotation(ConstrainedTo.class);
-         int priority = getPriority(priorityOverride, contracts, DynamicFeature.class, provider);
-         if (constrainedTo != null && constrainedTo.value() == RuntimeType.SERVER)
-         {
-            if (serverDynamicFeatures == null)
-            {
-               serverDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getServerDynamicFeatures());
-            }
-            serverDynamicFeatures.add((DynamicFeature) injectedInstance(provider));
-         }
-         if (constrainedTo != null && constrainedTo.value() == RuntimeType.CLIENT)
-         {
-            if (clientDynamicFeatures == null)
-            {
-               clientDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getClientDynamicFeatures());
-            }
-            clientDynamicFeatures.add((DynamicFeature) injectedInstance(provider));
-         }
-         if (constrainedTo == null)
-         {
-            if (serverDynamicFeatures == null)
-            {
-               serverDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getServerDynamicFeatures());
-            }
-            serverDynamicFeatures.add((DynamicFeature) injectedInstance(provider));
-            if (clientDynamicFeatures == null)
-            {
-               clientDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getClientDynamicFeatures());
-            }
-            clientDynamicFeatures.add((DynamicFeature) injectedInstance(provider));
-         }
-         newContracts.put(DynamicFeature.class, priority);
-      }
-      if (isA(provider, Feature.class, contracts))
-      {
-         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getAnnotation(ConstrainedTo.class);
-         int priority = getPriority(priorityOverride, contracts, Feature.class, provider);
+         int priority = Utils.getPriority(priorityOverride, contracts, Feature.class, provider);
          Feature feature = injectedInstance((Class<? extends Feature>) provider);
          if (constrainedTo == null || constrainedTo.value() == getRuntimeType())
          {
@@ -1600,24 +974,13 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
          }
          newContracts.put(Feature.class, priority);
       }
-      if (isA(provider, RxInvokerProvider.class, contracts))
+      if (Utils.isA(provider, ResourceClassProcessor.class, contracts))
       {
-         int priority = getPriority(priorityOverride, contracts, RxInvokerProvider.class, provider);
-         newContracts.put(RxInvokerProvider.class, priority);
-         Class<?> clazz = Types.getTemplateParameterOfInterface(provider, RxInvokerProvider.class);
-         clazz = Types.getTemplateParameterOfInterface(clazz, RxInvoker.class);
-         if (clazz != null)
-         {
-            reactiveClasses.put(clazz, provider);
-         }
-      }
-      if (isA(provider, ResourceClassProcessor.class, contracts))
-      {
-         int priority = getPriority(priorityOverride, contracts, ResourceClassProcessor.class, provider);
+         int priority = Utils.getPriority(priorityOverride, contracts, ResourceClassProcessor.class, provider);
          addResourceClassProcessor(provider, priority);
          newContracts.put(ResourceClassProcessor.class, priority);
       }
-      if (isA(provider, HeaderDelegate.class, contracts))
+      if (Utils.isA(provider, HeaderDelegate.class, contracts))
       {
          Type[] headerTypes = Types.getActualTypeArgumentsOfAnInterface(provider, HeaderDelegate.class);
          if (headerTypes.length == 0)
@@ -1659,10 +1022,13 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       classContracts.put(providerClass, newContracts);
    }
 
-   protected void processProviderInstanceContracts(Object provider, Map<Class<?>, Integer> contracts,
+   private void processProviderInstanceContracts(Object provider, Map<Class<?>, Integer> contracts,
          Integer priorityOverride, boolean builtIn, Map<Class<?>, Integer> newContracts)
    {
-      if (isA(provider, ParamConverterProvider.class, contracts))
+      clientHelper.processProviderInstanceContracts(provider, contracts, priorityOverride, builtIn, newContracts, parent);
+      serverHelper.processProviderInstanceContracts(provider, contracts, priorityOverride, builtIn, newContracts, parent);
+
+      if (Utils.isA(provider, ParamConverterProvider.class, contracts))
       {
          injectProperties(provider);
          if (sortedParamConverterProviders == null)
@@ -1670,43 +1036,17 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
             sortedParamConverterProviders = Collections
                   .synchronizedSortedSet(new TreeSet<>(parent.getSortedParamConverterProviders()));
          }
-         int priority = getPriority(priorityOverride, contracts, ParamConverterProvider.class, provider.getClass());
+         int priority = Utils.getPriority(priorityOverride, contracts, ParamConverterProvider.class, provider.getClass());
          sortedParamConverterProviders.add(
                new ExtSortedKey<>(null, (ParamConverterProvider) provider, provider.getClass(), priority, builtIn));
          newContracts.put(ParamConverterProvider.class, priority);
       }
-      if (isA(provider, MessageBodyReader.class, contracts))
-      {
-         try
-         {
-            int priority = getPriority(priorityOverride, contracts, MessageBodyReader.class, provider.getClass());
-            addMessageBodyReader((MessageBodyReader) provider, provider.getClass(), priority, builtIn);
-            newContracts.put(MessageBodyReader.class, priority);
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateMessageBodyReader(), e);
-         }
-      }
-      if (isA(provider, MessageBodyWriter.class, contracts))
-      {
-         try
-         {
-            int priority = getPriority(priorityOverride, contracts, MessageBodyWriter.class, provider.getClass());
-            addMessageBodyWriter((MessageBodyWriter) provider, provider.getClass(), priority, builtIn);
-            newContracts.put(MessageBodyWriter.class, priority);
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateMessageBodyWriter(), e);
-         }
-      }
-      if (isA(provider, ExceptionMapper.class, contracts))
+      if (Utils.isA(provider, ExceptionMapper.class, contracts))
       {
          try
          {
             addExceptionMapper((ExceptionMapper) provider, provider.getClass(), builtIn);
-            int priority = getPriority(priorityOverride, contracts, ExceptionMapper.class, provider.getClass());
+            int priority = Utils.getPriority(priorityOverride, contracts, ExceptionMapper.class, provider.getClass());
             newContracts.put(ExceptionMapper.class, priority);
          }
          catch (Exception e)
@@ -1714,51 +1054,11 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
             throw new RuntimeException(Messages.MESSAGES.unableToInstantiateExceptionMapper(), e);
          }
       }
-      if (isA(provider, AsyncResponseProvider.class, contracts))
+      if (Utils.isA(provider, ContextResolver.class, contracts))
       {
          try
          {
-            addAsyncResponseProvider((AsyncResponseProvider) provider, provider.getClass());
-            int priority = getPriority(priorityOverride, contracts, AsyncResponseProvider.class, provider.getClass());
-            newContracts.put(AsyncResponseProvider.class, priority);
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateAsyncResponseProvider(), e);
-         }
-      }
-      if (isA(provider, AsyncClientResponseProvider.class, contracts))
-      {
-         try
-         {
-            addAsyncClientResponseProvider((AsyncClientResponseProvider) provider, provider.getClass());
-            int priority = getPriority(priorityOverride, contracts, AsyncClientResponseProvider.class,
-                  provider.getClass());
-            newContracts.put(AsyncClientResponseProvider.class, priority);
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateAsyncClientResponseProvider(), e);
-         }
-      }
-      if (isA(provider, AsyncStreamProvider.class, contracts))
-      {
-         try
-         {
-            addAsyncStreamProvider((AsyncStreamProvider) provider, provider.getClass());
-            int priority = getPriority(priorityOverride, contracts, AsyncStreamProvider.class, provider.getClass());
-            newContracts.put(AsyncStreamProvider.class, priority);
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateAsyncStreamProvider(), e);
-         }
-      }
-      if (isA(provider, ContextResolver.class, contracts))
-      {
-         try
-         {
-            int priority = getPriority(priorityOverride, contracts, ContextResolver.class, provider.getClass());
+            int priority = Utils.getPriority(priorityOverride, contracts, ContextResolver.class, provider.getClass());
             addContextResolver((ContextResolver) provider, priority, provider.getClass(), false);
             newContracts.put(ContextResolver.class, priority);
          }
@@ -1767,12 +1067,12 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
             throw new RuntimeException(Messages.MESSAGES.unableToInstantiateContextResolver(), e);
          }
       }
-      if (isA(provider, ContextInjector.class, contracts))
+      if (Utils.isA(provider, ContextInjector.class, contracts))
       {
          try
          {
             addContextInjector((ContextInjector) provider, provider.getClass());
-            int priority = getPriority(priorityOverride, contracts, ContextInjector.class, provider.getClass());
+            int priority = Utils.getPriority(priorityOverride, contracts, ContextInjector.class, provider.getClass());
             newContracts.put(ContextInjector.class, priority);
          }
          catch (Exception e)
@@ -1780,160 +1080,15 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
             throw new RuntimeException(Messages.MESSAGES.unableToInstantiateContextInjector(), e);
          }
       }
-      if (isA(provider, ClientRequestFilter.class, contracts))
-      {
-         if (clientRequestFilterRegistry == null)
-         {
-            clientRequestFilterRegistry = parent.getClientRequestFilterRegistry().clone(this);
-         }
-         int priority = getPriority(priorityOverride, contracts, ClientRequestFilter.class, provider.getClass());
-         clientRequestFilterRegistry.registerSingleton((ClientRequestFilter) provider, priority);
-         newContracts.put(ClientRequestFilter.class, priority);
-      }
-      if (isA(provider, ClientResponseFilter.class, contracts))
-      {
-         if (clientResponseFilters == null)
-         {
-            clientResponseFilters = parent.getClientResponseFilters().clone(this);
-         }
-         int priority = getPriority(priorityOverride, contracts, ClientResponseFilter.class, provider.getClass());
-         clientResponseFilters.registerSingleton((ClientResponseFilter) provider, priority);
-         newContracts.put(ClientResponseFilter.class, priority);
-      }
-      if (isA(provider, ContainerRequestFilter.class, contracts))
-      {
-         if (containerRequestFilterRegistry == null)
-         {
-            containerRequestFilterRegistry = parent.getContainerRequestFilterRegistry().clone(this);
-         }
-         int priority = getPriority(priorityOverride, contracts, ContainerRequestFilter.class, provider.getClass());
-         containerRequestFilterRegistry.registerSingleton((ContainerRequestFilter) provider, priority);
-         newContracts.put(ContainerRequestFilter.class, priority);
-      }
-      if (isA(provider, ContainerResponseFilter.class, contracts))
-      {
-         if (containerResponseFilterRegistry == null)
-         {
-            containerResponseFilterRegistry = parent.getContainerResponseFilterRegistry().clone(this);
-         }
-         int priority = getPriority(priorityOverride, contracts, ContainerResponseFilter.class, provider.getClass());
-         containerResponseFilterRegistry.registerSingleton((ContainerResponseFilter) provider, priority);
-         newContracts.put(ContainerResponseFilter.class, priority);
-      }
-      if (isA(provider, ReaderInterceptor.class, contracts))
-      {
-         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getClass().getAnnotation(ConstrainedTo.class);
-         int priority = getPriority(priorityOverride, contracts, ReaderInterceptor.class, provider.getClass());
-         if (constrainedTo != null && constrainedTo.value() == RuntimeType.SERVER)
-         {
-            if (serverReaderInterceptorRegistry == null)
-            {
-               serverReaderInterceptorRegistry = parent.getServerReaderInterceptorRegistry().clone(this);
-            }
-            serverReaderInterceptorRegistry.registerSingleton((ReaderInterceptor) provider, priority);
-         }
-         if (constrainedTo != null && constrainedTo.value() == RuntimeType.CLIENT)
-         {
-            if (clientReaderInterceptorRegistry == null)
-            {
-               clientReaderInterceptorRegistry = parent.getClientReaderInterceptorRegistry().clone(this);
-            }
-            clientReaderInterceptorRegistry.registerSingleton((ReaderInterceptor) provider, priority);
-         }
-         if (constrainedTo == null)
-         {
-            if (serverReaderInterceptorRegistry == null)
-            {
-               serverReaderInterceptorRegistry = parent.getServerReaderInterceptorRegistry().clone(this);
-            }
-            serverReaderInterceptorRegistry.registerSingleton((ReaderInterceptor) provider, priority);
-            if (clientReaderInterceptorRegistry == null)
-            {
-               clientReaderInterceptorRegistry = parent.getClientReaderInterceptorRegistry().clone(this);
-            }
-            clientReaderInterceptorRegistry.registerSingleton((ReaderInterceptor) provider, priority);
-         }
-         newContracts.put(ReaderInterceptor.class, priority);
-      }
-      if (isA(provider, WriterInterceptor.class, contracts))
-      {
-         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getClass().getAnnotation(ConstrainedTo.class);
-         int priority = getPriority(priorityOverride, contracts, WriterInterceptor.class, provider.getClass());
-         if (constrainedTo != null && constrainedTo.value() == RuntimeType.SERVER)
-         {
-            if (serverWriterInterceptorRegistry == null)
-            {
-               serverWriterInterceptorRegistry = parent.getServerWriterInterceptorRegistry().clone(this);
-            }
-            serverWriterInterceptorRegistry.registerSingleton((WriterInterceptor) provider, priority);
-         }
-         if (constrainedTo != null && constrainedTo.value() == RuntimeType.CLIENT)
-         {
-            if (clientWriterInterceptorRegistry == null)
-            {
-               clientWriterInterceptorRegistry = parent.getClientWriterInterceptorRegistry().clone(this);
-            }
-            clientWriterInterceptorRegistry.registerSingleton((WriterInterceptor) provider, priority);
-         }
-         if (constrainedTo == null)
-         {
-            if (serverWriterInterceptorRegistry == null)
-            {
-               serverWriterInterceptorRegistry = parent.getServerWriterInterceptorRegistry().clone(this);
-            }
-            serverWriterInterceptorRegistry.registerSingleton((WriterInterceptor) provider, priority);
-            if (clientWriterInterceptorRegistry == null)
-            {
-               clientWriterInterceptorRegistry = parent.getClientWriterInterceptorRegistry().clone(this);
-            }
-            clientWriterInterceptorRegistry.registerSingleton((WriterInterceptor) provider, priority);
-         }
-         newContracts.put(WriterInterceptor.class, priority);
-      }
-      if (isA(provider, InjectorFactory.class, contracts))
+      if (Utils.isA(provider, InjectorFactory.class, contracts))
       {
          this.injectorFactory = (InjectorFactory) provider;
          newContracts.put(InjectorFactory.class, 0);
       }
-      if (isA(provider, DynamicFeature.class, contracts))
-      {
-         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getClass().getAnnotation(ConstrainedTo.class);
-         int priority = getPriority(priorityOverride, contracts, DynamicFeature.class, provider.getClass());
-         if (constrainedTo != null && constrainedTo.value() == RuntimeType.SERVER)
-         {
-            if (serverDynamicFeatures == null)
-            {
-               serverDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getServerDynamicFeatures());
-            }
-            serverDynamicFeatures.add((DynamicFeature) provider);
-         }
-         if (constrainedTo != null && constrainedTo.value() == RuntimeType.CLIENT)
-         {
-            if (clientDynamicFeatures == null)
-            {
-               clientDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getClientDynamicFeatures());
-            }
-            clientDynamicFeatures.add((DynamicFeature) provider);
-         }
-         if (constrainedTo == null)
-         {
-            if (serverDynamicFeatures == null)
-            {
-               serverDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getServerDynamicFeatures());
-            }
-            serverDynamicFeatures.add((DynamicFeature) provider);
-            if (clientDynamicFeatures == null)
-            {
-               clientDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getClientDynamicFeatures());
-            }
-            clientDynamicFeatures.add((DynamicFeature) provider);
-         }
-         newContracts.put(DynamicFeature.class, priority);
-      }
-      if (isA(provider, Feature.class, contracts))
+      if (Utils.isA(provider, Feature.class, contracts))
       {
          Feature feature = (Feature) provider;
-         injectProperties(provider.getClass(), provider);
+         Utils.injectProperties(this, provider.getClass(), provider);
          ConstrainedTo constrainedTo = (ConstrainedTo) provider.getClass().getAnnotation(ConstrainedTo.class);
          if (constrainedTo == null || constrainedTo.value() == getRuntimeType())
          {
@@ -1942,17 +1097,17 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
                enabledFeatures.add(feature);
             }
          }
-         int priority = getPriority(priorityOverride, contracts, Feature.class, provider.getClass());
+         int priority = Utils.getPriority(priorityOverride, contracts, Feature.class, provider.getClass());
          newContracts.put(Feature.class, priority);
 
       }
-      if (isA(provider, ResourceClassProcessor.class, contracts))
+      if (Utils.isA(provider, ResourceClassProcessor.class, contracts))
       {
-         int priority = getPriority(priorityOverride, contracts, ResourceClassProcessor.class, provider.getClass());
+         int priority = Utils.getPriority(priorityOverride, contracts, ResourceClassProcessor.class, provider.getClass());
          addResourceClassProcessor((ResourceClassProcessor) provider, priority);
          newContracts.put(ResourceClassProcessor.class, priority);
       }
-      if (isA(provider, HeaderDelegate.class, contracts))
+      if (Utils.isA(provider, HeaderDelegate.class, contracts))
       {
          Type[] headerTypes = Types.getActualTypeArgumentsOfAnInterface(provider.getClass(), HeaderDelegate.class);
          if (headerTypes.length == 0)
@@ -2044,9 +1199,9 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       List<SortedKey<MessageBodyWriter>> writers = getServerMessageBodyWriters().getPossible(mediaType, type);
       for (SortedKey<MessageBodyWriter> writer : writers)
       {
-         if (writer.obj.isWriteable(type, genericType, annotations, mediaType))
+         if (writer.getObj().isWriteable(type, genericType, annotations, mediaType))
          {
-            MessageBodyWriter mbw = writer.obj;
+            MessageBodyWriter mbw = writer.getObj();
             Class writerType = Types.getTemplateParameterOfInterface(mbw.getClass(), MessageBodyWriter.class);
             if (writerType == null || writerType.equals(Object.class) || !writerType.isAssignableFrom(type))
                continue;
@@ -2072,9 +1227,9 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       List<SortedKey<MessageBodyWriter>> writers = getServerMessageBodyWriters().getPossible(accept, type);
       for (SortedKey<MessageBodyWriter> writer : writers)
       {
-         if (writer.obj.isWriteable(type, genericType, annotations, accept))
+         if (writer.getObj().isWriteable(type, genericType, annotations, accept))
          {
-            Class<?> mbwc = writer.obj.getClass();
+            Class<?> mbwc = writer.getObj().getClass();
             if (!mbwc.isInterface() && mbwc.getSuperclass() != null && !mbwc.getSuperclass().equals(Object.class)
                   && mbwc.isSynthetic())
             {
@@ -2083,7 +1238,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
             Class writerType = Types.getTemplateParameterOfInterface(mbwc, MessageBodyWriter.class);
             if (writerType == null || !writerType.isAssignableFrom(type))
                continue;
-            map.put(writer.obj, writerType);
+            map.put(writer.getObj(), writerType);
          }
       }
       return map;
@@ -2155,17 +1310,17 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
 
       for (SortedKey<MessageBodyWriter> writer : writers)
       {
-         if (writer.obj.isWriteable(type, genericType, annotations, mediaType))
+         if (writer.getObj().isWriteable(type, genericType, annotations, mediaType))
          {
             LogMessages.LOGGER.debugf("MessageBodyWriter: %s", writer.getClass().getName());
             //logger.info("   picking: " + writer.obj.getClass().getName());
-            return (MessageBodyWriter<T>) writer.obj;
+            return (MessageBodyWriter<T>) writer.getObj();
          }
       }
       return null;
    }
 
-   protected <T> MessageBodyWriter<T> resolveMessageBodyWriter(Class<T> type, Type genericType,
+   private <T> MessageBodyWriter<T> resolveMessageBodyWriter(Class<T> type, Type genericType,
          Annotation[] annotations, MediaType mediaType, MediaTypeMap<SortedKey<MessageBodyWriter>> availableWriters,
          RESTEasyTracingLogger tracingLogger)
    {
@@ -2185,10 +1340,10 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       while (iterator.hasNext())
       {
          final SortedKey<MessageBodyWriter> writer = iterator.next();
-         if (writer.obj.isWriteable(type, genericType, annotations, mediaType))
+         if (writer.getObj().isWriteable(type, genericType, annotations, mediaType))
          {
             LogMessages.LOGGER.debugf("MessageBodyWriter: %s", writer.getClass().getName());
-            result = (MessageBodyWriter<T>) writer.obj;
+            result = (MessageBodyWriter<T>) writer.getObj();
             tracingLogger.log("MBW_SELECTED", result);
             break;
          }
@@ -2200,7 +1355,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
          while (iterator.hasNext())
          {
             final SortedKey<MessageBodyWriter> writer = iterator.next();
-            tracingLogger.log("MBW_SKIPPED", writer.obj);
+            tracingLogger.log("MBW_SKIPPED", writer.getObj());
          }
       }
       return result;
@@ -2255,21 +1410,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
     */
    public <T> T createProviderInstance(Class<? extends T> clazz)
    {
-      ConstructorInjector constructorInjector = createConstructorInjector(clazz);
-
-      T provider = (T) constructorInjector.construct(false).toCompletableFuture().getNow(null);
-      return provider;
-   }
-
-   private <T> ConstructorInjector createConstructorInjector(Class<? extends T> clazz)
-   {
-      Constructor<?> constructor = PickConstructor.pickSingletonConstructor(clazz);
-      if (constructor == null)
-      {
-         throw new IllegalArgumentException(
-               Messages.MESSAGES.unableToFindPublicConstructorForProvider(clazz.getName()));
-      }
-      return getInjectorFactory().createConstructor(constructor, this);
+      return Utils.createProviderInstance(this, clazz);
    }
 
    /**
@@ -2315,24 +1456,6 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
 
       propertyInjector.inject(request, response, obj, false).toCompletableFuture().getNow(null);
       return (T) obj;
-   }
-
-   private void injectProperties(Class declaring, Object obj)
-   {
-      getInjectorFactory().createPropertyInjector(declaring, this).inject(obj, false).toCompletableFuture()
-            .getNow(null);
-   }
-
-   public void injectProperties(Object obj)
-   {
-      getInjectorFactory().createPropertyInjector(obj.getClass(), this).inject(obj, false).toCompletableFuture()
-            .getNow(null);
-   }
-
-   public void injectProperties(Object obj, HttpRequest request, HttpResponse response)
-   {
-      getInjectorFactory().createPropertyInjector(obj.getClass(), this).inject(request, response, obj, false)
-            .toCompletableFuture().getNow(null);
    }
 
    // Configurable
@@ -2577,7 +1700,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
    @Override
    public Link.Builder createLinkBuilder()
    {
-      return new LinkBuilderImpl();
+      return Utils.createLinkBuilder();
    }
 
    public <I extends RxInvoker> RxInvokerProvider<I> getRxInvokerProvider(Class<I> clazz)
@@ -2598,17 +1721,12 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
 
    public RxInvokerProvider<?> getRxInvokerProviderFromReactiveClass(Class<?> clazz)
    {
-      Class<? extends RxInvokerProvider> rxInvokerProviderClass = reactiveClasses.get(clazz);
-      if (rxInvokerProviderClass != null)
-      {
-         return createProviderInstance(rxInvokerProviderClass);
-      }
-      return null;
+      return clientHelper.getRxInvokerProviderFromReactiveClass(clazz);
    }
 
    public boolean isReactive(Class<?> clazz)
    {
-      return reactiveClasses.keySet().contains(clazz);
+      return clientHelper.isReactive(clazz);
    }
 
    private void addResourceClassProcessor(Class<ResourceClassProcessor> processorClass, int priority)
@@ -2632,11 +1750,18 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       return ResteasyContext.getContextData(type);
    }
 
-   @Override
    public void initializeClientProviders(ResteasyProviderFactory factory)
    {
-      clientRequestFilterRegistry = factory == null ? new ClientRequestFilterRegistryImpl(this) : factory.getClientRequestFilterRegistry().clone(this);
-      clientResponseFilters =  factory == null ? new ClientResponseFilterRegistryImpl(this) : factory.getClientResponseFilters().clone(this);
+      clientHelper.initializeClientProviders(factory);
    }
 
+   public void injectProperties(Object obj)
+   {
+      Utils.injectProperties(this, obj);
+   }
+
+   public void injectProperties(Object obj, HttpRequest request, HttpResponse response)
+   {
+      Utils.injectProperties(this, obj, request, response);
+   }
 }

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ResteasyProviderFactoryImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ResteasyProviderFactoryImpl.java
@@ -191,7 +191,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
       providerClasses = parent == null ? new CopyOnWriteArraySet<>() : new CopyOnWriteArraySet<>(parent.getProviderClasses());
       providerInstances = parent == null ? new CopyOnWriteArraySet<>() : new CopyOnWriteArraySet<>(parent.getProviderInstances());
       classContracts = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getClassContracts());
-      sortedExceptionMappers = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getSortedExceptionMappers());
+      sortedExceptionMappers = parent == null ? new ConcurrentHashMap<>(4) : new ConcurrentHashMap<>(parent.getSortedExceptionMappers());
       contextResolvers = new ConcurrentHashMap<>();
       if (parent != null)
       {
@@ -200,10 +200,10 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory impleme
             contextResolvers.put(entry.getKey(), entry.getValue().clone());
          }
       }
-      contextInjectors = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getContextInjectors());
-      asyncContextInjectors = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getAsyncContextInjectors());
+      contextInjectors = parent == null ? new ConcurrentHashMap<>(2) : new ConcurrentHashMap<>(parent.getContextInjectors());
+      asyncContextInjectors = parent == null ? new ConcurrentHashMap<>(2) : new ConcurrentHashMap<>(parent.getAsyncContextInjectors());
       sortedParamConverterProviders = Collections.synchronizedSortedSet(parent == null ? new TreeSet<>() : new TreeSet<>(parent.getSortedParamConverterProviders()));
-      stringParameterUnmarshallers = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getStringParameterUnmarshallers());
+      stringParameterUnmarshallers = parent == null ? new ConcurrentHashMap<>(2) : new ConcurrentHashMap<>(parent.getStringParameterUnmarshallers());
 
       resourceBuilder = new ResourceBuilder();
 

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ServerHelper.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ServerHelper.java
@@ -1,0 +1,537 @@
+package org.jboss.resteasy.core.providerfactory;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.ReaderInterceptor;
+import javax.ws.rs.ext.WriterInterceptor;
+
+import org.jboss.resteasy.core.MediaTypeMap;
+import org.jboss.resteasy.core.interception.jaxrs.ContainerRequestFilterRegistryImpl;
+import org.jboss.resteasy.core.interception.jaxrs.ContainerResponseFilterRegistryImpl;
+import org.jboss.resteasy.core.interception.jaxrs.ReaderInterceptorRegistryImpl;
+import org.jboss.resteasy.core.interception.jaxrs.WriterInterceptorRegistryImpl;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
+import org.jboss.resteasy.spi.AsyncResponseProvider;
+import org.jboss.resteasy.spi.AsyncStreamProvider;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.interception.JaxrsInterceptorRegistry;
+import org.jboss.resteasy.spi.util.Types;
+
+/**
+ *
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class ServerHelper
+{
+   private final ResteasyProviderFactoryImpl rpf;
+   private MediaTypeMap<SortedKey<MessageBodyReader>> serverMessageBodyReaders;
+   private MediaTypeMap<SortedKey<MessageBodyWriter>> serverMessageBodyWriters;
+   private JaxrsInterceptorRegistry<ContainerRequestFilter> containerRequestFilterRegistry;
+   private JaxrsInterceptorRegistry<ContainerResponseFilter> containerResponseFilterRegistry;
+   private JaxrsInterceptorRegistry<ReaderInterceptor> serverReaderInterceptorRegistry;
+   private JaxrsInterceptorRegistry<WriterInterceptor> serverWriterInterceptorRegistry;
+   private Set<DynamicFeature> serverDynamicFeatures;
+   private Map<Class<?>, AsyncResponseProvider> asyncResponseProviders;
+   private Map<Class<?>, AsyncStreamProvider> asyncStreamProviders;
+
+   public ServerHelper(final ResteasyProviderFactoryImpl rpf)
+   {
+      this.rpf = rpf;
+   }
+
+   protected void initialize(ResteasyProviderFactoryImpl parent)
+   {
+      serverDynamicFeatures = parent == null ? new CopyOnWriteArraySet<>() : new CopyOnWriteArraySet<>(parent.getServerDynamicFeatures());
+      asyncResponseProviders = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getAsyncResponseProviders());
+      asyncStreamProviders = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getAsyncStreamProviders());
+
+      serverMessageBodyReaders = parent == null ? new MediaTypeMap<>() : parent.getServerMessageBodyReaders().clone();
+      serverMessageBodyWriters = parent == null ? new MediaTypeMap<>() : parent.getServerMessageBodyWriters().clone();
+      containerRequestFilterRegistry = parent == null ? new ContainerRequestFilterRegistryImpl(rpf) : parent.getContainerRequestFilterRegistry().clone(rpf);
+      containerResponseFilterRegistry = parent == null ? new ContainerResponseFilterRegistryImpl(rpf) : parent.getContainerResponseFilterRegistry().clone(rpf);
+      serverReaderInterceptorRegistry = parent == null ? new ReaderInterceptorRegistryImpl(rpf) : parent.getServerReaderInterceptorRegistry().clone(rpf);
+      serverWriterInterceptorRegistry = parent == null ? new WriterInterceptorRegistryImpl(rpf) : parent.getServerWriterInterceptorRegistry().clone(rpf);
+   }
+
+   protected JaxrsInterceptorRegistry<ReaderInterceptor> getServerReaderInterceptorRegistry(ResteasyProviderFactory parent)
+   {
+      if (serverReaderInterceptorRegistry == null && parent != null)
+         return parent.getServerReaderInterceptorRegistry();
+      return serverReaderInterceptorRegistry;
+   }
+
+   protected JaxrsInterceptorRegistry<WriterInterceptor> getServerWriterInterceptorRegistry(ResteasyProviderFactory parent)
+   {
+      if (serverWriterInterceptorRegistry == null && parent != null)
+         return parent.getServerWriterInterceptorRegistry();
+      return serverWriterInterceptorRegistry;
+   }
+
+   protected JaxrsInterceptorRegistry<ContainerRequestFilter> getContainerRequestFilterRegistry(ResteasyProviderFactory parent)
+   {
+      if (containerRequestFilterRegistry == null && parent != null)
+         return parent.getContainerRequestFilterRegistry();
+      return containerRequestFilterRegistry;
+   }
+
+   protected JaxrsInterceptorRegistry<ContainerResponseFilter> getContainerResponseFilterRegistry(ResteasyProviderFactory parent)
+   {
+      if (containerResponseFilterRegistry == null && parent != null)
+         return parent.getContainerResponseFilterRegistry();
+      return containerResponseFilterRegistry;
+   }
+
+   protected Set<DynamicFeature> getServerDynamicFeatures(ResteasyProviderFactory parent)
+   {
+      if (serverDynamicFeatures == null && parent != null)
+         return parent.getServerDynamicFeatures();
+      return serverDynamicFeatures;
+   }
+
+   protected Map<Class<?>, AsyncResponseProvider> getAsyncResponseProviders(ResteasyProviderFactory parent)
+   {
+      if (asyncResponseProviders == null && parent != null)
+         return parent.getAsyncResponseProviders();
+      return asyncResponseProviders;
+   }
+
+   protected Map<Class<?>, AsyncStreamProvider> getAsyncStreamProviders(ResteasyProviderFactory parent)
+   {
+      if (asyncStreamProviders == null && parent != null)
+         return parent.getAsyncStreamProviders();
+      return asyncStreamProviders;
+   }
+
+   protected void processProviderContracts(Class provider, Integer priorityOverride, boolean isBuiltin,
+         Map<Class<?>, Integer> contracts, Map<Class<?>, Integer> newContracts, ResteasyProviderFactoryImpl parent)
+   {
+      if (Utils.isA(provider, MessageBodyReader.class, contracts))
+      {
+         try
+         {
+            int priority = Utils.getPriority(priorityOverride, contracts, MessageBodyReader.class, provider);
+            addMessageBodyReader(Utils.createProviderInstance(rpf, (Class<? extends MessageBodyReader>) provider), provider,
+                  priority, isBuiltin, parent);
+            newContracts.put(MessageBodyReader.class, priority);
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateMessageBodyReader(), e);
+         }
+      }
+      if (Utils.isA(provider, MessageBodyWriter.class, contracts))
+      {
+         try
+         {
+            int priority = Utils.getPriority(priorityOverride, contracts, MessageBodyWriter.class, provider);
+            addMessageBodyWriter(Utils.createProviderInstance(rpf, (Class<? extends MessageBodyWriter>) provider), provider,
+                  priority, isBuiltin, parent);
+            newContracts.put(MessageBodyWriter.class, priority);
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateMessageBodyWriter(), e);
+         }
+      }
+      if (Utils.isA(provider, ContainerRequestFilter.class, contracts))
+      {
+         if (containerRequestFilterRegistry == null)
+         {
+            containerRequestFilterRegistry = parent.getContainerRequestFilterRegistry().clone(rpf);
+         }
+         int priority = Utils.getPriority(priorityOverride, contracts, ContainerRequestFilter.class, provider);
+         containerRequestFilterRegistry.registerClass(provider, priority);
+         newContracts.put(ContainerRequestFilter.class, priority);
+      }
+      if (Utils.isA(provider, ContainerResponseFilter.class, contracts))
+      {
+         if (containerResponseFilterRegistry == null)
+         {
+            containerResponseFilterRegistry = parent.getContainerResponseFilterRegistry().clone(rpf);
+         }
+         int priority = Utils.getPriority(priorityOverride, contracts, ContainerResponseFilter.class, provider);
+         containerResponseFilterRegistry.registerClass(provider, priority);
+         newContracts.put(ContainerResponseFilter.class, priority);
+      }
+      if (Utils.isA(provider, ReaderInterceptor.class, contracts))
+      {
+         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getAnnotation(ConstrainedTo.class);
+         int priority = Utils.getPriority(priorityOverride, contracts, ReaderInterceptor.class, provider);
+         if (constrainedTo != null && constrainedTo.value() == RuntimeType.SERVER)
+         {
+            if (serverReaderInterceptorRegistry == null)
+            {
+               serverReaderInterceptorRegistry = parent.getServerReaderInterceptorRegistry().clone(rpf);
+            }
+            serverReaderInterceptorRegistry.registerClass(provider, priority);
+         }
+         if (constrainedTo == null)
+         {
+            if (serverReaderInterceptorRegistry == null)
+            {
+               serverReaderInterceptorRegistry = parent.getServerReaderInterceptorRegistry().clone(rpf);
+            }
+            serverReaderInterceptorRegistry.registerClass(provider, priority);
+         }
+         newContracts.put(ReaderInterceptor.class, priority);
+      }
+      if (Utils.isA(provider, WriterInterceptor.class, contracts))
+      {
+         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getAnnotation(ConstrainedTo.class);
+         int priority = Utils.getPriority(priorityOverride, contracts, WriterInterceptor.class, provider);
+         if (constrainedTo != null && constrainedTo.value() == RuntimeType.SERVER)
+         {
+            if (serverWriterInterceptorRegistry == null)
+            {
+               serverWriterInterceptorRegistry = parent.getServerWriterInterceptorRegistry().clone(rpf);
+            }
+            serverWriterInterceptorRegistry.registerClass(provider, priority);
+         }
+         if (constrainedTo == null)
+         {
+            if (serverWriterInterceptorRegistry == null)
+            {
+               serverWriterInterceptorRegistry = parent.getServerWriterInterceptorRegistry().clone(rpf);
+            }
+            serverWriterInterceptorRegistry.registerClass(provider, priority);
+         }
+         newContracts.put(WriterInterceptor.class, priority);
+      }
+      if (Utils.isA(provider, DynamicFeature.class, contracts))
+      {
+         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getAnnotation(ConstrainedTo.class);
+         int priority = Utils.getPriority(priorityOverride, contracts, DynamicFeature.class, provider);
+         if (constrainedTo != null && constrainedTo.value() == RuntimeType.SERVER)
+         {
+            if (serverDynamicFeatures == null)
+            {
+               serverDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getServerDynamicFeatures());
+            }
+            serverDynamicFeatures.add((DynamicFeature) rpf.injectedInstance(provider));
+         }
+         if (constrainedTo == null)
+         {
+            if (serverDynamicFeatures == null)
+            {
+               serverDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getServerDynamicFeatures());
+            }
+            serverDynamicFeatures.add((DynamicFeature) rpf.injectedInstance(provider));
+         }
+         newContracts.put(DynamicFeature.class, priority);
+      }
+      if (Utils.isA(provider, AsyncResponseProvider.class, contracts))
+      {
+         try
+         {
+            addAsyncResponseProvider(rpf.createProviderInstance((Class<? extends AsyncResponseProvider>) provider),
+                  provider, parent);
+            newContracts.put(AsyncResponseProvider.class,
+                  Utils.getPriority(priorityOverride, contracts, AsyncResponseProvider.class, provider));
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateAsyncResponseProvider(), e);
+         }
+      }
+      if (Utils.isA(provider, AsyncStreamProvider.class, contracts))
+      {
+         try
+         {
+            addAsyncStreamProvider(rpf.createProviderInstance((Class<? extends AsyncStreamProvider>) provider), provider, parent);
+            newContracts.put(AsyncStreamProvider.class,
+                  Utils.getPriority(priorityOverride, contracts, AsyncStreamProvider.class, provider));
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateAsyncStreamProvider(), e);
+         }
+      }
+
+   }
+
+   protected void processProviderInstanceContracts(Object provider, Map<Class<?>, Integer> contracts,
+         Integer priorityOverride, boolean builtIn, Map<Class<?>, Integer> newContracts, ResteasyProviderFactoryImpl parent)
+   {
+      if (Utils.isA(provider, MessageBodyReader.class, contracts))
+      {
+         try
+         {
+            int priority = Utils.getPriority(priorityOverride, contracts, MessageBodyReader.class, provider.getClass());
+            addMessageBodyReader((MessageBodyReader) provider, provider.getClass(), priority, builtIn, parent);
+            newContracts.put(MessageBodyReader.class, priority);
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateMessageBodyReader(), e);
+         }
+      }
+      if (Utils.isA(provider, MessageBodyWriter.class, contracts))
+      {
+         try
+         {
+            int priority = Utils.getPriority(priorityOverride, contracts, MessageBodyWriter.class, provider.getClass());
+            addMessageBodyWriter((MessageBodyWriter) provider, provider.getClass(), priority, builtIn, parent);
+            newContracts.put(MessageBodyWriter.class, priority);
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateMessageBodyWriter(), e);
+         }
+      }
+      if (Utils.isA(provider, ContainerRequestFilter.class, contracts))
+      {
+         if (containerRequestFilterRegistry == null)
+         {
+            containerRequestFilterRegistry = parent.getContainerRequestFilterRegistry().clone(rpf);
+         }
+         int priority = Utils.getPriority(priorityOverride, contracts, ContainerRequestFilter.class, provider.getClass());
+         containerRequestFilterRegistry.registerSingleton((ContainerRequestFilter) provider, priority);
+         newContracts.put(ContainerRequestFilter.class, priority);
+      }
+      if (Utils.isA(provider, ContainerResponseFilter.class, contracts))
+      {
+         if (containerResponseFilterRegistry == null)
+         {
+            containerResponseFilterRegistry = parent.getContainerResponseFilterRegistry().clone(rpf);
+         }
+         int priority = Utils.getPriority(priorityOverride, contracts, ContainerResponseFilter.class, provider.getClass());
+         containerResponseFilterRegistry.registerSingleton((ContainerResponseFilter) provider, priority);
+         newContracts.put(ContainerResponseFilter.class, priority);
+      }
+      if (Utils.isA(provider, ReaderInterceptor.class, contracts))
+      {
+         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getClass().getAnnotation(ConstrainedTo.class);
+         int priority = Utils.getPriority(priorityOverride, contracts, ReaderInterceptor.class, provider.getClass());
+         if (constrainedTo != null && constrainedTo.value() == RuntimeType.SERVER)
+         {
+            if (serverReaderInterceptorRegistry == null)
+            {
+               serverReaderInterceptorRegistry = parent.getServerReaderInterceptorRegistry().clone(rpf);
+            }
+            serverReaderInterceptorRegistry.registerSingleton((ReaderInterceptor) provider, priority);
+         }
+         if (constrainedTo == null)
+         {
+            if (serverReaderInterceptorRegistry == null)
+            {
+               serverReaderInterceptorRegistry = parent.getServerReaderInterceptorRegistry().clone(rpf);
+            }
+            serverReaderInterceptorRegistry.registerSingleton((ReaderInterceptor) provider, priority);
+         }
+         newContracts.put(ReaderInterceptor.class, priority);
+      }
+      if (Utils.isA(provider, WriterInterceptor.class, contracts))
+      {
+         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getClass().getAnnotation(ConstrainedTo.class);
+         int priority = Utils.getPriority(priorityOverride, contracts, WriterInterceptor.class, provider.getClass());
+         if (constrainedTo != null && constrainedTo.value() == RuntimeType.SERVER)
+         {
+            if (serverWriterInterceptorRegistry == null)
+            {
+               serverWriterInterceptorRegistry = parent.getServerWriterInterceptorRegistry().clone(rpf);
+            }
+            serverWriterInterceptorRegistry.registerSingleton((WriterInterceptor) provider, priority);
+         }
+         if (constrainedTo == null)
+         {
+            if (serverWriterInterceptorRegistry == null)
+            {
+               serverWriterInterceptorRegistry = parent.getServerWriterInterceptorRegistry().clone(rpf);
+            }
+            serverWriterInterceptorRegistry.registerSingleton((WriterInterceptor) provider, priority);
+         }
+         newContracts.put(WriterInterceptor.class, priority);
+      }
+      if (Utils.isA(provider, DynamicFeature.class, contracts))
+      {
+         ConstrainedTo constrainedTo = (ConstrainedTo) provider.getClass().getAnnotation(ConstrainedTo.class);
+         int priority = Utils.getPriority(priorityOverride, contracts, DynamicFeature.class, provider.getClass());
+         if (constrainedTo != null && constrainedTo.value() == RuntimeType.SERVER)
+         {
+            if (serverDynamicFeatures == null)
+            {
+               serverDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getServerDynamicFeatures());
+            }
+            serverDynamicFeatures.add((DynamicFeature) provider);
+         }
+         if (constrainedTo == null)
+         {
+            if (serverDynamicFeatures == null)
+            {
+               serverDynamicFeatures = new CopyOnWriteArraySet<DynamicFeature>(parent.getServerDynamicFeatures());
+            }
+            serverDynamicFeatures.add((DynamicFeature) provider);
+         }
+         newContracts.put(DynamicFeature.class, priority);
+      }
+      if (Utils.isA(provider, AsyncResponseProvider.class, contracts))
+      {
+         try
+         {
+            addAsyncResponseProvider((AsyncResponseProvider) provider, provider.getClass(), parent);
+            int priority = Utils.getPriority(priorityOverride, contracts, AsyncResponseProvider.class, provider.getClass());
+            newContracts.put(AsyncResponseProvider.class, priority);
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateAsyncResponseProvider(), e);
+         }
+      }
+      if (Utils.isA(provider, AsyncStreamProvider.class, contracts))
+      {
+         try
+         {
+            addAsyncStreamProvider((AsyncStreamProvider) provider, provider.getClass(), parent);
+            int priority = Utils.getPriority(priorityOverride, contracts, AsyncStreamProvider.class, provider.getClass());
+            newContracts.put(AsyncStreamProvider.class, priority);
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(Messages.MESSAGES.unableToInstantiateAsyncStreamProvider(), e);
+         }
+      }
+   }
+
+   protected MediaTypeMap<SortedKey<MessageBodyReader>> getServerMessageBodyReaders(ResteasyProviderFactoryImpl parent)
+   {
+      if (serverMessageBodyReaders == null && parent != null)
+         return parent.getServerMessageBodyReaders();
+      return serverMessageBodyReaders;
+   }
+
+   protected MediaTypeMap<SortedKey<MessageBodyWriter>> getServerMessageBodyWriters(ResteasyProviderFactoryImpl parent)
+   {
+      if (serverMessageBodyWriters == null && parent != null)
+         return parent.getServerMessageBodyWriters();
+      return serverMessageBodyWriters;
+   }
+
+   protected void addMessageBodyReader(MessageBodyReader provider, Class<?> providerClass, int priority,
+         boolean isBuiltin, ResteasyProviderFactoryImpl parent)
+   {
+      SortedKey<MessageBodyReader> key = new SortedKey<MessageBodyReader>(MessageBodyReader.class, provider,
+            providerClass, priority, isBuiltin);
+      Utils.injectProperties(rpf, providerClass, provider);
+      Consumes consumeMime = provider.getClass().getAnnotation(Consumes.class);
+      RuntimeType type = null;
+      ConstrainedTo constrainedTo = providerClass.getAnnotation(ConstrainedTo.class);
+      if (constrainedTo != null)
+         type = constrainedTo.value();
+
+      if ((type == null || type == RuntimeType.SERVER) && serverMessageBodyReaders == null)
+      {
+         serverMessageBodyReaders = parent.getServerMessageBodyReaders().clone();
+      }
+      if (consumeMime != null)
+      {
+         for (String consume : consumeMime.value())
+         {
+            if (type == null)
+            {
+               serverMessageBodyReaders.add(MediaType.valueOf(consume), key);
+            }
+            else if (type == RuntimeType.SERVER)
+            {
+               serverMessageBodyReaders.add(MediaType.valueOf(consume), key);
+            }
+         }
+      }
+      else
+      {
+         if (type == null)
+         {
+            serverMessageBodyReaders.add(new MediaType("*", "*"), key);
+         }
+         else if (type == RuntimeType.SERVER)
+         {
+            serverMessageBodyReaders.add(new MediaType("*", "*"), key);
+         }
+      }
+   }
+
+   protected void addMessageBodyWriter(MessageBodyWriter provider, Class<?> providerClass, int priority,
+         boolean isBuiltin, ResteasyProviderFactoryImpl parent)
+   {
+      Utils.injectProperties(rpf, providerClass, provider);
+      Produces consumeMime = provider.getClass().getAnnotation(Produces.class);
+      SortedKey<MessageBodyWriter> key = new SortedKey<MessageBodyWriter>(MessageBodyWriter.class, provider,
+            providerClass, priority, isBuiltin);
+      RuntimeType type = null;
+      ConstrainedTo constrainedTo = providerClass.getAnnotation(ConstrainedTo.class);
+      if (constrainedTo != null)
+         type = constrainedTo.value();
+
+      if ((type == null || type == RuntimeType.SERVER) && serverMessageBodyWriters == null)
+      {
+         serverMessageBodyWriters = parent.getServerMessageBodyWriters().clone();
+      }
+      if (consumeMime != null)
+      {
+         for (String consume : consumeMime.value())
+         {
+            //logger.info(">>> Adding provider: " + provider.getClass().getName() + " with mime type of: " + mime);
+            if (type == null)
+            {
+               serverMessageBodyWriters.add(MediaType.valueOf(consume), key);
+            }
+            else if (type == RuntimeType.SERVER)
+            {
+               serverMessageBodyWriters.add(MediaType.valueOf(consume), key);
+            }
+         }
+      }
+      else
+      {
+         //logger.info(">>> Adding provider: " + provider.getClass().getName() + " with mime type of: default */*");
+         if (type == null)
+         {
+            serverMessageBodyWriters.add(new MediaType("*", "*"), key);
+         }
+         else if (type == RuntimeType.SERVER)
+         {
+            serverMessageBodyWriters.add(new MediaType("*", "*"), key);
+         }
+      }
+   }
+
+   private void addAsyncResponseProvider(AsyncResponseProvider provider, Class providerClass, ResteasyProviderFactory parent)
+   {
+      Type asyncType = Types.getActualTypeArgumentsOfAnInterface(providerClass, AsyncResponseProvider.class)[0];
+      Utils.injectProperties(rpf, provider.getClass(), provider);
+      Class<?> asyncClass = Types.getRawType(asyncType);
+      if (asyncResponseProviders == null)
+      {
+         asyncResponseProviders = new ConcurrentHashMap<Class<?>, AsyncResponseProvider>();
+         asyncResponseProviders.putAll(parent.getAsyncResponseProviders());
+      }
+      asyncResponseProviders.put(asyncClass, provider);
+   }
+
+   private void addAsyncStreamProvider(AsyncStreamProvider provider, Class providerClass, ResteasyProviderFactory parent)
+   {
+      Type asyncType = Types.getActualTypeArgumentsOfAnInterface(providerClass, AsyncStreamProvider.class)[0];
+      Utils.injectProperties(rpf, provider.getClass(), provider);
+      Class<?> asyncClass = Types.getRawType(asyncType);
+      if (asyncStreamProviders == null)
+      {
+         asyncStreamProviders = new ConcurrentHashMap<Class<?>, AsyncStreamProvider>();
+         asyncStreamProviders.putAll(parent.getAsyncStreamProviders());
+      }
+      asyncStreamProviders.put(asyncClass, provider);
+   }
+
+}

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ServerHelper.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ServerHelper.java
@@ -56,8 +56,8 @@ public class ServerHelper
    protected void initialize(ResteasyProviderFactoryImpl parent)
    {
       serverDynamicFeatures = parent == null ? new CopyOnWriteArraySet<>() : new CopyOnWriteArraySet<>(parent.getServerDynamicFeatures());
-      asyncResponseProviders = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getAsyncResponseProviders());
-      asyncStreamProviders = parent == null ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(parent.getAsyncStreamProviders());
+      asyncResponseProviders = parent == null ? new ConcurrentHashMap<>(4) : new ConcurrentHashMap<>(parent.getAsyncResponseProviders());
+      asyncStreamProviders = parent == null ? new ConcurrentHashMap<>(4) : new ConcurrentHashMap<>(parent.getAsyncStreamProviders());
 
       serverMessageBodyReaders = parent == null ? new MediaTypeMap<>() : parent.getServerMessageBodyReaders().clone();
       serverMessageBodyWriters = parent == null ? new MediaTypeMap<>() : parent.getServerMessageBodyWriters().clone();

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/SortedKey.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/SortedKey.java
@@ -1,0 +1,77 @@
+package org.jboss.resteasy.core.providerfactory;
+
+import javax.ws.rs.Priorities;
+
+import org.jboss.resteasy.core.MediaTypeMap;
+import org.jboss.resteasy.spi.util.Types;
+
+/**
+ * Allow us to sort message body implementations that are more specific for their types
+ * i.e. MessageBodyWriter&#x3C;Object&#x3E; is less specific than MessageBodyWriter&#x3C;String&#x3E;.
+ * <p>
+ * This helps out a lot when the desired media type is a wildcard and to weed out all the possible
+ * default mappings.
+ */
+public class SortedKey<T> implements Comparable<SortedKey<T>>, MediaTypeMap.Typed
+{
+   private final T obj;
+   private final boolean isBuiltin;
+   private final Class<?> template;
+   private final int priority;
+
+   public SortedKey(final Class<?> intf, final T reader, final Class<?> readerClass, final int priority, final boolean isBuiltin)
+   {
+      this.obj = reader;
+      // check the super class for the generic type 1st
+      Class<?> t = Types.getTemplateParameterOfInterface(readerClass, intf);
+      template = (t != null) ? t : Object.class;
+      this.priority = priority;
+      this.isBuiltin = isBuiltin;
+   }
+
+   public SortedKey(final Class<?> intf, final T reader, final Class<?> readerClass, final boolean isBuiltin)
+   {
+      this(intf, reader, readerClass, Priorities.USER, isBuiltin);
+   }
+
+   public SortedKey(final Class<?> intf, final T reader, final Class<?> readerClass)
+   {
+      this(intf, reader, readerClass, Priorities.USER, false);
+   }
+
+   public int compareTo(SortedKey<T> tMessageBodyKey)
+   {
+      // Sort user provider before builtins
+      if (this == tMessageBodyKey)
+         return 0;
+      if (isBuiltin == tMessageBodyKey.isBuiltin)
+      {
+         if (this.priority < tMessageBodyKey.priority)
+         {
+            return -1;
+         }
+         if (this.priority == tMessageBodyKey.priority)
+         {
+            return 0;
+         }
+         if (this.priority > tMessageBodyKey.priority)
+         {
+            return 1;
+         }
+      }
+      if (isBuiltin)
+         return 1;
+      else
+         return -1;
+   }
+
+   public Class<?> getType()
+   {
+      return template;
+   }
+
+   public T getObj()
+   {
+      return obj;
+   }
+}

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/Utils.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/Utils.java
@@ -1,0 +1,164 @@
+package org.jboss.resteasy.core.providerfactory;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.Variant;
+import javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
+
+import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
+import org.jboss.resteasy.specimpl.LinkBuilderImpl;
+import org.jboss.resteasy.specimpl.ResponseBuilderImpl;
+import org.jboss.resteasy.specimpl.ResteasyUriBuilderImpl;
+import org.jboss.resteasy.specimpl.VariantListBuilderImpl;
+import org.jboss.resteasy.spi.ConstructorInjector;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.util.PickConstructor;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+public final class Utils
+{
+   private Utils() {
+   }
+
+   static boolean isA(Class target, Class type, Map<Class<?>, Integer> contracts)
+   {
+      if (!type.isAssignableFrom(target))
+         return false;
+      if (contracts == null || contracts.size() == 0)
+         return true;
+      for (Class<?> contract : contracts.keySet())
+      {
+         if (contract.equals(type))
+            return true;
+      }
+      return false;
+   }
+
+   static boolean isA(Object target, Class type, Map<Class<?>, Integer> contracts)
+   {
+      return isA(target.getClass(), type, contracts);
+   }
+
+   static int getPriority(Integer override, Map<Class<?>, Integer> contracts, Class type, Class<?> component)
+   {
+      if (override != null)
+         return override;
+      if (contracts != null)
+      {
+         Integer p = contracts.get(type);
+         if (p != null)
+            return p;
+      }
+      // Check for weld proxy.
+      component = component.isSynthetic() ? component.getSuperclass() : component;
+      Priority priority = component.getAnnotation(Priority.class);
+      if (priority == null)
+         return Priorities.USER;
+      return priority.value();
+   }
+
+   static void injectProperties(ResteasyProviderFactory rpf, Class declaring, Object obj)
+   {
+      rpf.getInjectorFactory().createPropertyInjector(declaring, rpf).inject(obj, false).toCompletableFuture()
+            .getNow(null);
+   }
+
+   static void injectProperties(ResteasyProviderFactory rpf, Object obj)
+   {
+      rpf.getInjectorFactory().createPropertyInjector(obj.getClass(), rpf).inject(obj, false).toCompletableFuture()
+            .getNow(null);
+   }
+
+   static void injectProperties(ResteasyProviderFactory rpf, Object obj, HttpRequest request, HttpResponse response)
+   {
+      rpf.getInjectorFactory().createPropertyInjector(obj.getClass(), rpf).inject(request, response, obj, false)
+            .toCompletableFuture().getNow(null);
+   }
+
+   static <T> T createProviderInstance(ResteasyProviderFactory rpf, Class<? extends T> clazz)
+   {
+      ConstructorInjector constructorInjector = createConstructorInjector(rpf, clazz);
+
+      T provider = (T) constructorInjector.construct(false).toCompletableFuture().getNow(null);
+      return provider;
+   }
+
+   private static <T> ConstructorInjector createConstructorInjector(ResteasyProviderFactory rpf, Class<? extends T> clazz)
+   {
+      Constructor<?> constructor = PickConstructor.pickSingletonConstructor(clazz);
+      if (constructor == null)
+      {
+         throw new IllegalArgumentException(
+               Messages.MESSAGES.unableToFindPublicConstructorForProvider(clazz.getName()));
+      }
+      return rpf.getInjectorFactory().createConstructor(constructor, rpf);
+   }
+
+   static UriBuilder createUriBuilder()
+   {
+      return new ResteasyUriBuilderImpl();
+   }
+
+   static Response.ResponseBuilder createResponseBuilder()
+   {
+      return new ResponseBuilderImpl();
+   }
+
+   static Variant.VariantListBuilder createVariantListBuilder()
+   {
+      return new VariantListBuilderImpl();
+   }
+
+   static Link.Builder createLinkBuilder()
+   {
+      return new LinkBuilderImpl();
+   }
+
+   static <T> HeaderDelegate<T> createHeaderDelegate(Map<Class<?>, HeaderDelegate> headerDelegates, Class<T> tClass)
+   {
+      Class<?> clazz = tClass;
+      while (clazz != null)
+      {
+         HeaderDelegate<T> delegate = headerDelegates.get(clazz);
+         if (delegate != null)
+         {
+            return delegate;
+         }
+         delegate = createHeaderDelegateFromInterfaces(headerDelegates, clazz.getInterfaces());
+         if (delegate != null)
+         {
+            return delegate;
+         }
+         clazz = clazz.getSuperclass();
+      }
+
+      return createHeaderDelegateFromInterfaces(headerDelegates, tClass.getInterfaces());
+   }
+
+   private static <T> HeaderDelegate<T> createHeaderDelegateFromInterfaces(Map<Class<?>, HeaderDelegate> headerDelegates, Class<?>[] interfaces)
+   {
+      HeaderDelegate<T> delegate = null;
+      for (int i = 0; i < interfaces.length; i++)
+      {
+         delegate = headerDelegates.get(interfaces[i]);
+         if (delegate != null)
+         {
+            return delegate;
+         }
+         delegate = createHeaderDelegateFromInterfaces(headerDelegates, interfaces[i].getInterfaces());
+         if (delegate != null)
+         {
+            return delegate;
+         }
+      }
+      return null;
+   }
+}

--- a/resteasy-core/src/main/java/org/jboss/resteasy/mock/MockDispatcherFactory.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/mock/MockDispatcherFactory.java
@@ -1,7 +1,7 @@
 package org.jboss.resteasy.mock;
 
-import org.jboss.resteasy.core.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.spi.Dispatcher;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/CacheControlDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/CacheControlDelegate.java
@@ -14,6 +14,8 @@ import java.util.List;
  */
 public class CacheControlDelegate implements RuntimeDelegate.HeaderDelegate<CacheControl>
 {
+   public static final CacheControlDelegate INSTANCE = new CacheControlDelegate();
+
    public CacheControl fromString(String value) throws IllegalArgumentException
    {
       if (value == null) throw new IllegalArgumentException(Messages.MESSAGES.cacheControlValueNull());

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/CookieHeaderDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/CookieHeaderDelegate.java
@@ -10,7 +10,7 @@ import org.jboss.resteasy.util.CookieParser;
  */
 public class CookieHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Cookie>
 {
-
+   public static final CookieHeaderDelegate INSTANCE = new CookieHeaderDelegate();
    public Cookie fromString(String value) throws IllegalArgumentException
    {
       return CookieParser.parseCookies(value).get(0);

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/DateDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/DateDelegate.java
@@ -13,6 +13,8 @@ import java.util.Date;
  */
 public class DateDelegate implements RuntimeDelegate.HeaderDelegate<Date>
 {
+   public static final DateDelegate INSTANCE = new DateDelegate();
+
    @Override
    public Date fromString(String value)
    {

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/EntityTagDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/EntityTagDelegate.java
@@ -11,6 +11,8 @@ import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
  */
 public class EntityTagDelegate implements RuntimeDelegate.HeaderDelegate<EntityTag>
 {
+   public static final EntityTagDelegate INSTANCE = new EntityTagDelegate();
+
    public EntityTag fromString(String value) throws IllegalArgumentException
    {
       if (value == null) throw new IllegalArgumentException(Messages.MESSAGES.entityTagValueNull());

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/LinkDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/LinkDelegate.java
@@ -16,6 +16,8 @@ import java.util.Map;
  */
 public class LinkDelegate implements RuntimeDelegate.HeaderDelegate<Link>
 {
+   public static final LinkDelegate INSTANCE = new LinkDelegate();
+
    private static class Parser
    {
       private int curr;

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/LinkHeaderDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/LinkHeaderDelegate.java
@@ -20,6 +20,8 @@ import java.util.StringTokenizer;
  */
 public class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<LinkHeader>
 {
+   public static final LinkHeaderDelegate INSTANCE = new LinkHeaderDelegate();
+
    private static class Parser
    {
       private int curr;

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/LocaleDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/LocaleDelegate.java
@@ -13,6 +13,8 @@ import java.util.Locale;
  */
 public class LocaleDelegate implements RuntimeDelegate.HeaderDelegate<Locale>
 {
+   public static final LocaleDelegate INSTANCE = new LocaleDelegate();
+
    public Locale fromString(String value) throws IllegalArgumentException
    {
       if (value == null) throw new IllegalArgumentException(Messages.MESSAGES.localeValueNull());

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java
@@ -14,8 +14,6 @@ import java.util.HashMap;
  */
 public class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate
 {
-   public static final MediaTypeHeaderDelegate INSTANCE = new MediaTypeHeaderDelegate();
-
    public Object fromString(String type) throws IllegalArgumentException
    {
       if (type == null) throw new IllegalArgumentException(Messages.MESSAGES.mediaTypeValueNull());

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java
@@ -14,6 +14,8 @@ import java.util.HashMap;
  */
 public class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate
 {
+   public static final MediaTypeHeaderDelegate INSTANCE = new MediaTypeHeaderDelegate();
+
    public Object fromString(String type) throws IllegalArgumentException
    {
       if (type == null) throw new IllegalArgumentException(Messages.MESSAGES.mediaTypeValueNull());

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java
@@ -19,6 +19,7 @@ public class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate
    public static final MediaTypeHeaderDelegate INSTANCE = new MediaTypeHeaderDelegate();
 
    private static Map<String, MediaType> map = new ConcurrentHashMap<String, MediaType>();
+   private static Map<MediaType, String> reverseMap = new ConcurrentHashMap<MediaType, String>();
    private static final int MAX_MT_CACHE_SIZE =
        Integer.getInteger("org.jboss.resteasy.max_mediatype_cache_size", 200);
 
@@ -64,8 +65,10 @@ public class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate
           final int size = map.size();
           if (size >= MAX_MT_CACHE_SIZE) {
               map.clear();
+              reverseMap.clear();
           }
           map.put(type, result);
+          reverseMap.put(result, type);
       }
       return result;
    }
@@ -147,6 +150,22 @@ public class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate
    {
       if (o == null) throw new IllegalArgumentException(Messages.MESSAGES.paramNull());
       MediaType type = (MediaType) o;
+      String result = reverseMap.get(type);
+      if (result == null) {
+          result = internalToString(type);
+          final int size = reverseMap.size();
+          if (size >= MAX_MT_CACHE_SIZE) {
+             reverseMap.clear();
+             map.clear();
+          }
+          reverseMap.put(type, result);
+          map.put(result, type);
+      }
+      return result;
+   }
+
+   private String internalToString(MediaType type)
+   {
       StringBuilder buf = new StringBuilder();
 
       buf.append(type.getType().toLowerCase()).append("/").append(type.getSubtype().toLowerCase());

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/NewCookieHeaderDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/NewCookieHeaderDelegate.java
@@ -18,6 +18,7 @@ import java.util.Map;
  * @version $Revision: 1 $
  */
 public class NewCookieHeaderDelegate implements RuntimeDelegate.HeaderDelegate {
+   public static final NewCookieHeaderDelegate INSTANCE = new NewCookieHeaderDelegate();
    private static final String OLD_COOKIE_PATTERN = "EEE, dd-MMM-yyyy HH:mm:ss z";
 
    public Object fromString(String newCookie) throws IllegalArgumentException {

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/UriHeaderDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/UriHeaderDelegate.java
@@ -12,6 +12,8 @@ import java.net.URI;
  */
 public class UriHeaderDelegate implements RuntimeDelegate.HeaderDelegate
 {
+   public static final UriHeaderDelegate INSTANCE = new UriHeaderDelegate();
+
    public Object fromString(String value) throws IllegalArgumentException
    {
       if (value == null) throw new IllegalArgumentException(Messages.MESSAGES.uriValueNull());

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/RegisterBuiltin.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/RegisterBuiltin.java
@@ -19,8 +19,10 @@ import java.util.WeakHashMap;
 import javax.ws.rs.RuntimeType;
 import javax.ws.rs.ext.Providers;
 
-import org.jboss.resteasy.core.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.core.ThreadLocalResteasyProviderFactory;
+import org.jboss.resteasy.core.providerfactory.ClientHelper;
+import org.jboss.resteasy.core.providerfactory.NOOPServerHelper;
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.plugins.interceptors.AcceptEncodingGZIPFilter;
 import org.jboss.resteasy.plugins.interceptors.GZIPDecodingInterceptor;
 import org.jboss.resteasy.plugins.interceptors.GZIPEncodingInterceptor;
@@ -49,6 +51,12 @@ public class RegisterBuiltin
             public RuntimeType getRuntimeType()
             {
                return RuntimeType.CLIENT;
+            }
+            @Override
+            protected void initializeUtils()
+            {
+               clientHelper = new ClientHelper(this);
+               serverHelper = NOOPServerHelper.INSTANCE;
             }
          };
          if (!rpf.isBuiltinsRegistered()) {

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/sse/InboundSseEventImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/sse/InboundSseEventImpl.java
@@ -202,7 +202,9 @@ public class InboundSseEventImpl implements InboundSseEvent
       else
       {
          ResteasyProviderFactory factory = ResteasyProviderFactory.getInstance();
-         RegisterBuiltin.register(factory);
+         if (!factory.isBuiltinsRegistered()) {
+            RegisterBuiltin.register(factory);
+         }
          reader = factory.getClientMessageBodyReader(type.getRawType(), type.getType(), annotations, mediaType);
       }
       if (reader == null)

--- a/resteasy-core/src/main/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
+++ b/resteasy-core/src/main/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
@@ -1,1 +1,1 @@
-org.jboss.resteasy.core.ResteasyProviderFactoryImpl
+org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl

--- a/resteasy-jsapi/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesAbstract.java
+++ b/resteasy-jsapi/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesAbstract.java
@@ -10,7 +10,7 @@ import org.junit.Assert;
 
 import org.jboss.resteasy.core.InjectorFactoryImpl;
 import org.jboss.resteasy.core.ResourceMethodInvoker;
-import org.jboss.resteasy.core.ResteasyProviderFactoryImpl;
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
 import org.jboss.resteasy.jsapi.i18n.Messages;
 import org.jboss.resteasy.spi.InjectorFactory;

--- a/security/jose-jwt/src/main/java/org/jboss/resteasy/jwt/JsonSerialization.java
+++ b/security/jose-jwt/src/main/java/org/jboss/resteasy/jwt/JsonSerialization.java
@@ -12,7 +12,7 @@ import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Providers;
 
 import org.jboss.resteasy.core.ResteasyContext;
-import org.jboss.resteasy.core.ResteasyProviderFactoryImpl;
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.jose.i18n.Messages;
 import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/InContainerClientBenchTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/InContainerClientBenchTest.java
@@ -1,0 +1,107 @@
+package org.jboss.resteasy.test.client;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.InvocationCallback;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import javax.ws.rs.client.ClientBuilder;
+import org.jboss.resteasy.test.client.resource.AsyncInvokeResource;
+import org.jboss.resteasy.test.client.resource.InContainerClientResource;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @tpChapter Client tests
+ * @tpSubChapter Performances
+ * @tpTestCaseDetails https://issues.jboss.org/browse/RESTEASY-XYZ
+ * @tpSince RESTEasy 4.0.0
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@Ignore("Not a functional test")
+public class InContainerClientBenchTest extends ClientTestBase
+{
+
+   static Client nioClient;
+   private static Logger log = Logger.getLogger(InContainerClientBenchTest.class);
+
+   static final int ITERATIONS = 4000;
+   static final int MAX_CONNECTIONS = 40;
+
+   @Deployment
+   public static Archive<?> deploy()
+   {
+      WebArchive war = TestUtil.prepareArchive(InContainerClientBenchTest.class.getSimpleName());
+      war.addClass(InContainerClientBenchTest.class);
+      war.addClass(ClientTestBase.class);
+      return TestUtil.finishContainerPrepare(war, null, AsyncInvokeResource.class, InContainerClientResource.class);
+   }
+
+   @After
+   public void after() throws Exception
+   {
+      if (nioClient != null)
+         nioClient.close();
+   }
+
+   @Test
+   public void testAsyncComposedPost() throws Exception
+   {
+      long start = System.currentTimeMillis();
+      final String oldProp = System.getProperty("http.maxConnections");
+      System.setProperty("http.maxConnections", String.valueOf(MAX_CONNECTIONS));
+      nioClient = ((ResteasyClientBuilder)ClientBuilder.newBuilder()).useAsyncHttpEngine().build();
+      WebTarget wt = nioClient.target(generateURL("/test-client"));
+      runCallback(wt, "NIO", "client-post post ");
+      long end = System.currentTimeMillis() - start;
+      log.info("TEST COMPOSED NON BLOCKING IO - " + ITERATIONS + " iterations took " + end + "ms");
+      if (oldProp != null)
+      {
+         System.setProperty("http.maxConnections", oldProp);
+      }
+      else
+      {
+         System.clearProperty("http.maxConnections");
+      }
+   }
+
+   private void runCallback(WebTarget wt, String msg, String expectedResultPrefix) throws Exception
+   {
+      CountDownLatch latch = new CountDownLatch(ITERATIONS);
+      for (int i = 0; i < ITERATIONS; i++) {
+         final String m = msg + i;
+         wt.request().async().post(Entity.text(m), new InvocationCallback<Response>()
+         {
+            @Override
+            public void completed(Response response)
+            {
+               String entity = response.readEntity(String.class);
+               Assert.assertEquals("Got: "+ entity, expectedResultPrefix + m, entity);
+               latch.countDown();
+            }
+
+            @Override
+            public void failed(Throwable error)
+            {
+               throw new RuntimeException(error);
+            }
+         });
+      }
+      latch.await();
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/resource/InContainerClientResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/resource/InContainerClientResource.java
@@ -1,0 +1,30 @@
+package org.jboss.resteasy.test.client.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+@Path("/test-client")
+public class InContainerClientResource {
+
+   @Context
+   private UriInfo uriInfo;
+
+   @POST
+   @Consumes("text/plain")
+   public String post(String str) throws Exception {
+      Client client = ClientBuilder.newClient();
+      String result = null;
+      try {
+         result = client.target(uriInfo.getBaseUri() + "test").request().post(Entity.text(str)).readEntity(String.class);
+      } finally {
+         client.close();
+      }
+      return "client-post " + result;
+   }
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ConfigurationInheritanceTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ConfigurationInheritanceTest.java
@@ -34,7 +34,7 @@ import javax.ws.rs.ext.WriterInterceptor;
 
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
-import org.jboss.resteasy.core.ResteasyProviderFactoryImpl;
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.test.client.resource.ConfigurationInheritanceTestFeature1;
 import org.jboss.resteasy.test.client.resource.ConfigurationInheritanceTestFeature2;
 import org.jboss.resteasy.test.client.resource.ConfigurationInheritanceTestFeature3;

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/HeaderDelegateTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/HeaderDelegateTest.java
@@ -2,7 +2,7 @@ package org.jboss.resteasy.test.providers;
 
 import javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
 
-import org.jboss.resteasy.core.ResteasyProviderFactoryImpl;
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.junit.Assert;
 import org.junit.Test;

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/MultipurtContainsJsonTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/MultipurtContainsJsonTest.java
@@ -12,8 +12,8 @@ import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Providers;
 
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.client.jaxrs.internal.LocalResteasyProviderFactory;
 import org.jboss.resteasy.core.ResteasyContext;
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
@@ -43,7 +43,7 @@ public class MultipurtContainsJsonTest {
    }
 
    public static MessageBodyWriter<MultipartFormDataOutput> getWriter() {
-      ResteasyProviderFactory factory = new LocalResteasyProviderFactory(ResteasyProviderFactory.newInstance());
+      ResteasyProviderFactory factory = new ResteasyProviderFactoryImpl(ResteasyProviderFactory.newInstance(), true);
       RegisterBuiltin.register(factory);
       factory.registerProviderInstance(new ProviderFactoryPrecendencePlainTextWriter());
       factory.registerProviderInstance(new ProviderFactoryPrecedenceIntegerPlainTextWriter());

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/PriorityEqualityTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/PriorityEqualityTest.java
@@ -148,7 +148,7 @@ public class PriorityEqualityTest {
       ResteasyProviderFactoryImpl factory = new ResteasyProviderFactoryImpl();
       factory.register(ExceptionMapper1.class);
       factory.register(ExceptionMapper2.class);
-      Assert.assertEquals(1, factory.getExceptionMappers().size());
+      Assert.assertEquals(ExceptionMapper2.class, factory.getExceptionMapper(TestException.class).getClass());
    }
 
    /**
@@ -161,6 +161,6 @@ public class PriorityEqualityTest {
       ResteasyProviderFactoryImpl factory = new ResteasyProviderFactoryImpl();
       factory.registerProviderInstance(new ExceptionMapper1());
       factory.registerProviderInstance(new ExceptionMapper2());
-      Assert.assertEquals(1, factory.getExceptionMappers().size());
+      Assert.assertEquals(ExceptionMapper2.class, factory.getExceptionMapper(TestException.class).getClass());
    }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/PriorityEqualityTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/PriorityEqualityTest.java
@@ -10,7 +10,7 @@ import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
 import javax.ws.rs.ext.Provider;
 
-import org.jboss.resteasy.core.ResteasyProviderFactoryImpl;
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.junit.Assert;


### PR DESCRIPTION
This PR proposes a refactoring of the huge ResteasyProviderFactory(impl) class. With the distinction of public spi and core, we can afford to split the class into smaller components without too much concerns of users having access to them. Moreover, the ResteasyProviderFactory really covers client and server aspects together, while it's quite common to need an instance for client side usage only that results in memory/cpu waste for building and populating multiple server-side-related collections. Splitting the ResteasyProviderFactory isolating client and server only aspects allows avoiding that inefficiency in some scenarios.
Besides that, whenever needing a new ResteasyProviderFactory on client side (to be wrapped into a LocalResteasyProviderFactory), instead of creating a new instance from scratch, we can cache and reuse the default ResteasyProviderFactory for each ThreadContextClassLoader (as the initial configuration is effectively function of the classloader, which controls the providers discovery); this should reduce memory allocation. 
Speaking of memory allocation reduction, I've created few singletons for the HeaderDelegate that are added to almost all ResteasyProviderFactory instance.
Finally, I've added a simple cache to the MediaTypeHeaderDelegate to reduce the resources spent on converting media type strings into the MediaType immutable objects.