### PR TITLE
[RESTEASY-1404] Fix - create the builder using the JAX-RS API instead of ResteasyClientBuilderImpl

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithCorrectCertificateTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithCorrectCertificateTest.java
@@ -6,7 +6,6 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.jboss.resteasy.test.security.resource.CustomTrustManager;
 import org.jboss.resteasy.test.security.resource.SslResource;
 import org.jboss.resteasy.utils.TestUtil;
@@ -29,6 +28,7 @@ import java.security.cert.CertificateException;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
 import static org.jboss.resteasy.test.ContainerConstants.SSL_CONTAINER_PORT_OFFSET;
@@ -91,7 +91,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test
    public void testTrustedServer() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       client = resteasyClientBuilder.trustStore(correctTruststore).build();
@@ -108,7 +108,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test(expected = ProcessingException.class)
    public void testUntrustedServer() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       client = resteasyClientBuilder.trustStore(differentTruststore).build();
@@ -123,7 +123,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test(expected = ProcessingException.class)
    public void testClientWithoutTruststore() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       client = resteasyClientBuilder.build();
@@ -138,7 +138,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test
    public void testCustomSSLContext() throws Exception {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       SSLContext sslContext = SSLContext.getInstance("TLS");
@@ -159,7 +159,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test
    public void testHostnameVerificationPolicyStrict() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.STRICT);
@@ -179,7 +179,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test(expected = ProcessingException.class)
    public void testHostnameVerificationPolicyAny() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.ANY);
@@ -197,7 +197,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test
    public void testDisableTrustManager() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder = resteasyClientBuilder.disableTrustManager();
@@ -216,7 +216,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test
    public void testIsTrustSelfSignedCertificatesDefault() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
 
       client = resteasyClientBuilder.trustStore(differentTruststore).build();
       Response response = client.target(URL).request().get();
@@ -232,7 +232,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test
    public void testIsTrustSelfSignedCertificatesTrue() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(true);
 
       client = resteasyClientBuilder.trustStore(differentTruststore).build();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithWildcardHostnameCertificateTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithWildcardHostnameCertificateTest.java
@@ -6,7 +6,6 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.jboss.resteasy.test.security.resource.SslResource;
 import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
@@ -27,6 +26,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
 import static org.jboss.resteasy.test.ContainerConstants.SSL_CONTAINER_PORT_OFFSET_WILDCARD;
@@ -83,7 +83,7 @@ public class SslServerWithWildcardHostnameCertificateTest extends SslTestBase {
     */
    @Test
    public void testHostnameVerificationPolicyWildcard() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.WILDCARD);
@@ -104,7 +104,7 @@ public class SslServerWithWildcardHostnameCertificateTest extends SslTestBase {
    @Test(expected = ProcessingException.class)
    @Ignore("RESTEASY-2176")
    public void testHostnameVerificationPolicyStrict() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.STRICT);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithWrongHostnameCertificateTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithWrongHostnameCertificateTest.java
@@ -6,7 +6,6 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.jboss.resteasy.test.security.resource.SslResource;
 import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
@@ -27,6 +26,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import javax.net.ssl.HostnameVerifier;
 import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
 import static org.jboss.resteasy.test.ContainerConstants.SSL_CONTAINER_PORT_OFFSET_WRONG;
@@ -83,7 +83,7 @@ public class SslServerWithWrongHostnameCertificateTest extends SslTestBase {
     */
    @Test(expected = ProcessingException.class)
    public void testHostnameVerificationPolicyStrict() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.STRICT);
@@ -101,7 +101,7 @@ public class SslServerWithWrongHostnameCertificateTest extends SslTestBase {
     */
    @Test(expected = ProcessingException.class)
    public void testHostnameVerificationPolicyWildcard() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.WILDCARD);
@@ -119,7 +119,7 @@ public class SslServerWithWrongHostnameCertificateTest extends SslTestBase {
     */
    @Test
    public void testHostnameVerificationPolicyAny() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.ANY);
@@ -140,7 +140,7 @@ public class SslServerWithWrongHostnameCertificateTest extends SslTestBase {
     */
    @Test
    public void testCustomHostnameVerifier() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       HostnameVerifier hostnameVerifier = (s, sslSession) -> s.equals(HOSTNAME);
@@ -161,7 +161,7 @@ public class SslServerWithWrongHostnameCertificateTest extends SslTestBase {
     */
    @Test
    public void testCustomHostnameVerifierAcceptAll() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       HostnameVerifier acceptAll = (hostname, session) -> true;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithoutCertificateTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithoutCertificateTest.java
@@ -4,7 +4,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.security.resource.SslResource;
 import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
@@ -23,6 +23,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
 /**
@@ -64,7 +65,7 @@ public class SslServerWithoutCertificateTest extends SslTestBase {
     */
    @Test(expected = ProcessingException.class)
    public void testServerWithoutCertificate() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       client = resteasyClientBuilder.trustStore(truststore).build();
@@ -79,7 +80,7 @@ public class SslServerWithoutCertificateTest extends SslTestBase {
     */
    @Test
    public void testServerWithoutCertificateDisabledTrustManager() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder = resteasyClientBuilder.disableTrustManager();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslSniHostNamesTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslSniHostNamesTest.java
@@ -6,7 +6,7 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.category.ExpectedFailingOnWildFly14;
-import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.security.resource.SslResource;
 import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
@@ -30,6 +30,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
 import static org.jboss.resteasy.test.ContainerConstants.SSL_CONTAINER_PORT_OFFSET_SNI;
@@ -88,7 +89,7 @@ public class SslSniHostNamesTest extends SslTestBase {
     */
    @Test(expected = ProcessingException.class)
    public void testException() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       client = resteasyClientBuilder.trustStore(truststore).build();
@@ -103,7 +104,7 @@ public class SslSniHostNamesTest extends SslTestBase {
     */
    @Test
    public void test() {
-      resteasyClientBuilder = new ResteasyClientBuilderImpl();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.sniHostNames(HOSTNAME);


### PR DESCRIPTION
Minor fix for RESTEASY-1404

Jira: https://issues.jboss.org/browse/RESTEASY-1404
3.7: https://github.com/resteasy/Resteasy/pull/1976