### PR TITLE
Cleanup httpclient dependencies for resteasy-core

### DIFF
--- a/resteasy-client/pom.xml
+++ b/resteasy-client/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpasyncclient</artifactId>
             <optional>true</optional>

--- a/resteasy-core-spi/pom.xml
+++ b/resteasy-core-spi/pom.xml
@@ -77,22 +77,6 @@
             <artifactId>activation</artifactId>
         </dependency>
 
-        <!-- 4.0 refactor of apache httpclient -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-io</groupId>
-	        <artifactId>commons-io</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>net.jcip</groupId>
-            <artifactId>jcip-annotations</artifactId>
-        </dependency>
-
         <!-- Required by Hibernate Validator 5.x for testing -->
         <dependency>
             <groupId>org.jboss.spec.javax.el</groupId>

--- a/resteasy-core/pom.xml
+++ b/resteasy-core/pom.xml
@@ -83,22 +83,6 @@
             <artifactId>activation</artifactId>
         </dependency>
 
-        <!-- 4.0 refactor of apache httpclient -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-io</groupId>
-	        <artifactId>commons-io</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>net.jcip</groupId>
-            <artifactId>jcip-annotations</artifactId>
-        </dependency>
-
         <!-- Used by org.jboss.resteasy.plugins.server.tjws.* -->
         <!--
         <dependency>

--- a/security/jose-jwt/pom.xml
+++ b/security/jose-jwt/pom.xml
@@ -14,6 +14,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>net.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>


### PR DESCRIPTION
Remove unused dependencies from `resteasy-core` and `resteasy-core-spi`,
and add dependencies that were being depended on transitively.