### PR TITLE
Enforce Java 8 for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,6 +375,20 @@
                             </rules>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>use-java-8-for-release</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[1.8,9)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
Enforce Java 8 for release

Bound to deploy phase, but haven't tried as I don't have credentials to deploy.

Please try to deploy a snapshot release with Java 11 if the check kicks in properly.
I tried to bind it to compile phase and it worked well.

I noticed some checks when invoking `mvn deploy`
```
[INFO] --------------< org.jboss.resteasy:resteasy-dependencies >--------------
[INFO] Building RESTEasy dependencies BOM 4.0.0-SNAPSHOT                 [1/57]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M1:enforce (enforce-java-version) @ resteasy-dependencies ---
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M1:enforce (enforce-maven-version) @ resteasy-dependencies ---
...
Return code is: 401, ReasonPhrase: Unauthorized
...
```
These are coming from https://github.com/jboss/jboss-parent-pom/blob/jboss-parent-26/pom.xml#L662
