### PR TITLE
[RESTEASY-2268] ResteasyHttpHeaders does not follow JAX-RS spec concerning modifiability

### DIFF
--- a/profiling-tests/src/test/java/org/jboss/resteasy/test/profiling/InMemoryClientEngine.java
+++ b/profiling-tests/src/test/java/org/jboss/resteasy/test/profiling/InMemoryClientEngine.java
@@ -152,7 +152,7 @@ public class InMemoryClientEngine implements ClientHttpEngine
 
    public void commitHeaders(ClientInvocation request, MockHttpRequest mockHttpRequest)
    {
-      MultivaluedMap<String, String> headers = mockHttpRequest.getHttpHeaders().getRequestHeaders();
+      MultivaluedMap<String, String> headers = mockHttpRequest.getMutableHeaders();
       headers.putAll(request.getHeaders().asMap());
    }
 

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/InternalDispatcher.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/InternalDispatcher.java
@@ -2,7 +2,6 @@ package org.jboss.resteasy.core;
 
 import java.net.URI;
 
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
@@ -123,13 +122,8 @@ public class InternalDispatcher
       HttpRequest previousRequest = ResteasyContext.getContextData(HttpRequest.class);
       if (previousRequest != null)
       {
-         getHeaders(request).putAll(getHeaders(previousRequest));
+         request.getMutableHeaders().putAll(previousRequest.getHttpHeaders().getRequestHeaders());
       }
-   }
-
-   private MultivaluedMap<String, String> getHeaders(HttpRequest request)
-   {
-      return request.getHttpHeaders().getRequestHeaders();
    }
 
    public static MockHttpRequest createRequest(String relativeUri, String verb)

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/interception/jaxrs/PreMatchContainerRequestContext.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/interception/jaxrs/PreMatchContainerRequestContext.java
@@ -24,6 +24,7 @@ import javax.ws.rs.core.UriInfo;
 import org.jboss.resteasy.core.ResteasyContext;
 import org.jboss.resteasy.core.SynchronousDispatcher;
 import org.jboss.resteasy.specimpl.BuiltResponse;
+import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
 import org.jboss.resteasy.spi.ApplicationException;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
@@ -134,7 +135,7 @@ public class PreMatchContainerRequestContext implements SuspendableContainerRequ
    @Override
    public MultivaluedMap<String, String> getHeaders()
    {
-      return httpRequest.getHttpHeaders().getRequestHeaders();
+      return ((ResteasyHttpHeaders) httpRequest.getHttpHeaders()).getMutableHeaders();
    }
 
    @Override

--- a/resteasy-core/src/main/java/org/jboss/resteasy/mock/MockHttpRequest.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/mock/MockHttpRequest.java
@@ -162,7 +162,7 @@ public class MockHttpRequest extends BaseHttpRequest
 
    public MockHttpRequest header(String name, String value)
    {
-      httpHeaders.getRequestHeaders().add(name, value);
+      httpHeaders.getMutableHeaders().add(name, value);
       return this;
    }
 

