### PR TITLE
[RESTEASY-2188] Rely on io.rest-assured:json-path only (we don't need…

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -411,7 +411,7 @@
             </dependency>
             <dependency>
                 <groupId>io.rest-assured</groupId>
-                <artifactId>rest-assured</artifactId>
+                <artifactId>json-path</artifactId>
                 <version>${version.rest-assured}</version>
                 <scope>test</scope>
             </dependency>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -468,7 +468,7 @@
 
         <dependency>
             <groupId>io.rest-assured</groupId>
-            <artifactId>rest-assured</artifactId>
+            <artifactId>json-path</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
… the rest of the rest-assured lib atm)