### PR TITLE
resteasy-bom fixes as a consequence of RESTEASY-1864 changes

### DIFF
--- a/resteasy-bom/pom.xml
+++ b/resteasy-bom/pom.xml
@@ -13,6 +13,7 @@
     <description/>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-bom</artifactId>
+    <version>3.9.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <dependencyManagement>

--- a/resteasy-bom/pom.xml
+++ b/resteasy-bom/pom.xml
@@ -11,6 +11,7 @@
 
     <name>RESTEasy Maven Import (BOM)</name>
     <description/>
+    <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-bom</artifactId>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
This prevents RESTEASY-2317 from being included in 3.9.0.Final and also fixes the versioning issue that I patched on master just before 4.2.0.Final release