### PR TITLE
[RESTEASY-1955] - MicroprofileClientBuilder can't handle nested @BeanParam's

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/Params.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/Params.java
@@ -1,0 +1,45 @@
+package org.jboss.resteasy.test.client.proxy.resource;
+
+import org.jboss.resteasy.annotations.jaxrs.QueryParam;
+
+import javax.ws.rs.PathParam;
+
+/**
+ * Created by Marek Marusic <mmarusic@redhat.com> on 3/4/19.
+ */
+public class Params {
+    @PathParam("p1")
+    private String p1;
+
+    @QueryParam("q1")
+    private String q1;
+
+    private String p3;
+
+    public String getP1() {
+        return p1;
+    }
+
+    public void setP1(String p1) {
+        this.p1 = p1;
+    }
+
+    @PathParam("p3")
+    public String getP3() {
+        return p3;
+    }
+
+    @PathParam("p3")
+    public void setP3(String p3) {
+        this.p3 = p3;
+    }
+
+    public String getQ1() {
+        return q1;
+    }
+
+    public void setQ1(String q1) {
+        this.q1 = q1;
+    }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProxyBeanParam.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProxyBeanParam.java
@@ -1,0 +1,19 @@
+package org.jboss.resteasy.test.client.proxy.resource;
+
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+import org.jboss.resteasy.annotations.jaxrs.QueryParam;
+
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * Created by Marek Marusic <mmarusic@redhat.com> on 3/4/19.
+ */
+@Path("/a")
+public interface ProxyBeanParam {
+
+    @Path("a/{p1}/{p2}/{p3}")
+    @GET
+    String getAll(@BeanParam Params beanParam, @PathParam String p2, @QueryParam String queryParam);
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProxyBeanParamResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ProxyBeanParamResource.java
@@ -1,0 +1,20 @@
+package org.jboss.resteasy.test.client.proxy.resource;
+
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+import org.jboss.resteasy.annotations.jaxrs.QueryParam;
+
+/**
+ * Created by Marek Marusic <mmarusic@redhat.com> on 3/4/19.
+ */
+@Path("/a")
+public class ProxyBeanParamResource {
+
+    @GET
+    @Path("a/{p1}/{p2}/{p3}")
+    public String getAll(@BeanParam Params beanParam, @PathParam String p2, @QueryParam String queryParam) {
+        return beanParam.getP1() + "_" + p2 + "_" + beanParam.getP3() + "_" + beanParam.getQ1() + "_" + queryParam;
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/RESTEasyParamBasicTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/RESTEasyParamBasicTest.java
@@ -12,6 +12,9 @@ import org.jboss.logging.Logger;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import javax.ws.rs.client.ClientBuilder;
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
+import org.jboss.resteasy.test.client.proxy.resource.Params;
+import org.jboss.resteasy.test.client.proxy.resource.ProxyBeanParam;
+import org.jboss.resteasy.test.client.proxy.resource.ProxyBeanParamResource;
 import org.jboss.resteasy.test.client.proxy.resource.ProxyParameterAnotations;
 import org.jboss.resteasy.test.client.proxy.resource.ProxyParameterAnotationsResource;
 import org.jboss.resteasy.test.resource.param.resource.RESTEasyParamBasicCustomValuesResource;
@@ -54,6 +57,8 @@ public class RESTEasyParamBasicTest {
       war.addClass(RESTEasyParamBasicProxy.class);
       return TestUtil.finishContainerPrepare(war, null,
             RESTEasyParamBasicResource.class,
+            ProxyBeanParamResource.class,
+            Params.class,
             ProxyParameterAnotationsResource.class,
             RESTEasyParamBasicJaxRsParamDifferentResource.class,
             RESTEasyParamBasicJaxRsParamSameResource.class,
@@ -127,6 +132,29 @@ public class RESTEasyParamBasicTest {
       Assert.assertEquals("queryParam0 headerParam0 cookieParam0 pathParam0 formParam0 matrixParam0", response);
    }
 
+   /**
+    * @tpTestDetails Basic check of the Resteasy Microprofile client with BeanParam.
+    *                Test checks that Resteasy Microprofile client can inject correct values when BeanParam is used.
+    *                This test uses new annotation only without any annotation value.
+    * @tpSince RESTEasy 3.7
+    */
+   @Test
+   public void testMicroprofileBeanParam() throws MalformedURLException {
+      final String url = generateURL("");
+      String response;
+      Params params = new Params();
+      params.setP1("test");
+      params.setP3("param3");
+      params.setQ1("queryParam");
+
+     ProxyBeanParam proxy = new ResteasyClientBuilderImpl().build().target(url).proxy(ProxyBeanParam.class);
+     response = proxy.getAll(params, "param2", "queryParam1");
+     Assert.assertEquals("test_param2_param3_queryParam_queryParam1", response);
+
+     ProxyBeanParam mpRestClient = RestClientBuilder.newBuilder().baseUrl(new URL(url)).build(ProxyBeanParam.class);
+     response = mpRestClient.getAll(params, "param2", "queryParam1");
+     Assert.assertEquals("test_param2_param3_queryParam_queryParam1", response);
+   }
 
    /**
     * @tpTestDetails Basic check of new query parameters, matrix parameters, header parameters, cookie parameters and form parameters


### PR DESCRIPTION
Resteasy issue: https://issues.jboss.org/browse/RESTEASY-1955

The verifyInterface() method in MicroprofileClientBuilder didn't take into account that @PathParam's can be also defined in the @BeanParam annotated class. Therefore this PR adds behaviour to populate @PathParam's from the @BeanParam as well in the verifyInterface() method.

Cherrypicked the https://github.com/resteasy/Resteasy/pull/1895 to the master branch as well.