### PR TITLE
[RESTEASY-2197] Remove dependency to org.jboss.metadata

### DIFF
--- a/testsuite/integration-tests-spring/inmodule/src/test/resources/org/jboss/resteasy/test/spring/inmodule/module/module.xml
+++ b/testsuite/integration-tests-spring/inmodule/src/test/resources/org/jboss/resteasy/test/spring/inmodule/module/module.xml
@@ -62,7 +62,6 @@
         <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.as.web"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.metadata"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.vfs"/>


### PR DESCRIPTION
Remove dependency to "org.jboss.metadata" module from "inmodule" module of ts.

This module was private and have beed removed in [WFLY-11679](https://issues.jboss.org/browse/WFLY-11679).

This module is not necessary for the run of tests in "inmodule" module. All "inmodule" tests passes without "org.jboss.metadata" dependency.

This issue is not valid with WF16 (travis testing), but this issue is valid with latest WF.

---

Jira: https://issues.jboss.org/browse/RESTEASY-2197
Master PR: https://github.com/resteasy/Resteasy/pull/1952