### PR TITLE
Remove unnecessary and dangerous ArrayList cast

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/interceptors/MessageSanitizerContainerResponseFilter.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/interceptors/MessageSanitizerContainerResponseFilter.java
@@ -1,7 +1,7 @@
 package org.jboss.resteasy.plugins.interceptors;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.HashMap;
 
 import javax.annotation.Priority;
@@ -43,7 +43,7 @@ public class MessageSanitizerContainerResponseFilter implements ContainerRespons
       if (HttpResponseCodes.SC_BAD_REQUEST == responseContext.getStatus()) {
          Object entity = responseContext.getEntity();
          if (entity != null && entity instanceof String) {
-            ArrayList<Object> contentTypes = (ArrayList<Object>)responseContext.getHeaders().get("Content-Type");
+            List<Object> contentTypes = responseContext.getHeaders().get("Content-Type");
             if (contentTypes != null  && containsHtmlText(contentTypes)) {
                String escapedMsg = escapeXml((String) entity);
                responseContext.setEntity(escapedMsg);
@@ -88,7 +88,7 @@ public class MessageSanitizerContainerResponseFilter implements ContainerRespons
       return sb.toString();
    }
 
-   private boolean containsHtmlText(ArrayList<Object> list) {
+   private boolean containsHtmlText(List<Object> list) {
       for (Object o :list) {
          if (o instanceof MediaType && MediaType.TEXT_HTML_TYPE.isCompatible((MediaType) o)) {
             return true;


### PR DESCRIPTION
Please consider picking this into 4.0.0.Final -- we are encountering this exception with 4.0.0.CR2.  Thanks!

```
java.lang.ClassCastException: class java.util.LinkedList cannot be cast to class java.util.ArrayList (java.util.LinkedList and java.util.ArrayList are in module java.base of loader 'bootstrap')
at org.jboss.resteasy.plugins.interceptors.MessageSanitizerContainerResponseFilter.filter(MessageSanitizerContainerResponseFilter.java:46)
at org.jboss.resteasy.core.interception.jaxrs.ContainerResponseContextImpl.filter(ContainerResponseContextImpl.java:362)
at org.jboss.resteasy.core.ServerResponseWriter.executeFilters(ServerResponseWriter.java:219)
```