### PR TITLE
[RESTEASY-2009] Remove duplicated dependencies

### DIFF
--- a/server-adapters/resteasy-undertow-spring/pom.xml
+++ b/server-adapters/resteasy-undertow-spring/pom.xml
@@ -25,14 +25,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-webmvc</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>
@@ -45,10 +39,6 @@
             <artifactId>resteasy-jackson2-provider</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/RESTEASY-2009

This is a follow-up for https://github.com/resteasy/Resteasy/pull/1916 which introduced new warnings into build caused by duplicated dependencies declaration.