### PR TITLE
[RESTEASY-2229] Cs wrapped exception

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/AsyncResponseConsumer.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/AsyncResponseConsumer.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -237,7 +238,13 @@ public abstract class AsyncResponseConsumer
          }
          else
          {
-            internalResume(u, x -> complete(u));
+            // since this is called by the CompletionStage API, we want to unwrap its exceptions in order for the
+            // exception mappers to function
+            if(u instanceof CompletionException) {
+                u = u.getCause();
+            }
+            Throwable throwable = u;
+            internalResume(throwable, x -> complete(throwable));
          }
       }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/CompletionStageResponseTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/CompletionStageResponseTest.java
@@ -183,6 +183,27 @@ public class CompletionStageResponseTest {
    }
 
    /**
+    * @tpTestDetails Resource method throws a WebApplicationException in a CompletionStage
+    * pipeline
+    * @tpSince RESTEasy 3.5
+    */
+   @Test
+   public void testExceptionDelayWrapped() throws Exception
+   {
+      Invocation.Builder request = client.target(generateURL("/exception/delay-wrapped")).request();
+      Response response = request.get();
+      String entity = response.readEntity(String.class);
+      Assert.assertEquals(444, response.getStatus());
+      Assert.assertEquals(CompletionStageResponseResource.EXCEPTION, entity);
+
+      // make sure the completion callback was called with with an error
+      request = client.target(generateURL("/callback-called-with-error")).request();
+      response = request.get();
+      Assert.assertEquals(200, response.getStatus());
+      response.close();
+   }
+
+   /**
     * @tpTestDetails Resource method return type is CompletionStage<String>, but it
     * throws a RuntimeException without creating a CompletionStage.
     * @tpSince RESTEasy 3.5

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/CompletionStageResponseResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/CompletionStageResponseResource.java
@@ -135,6 +135,24 @@ public class CompletionStageResponseResource {
    }
 
    @GET
+   @Path("exception/delay-wrapped")
+   @Produces("text/plain")
+   public CompletionStage<String> exceptionDelayWrapped(@Context HttpRequest req) {
+      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback());
+      CompletableFuture<String> cs = CompletableFuture.completedFuture("OK");
+      ExecutorService executor = Executors.newSingleThreadExecutor();
+      return cs.thenApplyAsync(text -> {
+         try {
+            Thread.sleep(3000L); // make sure that response will be created after end-point method ends
+         } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+         }
+         Response response = Response.status(444).entity(EXCEPTION).build();
+         throw new WebApplicationException(response);
+      }, executor);
+   }
+
+   @GET
    @Path("exception/immediate/runtime")
    @Produces("text/plain")
    public CompletionStage<String> exceptionImmediateRuntime(@Context HttpRequest req) {


### PR DESCRIPTION
When CompletionStage completes exceptionally its exceptions are not wrapped, but when they complete exceptionally due to an exception throw in one of its pipeline callbacks (in thenApply() for example) then, CompletionStage wraps the exception before passing it to us. We should unwrap it, otherwise our exception mappers will never match and we get internal errors instead of the expected answers.