### PR TITLE
[RESTEASY-2181] Unify jboss-logging dependencies among providers

### DIFF
--- a/providers/jackson2/pom.xml
+++ b/providers/jackson2/pom.xml
@@ -67,6 +67,18 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-tracing-api</artifactId>
             <optional>true</optional>

--- a/providers/json-binding/pom.xml
+++ b/providers/json-binding/pom.xml
@@ -49,6 +49,10 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>

--- a/providers/json-p-ee7/pom.xml
+++ b/providers/json-p-ee7/pom.xml
@@ -33,6 +33,18 @@
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+        </dependency>
     </dependencies>
 
 

--- a/providers/resteasy-atom/pom.xml
+++ b/providers/resteasy-atom/pom.xml
@@ -34,6 +34,10 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/RESTEASY-2181

This PR fixes warning because of missing jboss-logging-annotations on the classpath:
```
[INFO] Compiling 8 source files to /home/travis/build/resteasy/Resteasy/providers/jackson2/target/classes
--
[WARNING] bootstrap class path not set in conjunction with -source 8
[WARNING] unknown enum constant org.jboss.logging.annotations.Message.Format.MESSAGE_FORMAT
reason: class file for org.jboss.logging.annotations.Message$Format not found
[WARNING] unknown enum constant org.jboss.logging.annotations.Message.Format.MESSAGE_FORMAT
```

According to jboss logging docs https://jboss-logging.github.io/jboss-logging-tools/ all three dependencies should be declared to function properly so to be consistent I declared them also in other providers if they weren't already there.

One note on code style: jboss-logging-annotations and jboss-logging-processor should be declared as provided, this is accomplished here by declaring them provided in dependency management but I tend to think that explicit declaration as provided in target pom is more mistake-proof. However, I was following the current style.