### PR TITLE
[RESTEASY-1432] - Interface with generic type does not work with client proxy

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/extractors/BodyEntityExtractor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/extractors/BodyEntityExtractor.java
@@ -6,12 +6,14 @@ package org.jboss.resteasy.client.jaxrs.internal.proxy.extractors;
 import org.jboss.resteasy.client.jaxrs.i18n.Messages;
 import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
+import org.jboss.resteasy.spi.util.Types;
 
 import javax.ws.rs.core.GenericType;
 
 import java.io.InputStream;
 import java.io.Reader;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 
 /**
@@ -48,13 +50,13 @@ public class BodyEntityExtractor implements EntityExtractor
          {
             throw new RuntimeException(Messages.MESSAGES.noTypeInformation());
          }
+         Type type = Types.resolveTypeVariables(context.getInvocation().getClientInvoker().getDeclaring(),
+                 method.getGenericReturnType());
          GenericType gt = null;
-         if (method.getGenericReturnType() != null && !(method.getGenericReturnType() instanceof TypeVariable))
-         {
-            gt = new GenericType(method.getGenericReturnType());
-         }
-         else
-         {
+
+         if(!(type instanceof TypeVariable)) {
+            gt = new GenericType(type);
+         } else {
             gt = new GenericType(method.getReturnType());
          }
          Object obj = ClientInvocation.extractResult(gt, response, method.getAnnotations());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/BaseEntity.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/BaseEntity.java
@@ -1,0 +1,13 @@
+package org.jboss.resteasy.test.client.proxy.resource.GenericEntities;
+
+public class BaseEntity {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/EntityExtendingBaseEntity.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/EntityExtendingBaseEntity.java
@@ -1,0 +1,20 @@
+package org.jboss.resteasy.test.client.proxy.resource.GenericEntities;
+
+public class EntityExtendingBaseEntity extends BaseEntity {
+    private String lastName;
+
+    public EntityExtendingBaseEntity() {}
+
+    public EntityExtendingBaseEntity(final String name, final String lastName) {
+        super.setName(name);
+        this.lastName = lastName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/GenericEntityExtendingBaseEntity.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/GenericEntityExtendingBaseEntity.java
@@ -1,0 +1,22 @@
+package org.jboss.resteasy.test.client.proxy.resource.GenericEntities;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+
+@Path("/")
+public interface GenericEntityExtendingBaseEntity<T extends BaseEntity> {
+
+    @GET
+    @Path("one")
+    @Produces(MediaType.APPLICATION_JSON)
+    T findOne();
+
+    @GET
+    @Path("all")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<T> findAll();
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/GenericEntityExtendingBaseEntityProxy.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/GenericEntityExtendingBaseEntityProxy.java
@@ -1,0 +1,6 @@
+package org.jboss.resteasy.test.client.proxy.resource.GenericEntities;
+
+public interface GenericEntityExtendingBaseEntityProxy extends GenericEntityExtendingBaseEntity<EntityExtendingBaseEntity> {
+
+}
+

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/GenericEntityExtendingBaseEntityResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/GenericEntityExtendingBaseEntityResource.java
@@ -1,0 +1,28 @@
+package org.jboss.resteasy.test.client.proxy.resource.GenericEntities;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GenericEntityExtendingBaseEntityResource implements GenericEntityExtendingBaseEntity<EntityExtendingBaseEntity> {
+    public static final String FIRST_NAME = "FirstName";
+    public static final String LAST_NAME = "LastName";
+
+    public static List<EntityExtendingBaseEntity> generateEntities(int count) {
+        List<EntityExtendingBaseEntity> entityExtendingBaseEntities = new ArrayList<>();
+        for(int i = 0; i < count; i++) {
+            entityExtendingBaseEntities.add(new EntityExtendingBaseEntity(FIRST_NAME, LAST_NAME));
+        }
+        return entityExtendingBaseEntities;
+    }
+
+    @Override
+    public List<EntityExtendingBaseEntity> findAll() {
+        return generateEntities(2);
+    }
+
+    @Override
+    public EntityExtendingBaseEntity findOne() {
+        return new EntityExtendingBaseEntity(FIRST_NAME, LAST_NAME);
+    }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/MultipleGenericEntities.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/MultipleGenericEntities.java
@@ -1,0 +1,17 @@
+package org.jboss.resteasy.test.client.proxy.resource.GenericEntities;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.HashMap;
+
+@Path("")
+public interface MultipleGenericEntities<K, V> {
+
+    @GET
+    @Path("hashMap")
+    @Produces(MediaType.APPLICATION_JSON)
+    HashMap<K,V> findHashMap();
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/MultipleGenericEntitiesProxy.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/MultipleGenericEntitiesProxy.java
@@ -1,0 +1,5 @@
+package org.jboss.resteasy.test.client.proxy.resource.GenericEntities;
+
+public interface MultipleGenericEntitiesProxy extends MultipleGenericEntities<String, EntityExtendingBaseEntity> {
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/MultipleGenericEntitiesResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/resource/GenericEntities/MultipleGenericEntitiesResource.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.test.client.proxy.resource.GenericEntities;
+
+import java.util.HashMap;
+
+import static org.jboss.resteasy.test.client.proxy.resource.GenericEntities.GenericEntityExtendingBaseEntityResource.FIRST_NAME;
+import static org.jboss.resteasy.test.client.proxy.resource.GenericEntities.GenericEntityExtendingBaseEntityResource.LAST_NAME;
+
+public class MultipleGenericEntitiesResource implements MultipleGenericEntities<String, EntityExtendingBaseEntity> {
+
+    @Override
+    public HashMap<String, EntityExtendingBaseEntity> findHashMap() {
+        HashMap<String, EntityExtendingBaseEntity> res =  new HashMap<>();
+        res.put(FIRST_NAME, new EntityExtendingBaseEntity(FIRST_NAME, LAST_NAME));
+        return res;
+    }
+}


### PR DESCRIPTION
RESTEASY issue: https://issues.jboss.org/browse/RESTEASY-1432

There was a problem with getting the GenericType from methods inside interfaces which use generics.