### PR TITLE
[RESTEASY-1404] Fix - create the builder using the JAX-RS API instead of ResteasyClientBuilderImpl

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithCorrectCertificateTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithCorrectCertificateTest.java
@@ -27,6 +27,7 @@ import java.security.cert.CertificateException;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
 import static org.jboss.resteasy.test.ContainerConstants.SSL_CONTAINER_PORT_OFFSET;
@@ -87,7 +88,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test
    public void testTrustedServer() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       client = resteasyClientBuilder.trustStore(correctTruststore).build();
@@ -104,7 +105,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test(expected = ProcessingException.class)
    public void testUntrustedServer() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       client = resteasyClientBuilder.trustStore(differentTruststore).build();
@@ -119,7 +120,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test(expected = ProcessingException.class)
    public void testClientWithoutTruststore() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       client = resteasyClientBuilder.build();
@@ -134,7 +135,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test
    public void testCustomSSLContext() throws Exception {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       SSLContext sslContext = SSLContext.getInstance("TLS");
@@ -155,7 +156,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test
    public void testHostnameVerificationPolicyStrict() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.STRICT);
@@ -175,7 +176,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test(expected = ProcessingException.class)
    public void testHostnameVerificationPolicyAny() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.ANY);
@@ -193,7 +194,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test
    public void testDisableTrustManager() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder = resteasyClientBuilder.disableTrustManager();
@@ -212,7 +213,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test
    public void testIsTrustSelfSignedCertificatesDefault() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
 
       client = resteasyClientBuilder.trustStore(differentTruststore).build();
       Response response = client.target(URL).request().get();
@@ -228,7 +229,7 @@ public class SslServerWithCorrectCertificateTest extends SslTestBase {
     */
    @Test
    public void testIsTrustSelfSignedCertificatesTrue() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(true);
 
       client = resteasyClientBuilder.trustStore(differentTruststore).build();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithWildcardHostnameCertificateTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithWildcardHostnameCertificateTest.java
@@ -25,6 +25,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
 import static org.jboss.resteasy.test.ContainerConstants.SSL_CONTAINER_PORT_OFFSET_WILDCARD;
@@ -79,7 +80,7 @@ public class SslServerWithWildcardHostnameCertificateTest extends SslTestBase {
     */
    @Test
    public void testHostnameVerificationPolicyWildcard() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.WILDCARD);
@@ -100,7 +101,7 @@ public class SslServerWithWildcardHostnameCertificateTest extends SslTestBase {
    @Test(expected = ProcessingException.class)
    @Ignore("RESTEASY-2176")
    public void testHostnameVerificationPolicyStrict() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.STRICT);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithWrongHostnameCertificateTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithWrongHostnameCertificateTest.java
@@ -25,6 +25,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import javax.net.ssl.HostnameVerifier;
 import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
 import static org.jboss.resteasy.test.ContainerConstants.SSL_CONTAINER_PORT_OFFSET_WRONG;
@@ -79,7 +80,7 @@ public class SslServerWithWrongHostnameCertificateTest extends SslTestBase {
     */
    @Test(expected = ProcessingException.class)
    public void testHostnameVerificationPolicyStrict() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.STRICT);
@@ -97,7 +98,7 @@ public class SslServerWithWrongHostnameCertificateTest extends SslTestBase {
     */
    @Test(expected = ProcessingException.class)
    public void testHostnameVerificationPolicyWildcard() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.WILDCARD);
@@ -115,7 +116,7 @@ public class SslServerWithWrongHostnameCertificateTest extends SslTestBase {
     */
    @Test
    public void testHostnameVerificationPolicyAny() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.ANY);
@@ -136,7 +137,7 @@ public class SslServerWithWrongHostnameCertificateTest extends SslTestBase {
     */
    @Test
    public void testCustomHostnameVerifier() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       HostnameVerifier hostnameVerifier = (s, sslSession) -> s.equals(HOSTNAME);
@@ -157,7 +158,7 @@ public class SslServerWithWrongHostnameCertificateTest extends SslTestBase {
     */
    @Test
    public void testCustomHostnameVerifierAcceptAll() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       HostnameVerifier acceptAll = (hostname, session) -> true;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithoutCertificateTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslServerWithoutCertificateTest.java
@@ -22,6 +22,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
 /**
@@ -61,7 +62,7 @@ public class SslServerWithoutCertificateTest extends SslTestBase {
     */
    @Test(expected = ProcessingException.class)
    public void testServerWithoutCertificate() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       client = resteasyClientBuilder.trustStore(truststore).build();
@@ -76,7 +77,7 @@ public class SslServerWithoutCertificateTest extends SslTestBase {
     */
    @Test
    public void testServerWithoutCertificateDisabledTrustManager() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder = resteasyClientBuilder.disableTrustManager();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslSniHostNamesTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SslSniHostNamesTest.java
@@ -29,6 +29,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
 import static org.jboss.resteasy.test.ContainerConstants.SSL_CONTAINER_PORT_OFFSET_SNI;
@@ -85,7 +86,7 @@ public class SslSniHostNamesTest extends SslTestBase {
     */
    @Test(expected = ProcessingException.class)
    public void testException() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       client = resteasyClientBuilder.trustStore(truststore).build();
@@ -100,7 +101,7 @@ public class SslSniHostNamesTest extends SslTestBase {
     */
    @Test
    public void test() {
-      resteasyClientBuilder = new ResteasyClientBuilder();
+      resteasyClientBuilder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
       resteasyClientBuilder.setIsTrustSelfSignedCertificates(false);
 
       resteasyClientBuilder.sniHostNames(HOSTNAME);


### PR DESCRIPTION
Minor fix for RESTEASY-1404

Jira: https://issues.jboss.org/browse/RESTEASY-1404
Master: https://github.com/resteasy/Resteasy/pull/1975