### PR TITLE
[RESTEASY-2181] Be explicit about non-varargs call

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientWebTarget.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientWebTarget.java
@@ -253,12 +253,12 @@ public class ClientWebTarget implements ResteasyWebTarget
       UriBuilder copy = uriBuilder.clone();
       if (values.length == 1 && values[0] == null)
       {
-         copy.replaceMatrixParam(name, null);
+         copy.replaceMatrixParam(name, (Object[]) null);
       }
       else
       {
          String[] stringValues = toStringValues(values);
-         copy.matrixParam(name, stringValues);
+         copy.matrixParam(name, (Object[]) stringValues);
       }
       return newInstance(client, copy, configuration);
    }
@@ -281,12 +281,12 @@ public class ClientWebTarget implements ResteasyWebTarget
       UriBuilder copy = uriBuilder.clone();
       if (values == null || (values.length == 1 && values[0] == null))
       {
-         copy.replaceQueryParam(name, null);
+         copy.replaceQueryParam(name, (Object[]) null);
       }
       else
       {
          String[] stringValues = toStringValues(values);
-         copy.queryParam(name, stringValues);
+         copy.queryParam(name, (Object[]) stringValues);
       }
       return newInstance(client, copy, configuration);
    }
@@ -300,7 +300,7 @@ public class ClientWebTarget implements ResteasyWebTarget
       for (Map.Entry<String, List<Object>> entry : parameters.entrySet())
       {
          String[] stringValues = toStringValues(entry.getValue().toArray());
-         copy.queryParam(entry.getKey(), stringValues);
+         copy.queryParam(entry.getKey(), (Object[]) stringValues);
       }
       return  newInstance(client, copy, configuration);
    }
@@ -324,7 +324,7 @@ public class ClientWebTarget implements ResteasyWebTarget
          copy = ResteasyUriBuilder.fromTemplate(uriBuilder.toTemplate());
       }
 
-      copy.clientQueryParam(name, stringValues);
+      copy.clientQueryParam(name, (Object[]) stringValues);
       return  newInstance(client, copy, configuration);
    }
 

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/ResteasyUriBuilder.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/ResteasyUriBuilder.java
@@ -108,7 +108,7 @@ public abstract class ResteasyUriBuilder extends UriBuilder
     * instead be treated as literal text". This means that it is an
     * explicit bug to perform contextual URI encoding of this method's
     * name parameter; hence, we must always encode said parameter. This
-    * method also foregoes contextual URI encoding on this method's value
+    * method also foregoes contextual URI encoding on this method's values
     * parameter because it represents arbitrary data passed to a
     * {@code QueryParam} parameter of a client proxy (since the client
     * proxy is nothing more than a transport layer, it should not be
@@ -117,7 +117,7 @@ public abstract class ResteasyUriBuilder extends UriBuilder
     * </ul>
     *
     * @param name  the name of the query parameter.
-    * @param value the value of the query parameter.
+    * @param values the value(s) of the query parameter.
     * @return Returns this instance to allow call chaining.
     */
    public abstract UriBuilder clientQueryParam(String name, Object... values) throws IllegalArgumentException;

--- a/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/ResteasyUriBuilderImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/ResteasyUriBuilderImpl.java
@@ -892,7 +892,7 @@ public class ResteasyUriBuilderImpl extends ResteasyUriBuilder
     * instead be treated as literal text". This means that it is an
     * explicit bug to perform contextual URI encoding of this method's
     * name parameter; hence, we must always encode said parameter. This
-    * method also foregoes contextual URI encoding on this method's value
+    * method also foregoes contextual URI encoding on this method's values
     * parameter because it represents arbitrary data passed to a
     * {@code QueryParam} parameter of a client proxy (since the client
     * proxy is nothing more than a transport layer, it should not be
@@ -901,7 +901,7 @@ public class ResteasyUriBuilderImpl extends ResteasyUriBuilder
     * </ul>
     *
     * @param name  the name of the query parameter.
-    * @param value the value of the query parameter.
+    * @param values the value(s) of the query parameter.
     * @return Returns this instance to allow call chaining.
     */
    @Override

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/ClientFilterResponseBuilderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/ClientFilterResponseBuilderTest.java
@@ -35,7 +35,7 @@ public class ClientFilterResponseBuilderTest {
                 ClientFilterResponseBuilderTest.class.getSimpleName());
         war.addClasses(ResponseBuilderCustomResponseFilter.class,
                 PriorityExecutionResource.class);
-        return TestUtil.finishContainerPrepare(war, null, null);
+        return TestUtil.finishContainerPrepare(war, null);
     }
 
     static Client client;


### PR DESCRIPTION
https://issues.jboss.org/browse/RESTEASY-2181

Fix few calls of methods with varargs which causes compiler warnings for ambiguity. 

I also slightly modified javadoc for used method, but there might be more changes needed (that should have been done with changes in https://issues.jboss.org/browse/RESTEASY-2100) so I may remove these change and address it individually.