### PR TITLE
[RESTEASY-2291] Native image improvements for MP REST Client on Quarkus

### DIFF
--- a/resteasy-client-microprofile/src/test/java/org/jboss/resteasy/microprofile/client/ProviderFactoryTest.java
+++ b/resteasy-client-microprofile/src/test/java/org/jboss/resteasy/microprofile/client/ProviderFactoryTest.java
@@ -1,0 +1,35 @@
+package org.jboss.resteasy.microprofile.client;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
+import org.jboss.resteasy.plugins.providers.DefaultTextPlain;
+import org.jboss.resteasy.plugins.providers.IIOImageProvider;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ProviderFactoryTest {
+
+    @Test
+    public void testDefaultProvider() {
+        // Reset to ensure we start from clean slate
+        RestClientBuilderImpl.setProviderFactory(null);
+
+        RestClientBuilderImpl builder = (RestClientBuilderImpl) RestClientBuilder.newBuilder();
+
+        Assert.assertTrue(builder.getBuilderDelegate().getProviderFactory().getProviderClasses().contains(IIOImageProvider.class));
+        Assert.assertTrue(builder.getBuilderDelegate().getProviderFactory().getProviderClasses().contains(DefaultTextPlain.class));
+    }
+
+    @Test
+    public void testCustomProvider() {
+        ResteasyProviderFactory provider = new ResteasyProviderFactoryImpl(null, true);
+        provider.registerProvider(IIOImageProvider.class);
+        RestClientBuilderImpl.setProviderFactory(provider);
+
+        RestClientBuilderImpl builder = (RestClientBuilderImpl) RestClientBuilder.newBuilder();
+
+        Assert.assertTrue(builder.getBuilderDelegate().getProviderFactory().getProviderClasses().contains(IIOImageProvider.class));
+        Assert.assertFalse(builder.getBuilderDelegate().getProviderFactory().getProviderClasses().contains(DefaultTextPlain.class));
+    }
+}

--- a/resteasy-client-microprofile/src/test/java/org/jboss/resteasy/microprofile/client/ProviderFactoryTest.java
+++ b/resteasy-client-microprofile/src/test/java/org/jboss/resteasy/microprofile/client/ProviderFactoryTest.java
@@ -12,9 +12,6 @@ public class ProviderFactoryTest {
 
     @Test
     public void testDefaultProvider() {
-        // Reset to ensure we start from clean slate
-        RestClientBuilderImpl.setProviderFactory(null);
-
         RestClientBuilderImpl builder = (RestClientBuilderImpl) RestClientBuilder.newBuilder();
 
         Assert.assertTrue(builder.getBuilderDelegate().getProviderFactory().getProviderClasses().contains(IIOImageProvider.class));
@@ -23,13 +20,18 @@ public class ProviderFactoryTest {
 
     @Test
     public void testCustomProvider() {
-        ResteasyProviderFactory provider = new ResteasyProviderFactoryImpl(null, true);
-        provider.registerProvider(IIOImageProvider.class);
-        RestClientBuilderImpl.setProviderFactory(provider);
+        try {
+            ResteasyProviderFactory provider = new ResteasyProviderFactoryImpl(null, true);
+            provider.registerProvider(IIOImageProvider.class);
+            RestClientBuilderImpl.setProviderFactory(provider);
 
-        RestClientBuilderImpl builder = (RestClientBuilderImpl) RestClientBuilder.newBuilder();
+            RestClientBuilderImpl builder = (RestClientBuilderImpl) RestClientBuilder.newBuilder();
 
-        Assert.assertTrue(builder.getBuilderDelegate().getProviderFactory().getProviderClasses().contains(IIOImageProvider.class));
-        Assert.assertFalse(builder.getBuilderDelegate().getProviderFactory().getProviderClasses().contains(DefaultTextPlain.class));
+            Assert.assertTrue(builder.getBuilderDelegate().getProviderFactory().getProviderClasses().contains(IIOImageProvider.class));
+            Assert.assertFalse(builder.getBuilderDelegate().getProviderFactory().getProviderClasses().contains(DefaultTextPlain.class));
+        } finally {
+            // Reset to default state
+            RestClientBuilderImpl.setProviderFactory(null);
+        }
     }
 }

--- a/resteasy-client-microprofile/src/test/java/org/jboss/resteasy/microprofile/client/SslTest.java
+++ b/resteasy-client-microprofile/src/test/java/org/jboss/resteasy/microprofile/client/SslTest.java
@@ -1,0 +1,18 @@
+package org.jboss.resteasy.microprofile.client;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SslTest {
+
+    @Test
+    public void testEnabled() {
+        Assert.assertTrue(RestClientBuilderImpl.SSL_ENABLED);
+    }
+
+    @Test
+    public void testDisabled() {
+        RestClientBuilderImpl.setSslEnabled(false);
+        Assert.assertFalse(RestClientBuilderImpl.SSL_ENABLED);
+    }
+}

--- a/resteasy-client-microprofile/src/test/java/org/jboss/resteasy/microprofile/client/SslTest.java
+++ b/resteasy-client-microprofile/src/test/java/org/jboss/resteasy/microprofile/client/SslTest.java
@@ -12,7 +12,12 @@ public class SslTest {
 
     @Test
     public void testDisabled() {
-        RestClientBuilderImpl.setSslEnabled(false);
-        Assert.assertFalse(RestClientBuilderImpl.SSL_ENABLED);
+        try {
+            RestClientBuilderImpl.setSslEnabled(false);
+            Assert.assertFalse(RestClientBuilderImpl.SSL_ENABLED);
+        } finally {
+            // Reset to default state
+            RestClientBuilderImpl.setSslEnabled(true);
+        }
     }
 }


### PR DESCRIPTION
Modify MP REST Client implementation to be able to completely disable SSL class usage if it's not enabled. This helps with DCE.