### PR TITLE
resteasy-core/MockHttpResponse: Fix charset detection

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/mock/MockHttpResponse.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/mock/MockHttpResponse.java
@@ -23,6 +23,7 @@ import java.util.List;
 public class MockHttpResponse implements HttpResponse
 {
    private static final String CHARSET_PREFIX = "charset=";
+   private static final String PARAMETER_SEPARATOR = ";";
    protected int status;
    protected ByteArrayOutputStream baos = new ByteArrayOutputStream();
    protected OutputStream os = baos;
@@ -89,10 +90,14 @@ public class MockHttpResponse implements HttpResponse
 
       if (value != null && !value.isEmpty())
       {
-         int charsetIndex = value.toLowerCase().indexOf(CHARSET_PREFIX);
-         if (charsetIndex != -1)
+         int charsetStartIndex = value.toLowerCase().indexOf(CHARSET_PREFIX);
+         if (charsetStartIndex != -1)
          {
-            characterEncoding = value.substring(charsetIndex + CHARSET_PREFIX.length());
+            characterEncoding = value.substring(charsetStartIndex + CHARSET_PREFIX.length());
+            int charsetEndIndex = characterEncoding.indexOf(PARAMETER_SEPARATOR);
+            if (charsetEndIndex != -1) {
+               characterEncoding = characterEncoding.substring(0, charsetEndIndex).trim();
+            }
          }
       }
       return characterEncoding;


### PR DESCRIPTION
Given a Content-Type header with additional parameters after the charset
parameter, then the detected charset also contains the other parameters.
For example 'application/json;charset=UTF-8;version=1.0' would lead to a
charset of 'UTF-8;version=1.0'.
This commit fixes this issues by using the semicolon as a separator.