### PR TITLE
[Resteasy 1958]: Reconnect delay override using last received 'retry' field value should not be a one time override

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/plugins/providers/sse/client/SseEventSourceImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/plugins/providers/sse/client/SseEventSourceImpl.java
@@ -335,6 +335,7 @@ public class SseEventSourceImpl implements SseEventSource
                if (eventInput == null && !alwaysReconnect)
                {
                   internalClose();
+                  return;
                }
             }
             else
@@ -357,16 +358,17 @@ public class SseEventSourceImpl implements SseEventSource
                   consumer.accept(ex);
                });
                reconnect(localReconnectDelay);
-               return;
             }
             else
             {
                onUnrecoverableError(ex);
             }
+            return;
          }
          catch (Throwable e)
          {
             onUnrecoverableError(e);
+            return;
          }
 
          while (!Thread.currentThread().isInterrupted() && state.get() == State.OPEN)

--- a/resteasy-client/src/main/java/org/jboss/resteasy/plugins/providers/sse/client/SseEventSourceImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/plugins/providers/sse/client/SseEventSourceImpl.java
@@ -428,10 +428,6 @@ public class SseEventSourceImpl implements SseEventSource
 
       private void onEvent(final InboundSseEvent event)
       {
-         if (event == null)
-         {
-            return;
-         }
          if (event.getId() != null)
          {
             lastEventId = event.getId();


### PR DESCRIPTION
This PR cancel and replace previous one: https://github.com/resteasy/Resteasy/pull/1605

JIRA: https://issues.jboss.org/browse/RESTEASY-1958