### PR TITLE
[RESTEASY-2205] Fix all remaining warnings on build

### DIFF
--- a/profiling-tests/src/test/java/org/jboss/resteasy/test/profiling/InMemoryClientEngine.java
+++ b/profiling-tests/src/test/java/org/jboss/resteasy/test/profiling/InMemoryClientEngine.java
@@ -31,6 +31,7 @@ import org.jboss.resteasy.mock.MockHttpResponse;
 import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
 import org.jboss.resteasy.spi.Registry;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -190,7 +191,7 @@ public class InMemoryClientEngine implements ClientHttpEngine
 
       protected InMemoryClientResponse(final ClientConfiguration configuration, final InputStream is)
       {
-         super(configuration);
+         super(configuration, RESTEasyTracingLogger.empty());
          stream = is;
       }
 

--- a/providers/fastinfoset/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/fastinfoset/FastinfoSetContext.java
+++ b/providers/fastinfoset/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/fastinfoset/FastinfoSetContext.java
@@ -4,7 +4,6 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.Validator;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -49,7 +48,7 @@ public class FastinfoSetContext extends JAXBContext
       return new FastinfoSetMarshaller(context);
    }
 
-   public Validator createValidator() throws JAXBException
+   public javax.xml.bind.Validator createValidator() throws JAXBException
    {
       return context.createValidator();
    }

--- a/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/JAXBContextWrapper.java
+++ b/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/JAXBContextWrapper.java
@@ -14,7 +14,6 @@ import javax.xml.bind.Marshaller;
 import javax.xml.bind.PropertyException;
 import javax.xml.bind.SchemaOutputResolver;
 import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.Validator;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
@@ -311,7 +310,7 @@ public class JAXBContextWrapper extends JAXBContext
     * @see javax.xml.bind.JAXBContext#createValidator()
     * @deprecated See javax.xml.bind.JAXBContext#createValidator().
     */
