### PR TITLE
[RESTEASY-2211] Explicitly close the JsonParser instances, as that ev…

### DIFF
--- a/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/ResteasyJackson2Provider.java
+++ b/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/ResteasyJackson2Provider.java
@@ -122,9 +122,13 @@ public class ResteasyJackson2Provider extends JacksonJaxbJsonProvider
       final ObjectReader reader = endpoint.getReader();
       final JsonParser jp = _createParser(reader, entityStream);
       // If null is returned, considered to be empty stream
-      if (jp == null || jp.nextToken() == null) {
+      if (jp == null) {
+         return null;
+      } else if (jp.nextToken() == null) {
+         jp.close();
          return null;
       }
+
       // [Issue#1]: allow 'binding' to JsonParser
       if (((Class<?>) type) == JsonParser.class) {
          return jp;
@@ -144,6 +148,8 @@ public class ResteasyJackson2Provider extends JacksonJaxbJsonProvider
          }
       } catch (PrivilegedActionException pae) {
          throw new IOException(pae);
+      } finally {
+         jp.close();
       }
       return result;
    }


### PR DESCRIPTION
…entually results in ByteBufferRecycler#releaseByteBuffer(..) being invoked for the byte buffer used for reading the JSON text stream; as a consequence, the previously allocated memory for such buffer will re-used next time the same thread needs to process another stream.