### PR TITLE
resteasy-reactor: Fix a `null` case that causes hang

### DIFF
--- a/resteasy-reactor/src/main/java/org/jboss/resteasy/reactor/MonoProvider.java
+++ b/resteasy-reactor/src/main/java/org/jboss/resteasy/reactor/MonoProvider.java
@@ -1,38 +1,20 @@
 package org.jboss.resteasy.reactor;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.spi.AsyncClientResponseProvider;
 import org.jboss.resteasy.spi.AsyncResponseProvider;
-import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 
 @Provider
 public class MonoProvider implements AsyncResponseProvider<Mono<?>>, AsyncClientResponseProvider<Mono<?>>
 {
-   private static class MonoAdaptor<T> extends CompletableFuture<T>
-   {
-      private Disposable subscription;
-
-      MonoAdaptor(final Mono<T> single)
-      {
-         this.subscription = single.subscribe(this::complete, this::completeExceptionally);
-      }
-
-      @Override
-      public boolean cancel(boolean mayInterruptIfRunning)
-      {
-         subscription.dispose();
-         return super.cancel(mayInterruptIfRunning);
-      }
-   }
 
    @Override
    public CompletionStage<?> toCompletionStage(Mono<?> asyncResponse)
    {
-      return new MonoAdaptor<>(asyncResponse);
+      return asyncResponse.toFuture();
    }
 
    @Override

--- a/resteasy-reactor/src/test/java/org/jboss/resteasy/reactor/MonoProviderTest.java
+++ b/resteasy-reactor/src/test/java/org/jboss/resteasy/reactor/MonoProviderTest.java
@@ -1,0 +1,42 @@
+package org.jboss.resteasy.reactor;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+
+public class MonoProviderTest
+{
+    private final MonoProvider provider = new MonoProvider();
+
+    @Test
+    public void testFromCompletionStage()
+    {
+        final CompletableFuture<Integer> cs = new CompletableFuture<>();
+        cs.complete(1);
+        final Mono<?> mono = provider.fromCompletionStage(cs);
+        assertEquals(1, mono.block());
+    }
+
+    @Test
+    public void testToCompletionStageCase() throws Exception
+    {
+        final Object actual = provider.toCompletionStage(Mono.just(1)).toCompletableFuture().get();
+        assertEquals(1, actual);
+    }
+
+    @Test
+    public void testToCompletionStageNullCase() throws Exception
+    {
+        // Kind of a weird test, but added with code that fixed a hang.
+        final CompletableFuture<Integer> cs = new CompletableFuture<>();
+        cs.complete(null);
+        final Mono<?> mono = Mono.fromCompletionStage(cs);
+        final Object actual = provider.toCompletionStage(mono).toCompletableFuture().get();
+        assertNull(actual);
+    }
+}


### PR DESCRIPTION
The replaced code in `MonoProvider` was blindly copied from rxjava2.  We
use this code in our application and the code in `testToCompletionStageNullCase`
represents a scenario our app deals with.  With the `MonoAdapter`, that
code hangs.  Leveraging the existing `Mono#toFuture`, which I should
have done in the first place, addresses that hang.