-   public Validator createValidator() throws JAXBException
+   public javax.xml.bind.Validator createValidator() throws JAXBException
    {
       return wrappedContext.createValidator();
    }

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestFacadeLinks.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestFacadeLinks.java
@@ -18,6 +18,7 @@ import org.jboss.resteasy.links.RESTServiceDiscovery;
 import org.jboss.resteasy.links.RESTServiceDiscovery.AtomLink;
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -69,7 +70,7 @@ public class TestFacadeLinks
 
    @Before
    public void before(){
-      POJOResourceFactory noDefaults = new POJOResourceFactory(resourceType);
+      POJOResourceFactory noDefaults = new POJOResourceFactory(new ResourceBuilder(), resourceType);
       dispatcher.getRegistry().addResourceFactory(noDefaults);
       httpClient = HttpClientBuilder.create().build();
       ApacheHttpClientEngine engine = ApacheHttpClientEngine.create(httpClient);

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestLinkIds.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestLinkIds.java
@@ -16,6 +16,7 @@ import org.jboss.resteasy.links.RESTServiceDiscovery;
 import org.jboss.resteasy.links.RESTServiceDiscovery.AtomLink;
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -37,7 +38,7 @@ public class TestLinkIds
       server.setRootResourcePath("/");
       server.start();
       dispatcher = server.getDeployment().getDispatcher();
-      POJOResourceFactory noDefaults = new POJOResourceFactory(IDServiceTestBean.class);
+      POJOResourceFactory noDefaults = new POJOResourceFactory(new ResourceBuilder(), IDServiceTestBean.class);
       dispatcher.getRegistry().addResourceFactory(noDefaults);
       httpClient = HttpClientBuilder.create().build();
       ApacheHttpClientEngine engine = ApacheHttpClientEngine.create(httpClient);

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestLinks.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestLinks.java
@@ -18,6 +18,7 @@ import org.jboss.resteasy.links.RESTServiceDiscovery;
 import org.jboss.resteasy.links.RESTServiceDiscovery.AtomLink;
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -68,7 +69,7 @@ public class TestLinks
 
    @Before
    public void before(){
-      POJOResourceFactory noDefaults = new POJOResourceFactory(resourceType);
+      POJOResourceFactory noDefaults = new POJOResourceFactory(new ResourceBuilder(), resourceType);
       dispatcher.getRegistry().addResourceFactory(noDefaults);
       httpClient = HttpClientBuilder.create().build();
       ApacheHttpClientEngine engine = ApacheHttpClientEngine.create(httpClient);

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestSecureLinks.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestSecureLinks.java
@@ -31,6 +31,7 @@ import org.jboss.resteasy.plugins.server.embedded.SecurityDomain;
 import org.jboss.resteasy.plugins.server.embedded.SimplePrincipal;
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -97,7 +98,7 @@ public class TestSecureLinks
 
    @Before
    public void before(){
-      POJOResourceFactory noDefaults = new POJOResourceFactory(resourceType);
+      POJOResourceFactory noDefaults = new POJOResourceFactory(new ResourceBuilder(), resourceType);
       dispatcher.getRegistry().addResourceFactory(noDefaults);
       url = generateBaseUrl();
 

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/el/TestLinksInvalidEL.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/el/TestLinksInvalidEL.java
@@ -19,6 +19,7 @@ import org.jboss.resteasy.spi.Dispatcher;
 import org.jboss.resteasy.links.test.BookStoreService;
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -74,7 +75,7 @@ public class TestLinksInvalidEL
 
    @Before
    public void before(){
-      POJOResourceFactory noDefaults = new POJOResourceFactory(resourceType);
+      POJOResourceFactory noDefaults = new POJOResourceFactory(new ResourceBuilder(), resourceType);
       dispatcher.getRegistry().addResourceFactory(noDefaults);
       httpClient = HttpClientBuilder.create().build();
       ApacheHttpClient43Engine engine = new ApacheHttpClient43Engine(httpClient);

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/el/TestLinksNoPackage.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/el/TestLinksNoPackage.java
@@ -20,6 +20,7 @@ import org.jboss.resteasy.links.test.Book;
 import org.jboss.resteasy.links.test.BookStoreService;
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -74,7 +75,7 @@ public class TestLinksNoPackage
 
    @Before
    public void before(){
-      POJOResourceFactory noDefaults = new POJOResourceFactory(resourceType);
+      POJOResourceFactory noDefaults = new POJOResourceFactory(new ResourceBuilder(), resourceType);
       dispatcher.getRegistry().addResourceFactory(noDefaults);
       httpClient = HttpClientBuilder.create().build();
       ApacheHttpClient43Engine engine = new ApacheHttpClient43Engine(httpClient);

--- a/server-adapters/resteasy-netty4-cdi/src/test/java/org/jboss/resteasy/plugins/server/netty/cdi/SeCdiNettyTest.java
+++ b/server-adapters/resteasy-netty4-cdi/src/test/java/org/jboss/resteasy/plugins/server/netty/cdi/SeCdiNettyTest.java
@@ -37,6 +37,7 @@ public class SeCdiNettyTest {
             .addClasses(EchoResource.class, DefaultExceptionMapper.class);
    }
 
+   @SuppressWarnings("unchecked")
    @Before
    public void init() {
       while (port < 8000)

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter.java
@@ -37,8 +37,7 @@ public abstract class AsyncResponseFilter implements ContainerResponseFilter {
       for (Entry<String, List<String>> entry : requestContext.getHeaders().entrySet())
       {
          if(entry.getKey().startsWith("RequestFilterCallback"))
-            // cast required to disambiguate with Object... method
-            responseContext.getHeaders().addAll(entry.getKey(), (List)entry.getValue());
+            addValuesToContext(responseContext, entry);
       }
       responseContext.getHeaders().add("ResponseFilterCallback"+name, String.valueOf(callbackException));
       callbackException = null;
@@ -112,5 +111,12 @@ public abstract class AsyncResponseFilter implements ContainerResponseFilter {
          });
       }
       LOG.error("Filter response for "+name+" with action: "+action+" done");
+   }
+
+   @SuppressWarnings("unchecked")
+   private void addValuesToContext(ContainerResponseContext responseContext, Entry<String, List<String>> entry)
+   {
+      // cast required to disambiguate with Object... method
+      responseContext.getHeaders().addAll(entry.getKey(), (List)entry.getValue());
    }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/resource/resteasy1082/FooResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/resource/resteasy1082/FooResource.java
@@ -21,7 +21,7 @@ public class FooResource {
    @GET
    @Produces({"application/json"})
    public List<String> getAll() {
-      List<String> data = new ArrayList();
+      List<String> data = new ArrayList<>();
 
       for(int i = 0; i < 10; ++i) {
          data.add(UUID.randomUUID().toString());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/resource/resteasy1082/TestApplication.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/resource/resteasy1082/TestApplication.java
@@ -11,7 +11,7 @@ public class TestApplication extends Application {
    }
 
    public Set<Class<?>> getClasses() {
-      HashSet<Class<?>> classes = new HashSet();
+      HashSet<Class<?>> classes = new HashSet<>();
       classes.add(FooResource.class);
       return classes;
    }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/RxInvokerTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/RxInvokerTest.java
@@ -137,6 +137,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientGet(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientGet(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -157,6 +158,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientGetClass(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientGetClass(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -175,6 +177,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientGetGenericType(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientGetGenericType(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -193,6 +196,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientPut(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientPut(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -212,6 +216,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientPutClass(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientPutClass(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -231,6 +236,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientPutGenericType(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientPutGenericType(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -250,6 +256,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientPost(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientPost(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -269,6 +276,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientPostClass(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientPostClass(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -288,6 +296,7 @@ public class RxInvokerTest extends ClientTestBase
       dotestRxClientPostGenericType(true);
    }
 
+   @SuppressWarnings("unchecked")
    void dotestRxClientPostGenericType(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -307,6 +316,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientDelete(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientDelete(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -326,6 +336,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientDeleteClass(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientDeleteClass(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -344,6 +355,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientDeleteGenericType(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientDeleteGenericType(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -362,6 +374,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientHead(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientHead(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -382,6 +395,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientOptions(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientOptions(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -401,6 +415,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientOptionsClass(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientOptionsClass(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -419,6 +434,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientOptionsGenericType(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientOptionsGenericType(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -437,6 +453,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientTrace(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientTrace(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -456,6 +473,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientTraceClass(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientTraceClass(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -474,6 +492,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientTraceGenericType(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientTraceGenericType(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -492,6 +511,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientMethod(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientMethod(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -511,6 +531,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientMethodClass(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientMethodClass(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -529,6 +550,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientMethodGenericType(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientMethodGenericType(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -547,6 +569,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientMethodEntity(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientMethodEntity(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -566,6 +589,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientMethodClassEntity(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientMethodClassEntity(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -585,6 +609,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestRxClientMethodGenericTypeEntity(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestRxClientMethodGenericTypeEntity(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);
@@ -610,6 +635,7 @@ public class RxInvokerTest extends ClientTestBase
       doTestGetDataWithDelay(true);
    }
 
+   @SuppressWarnings("unchecked")
    void doTestGetDataWithDelay(boolean useCustomInvoker) throws Exception
    {
       final Client client = newClient(useCustomInvoker);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jaxb/resource/HomecontrolCustomJAXBContext.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jaxb/resource/HomecontrolCustomJAXBContext.java
@@ -6,7 +6,6 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.Validator;
 
 public class HomecontrolCustomJAXBContext extends JAXBContext {
 
@@ -33,8 +32,9 @@ public class HomecontrolCustomJAXBContext extends JAXBContext {
       return this.delegate.createMarshaller();
    }
 
+   @SuppressWarnings("deprecation")
    @Override
-   public Validator createValidator() throws JAXBException {
+   public javax.xml.bind.Validator createValidator() throws JAXBException {
       return this.delegate.createValidator();
    }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcasterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcasterTest.java
@@ -244,6 +244,7 @@ public class SseBroadcasterTest
       }
    }
 
+   @SuppressWarnings("unchecked")
    private ConcurrentLinkedQueue<SseEventSink> getOutputQueue(SseBroadcasterImpl sseBroadcasterImpl) throws NoSuchFieldException, IllegalAccessException {
       Field fld = SseBroadcasterImpl.class.getDeclaredField("outputQueue");
       fld.setAccessible(true);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/ResponseHeaderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/ResponseHeaderTest.java
@@ -55,10 +55,9 @@ public class ResponseHeaderTest {
               ResponseHeaderTest.class.getSimpleName()));
       Response response = base.request().get();
       MultivaluedMap<String, Object> headers = response.getHeaders();
-      Object obj = headers.get("Server");
+      List<Object> objs = headers.get("Server");
 
-      if (obj instanceof ArrayList) {
-         List<Object> objs = (List<Object>)obj;
+      if (objs instanceof ArrayList) {
          if (objs.size() != 2) {
             Assert.fail("2 array objects expected " + objs.size() + " were returned");
          }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/rx/resource/RxCompletionStageResourceImpl.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/rx/resource/RxCompletionStageResourceImpl.java
@@ -166,6 +166,7 @@ public class RxCompletionStageResourceImpl {
       throw new TestException("handled");
    }
 
+   @SuppressWarnings("unchecked")
    @FilterException
    @GET
    @Path("exception/filter")

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/tracing/JsonFormattedTracingInfoTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/tracing/JsonFormattedTracingInfoTest.java
@@ -1,11 +1,11 @@
 package org.jboss.resteasy.test.tracing;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.tracing.api.RESTEasyTracing;
-import org.jboss.resteasy.tracing.api.RESTEasyTracingMessage;
 import org.jboss.resteasy.spi.HttpResponseCodes;
+import org.jboss.resteasy.tracing.api.RESTEasyTracing;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -23,10 +23,7 @@ public class JsonFormattedTracingInfoTest extends BasicTracingTest {
 
    @Test
    @OperateOnDeployment(WAR_BASIC_TRACING_FILE)
-//    @Category({ExpectedFailingOnWildFly11.class,
-//            ExpectedFailingOnWildFly12.class,})
-   public void testJsonTracing() throws Exception {
-//        Thread.currentThread().join();
+   public void testJsonTracing() {
 
       String url = generateURL("/logger", WAR_BASIC_TRACING_FILE);
       WebTarget base = client.target(url);
@@ -37,16 +34,17 @@ public class JsonFormattedTracingInfoTest extends BasicTracingTest {
          Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
          boolean hasTracing = false;
          for (Map.Entry entry : response.getStringHeaders().entrySet()) {
-//                System.out.println("<K, V> ->" + entry);
             if (entry.getKey().toString().startsWith(RESTEasyTracing.HEADER_TRACING_PREFIX)) {
                hasTracing = true;
                String jsonText = entry.getValue().toString();
                ObjectMapper objectMapper = new ObjectMapper();
 
-               List<RESTEasyTracingMessage> messageList = objectMapper.readValue(jsonText, List.class);
+               TypeReference<List<List<Map<String, String>>>> jsonTraceMsgsListTypeRef =
+                     new TypeReference<List<List<Map<String, String>>>>() {};
+               List<List<Map>> messageList = objectMapper.readValue(jsonText, jsonTraceMsgsListTypeRef);
                assertNotNull(messageList);
                assertNotNull(messageList.get(0));
-               List<Map> list = (List<Map>) messageList.get(0);
+               List<Map> list = messageList.get(0);
 
                String[] keys = {"requestId", "duration", "text", "event", "timestamp"};
                for (Map map : list) {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/tracing/TracingApp.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/tracing/TracingApp.java
@@ -13,7 +13,7 @@ public class TracingApp extends Application {
 
    @Override
    public Set<Class<?>> getClasses() {
-      Set set = new HashSet<Class<?>>();
+      Set<Class<?>> set = new HashSet<>();
       set.add(HttpMethodOverride.class);
       set.add(GZIPEncodingInterceptor.class);
       set.add(GZIPDecodingInterceptor.class);
@@ -22,7 +22,7 @@ public class TracingApp extends Application {
 
    @Override
    public Set<Object> getSingletons() {
-      Set set = new HashSet<Class<?>>();
+      Set<Object> set = new HashSet<>();
       set.add(new TracingConfigResource());
       set.add(new FooLocator());
       return set;

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/ProgammaticTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/ProgammaticTest.java
@@ -54,7 +54,7 @@ public class ProgammaticTest {
       Field configurable = ProgrammaticResource.class.getDeclaredField("configurable");
       Constructor<?> constructor = ProgrammaticResource.class.getConstructor(Configurable.class);
 
-      ResourceClass resourceclass = ResourceBuilder.rootResource(ProgrammaticResource.class)
+      ResourceClass resourceclass = new ResourceBuilder().buildRootResource(ProgrammaticResource.class)
               .constructor(constructor).param(0).context().buildConstructor()
               .method(get).get().path("test").produces("text/plain").param(0).queryParam("a").buildMethod()
               .method(put).put().path("test").consumes("text/plain").param(0).messageBody().buildMethod()
@@ -89,7 +89,7 @@ public class ProgammaticTest {
       Field uriInfo = ProgrammaticResource.class.getDeclaredField("uriInfo");
       Field configurable = ProgrammaticResource.class.getDeclaredField("configurable");
 
-      ResourceClass resourceclass = ResourceBuilder.rootResource(ProgrammaticResource.class)
+      ResourceClass resourceclass = new ResourceBuilder().buildRootResource(ProgrammaticResource.class)
             .method(get).get().path("test").produces("text/plain").param(0).queryParam("a").buildMethod()
             .field(uriInfo).context().buildField()
             .field(configurable).context().buildField()
@@ -119,7 +119,7 @@ public class ProgammaticTest {
       Field configurable = ProgrammaticResource.class.getDeclaredField("configurable");
       Constructor<?> constructor = ProgrammaticResource.class.getConstructor(Configurable.class);
 
-      ResourceClass resourceclass = ResourceBuilder.rootResource(ProgrammaticResource.class)
+      ResourceClass resourceclass = new ResourceBuilder().buildRootResource(ProgrammaticResource.class)
               .constructor(constructor).param(0).context().buildConstructor()
               .method(get).get().path("test").produces("text/html;charset=UTF-16").param(0).queryParam("a").buildMethod()
               .field(uriInfo).context().buildField()


### PR DESCRIPTION
https://issues.jboss.org/browse/RESTEASY-2205

This PR removes all compilation warnings on build of the project.

The change with javax.xml.bind.Validator is a workaround for JDK bug https://bugs.openjdk.java.net/browse/JDK-8042566

To get rid of warnings in JsonFormattedTracingInfoTest I had to fix the test itself as it was trying to map json directly to list of RESTEasyTracingMessage but then expecting list of list of maps.