### PR TITLE
ResteasyJackson2Provider: fix ConcurrentHashMap contention

### DIFF
--- a/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/ResteasyJackson2Provider.java
+++ b/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/ResteasyJackson2Provider.java
@@ -9,6 +9,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.ws.rs.Consumes;
@@ -30,7 +31,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.jaxrs.cfg.AnnotationBundleKey;
 import com.fasterxml.jackson.jaxrs.cfg.ObjectWriterInjector;
 import com.fasterxml.jackson.jaxrs.cfg.ObjectWriterModifier;
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
@@ -69,13 +69,13 @@ public class ResteasyJackson2Provider extends JacksonJaxbJsonProvider
 
    private static class ClassAnnotationKey
    {
-      private AnnotationBundleKey annotations;
+      private AnnotationArrayKey annotations;
       private ClassKey classKey;
       private int hash;
 
       private ClassAnnotationKey(final Class<?> clazz, final Annotation[] annotations)
       {
-         this.annotations = new AnnotationBundleKey(annotations, AnnotationBundleKey.class);
+         this.annotations = new AnnotationArrayKey(annotations);
          this.classKey = new ClassKey(clazz);
          hash = this.annotations.hashCode();
          hash = 31 * hash + classKey.hashCode();
@@ -99,6 +99,48 @@ public class ResteasyJackson2Provider extends JacksonJaxbJsonProvider
       public int hashCode()
       {
          return hash;
+      }
+   }
+
+   // Alternative to Jackson's AnnotationBundleKey that uses object equality
+   // instead of referential equality (==) due to how parameter annotations are proxied and not cached.
+   private static class AnnotationArrayKey
+   {
+      private static final Annotation[] NO_ANNOTATIONS = new Annotation[0];
+
+      private final Annotation[] annotations;
+      private final int hash;
+
+      private AnnotationArrayKey(final Annotation[] annotations)
+      {
+         if (annotations == null || annotations.length == 0) {
+            this.annotations = NO_ANNOTATIONS;
+         } else {
+            this.annotations = annotations;
+         }
+         this.hash = calcHash(this.annotations);
+      }
+
+      private static int calcHash(Annotation[] annotations)
+      {
+         int result = annotations.length;
+         result = 31 * result + Arrays.hashCode(annotations);
+         return result;
+      }
+
+      @Override
+      public int hashCode()
+      {
+         return hash;
+      }
+
+      @Override
+      public boolean equals(Object object)
+      {
+         if (this == object) return true;
+         if (object == null || getClass() != object.getClass()) return false;
+         AnnotationArrayKey that = (AnnotationArrayKey) object;
+         return hash == that.hash && java.util.Arrays.equals(annotations, that.annotations);
       }
    }
 


### PR DESCRIPTION
Master version of #1984 

Replace Jackson's AnnotationBundleKey with an implementation that uses `.equals()` instead of `==` to compare annotations. AnnotationBundleKey assumed annotation references were unique which breaks because the JRE doesn't cache parameter annotations, returning new references each time parameter annotations are queried. This was causing a severe performance degradation over time since matching ClassAnnotationKey instances had the same `hashCode` while failing equality checks, leading to a large and growing single bucket with identical objects and lock contention.