### PR TITLE
[RESTEASY-2173] Move towards WildFly 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,14 @@ jdk:
   - openjdk8
   - oraclejdk11
 env:
-  - SERVER_VERSION=13.0.0.Final
   - SERVER_VERSION=14.0.0.Final
   - SERVER_VERSION=15.0.0.Final
-  - SERVER_VERSION=15.0.0.Final ELYTRON=true
+  - SERVER_VERSION=16.0.0.Final
+  - SERVER_VERSION=16.0.0.Final ELYTRON=true
 jobs:
   exclude:
     - jdk: oraclejdk11
-      env: SERVER_VERSION=13.0.0.Final
-    - jdk: oraclejdk11
-      env: SERVER_VERSION=15.0.0.Final ELYTRON=true
+      env: SERVER_VERSION=16.0.0.Final ELYTRON=true
   include:
     - stage: "javadoc"
       script: mvn -B -DskipTests install && mvn -B -Dmaven.javadoc.skip=false javadoc:javadoc

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/category/ExpectedFailingOnWildFly13.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/category/ExpectedFailingOnWildFly13.java
@@ -1,9 +1,0 @@
-package org.jboss.resteasy.category;
-
-/**
- * Marker interface for tests which are expected to fail on WildFly 13.0.0.Final
- *
- */
-public interface ExpectedFailingOnWildFly13 {
-
-}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProxyTest.java
@@ -9,7 +9,6 @@ import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.client.microprofile.MicroprofileClientBuilderResolver;
 import org.jboss.resteasy.utils.PortProviderUtil;
 import org.jboss.resteasy.utils.TestUtil;
@@ -36,7 +35,6 @@ public class RestClientProxyTest
       war.addPackage(HelloResource.class.getPackage());
       war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
       war.addClass(PortProviderUtil.class);
-      war.addClass(ExpectedFailingOnWildFly13.class);
       war.addClass(Category.class);
       war.addAsManifestResource(new StringAsset("Dependencies: org.eclipse.microprofile.restclient\n"), "MANIFEST.MF");
       return TestUtil.finishContainerPrepare(war, null);
@@ -48,7 +46,6 @@ public class RestClientProxyTest
    }
 
    @Test
