### PR TITLE
[RESTEASY-2042] module.xml in resteasy-jaxrs is missing dependency to microprofile-config-api

### DIFF
--- a/jboss-modules/src/main/resources/modules/org/jboss/resteasy/resteasy-jackson-provider/main/module.xml
+++ b/jboss-modules/src/main/resources/modules/org/jboss/resteasy/resteasy-jackson-provider/main/module.xml
@@ -39,6 +39,6 @@
         <module name="javax.ws.rs.api"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
         <module name="org.jboss.logging"/>
-        <module name="org.eclipse.microprofile.config.api" optional="true"/>
+        <module name="org.eclipse.microprofile.config.api" optional="true"/> <!-- not really optional, just a workaround for WFLY12/13 missing MP Config API -->
     </dependencies>
 </module>

--- a/jboss-modules/src/main/resources/modules/org/jboss/resteasy/resteasy-jackson-provider/main/module.xml
+++ b/jboss-modules/src/main/resources/modules/org/jboss/resteasy/resteasy-jackson-provider/main/module.xml
@@ -39,5 +39,6 @@
         <module name="javax.ws.rs.api"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
         <module name="org.jboss.logging"/>
+        <module name="org.eclipse.microprofile.config.api" optional="true"/>
     </dependencies>
 </module>

--- a/jboss-modules/src/main/resources/modules/org/jboss/resteasy/resteasy-jaxrs/main/module.xml
+++ b/jboss-modules/src/main/resources/modules/org/jboss/resteasy/resteasy-jaxrs/main/module.xml
@@ -47,6 +47,6 @@
         <module name="org.jboss.logging"/>
         <module name="org.reactivestreams"/>
         <module name="org.eclipse.microprofile.restclient"/>
-        <module name="org.eclipse.microprofile.config.api" optional="true"/>
+        <module name="org.eclipse.microprofile.config.api" optional="true"/> <!-- not really optional, just a workaround for WFLY12/13 missing MP Config API -->
     </dependencies>
 </module>

--- a/jboss-modules/src/main/resources/modules/org/jboss/resteasy/resteasy-jaxrs/main/module.xml
+++ b/jboss-modules/src/main/resources/modules/org/jboss/resteasy/resteasy-jaxrs/main/module.xml
@@ -47,5 +47,6 @@
         <module name="org.jboss.logging"/>
         <module name="org.reactivestreams"/>
         <module name="org.eclipse.microprofile.restclient"/>
+        <module name="org.eclipse.microprofile.config.api" optional="true"/>
     </dependencies>
 </module>

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/category/ExpectedFailingOnWildFly12.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/category/ExpectedFailingOnWildFly12.java
@@ -1,0 +1,9 @@
+package org.jboss.resteasy.category;
+
+/**
+ * Marker interface for tests which are expected to fail on WildFly 12.0.0.Final
+ *
+ */
+public interface ExpectedFailingOnWildFly12 {
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HelloClient.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HelloClient.java
@@ -1,0 +1,13 @@
+package org.jboss.resteasy.test.microprofile.restclient;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/")
+public interface HelloClient {
+
+    @GET
+    @Path("/hello")
+    String hello();
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HelloResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HelloResource.java
@@ -1,0 +1,17 @@
+package org.jboss.resteasy.test.microprofile.restclient;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path("/")
+public class HelloResource {
+
+    @GET
+    @Produces("text/plain")
+    @Path("/hello")
+    public String hello() {
+       return "Hello";
+    }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProxyTest.java
@@ -1,0 +1,65 @@
+package org.jboss.resteasy.test.microprofile.restclient;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.net.URL;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.resteasy.category.ExpectedFailingOnWildFly12;
+import org.jboss.resteasy.category.ExpectedFailingOnWildFly13;
+import org.jboss.resteasy.client.microprofile.MicroprofileClientBuilderResolver;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class RestClientProxyTest
+{
+
+   @ArquillianResource
+   URL url;
+
+   @Deployment
+   public static Archive<?> deploy()
+   {
+      WebArchive war = TestUtil.prepareArchive(RestClientProxyTest.class.getSimpleName());
+      war.addClass(RestClientProxyTest.class);
+      war.addPackage(HelloResource.class.getPackage());
+      war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+      war.addClass(PortProviderUtil.class);
+      war.addClass(ExpectedFailingOnWildFly12.class);
+      war.addClass(ExpectedFailingOnWildFly13.class);
+      war.addClass(Category.class);
+      war.addAsManifestResource(new StringAsset("Dependencies: org.eclipse.microprofile.restclient\n"), "MANIFEST.MF");
+      return TestUtil.finishContainerPrepare(war, null);
+   }
+
+   private String generateURL(String path)
+   {
+      return PortProviderUtil.generateURL(path, RestClientProxyTest.class.getSimpleName());
+   }
+
+   @Test
+   @Category({ExpectedFailingOnWildFly12.class, ExpectedFailingOnWildFly13.class})
+   public void testGetClient() throws Exception
+   {
+      RestClientBuilder builder = RestClientBuilder.newBuilder();
+      RestClientBuilder resteasyBuilder = MicroprofileClientBuilderResolver.instance().newBuilder();
+      assertEquals(resteasyBuilder.getClass(), builder.getClass());
+      HelloClient client = builder.baseUrl(new URL(generateURL(""))).build(HelloClient.class);
+
+      assertNotNull(client);
+      assertEquals("Hello", client.hello());
+   }
+
+}

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -119,6 +119,18 @@
             </properties>
         </profile>
         <profile>
+            <id>server-version-12x-exclusions</id>
+            <activation>
+              <property>
+                <name>server.version</name>
+                <value>12.0.0.Final</value>
+              </property>
+            </activation>
+            <properties>
+              <additional.surefire.excluded.groups>org.jboss.resteasy.category.ExpectedFailingOnWildFly12</additional.surefire.excluded.groups>
+            </properties>
+        </profile>
+        <profile>
             <id>server-version-13x-exclusions</id>
             <activation>
               <property>


### PR DESCRIPTION
Backporting RESTEASY-2042 to the 3.6.1.SPx branch.

https://issues.jboss.org/browse/RESTEASY-2042
