### PR TITLE
[RESTEASY-1887] Additional JPMS fixes: lefovers of RESTEASY-2185, tra…

### DIFF
--- a/providers/multipart/pom.xml
+++ b/providers/multipart/pom.xml
@@ -46,6 +46,10 @@
             <artifactId>apache-mime4j-storage</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
             <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>

--- a/resteasy-cache/resteasy-cache-core/pom.xml
+++ b/resteasy-cache/resteasy-cache-core/pom.xml
@@ -15,6 +15,12 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.transaction</groupId>
+                    <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.marshalling</groupId>
@@ -24,6 +30,10 @@
         <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>
             <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/resteasy-core-spi/pom.xml
+++ b/resteasy-core-spi/pom.xml
@@ -74,7 +74,7 @@
         <!-- javax.activation.DataSource provider is required by spec -->
         <dependency>
             <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <artifactId>activation</artifactId>
         </dependency>
 
         <!-- 4.0 refactor of apache httpclient -->

--- a/resteasy-core/pom.xml
+++ b/resteasy-core/pom.xml
@@ -80,7 +80,7 @@
         <!-- javax.activation.DataSource provider is required by spec -->
         <dependency>
             <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <artifactId>activation</artifactId>
         </dependency>
 
         <!-- 4.0 refactor of apache httpclient -->

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -31,7 +31,7 @@
         <version.io.netty.netty4>4.1.32.Final</version.io.netty.netty4>
         <version.io.vertx>3.6.2</version.io.vertx>
         <version.io.undertow>2.0.16.Final</version.io.undertow>
-        <version.javax.activation>1.2.0</version.javax.activation>
+        <version.javax.activation>1.1.1</version.javax.activation>
         <version.javax.enterprise.cdi-api>2.0.SP1</version.javax.enterprise.cdi-api>
         <version.javax.interceptor-api>1.0.1.Final</version.javax.interceptor-api>
         <version.javax.json-api>1.1.2</version.javax.json-api>
@@ -307,7 +307,7 @@
 
             <dependency>
                 <groupId>javax.activation</groupId>
-                <artifactId>javax.activation-api</artifactId>
+                <artifactId>activation</artifactId>
                 <version>${version.javax.activation}</version>
             </dependency>
             <dependency>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -69,6 +69,7 @@
         <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.2.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
         <version.org.jboss.spec.javax.xml.bind-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.bind-api_2.3_spec>
         <version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>1.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>
+        <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.1.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
         <version.org.jboss.shrinkwrap.resolver>2.2.4</version.org.jboss.shrinkwrap.resolver>
         <version.microprofile.restclient>1.0.1</version.microprofile.restclient>
         <version.microprofile.config>1.3</version.microprofile.config>
@@ -201,6 +202,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jboss.spec.javax.transaction</groupId>
+                <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                <version>${version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.jboss.spec.javax.ws.rs</groupId>
                 <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
                 <version>${version.javax.ws.rs-api}</version>
@@ -228,6 +235,12 @@
                 <groupId>com.sun.mail</groupId>
                 <artifactId>javax.mail</artifactId>
                 <version>${version.com.sun.mail}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.activation</groupId>
+                        <artifactId>activation</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.stream</groupId>

--- a/resteasy-spring/pom.xml
+++ b/resteasy-spring/pom.xml
@@ -126,7 +126,7 @@
         <!-- javax.activation.DataSource provider is required by spec -->
         <dependency>
             <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <artifactId>activation</artifactId>
         </dependency>
 
         <!-- Used for org.jboss.resteasy.plugins.client.httpclient.* -->

--- a/security/resteasy-crypto/pom.xml
+++ b/security/resteasy-crypto/pom.xml
@@ -69,6 +69,10 @@
             <artifactId>javax.mail</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.james</groupId>
             <artifactId>apache-mime4j-dom</artifactId>
         </dependency>


### PR DESCRIPTION
…nsaction api

As part of this PR's proposal, I'm reverting the changes that Rebecca applied for RESTEASY-2185: the javax.activation-api clearly is an API only subset of activation, but unfortunately the implementation classes are needed too in resteasy-multipart; so when I tried excluding the activation transitive dependency from javax.mail (which was the last remaining JPMS failure for RESTEASY-1887), I started getting NCDFE in resteasy-multipart.
With the changes in the PR I'm able to properly list the modules of a sample client project as per RESTEASY-1887 description.