-   @Category({ExpectedFailingOnWildFly13.class})
    public void testGetClient() throws Exception
    {
       RestClientBuilder builder = RestClientBuilder.newBuilder();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/Jackson2Test.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/Jackson2Test.java
@@ -4,7 +4,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import javax.ws.rs.client.ClientBuilder;
@@ -131,7 +130,6 @@ public class Jackson2Test {
     * @tpSince RESTEasy 3.0.16
     */
    @Test
-   @Category({ExpectedFailingOnWildFly13.class})
    public void testJacksonString() throws Exception {
       WebTarget target = client.target(generateURL("/products/333"));
       Response response = target.request().get();
@@ -179,7 +177,7 @@ public class Jackson2Test {
     * @tpSince RESTEasy 3.1.0.Final
     */
    @Test
-   @Category({NotForForwardCompatibility.class, ExpectedFailingOnWildFly13.class})
+   @Category({NotForForwardCompatibility.class})
    public void testJacksonJsonpDisabled() throws Exception {
       WebTarget target = client.target(PortProviderUtil.generateURL("/products/333?callback=foo", JSONP_DISABLED));
       Response response = target.request().get();
@@ -198,7 +196,7 @@ public class Jackson2Test {
     * @tpSince RESTEasy 3.0.16 (as testJacksonJsonp() but Jackson2JsonpInterceptor would have been enabled)
     */
    @Test
-   @Category({NotForForwardCompatibility.class, ExpectedFailingOnWildFly13.class})
+   @Category({NotForForwardCompatibility.class})
    public void testJacksonJsonpDefault() throws Exception {
       WebTarget target = client.target(generateURL("/products/333?callback=foo"));
       Response response = target.request().get();
@@ -217,7 +215,6 @@ public class Jackson2Test {
     * @tpSince RESTEasy 3.0.16
     */
    @Test
-   @Category({ExpectedFailingOnWildFly13.class})
    public void testFormattedJacksonString() throws Exception {
       WebTarget target = client.target(generateURL("/products/formatted/333"));
       Response response = target.request().get();
@@ -285,7 +282,6 @@ public class Jackson2Test {
     * @tpSince RESTEasy 3.0.16
     */
    @Test
-   @Category({ExpectedFailingOnWildFly13.class})
    public void testJacksonJAXB() throws Exception {
       {
          WebTarget target = client.target(generateURL("/jaxb"));

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/JacksonDatatypeTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/JacksonDatatypeTest.java
@@ -4,7 +4,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import javax.ws.rs.client.ClientBuilder;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
@@ -21,7 +20,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.WebTarget;
@@ -125,7 +123,6 @@ public class JacksonDatatypeTest {
     * @tpSince RESTEasy 3.1.0.CR3
     */
    @Test
-   @Category({ExpectedFailingOnWildFly13.class})
    public void testDatatypeNotSupportedOptionalNull() throws Exception {
       String strResponse = requestHelper("optional/true", DEFAULT_DEPLOYMENT);
       Assert.assertThat("Wrong conversion of Optional (null)", strResponse, not(containsString("null")));

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/JacksonJaxbCoexistenceTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/JacksonJaxbCoexistenceTest.java
@@ -4,7 +4,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import javax.ws.rs.client.ClientBuilder;
 import org.jboss.resteasy.test.providers.jackson2.resource.JacksonJaxbCoexistenceJacksonResource;
@@ -22,7 +21,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Entity;
@@ -72,7 +70,6 @@ public class JacksonJaxbCoexistenceTest {
     * @tpSince RESTEasy 3.0.16
     */
    @Test
-   @Category({ExpectedFailingOnWildFly13.class})
    public void testJacksonString() throws Exception {
       WebTarget target = client.target(generateURL("/products/333"));
       Response response = target.request().get();
@@ -99,7 +96,6 @@ public class JacksonJaxbCoexistenceTest {
     * @tpSince RESTEasy 3.0.16
     */
    @Test
-   @Category({ExpectedFailingOnWildFly13.class})
    public void testJacksonXmlString() throws Exception {
       WebTarget target = client.target(generateURL("/jxml/products/333"));
       Response response = target.request().get();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/JacksonJsonViewTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/JacksonJsonViewTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonView;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import javax.ws.rs.client.ClientBuilder;
@@ -123,7 +122,6 @@ public class JacksonJsonViewTest {
     * @tpSince RESTEasy 3.1.0
     */
    @Test
-   @Category({ExpectedFailingOnWildFly13.class})
    public void testJacksonProxyJsonView2WithJasonViewTest() throws Exception {
       JacksonViewProxy proxy = client.target(generateURL("")).proxy(JacksonViewProxy.class);
       Something p = proxy.getSomethingWithView2();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/ProxyWithGenericReturnTypeJacksonTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/ProxyWithGenericReturnTypeJacksonTest.java
@@ -4,7 +4,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import javax.ws.rs.client.ClientBuilder;
 import org.jboss.resteasy.test.providers.jackson2.resource.ProxyWithGenericReturnTypeJacksonResource;
@@ -22,7 +21,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
@@ -34,7 +32,6 @@ import javax.ws.rs.core.Response;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Category({ExpectedFailingOnWildFly13.class})
 public class ProxyWithGenericReturnTypeJacksonTest {
 
    protected static final Logger logger = Logger.getLogger(ProxyWithGenericReturnTypeJacksonTest.class.getName());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterSuperClassTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterSuperClassTest.java
@@ -8,7 +8,6 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.spi.HttpResponseCodes;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.JsonFilterChild;
@@ -36,7 +35,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Category({NotForForwardCompatibility.class, ExpectedFailingOnWildFly13.class})
+@Category({NotForForwardCompatibility.class})
 public class JsonFilterSuperClassTest {
 
    @Deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithInterceptorConditionalFilterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithInterceptorConditionalFilterTest.java
@@ -3,7 +3,6 @@ package org.jboss.resteasy.test.providers.jackson2.jsonfilter;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import javax.ws.rs.client.ClientBuilder;
@@ -68,7 +67,6 @@ public class JsonFilterWithInterceptorConditionalFilterTest {
     * @tpSince RESTEasy 3.1.0
     */
    @Test
-   @Category({ExpectedFailingOnWildFly13.class})
    public void testJacksonConditionalStringPropertyFiltered() throws Exception {
       WebTarget target = client.target(generateURL("/products/-1"));
       Response response = target.request().get();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithInterceptorMultipleFiltersTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithInterceptorMultipleFiltersTest.java
@@ -8,7 +8,6 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.Jackson2Person;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.Jackson2PersonResource;
@@ -35,7 +34,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Category({NotForForwardCompatibility.class, ExpectedFailingOnWildFly13.class})
+@Category({NotForForwardCompatibility.class})
 public class JsonFilterWithInterceptorMultipleFiltersTest {
 
    @Deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithInterceptrTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithInterceptrTest.java
@@ -8,7 +8,6 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.Jackson2Product;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.Jackson2Resource;
@@ -32,7 +31,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Category({NotForForwardCompatibility.class, ExpectedFailingOnWildFly13.class})
+@Category({NotForForwardCompatibility.class})
 public class JsonFilterWithInterceptrTest {
 
    @Deployment(name = "default")

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithSerlvetFilterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithSerlvetFilterTest.java
@@ -7,7 +7,6 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 
@@ -34,7 +33,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Category({NotForForwardCompatibility.class, ExpectedFailingOnWildFly13.class})
+@Category({NotForForwardCompatibility.class})
 public class JsonFilterWithSerlvetFilterTest {
 
    @Deployment(name = "default")

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithServletConditionalFilterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithServletConditionalFilterTest.java
@@ -6,7 +6,6 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import javax.ws.rs.client.ClientBuilder;
@@ -69,7 +68,6 @@ public class JsonFilterWithServletConditionalFilterTest {
     * @tpSince RESTEasy 3.1.0
     */
    @Test
-   @Category({ExpectedFailingOnWildFly13.class})
    public void testJacksonConditionalStringPropertyFiltered() throws Exception {
       WebTarget target = client.target(generateURL("/products/-1"));
       Response response = target.request().get();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithServletMultipleFiltersTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/jsonfilter/JsonFilterWithServletMultipleFiltersTest.java
@@ -8,7 +8,6 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.Jackson2Person;
 import org.jboss.resteasy.test.providers.jackson2.jsonfilter.resource.Jackson2PersonResource;
@@ -35,7 +34,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Category({NotForForwardCompatibility.class, ExpectedFailingOnWildFly13.class})
+@Category({NotForForwardCompatibility.class})
 public class JsonFilterWithServletMultipleFiltersTest {
    @Deployment(name = "default")
    public static Archive<?> deploy() {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/DuplicitePathTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/DuplicitePathTest.java
@@ -3,7 +3,6 @@ package org.jboss.resteasy.test.response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import javax.ws.rs.client.ClientBuilder;
@@ -100,7 +99,7 @@ public class DuplicitePathTest {
     * @tpSince RESTEasy 3.0.17
     */
    @Test
-   @Category({NotForForwardCompatibility.class, ExpectedFailingOnWildFly13.class})
+   @Category({NotForForwardCompatibility.class})
    public void testDuplicationTwoAppTwoResourceSameMethodPath() throws Exception {
       WebTarget base = client.target(generateURL("/a/b/c"));
       Response response = null;

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -120,19 +120,7 @@
               </property>
             </activation>
             <properties>
-                <server.version>15.0.0.Final</server.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>server-version-13x-exclusions</id>
-            <activation>
-              <property>
-                <name>server.version</name>
-                <value>13.0.0.Final</value>
-              </property>
-            </activation>
-            <properties>
-              <additional.surefire.excluded.groups>org.jboss.resteasy.category.ExpectedFailingOnWildFly13</additional.surefire.excluded.groups>
+                <server.version>16.0.0.Final</server.version>
             </properties>
         </profile>
         <!-- If resteasy.version is specified, it will be used for tests instead of the project.version -->


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/RESTEASY-2173
3.7 PR: https://github.com/resteasy/Resteasy/pull/1881

Move towards WildFly 16
*  set default server version to WildFly 16
*  update Travis configuration to run WF 14/15/16