### PR TITLE
Use Apache-2.0 licensed version of the JCIP annotations

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -39,7 +39,7 @@
         <version.javax.ws.rs-api>1.0.2.Final</version.javax.ws.rs-api>
         <version.junit>4.12</version.junit>
         <version.log4j>2.9.1</version.log4j>
-        <version.net.jcip.jcip-annotations>1.0</version.net.jcip.jcip-annotations>
+        <version.stephenc.jcip.jcip-annotations>1.0-1</version.stephenc.jcip.jcip-annotations>
         <version.org.apache.httpcomponents.httpclient>4.5.4</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.5</version.org.apache.httpcomponents.httpcore>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.3</version.org.apache.httpcomponents.httpasyncclient>
@@ -315,9 +315,9 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>net.jcip</groupId>
+                <groupId>com.github.stephenc.jcip</groupId>
                 <artifactId>jcip-annotations</artifactId>
-                <version>${version.net.jcip.jcip-annotations}</version>
+                <version>${version.stephenc.jcip.jcip-annotations}</version>
             </dependency>
 
             <dependency>

--- a/security/jose-jwt/pom.xml
+++ b/security/jose-jwt/pom.xml
@@ -14,7 +14,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>net.jcip</groupId>
+            <groupId>com.github.stephenc.jcip</groupId>
             <artifactId>jcip-annotations</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
The JCIP Annotations are released under the [Creative Commons Attribution License](http://creativecommons.org/licenses/by/2.5), which is [not recommended for licensing software](http://wiki.creativecommons.org/FAQ#Can_I_use_a_Creative_Commons_license_for_software.3F).

I'd like to move them over to using the Apache-2.0 licensed version provided by @stephenc:
https://github.com/stephenc/jcip-annotations