### PR TITLE
[RESTEASY-2297] (3.8 branch) updated jboss-parent version.  Version u…

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -36,8 +36,6 @@
             <property name="message" value="Line has trailing spaces."/>
         </module>
 
-        <property name="cacheFile" value="${checkstyle.cache.file}"/>
-
         <!-- Checks for imports                              -->
         <module name="AvoidStarImport">
             <property name="allowStaticMemberImports" value="true"/>

--- a/eagledns/pom.xml
+++ b/eagledns/pom.xml
@@ -16,6 +16,14 @@
         <project.build.sourceEncoding>ISO8859_1</project.build.sourceEncoding>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>jboss</id>
+            <name>jboss repo</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.xbill</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>26</version>
+        <version>35</version>
         <relativePath/>
     </parent>
 
@@ -233,10 +233,6 @@
     </contributors>
 
     <repositories>
-        <repository>
-            <id>jboss</id>
-            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-        </repository>
     </repositories>
     <pluginRepositories>
     </pluginRepositories>

--- a/resteasy-bom/pom.xml
+++ b/resteasy-bom/pom.xml
@@ -3,10 +3,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>3.8.2-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>35</version>
+        <relativePath/>
     </parent>
 
     <name>RESTEasy Maven Import (BOM)</name>

--- a/resteasy-client/pom.xml
+++ b/resteasy-client/pom.xml
@@ -53,10 +53,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
             <scope>provided</scope>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>26</version>
+        <version>35</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -98,10 +98,6 @@
         </repository>
     </distributionManagement>
     <repositories>
-        <repository>
-            <id>jboss</id>
-            <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>
@@ -202,7 +198,7 @@
             <dependency>
                 <groupId>org.jboss.weld.se</groupId>
                 <artifactId>weld-se-core</artifactId>
-                <version>${version.org.jboss.weld.se.weld-se-core}</version>
+                <version>${version.weld}</version>
             </dependency>
 
             <dependency>
@@ -482,11 +478,6 @@
                 <version>${version.org.codehaus.jackson}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock</artifactId>
-                <version>${version.com.github.tomakehurst.wiremock}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-core</artifactId>
                 <version>${version.org.infinispan}</version>
@@ -758,12 +749,6 @@
                 <artifactId>weld-core-impl</artifactId>
                 <version>${version.weld}</version>
            </dependency>
-
-           <dependency>
-                <groupId>org.jboss.weld.se</groupId>
-                <artifactId>weld-se-core</artifactId>
-                <version>${version.weld}</version> 
-           </dependency> 
 
             <dependency>
                 <groupId>org.wildfly.core</groupId>

--- a/security-legacy/keystone/keystone-as7/pom.xml
+++ b/security-legacy/keystone/keystone-as7/pom.xml
@@ -13,6 +13,14 @@
     <name>RESTEasy Security: Keystone AS7 Integration</name>
     <description/>
 
+    <repositories>
+        <repository>
+            <id>jboss</id>
+            <name>jboss repo</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/security-legacy/login-module-authenticator/pom.xml
+++ b/security-legacy/login-module-authenticator/pom.xml
@@ -13,6 +13,14 @@
     <name>RESTEasy Security: AS7 Login Module Authenticator</name>
     <description/>
 
+    <repositories>
+        <repository>
+            <id>jboss</id>
+            <name>jboss repo</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>

--- a/security-legacy/skeleton-key-idm/skeleton-key-as7/pom.xml
+++ b/security-legacy/skeleton-key-idm/skeleton-key-as7/pom.xml
@@ -13,6 +13,14 @@
     <name>RESTEasy Security: Skeleton Key AS7 Integration</name>
     <description/>
 
+    <repositories>
+        <repository>
+            <id>jboss</id>
+            <name>jboss repo</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
…pdate required removal of checkstyle property cacheFile. It is obsolete with checkin-plugin:3.0.0. enforcer required select removal of http://repository.jboss.org/nexus/content/groups/public/