### PR TITLE
RESTEASY-2326 Allow extending resteasy-vertx classes

### DIFF
--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/RequestDispatcher.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/RequestDispatcher.java
@@ -74,7 +74,7 @@ public class RequestDispatcher
          SecurityContext securityContext;
          if (domain != null)
          {
-            securityContext = basicAuthentication(vertxReq, vertxResp);
+            securityContext = authenticate(vertxReq, vertxResp);
             if (securityContext == null) // not authenticated
             {
                return;
@@ -113,7 +113,7 @@ public class RequestDispatcher
       }
    }
 
-   private SecurityContext basicAuthentication(HttpRequest request, HttpResponse response) throws IOException
+   protected SecurityContext authenticate(HttpRequest request, HttpResponse response) throws IOException
    {
       List<String> headers = request.getHttpHeaders().getRequestHeader(HttpHeaderNames.AUTHORIZATION);
       if (!headers.isEmpty())

--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxRequestHandler.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxRequestHandler.java
@@ -27,11 +27,16 @@ public class VertxRequestHandler implements Handler<HttpServerRequest>
    protected final RequestDispatcher dispatcher;
    private final String servletMappingPrefix;
 
+   public VertxRequestHandler(final Vertx vertx, final RequestDispatcher dispatcher, final String servletMappingPrefix)
+   {
+     this.vertx = vertx;
+     this.dispatcher = dispatcher;
+     this.servletMappingPrefix = servletMappingPrefix;
+   }
+
    public VertxRequestHandler(final Vertx vertx, final ResteasyDeployment deployment, final String servletMappingPrefix, final SecurityDomain domain)
    {
-      this.vertx = vertx;
-      this.dispatcher = new RequestDispatcher((SynchronousDispatcher) deployment.getDispatcher(), deployment.getProviderFactory(), domain);
-      this.servletMappingPrefix = servletMappingPrefix;
+      this(vertx, new RequestDispatcher((SynchronousDispatcher) deployment.getDispatcher(), deployment.getProviderFactory(), domain), servletMappingPrefix);
    }
 
    public VertxRequestHandler(final Vertx vertx, final ResteasyDeployment deployment, final String servletMappingPrefix)


### PR DESCRIPTION
To address RESTEASY-2326, I have simply made it possible to override the require methods so we can provide our own implementation of authentication for resteasy-vertx, by allowing injection of our own `RequestDispatcher` and allowing us to override the `authenticate` method of that class.