### PR TITLE
RESTEASY-1419 - Add support for injecting Optional<T> parameter types

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/InjectorFactoryImpl.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/InjectorFactoryImpl.java
@@ -4,6 +4,8 @@ import org.jboss.resteasy.annotations.Form;
 import org.jboss.resteasy.annotations.Query;
 import org.jboss.resteasy.annotations.Suspend;
 import org.jboss.resteasy.spi.ConstructorInjector;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.InjectorFactory;
 import org.jboss.resteasy.spi.MethodInjector;
 import org.jboss.resteasy.spi.PropertyInjector;
@@ -30,8 +32,16 @@ import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static org.jboss.resteasy.util.FindAnnotation.findAnnotation;
 
@@ -73,55 +83,75 @@ public class InjectorFactoryImpl implements InjectorFactory
    }
 
    @Override
-   public ValueInjector createParameterExtractor(Parameter parameter, ResteasyProviderFactory providerFactory)
-   {
-      switch (parameter.getParamType())
-      {
+   public ValueInjector createParameterExtractor(Parameter parameter, ResteasyProviderFactory providerFactory) {
+
+      return OptionalInjections.wrap(parameter.getGenericType(), innerType -> createParameterExtractor0(parameter, providerFactory, innerType));
+   }
+
+   private ValueInjector createParameterExtractor0(Parameter parameter, ResteasyProviderFactory providerFactory, Type parameterType) {
+      Class<?> rawType = Types.getRawType(parameterType);
+
+      switch (parameter.getParamType()) {
          case QUERY_PARAM:
-            return new QueryParamInjector(parameter.getType(), parameter.getGenericType(), parameter.getAccessibleObject(), parameter.getParamName(), parameter.getDefaultValue(), parameter.isEncoded(), parameter.getAnnotations(), providerFactory);
+            return new QueryParamInjector(rawType, parameterType, parameter.getAccessibleObject(), parameter.getParamName(), parameter.getDefaultValue(), parameter.isEncoded(), parameter.getAnnotations(), providerFactory);
          case QUERY:
-            return new QueryInjector(parameter.getType(), providerFactory);
+            return new QueryInjector(rawType, providerFactory);
+
          case HEADER_PARAM:
-            return new HeaderParamInjector(parameter.getType(), parameter.getGenericType(), parameter.getAccessibleObject(), parameter.getParamName(), parameter.getDefaultValue(), parameter.getAnnotations(), providerFactory);
+            return new HeaderParamInjector(rawType, parameterType, parameter.getAccessibleObject(), parameter.getParamName(), parameter.getDefaultValue(), parameter.getAnnotations(), providerFactory);
+
          case FORM_PARAM:
-            return new FormParamInjector(parameter.getType(), parameter.getGenericType(), parameter.getAccessibleObject(), parameter.getParamName(), parameter.getDefaultValue(), parameter.isEncoded(), parameter.getAnnotations(), providerFactory);
+            return new FormParamInjector(rawType, parameterType, parameter.getAccessibleObject(), parameter.getParamName(), parameter.getDefaultValue(), parameter.isEncoded(), parameter.getAnnotations(), providerFactory);
+
          case COOKIE_PARAM:
-            return new CookieParamInjector(parameter.getType(), parameter.getGenericType(), parameter.getAccessibleObject(), parameter.getParamName(), parameter.getDefaultValue(), parameter.getAnnotations(), providerFactory);
+            return new CookieParamInjector(rawType, parameterType, parameter.getAccessibleObject(), parameter.getParamName(), parameter.getDefaultValue(), parameter.getAnnotations(), providerFactory);
+
          case PATH_PARAM:
-            return new PathParamInjector(parameter.getType(), parameter.getGenericType(), parameter.getAccessibleObject(), parameter.getParamName(), parameter.getDefaultValue(), parameter.isEncoded(), parameter.getAnnotations(), providerFactory);
+            return new PathParamInjector(rawType, parameterType, parameter.getAccessibleObject(), parameter.getParamName(), parameter.getDefaultValue(), parameter.isEncoded(), parameter.getAnnotations(), providerFactory);
+
          case FORM:
          {
             String prefix = parameter.getParamName();
             if (prefix.length() > 0)
             {
-               if (parameter.getGenericType() instanceof ParameterizedType)
+               if (parameterType instanceof ParameterizedType)
+
                {
-                  ParameterizedType pType = (ParameterizedType) parameter.getGenericType();
+                  ParameterizedType pType = (ParameterizedType) parameterType;
+
                   if (Types.isA(List.class, pType))
                   {
-                     return new ListFormInjector(parameter.getType(), Types.getArgumentType(pType, 0), prefix, providerFactory);
+                     return new ListFormInjector(rawType, Types.getArgumentType(pType, 0), prefix, providerFactory);
+
                   }
                   if (Types.isA(Map.class, pType))
                   {
-                     return new MapFormInjector(parameter.getType(), Types.getArgumentType(pType, 0), Types.getArgumentType(pType, 1), prefix, providerFactory);
+                     return new MapFormInjector(rawType, Types.getArgumentType(pType, 0), Types.getArgumentType(pType, 1), prefix, providerFactory);
+
                   }
                }
-               return new PrefixedFormInjector(parameter.getType(), prefix, providerFactory);
+               return new PrefixedFormInjector(rawType, prefix, providerFactory);
+
             }
-            return new FormInjector(parameter.getType(), providerFactory);
+            return new FormInjector(rawType, providerFactory);
+
          }
          case BEAN_PARAM:
-            return new FormInjector(parameter.getType(), providerFactory);
+            return new FormInjector(rawType, providerFactory);
+
          case MATRIX_PARAM:
-            return new MatrixParamInjector(parameter.getType(), parameter.getGenericType(), parameter.getAccessibleObject(), parameter.getParamName(), parameter.getDefaultValue(), parameter.isEncoded(), parameter.getAnnotations(), providerFactory);
+            return new MatrixParamInjector(rawType, parameterType, parameter.getAccessibleObject(), parameter.getParamName(), parameter.getDefaultValue(), parameter.isEncoded(), parameter.getAnnotations(), providerFactory);
+
          case SUSPEND:
-            return new SuspendInjector(parameter.getSuspendTimeout(), parameter.getType());
+            return new SuspendInjector(parameter.getSuspendTimeout(), rawType);
          case CONTEXT:
-            return new ContextParameterInjector(null, parameter.getType(), providerFactory);
+            return new ContextParameterInjector(null, rawType, providerFactory);
+
          case SUSPENDED:
             return new AsynchronousResponseInjector();
          case MESSAGE_BODY:
-            return new MessageBodyParameterInjector(parameter.getResourceClass().getClazz(), parameter.getAccessibleObject(), parameter.getType(), parameter.getGenericType(), parameter.getAnnotations(), providerFactory);
+            return new MessageBodyParameterInjector(parameter.getResourceClass().getClazz(), parameter.getAccessibleObject(), rawType, parameterType, parameter.getAnnotations(), providerFactory);
+
          default:
             return null;
       }
@@ -301,4 +331,73 @@ public class InjectorFactoryImpl implements InjectorFactory
          return null;
       }
    }
+    enum OptionalInjections {
+        OPT     (Optional.class, OptionalInjections::getTypeArgument, Optional::empty, Optional::of),
+        OINT    (OptionalInt.class, x -> Integer.class, OptionalInt::empty, v -> OptionalInt.of((Integer) v)),
+        OLONG   (OptionalLong.class, x -> Long.class, OptionalLong::empty, v -> OptionalLong.of((Long) v)),
+        ODOUBLE (OptionalDouble.class, x -> Double.class, OptionalDouble::empty, v -> OptionalDouble.of((Double) v)),
+        ;
+
+        static Map<Class<?>, OptionalInjections> optionalTypes;
+
+        static {
+            optionalTypes = Arrays.stream(OptionalInjections.values())
+                    .collect(Collectors.toMap(o -> o.optional, Function.identity()));
+        }
+
+        final Class<?> optional;
+        final Function<Type, Type> valueType;
+        final Supplier<Object> empty;
+        final Function<Object, Object> present;
+
+        OptionalInjections(final Class<?> optional, final Function<Type, Type> valueType,
+                           final Supplier<Object> empty, final Function<Object, Object> present)
+        {
+            this.optional = optional;
+            this.valueType = valueType;
+            this.empty = empty;
+            this.present = present;
+        }
+
+
+        static ValueInjector wrap(Type paramType, Function<Type, ValueInjector> injectorFactory) {
+            return Optional.ofNullable(optionalTypes.get(Types.getRawType(paramType)))
+                    .<ValueInjector>map(oi -> new DelegatingInjector(oi, injectorFactory.apply(oi.valueType.apply(paramType))))
+                    .orElseGet(() -> injectorFactory.apply(paramType));
+        }
+
+        static Type getTypeArgument(Type type) {
+             if (!(type instanceof ParameterizedType))
+                 throw new UnsupportedOperationException("non-parameterized Optional type: " + type);
+             return ((ParameterizedType) type).getActualTypeArguments()[0];
+        }
+
+        static class DelegatingInjector implements ValueInjector {
+            private final OptionalInjections oi;
+            private final ValueInjector delegate;
+
+            DelegatingInjector(final OptionalInjections oi, final ValueInjector delegate) {
+                this.oi = oi;
+                this.delegate = delegate;
+            }
+
+            @Override
+            public Object inject() {
+                return wrap(delegate.inject());
+            }
+
+            @Override
+            public Object inject(HttpRequest request, HttpResponse response) {
+                return wrap(delegate.inject(request, response));
+            }
+
+            public Object wrap(Object value) {
+                if (value == null) {
+                    return oi.empty.get();
+                }
+                return oi.present.apply(value);
+            }
+        }
+    }
+
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/OptionalInjectionTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/OptionalInjectionTest.java
@@ -11,6 +11,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.ws.rs.NotFoundException;
+
 /**
  * @tpSubChapter Resource tests
  * @tpChapter Unit tests
@@ -32,6 +34,7 @@ public class OptionalInjectionTest {
         Assert.assertEquals("none", registry.getResourceInvoker(req).invoke(req, resp).getEntity());
 
     }
+
 
     @Test
     public void testOptionalStringPresent() throws Exception {
@@ -63,6 +66,81 @@ public class OptionalInjectionTest {
         Assert.assertEquals("42", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
+
+    @Test
+    public void testMatrixParamAbsent() throws Exception {
+        MockHttpRequest httpRequest = MockHttpRequest.post("/optional/matrix");
+        Assert.assertEquals("42", registry
+                .getResourceInvoker(httpRequest)
+                .invoke(httpRequest, resp)
+                .getEntity());
+    }
+
+    @Test
+    public void testMatrixParamPresent() throws Exception {
+        MockHttpRequest httpRequest = MockHttpRequest.post("/optional/matrix;value=24");
+        Assert.assertEquals("24", registry
+                .getResourceInvoker(httpRequest)
+                .invoke(httpRequest, resp)
+                .getEntity());
+    }
+
+    @Test
+    public void testPathParamPresent() throws Exception {
+        MockHttpRequest httpRequest = MockHttpRequest.get("/optional/path/24");
+        Assert.assertEquals("24", registry
+                .getResourceInvoker(httpRequest)
+                .invoke(httpRequest, resp)
+                .getEntity());
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testPathParamNeverAbsentThrowsException() throws Exception {
+        MockHttpRequest httpRequest = MockHttpRequest.get("/optional/path/");
+        registry.getResourceInvoker(httpRequest)
+                .invoke(httpRequest, resp)
+                .getEntity();
+    }
+
+    @Test
+    public void testHeaderParamAbsent() throws Exception {
+        MockHttpRequest httpRequest = MockHttpRequest.get("/optional/header");
+        Assert.assertEquals("42", registry
+                .getResourceInvoker(httpRequest)
+                .invoke(httpRequest, resp)
+                .getEntity());
+    }
+
+
+    @Test
+    public void testHeaderParamPresent() throws Exception {
+        MockHttpRequest httpRequest = MockHttpRequest.get("/optional/header");
+        httpRequest.header("value", "24");
+        Assert.assertEquals("24", registry
+                .getResourceInvoker(httpRequest)
+                .invoke(httpRequest, resp)
+                .getEntity());
+    }
+
+    @Test
+    public void testCookieParamAbsent() throws Exception {
+        MockHttpRequest httpRequest = MockHttpRequest.get("/optional/cookie");
+        Assert.assertEquals("42", registry
+                .getResourceInvoker(httpRequest)
+                .invoke(httpRequest, resp)
+                .getEntity());
+    }
+
+    @Test
+    public void testCookieParamPresent() throws Exception {
+        MockHttpRequest httpRequest = MockHttpRequest.get("/optional/cookie");
+        httpRequest.cookie("value", "24");
+        Assert.assertEquals("24", registry
+                .getResourceInvoker(httpRequest)
+                .invoke(httpRequest, resp)
+                .getEntity());
+    }
+
 
     @Test
     public void testOptionalLongPresent() throws Exception {

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/OptionalInjectionTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/OptionalInjectionTest.java
@@ -1,0 +1,107 @@
+package org.jboss.resteasy.test.resource;
+
+import java.io.ByteArrayInputStream;
+
+import org.jboss.resteasy.core.ResourceMethodRegistry;
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.jboss.resteasy.mock.MockHttpResponse;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.test.resource.resource.OptionalResource;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @tpSubChapter Resource tests
+ * @tpChapter Unit tests
+ * @tpTestCaseDetails Tests to make sure that Optional<T> types are injectable
+ */
+public class OptionalInjectionTest {
+
+    ResourceMethodRegistry registry = new ResourceMethodRegistry(ResteasyProviderFactory.getInstance());
+    MockHttpResponse resp = new MockHttpResponse();
+
+    @Before
+    public void setup() {
+        registry.addPerRequestResource(OptionalResource.class);
+    }
+
+    @Test
+    public void testOptionalStringAbsent() throws Exception {
+        MockHttpRequest req = MockHttpRequest.get("/optional/string");
+        Assert.assertEquals("none", registry.getResourceInvoker(req).invoke(req, resp).getEntity());
+
+    }
+
+    @Test
+    public void testOptionalStringPresent() throws Exception {
+        MockHttpRequest req = MockHttpRequest.get("/optional/string?value=88");
+        Assert.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
+                .getEntity());
+    }
+
+    @Test
+    public void testOptionalHolderAbsent() throws Exception {
+        MockHttpRequest req = MockHttpRequest.get("/optional/holder");
+        Assert.assertEquals("none", registry.getResourceInvoker(req).invoke(req, resp)
+                .getEntity());
+    }
+
+    @Test
+    public void testOptionalHolderPresent() throws Exception {
+        MockHttpRequest req = MockHttpRequest.get("/optional/holder?value=88");
+        Assert.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
+                .getEntity());
+    }
+
+    @Test
+    public void testOptionalLongAbsent() throws Exception {
+        MockHttpRequest req = MockHttpRequest.post("/optional/long");
+        req.addFormHeader("notvalue", "badness");
+        req.setInputStream(new ByteArrayInputStream(new byte[0]));
+
+        Assert.assertEquals("42", registry.getResourceInvoker(req).invoke(req, resp)
+                .getEntity());
+    }
+
+    @Test
+    public void testOptionalLongPresent() throws Exception {
+        MockHttpRequest req = MockHttpRequest.post("/optional/long");
+        req.addFormHeader("value", "88");
+
+        Assert.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
+                .getEntity());
+    }
+
+    @Test
+    public void testOptionalIntAbsent() throws Exception {
+        MockHttpRequest req = MockHttpRequest.get("/optional/int");
+
+        Assert.assertEquals("424242", registry.getResourceInvoker(req).invoke(req, resp)
+                .getEntity());
+    }
+
+    @Test
+    public void testOptionalIntPresent() throws Exception {
+        MockHttpRequest req = MockHttpRequest.get("/optional/int?value=88");
+
+        Assert.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
+                .getEntity());
+    }
+
+    @Test
+    public void testOptionalDoubleAbsent() throws Exception {
+        MockHttpRequest req = MockHttpRequest.get("/optional/double");
+
+        Assert.assertEquals("4242.0", registry.getResourceInvoker(req).invoke(req, resp)
+                .getEntity());
+    }
+
+    @Test
+    public void testOptionalDoublePresent() throws Exception {
+        MockHttpRequest req = MockHttpRequest.get("/optional/double?value=88.88");
+
+        Assert.assertEquals("88.88", registry.getResourceInvoker(req).invoke(req, resp)
+                .getEntity());
+    }
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/OptionalResource.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/OptionalResource.java
@@ -1,0 +1,60 @@
+package org.jboss.resteasy.test.resource.resource;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+@Path("/optional")
+public class OptionalResource {
+    @Path("/string")
+    @GET
+    public String string(@QueryParam("value") Optional<String> value) {
+        return value.orElse("none");
+    }
+
+    @Path("/holder")
+    @GET
+    public String holder(@QueryParam("value") Optional<Holder<String>> value) {
+        return value.map(Holder::get).orElse("none");
+    }
+
+    @Path("/long")
+    @POST
+    public String optLong(@FormParam("value") OptionalLong value) {
+        return Long.toString(value.orElse(42));
+    }
+
+    @Path("/double")
+    @GET
+    public String optDouble(@QueryParam("value") OptionalDouble value) {
+        return Double.toString(value.orElse(4242.0));
+    }
+
+    @Path("/int")
+    @GET
+    public String optInt(@QueryParam("value") OptionalInt value) {
+        return Integer.toString(value.orElse(424242));
+    }
+
+    public static class Holder<T> {
+        private final T value;
+        private Holder(final T value) {
+            this.value = value;
+        }
+
+        T get() {
+            return value;
+        }
+
+        public static Holder<String> valueOf(String value) {
+            return new Holder<>(value);
+        }
+    }
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/OptionalResource.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/OptionalResource.java
@@ -1,15 +1,20 @@
 package org.jboss.resteasy.test.resource.resource;
 
+import org.jboss.resteasy.annotations.jaxrs.MatrixParam;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.QueryParam;
 
 @Path("/optional")
 public class OptionalResource {
@@ -57,4 +62,22 @@ public class OptionalResource {
             return new Holder<>(value);
         }
     }
+
+    @Path("/matrix")
+    @POST
+    public String matrix(@MatrixParam("value") OptionalLong value) {
+        return Long.toString(value.orElse(42));
+    }
+
+    @Path("/path/{value}")
+    @GET
+    public String path(@PathParam("value") OptionalLong value) { return Long.toString(value.orElse(42)); }
+
+    @Path("/header")
+    @GET
+    public String header(@HeaderParam("value") OptionalLong value) { return Long.toString(value.orElse(42)); }
+
+    @Path("/cookie")
+    @GET
+    public String cookie(@CookieParam("value") OptionalLong value) { return Long.toString(value.orElse(42)); }
 }


### PR DESCRIPTION
RESTEASY-1419 - Add support for injecting Optional<T> parameter types
This is the backport for branch 3.9