### PR TITLE
[JBEAP-16542,RESTEASY-2157] Resteasy is not able to load the proxy interface

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
@@ -12,12 +12,19 @@ import javax.ws.rs.Path;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.net.URL;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.security.SecureClassLoader;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 public class ProxyBuilder<T>
@@ -82,7 +89,14 @@ public class ProxyBuilder<T>
 		// infrastructure had some problems without this.
 		clientProxy.setClazz(iface);
 
-		return (T) Proxy.newProxyInstance(config.getLoader(), intfs, clientProxy);
+		ClassLoader cl = config.getLoader();
+		try {
+			cl.loadClass(iface.getName());
+		} catch (Throwable t) {
+			cl = new DelegateClassLoader(iface.getClassLoader(), cl);
+		}
+
+		return (T) Proxy.newProxyInstance(cl, intfs, clientProxy);
 	}
 
    private static <T> ClientInvoker createClientInvoker(Class<T> clazz, Method method, ResteasyWebTarget base, ProxyConfig config)
@@ -153,5 +167,107 @@ public class ProxyBuilder<T>
 	}
 
 
+	public static class DelegateClassLoader extends SecureClassLoader
+	{
+		private final ClassLoader delegate;
+
+		private final ClassLoader parent;
+
+		public DelegateClassLoader(final ClassLoader delegate, final ClassLoader parent)
+		{
+			super(parent);
+			this.delegate = delegate;
+			this.parent = parent;
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public Class<?> loadClass(final String className) throws ClassNotFoundException
+		{
+			if (parent != null)
+			{
+				try
+				{
+					return parent.loadClass(className);
+				}
+				catch (ClassNotFoundException cnfe)
+				{
+					//NOOP, use delegate
+				}
+			}
+			return delegate.loadClass(className);
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public URL getResource(final String name)
+		{
+			URL url = null;
+			if (parent != null)
+			{
+				url = parent.getResource(name);
+			}
+			return (url == null) ? delegate.getResource(name) : url;
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public Enumeration<URL> getResources(final String name) throws IOException
+		{
+			final ArrayList<Enumeration<URL>> foundResources = new ArrayList<Enumeration<URL>>();
+
+			foundResources.add(delegate.getResources(name));
+			if (parent != null)
+			{
+				foundResources.add(parent.getResources(name));
+			}
+
+			return new Enumeration<URL>()
+			{
+				private int position = foundResources.size() - 1;
+
+				public boolean hasMoreElements()
+				{
+					while (position >= 0)
+					{
+						if (foundResources.get(position).hasMoreElements())
+						{
+							return true;
+						}
+						position--;
+					}
+					return false;
+				}
+
+				public URL nextElement()
+				{
+					while (position >= 0)
+					{
+						try
+						{
+							return (foundResources.get(position)).nextElement();
+						}
+						catch (NoSuchElementException e)
+						{
+						}
+						position--;
+					}
+					throw new NoSuchElementException();
+				}
+			};
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public InputStream getResourceAsStream(final String name)
+		{
+			InputStream is = null;
+			if (parent != null)
+			{
+				is = parent.getResourceAsStream(name);
+			}
+			return (is == null) ? delegate.getResourceAsStream(name) : is;
+		}
+	}
 
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/ProxyClassloaderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/ProxyClassloaderTest.java
@@ -1,0 +1,49 @@
+package org.jboss.resteasy.test.client.proxy;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.test.client.proxy.resource.ClassloaderResource;
+import org.jboss.resteasy.test.client.proxy.resource.ClientSmokeResource;
+import org.jboss.resteasy.test.core.smoke.resource.ResourceWithInterfaceSimpleClient;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ProxyClassloaderTest
+{
+
+   @Deployment
+   public static Archive<?> deploySimpleResource()
+   {
+      WebArchive war = TestUtil.prepareArchive(ProxyClassloaderTest.class.getSimpleName());
+      war.addClass(ResourceWithInterfaceSimpleClient.class);
+      return TestUtil.finishContainerPrepare(war, null, ClientSmokeResource.class, ClassloaderResource.class);
+   }
+
+   @Test
+   @Ignore("RESTEASY-2157")
+   public void testNoTCCL() throws Exception
+   {
+      ResteasyClient client = (ResteasyClient) ClientBuilder.newClient();
+      String target2 = PortProviderUtil.generateURL("", ProxyClassloaderTest.class.getSimpleName());
+      String target = PortProviderUtil.generateURL("/cl/cl?param=" + target2, ProxyClassloaderTest.class.getSimpleName());
+      Response response = client.target(target).request().get();
+      String entity = response.readEntity(String.class);
+      Assert.assertEquals("basic", entity);
+      response.close();
+      client.close();
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/ProxyClassloaderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/ProxyClassloaderTest.java
@@ -15,7 +15,6 @@ import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -33,7 +32,6 @@ public class ProxyClassloaderTest
    }
 
    @Test
-   @Ignore("RESTEASY-2157")
    public void testNoTCCL() throws Exception
    {
       ResteasyClient client = (ResteasyClient) ClientBuilder.newClient();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ClassloaderResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ClassloaderResource.java
@@ -1,0 +1,43 @@
+package org.jboss.resteasy.test.client.proxy.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.client.ClientBuilder;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl;
+import org.jboss.resteasy.test.core.smoke.resource.ResourceWithInterfaceSimpleClient;
+
+@Path("/cl")
+public class ClassloaderResource
+{
+
+   @GET
+   @Path("cl")
+   @Produces("text/plain")
+   public String test(@QueryParam("param") String targetBase) throws Exception
+   {
+      ClassLoader orig = Thread.currentThread().getContextClassLoader();
+      //create the client...
+      ResteasyClient client = (ResteasyClient) ClientBuilder.newClient();
+      try
+      {
+         //replace the TCCL with the classloader from the resteasy-client module
+         Thread.currentThread().setContextClassLoader(ProxyBuilderImpl.class.getClassLoader());
+         //try building the proxy; the TCCL does not have visibility over the deployment classes
+         ResourceWithInterfaceSimpleClient proxy = client.target(targetBase)
+               .proxyBuilder(ResourceWithInterfaceSimpleClient.class).build();
+
+         return proxy.getBasic();
+      }
+      finally
+      {
+         client.close();
+         //restore original TCCL
+         Thread.currentThread().setContextClassLoader(orig);
+      }
+   }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ClassloaderResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/ClassloaderResource.java
@@ -6,8 +6,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.client.ClientBuilder;
 
+import org.jboss.resteasy.client.jaxrs.ProxyBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
-import org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl;
 import org.jboss.resteasy.test.core.smoke.resource.ResourceWithInterfaceSimpleClient;
 
 @Path("/cl")
@@ -25,7 +25,7 @@ public class ClassloaderResource
       try
       {
          //replace the TCCL with the classloader from the resteasy-client module
-         Thread.currentThread().setContextClassLoader(ProxyBuilderImpl.class.getClassLoader());
+         Thread.currentThread().setContextClassLoader(ProxyBuilder.class.getClassLoader());
          //try building the proxy; the TCCL does not have visibility over the deployment classes
          ResourceWithInterfaceSimpleClient proxy = client.target(targetBase)
                .proxyBuilder(ResourceWithInterfaceSimpleClient.class).build();


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/JBEAP-16542
Upstream Issue: https://issues.jboss.org/browse/RESTEASY-2157
Upstream PR: #1914 

cherry-picked from:
https://github.com/resteasy/Resteasy/commit/80440df6576bf282bd61e6d80eb09b34ee5a9c42
https://github.com/resteasy/Resteasy/commit/7053eddcc5f36d97af4035f91d874509e4fc4938