### PR TITLE
Avoid reflection on String parameters

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/StringParameterInjector.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/StringParameterInjector.java
@@ -543,7 +543,7 @@ public class StringParameterInjector
       catch (NoSuchMethodException e)
       {
       }
-      if (baseType.isPrimitive())
+      if (StringToPrimitive.isPrimitive(baseType))
       {
          return true;
       }
@@ -669,7 +669,7 @@ public class StringParameterInjector
          if (defaultValue == null)
          {
             //System.out.println("NO DEFAULT VALUE");
-            if (!baseType.isPrimitive()) return null;
+            if (!StringToPrimitive.isPrimitive(baseType)) return null;
             else
                return StringToPrimitive.stringToPrimitiveBoxType(baseType, strVal);
          }
@@ -752,7 +752,7 @@ public class StringParameterInjector
       }
       try
       {
-         if (baseType.isPrimitive()) return StringToPrimitive.stringToPrimitiveBoxType(baseType, strVal);
+         if (StringToPrimitive.isPrimitive(baseType)) return StringToPrimitive.stringToPrimitiveBoxType(baseType, strVal);
       }
       catch (Exception e)
       {

--- a/resteasy-core/src/main/java/org/jboss/resteasy/util/StringToPrimitive.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/util/StringToPrimitive.java
@@ -6,6 +6,16 @@ package org.jboss.resteasy.util;
  */
 public class StringToPrimitive
 {
+   /**
+    * Include string as a primitive type
+    *
+    * @param primitiveType
+    * @return
+    */
+   public static boolean isPrimitive(Class primitiveType) {
+      return primitiveType.isPrimitive() || primitiveType.equals(String.class);
+   }
+
    public static Object stringToPrimitiveBoxType(Class primitiveType, String value)
    {
       if (primitiveType.equals(String.class)) return value;


### PR DESCRIPTION
Any String parameters where being unmarshalled by reflectively calling String.valueOf(param).  Should improve performance!

This was found by running Graal and finding that String.class had to be added as a reflective type!