--- a/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/ResteasyHttpHeaders.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/ResteasyHttpHeaders.java
@@ -26,6 +26,7 @@ public class ResteasyHttpHeaders implements HttpHeaders
 {
 
    private MultivaluedMap<String, String> requestHeaders;
+   private MultivaluedMap<String, String> unmodifiableRequestHeaders;
    private Map<String, Cookie> cookies;
 
    public ResteasyHttpHeaders(final MultivaluedMap<String, String> requestHeaders)
@@ -36,13 +37,14 @@ public class ResteasyHttpHeaders implements HttpHeaders
    public ResteasyHttpHeaders(final MultivaluedMap<String, String> requestHeaders, final Map<String, Cookie> cookies)
    {
       this.requestHeaders = requestHeaders;
-      this.cookies = (cookies == null ? new HashMap<String, Cookie>() : cookies);
+      this.unmodifiableRequestHeaders = new UnmodifiableMultivaluedMap<>(requestHeaders);
+      this.cookies = (cookies == null ? new HashMap<>() : cookies);
    }
 
    @Override
    public MultivaluedMap<String, String> getRequestHeaders()
    {
-      return requestHeaders;
+      return unmodifiableRequestHeaders;
    }
 
    public MultivaluedMap<String, String> getMutableHeaders()
@@ -63,9 +65,8 @@ public class ResteasyHttpHeaders implements HttpHeaders
    @Override
    public List<String> getRequestHeader(String name)
    {
-      List<String> vals = requestHeaders.get(name);
-      if (vals == null) return Collections.<String>emptyList();
-      return Collections.unmodifiableList(vals);
+      List<String> vals = unmodifiableRequestHeaders.get(name);
+      return vals == null ? Collections.<String>emptyList() : vals;
    }
 
    @Override

--- a/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/UnmodifiableMultivaluedMap.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/UnmodifiableMultivaluedMap.java
@@ -1,11 +1,13 @@
 package org.jboss.resteasy.specimpl;
 
-import javax.ws.rs.core.MultivaluedMap;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.ws.rs.core.MultivaluedMap;
 
 /**
  * Unmodifiable implementation of {@link javax.ws.rs.core.MultivaluedMap} interface
@@ -18,9 +20,48 @@ public class UnmodifiableMultivaluedMap<K, V> implements MultivaluedMap<K, V>
 
    private final MultivaluedMap<K, V> delegate;
 
+   private final Set<java.util.Map.Entry<K, List<V>>> entrySet;
+
    public UnmodifiableMultivaluedMap(final MultivaluedMap<K, V> delegate)
    {
       this.delegate = delegate;
+      this.entrySet = buildEntrySet();
+   }
+
+   private Set<java.util.Map.Entry<K, List<V>>> buildEntrySet()
+   {
+      Set<java.util.Map.Entry<K, List<V>>> entrySetDelegator = delegate.entrySet();
+      if (entrySetDelegator == null)
+      {
+         return null;
+      }
+      Set<java.util.Map.Entry<K, List<V>>> entrySetToReturn = new HashSet<>();
+      for (final java.util.Map.Entry<K, List<V>> entry : entrySetDelegator)
+      {
+         entrySetToReturn.add(new Entry<K, List<V>>()
+         {
+
+            @Override
+            public K getKey()
+            {
+               return entry.getKey();
+            }
+
+            @Override
+            public List<V> getValue()
+            {
+               List<V> value = entry.getValue();
+               return value == null ? null : Collections.unmodifiableList(value);
+            }
+
+            @Override
+            public List<V> setValue(List<V> value)
+            {
+               throw new UnsupportedOperationException();
+            }
+         });
+      }
+      return Collections.unmodifiableSet(entrySetToReturn);
    }
 
    @Override
@@ -75,13 +116,14 @@ public class UnmodifiableMultivaluedMap<K, V> implements MultivaluedMap<K, V>
    @Override
    public Set<Entry<K, List<V>>> entrySet()
    {
-      return Collections.unmodifiableSet(delegate.entrySet());
+      return this.entrySet;
    }
 
    @Override
    public List<V> get(Object key)
    {
-      return delegate.get(key);
+      List<V> list = delegate.get(key);
+      return list == null ? null : Collections.unmodifiableList(list);
    }
 
    @Override

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/ResteasyHttpHeadersTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/ResteasyHttpHeadersTest.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, the OpenSource J2EE webOS
- * 
+ *
  * Distributable under LGPL license.
  * See terms of license at gnu.org.
  */
@@ -17,7 +17,7 @@ import org.junit.Test;
  * @tpSubChapter Util tests
  * @tpChapter Unit tests
  * @tpTestCaseDetails Test for UnmodifiableMultivaluedMap
- * @tpSince RESTEasy 
+ * @tpSince RESTEasy
  * @author Nicolas NESMON
  */
 public class ResteasyHttpHeadersTest

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/ResteasyHttpHeadersTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/ResteasyHttpHeadersTest.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, the OpenSource J2EE webOS
+ * 
+ * Distributable under LGPL license.
+ * See terms of license at gnu.org.
+ */
+package org.jboss.resteasy.test.util;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @tpSubChapter Util tests
+ * @tpChapter Unit tests
+ * @tpTestCaseDetails Test for UnmodifiableMultivaluedMap
+ * @tpSince RESTEasy 
+ * @author Nicolas NESMON
+ */
+public class ResteasyHttpHeadersTest
+{
+
+   @Test
+   public void testNotModifiable()
+   {
+      MultivaluedMap<String, String> modifiableMultivaluedMap = new MultivaluedHashMap<>();
+      modifiableMultivaluedMap.addAll("Hello", "Bonjour");
+
+      ResteasyHttpHeaders httpHeaders = new ResteasyHttpHeaders(modifiableMultivaluedMap);
+      try
+      {
+         httpHeaders.getRequestHeader("Hello").add("Interdit");
+         Assert.fail("getRequestHeader() must return a read-only List");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+      try
+      {
+         httpHeaders.getRequestHeaders().clear();
+         Assert.fail("getRequestHeaders() must return a read-only Map");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+   }
+
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/UnmodifiableMultivaluedMapTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/UnmodifiableMultivaluedMapTest.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, the OpenSource J2EE webOS
- * 
+ *
  * Distributable under LGPL license.
  * See terms of license at gnu.org.
  */
@@ -22,7 +22,7 @@ import org.junit.Test;
  * @tpSubChapter Util tests
  * @tpChapter Unit tests
  * @tpTestCaseDetails Test for UnmodifiableMultivaluedMap
- * @tpSince RESTEasy 
+ * @tpSince RESTEasy
  * @author Nicolas NESMON
  */
 public class UnmodifiableMultivaluedMapTest

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/UnmodifiableMultivaluedMapTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/UnmodifiableMultivaluedMapTest.java
@@ -1,0 +1,182 @@
+/*
+ * JBoss, the OpenSource J2EE webOS
+ * 
+ * Distributable under LGPL license.
+ * See terms of license at gnu.org.
+ */
+package org.jboss.resteasy.test.util;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.jboss.resteasy.specimpl.UnmodifiableMultivaluedMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @tpSubChapter Util tests
+ * @tpChapter Unit tests
+ * @tpTestCaseDetails Test for UnmodifiableMultivaluedMap
+ * @tpSince RESTEasy 
+ * @author Nicolas NESMON
+ */
+public class UnmodifiableMultivaluedMapTest
+{
+
+   @Test
+   public void testNotModifiable()
+   {
+      MultivaluedMap<String, String> modifiableMultivaluedMap = new MultivaluedHashMap<>();
+      modifiableMultivaluedMap.addAll("Hello", "Bonjour");
+
+      UnmodifiableMultivaluedMap<String, String> unmodifiableMultivaluedMap = new UnmodifiableMultivaluedMap<>(
+            modifiableMultivaluedMap);
+
+      try
+      {
+         unmodifiableMultivaluedMap.add("Forbidden", "Interdit");
+         Assert.fail("Add() must not be supported on an unmodifiable multi valued map");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+
+      try
+      {
+         unmodifiableMultivaluedMap.addAll("Forbidden", Arrays.asList("Interdit"));
+         Assert.fail("addAll() must not be supported on an unmodifiable multi valued Map");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+
+      try
+      {
+         unmodifiableMultivaluedMap.addAll("Forbidden", "Interdit");
+         Assert.fail("addAll() must not be supported on an unmodifiable multi valued Map");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+
+      try
+      {
+         unmodifiableMultivaluedMap.addFirst("Forbidden", "Interdit");
+         Assert.fail("addFirst() must not be supported on an unmodifiable multi valued Map");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+
+      try
+      {
+         unmodifiableMultivaluedMap.clear();
+         Assert.fail("clear() must not be supported on an unmodifiable multi valued Map");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+
+      try
+      {
+         unmodifiableMultivaluedMap.remove("Hello");
+         Assert.fail("remove() must not be supported on an unmodifiable multi valued Map");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+
+      try
+      {
+         unmodifiableMultivaluedMap.put("Forbidden", Arrays.asList("Interdit"));
+         Assert.fail("put() must not be supported on an unmodifiable multi valued Map");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+
+      try
+      {
+         unmodifiableMultivaluedMap.putSingle("Forbidden", "Interdit");
+         Assert.fail("putSingle() must not be supported on an unmodifiable multi valued Map");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+
+      try
+      {
+         unmodifiableMultivaluedMap.putAll(Collections.singletonMap("Forbidden", Arrays.asList("Interdit")));
+         Assert.fail("putAll() must not be supported on an unmodifiable multi valued Map");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+
+      try
+      {
+         unmodifiableMultivaluedMap.keySet().add("Forbidden");
+         Assert.fail("keySet() must return an unmodifiable Set");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+
+      try
+      {
+         unmodifiableMultivaluedMap.values().add(Arrays.asList("Interdit"));
+         Assert.fail("values() must return an unmodifiable Collection");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+
+      try
+      {
+         unmodifiableMultivaluedMap.get("Hello").add("Interdit");
+         Assert.fail("get() must return an unmodifiable List");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+
+      try
+      {
+         unmodifiableMultivaluedMap.entrySet().clear();
+         Assert.fail("entrySet() must return an unmodifiable Set");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+
+      try
+      {
+         for (Entry<String, List<String>> entry : unmodifiableMultivaluedMap.entrySet())
+         {
+            entry.setValue(Arrays.asList("Interdit"));
+         }
+         Assert.fail("entry must be unmodifiable");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+
+      try
+      {
+         for (Entry<String, List<String>> entry : unmodifiableMultivaluedMap.entrySet())
+         {
+            entry.getValue().add("Interdit");
+         }
+         Assert.fail("entry must be unmodifiable");
+      }
+      catch (UnsupportedOperationException e)
+      {
+      }
+   }
+
+}


### PR DESCRIPTION
ResteasyHttpHeaders.getRequestHeaders() and ResteasyHttpHeaders.getRequestHeader() must return not modifiable collection

Signed-off-by: NicoNes <nicolas.nesmon@gmail.com>