### PR TITLE
Add support for remote ip/address without requiring HttpServletRequest

### DIFF
--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/HttpRequest.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/HttpRequest.java
@@ -90,4 +90,24 @@ public interface HttpRequest
 
    boolean wasForwarded();
 
+   /**
+    * Returns the Internet Protocol (IP) address of the client
+    * or last proxy that sent the request.
+    *
+    * @return a <code>String</code> containing the
+    * IP address of the client that sent the request
+    */
+   String getRemoteAddress();
+
+   /**
+    * Returns the fully qualified name of the client
+    * or the last proxy that sent the request.
+    * If the engine cannot or chooses not to resolve the hostname
+    * (to improve performance), this method returns the dotted-string form of
+    * the IP address.
+    *
+    * @return a <code>String</code> containing the fully
+    * qualified name of the client
+    */
+   String getRemoteHost();
 }

--- a/resteasy-core/src/main/java/org/jboss/resteasy/mock/MockHttpRequest.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/mock/MockHttpRequest.java
@@ -372,4 +372,16 @@ public class MockHttpRequest extends BaseHttpRequest
    {
       return false;
    }
+
+   @Override
+   public String getRemoteHost()
+   {
+      return null;
+   }
+
+   @Override
+   public String getRemoteAddress()
+   {
+      return null;
+   }
 }

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/HttpServletInputMessage.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/HttpServletInputMessage.java
@@ -284,4 +284,16 @@ public class HttpServletInputMessage extends BaseHttpRequest
       }
       return true;
    }
+
+   @Override
+   public String getRemoteHost()
+   {
+      return request.getRemoteHost();
+   }
+
+   @Override
+   public String getRemoteAddress()
+   {
+      return request.getRemoteAddr();
+   }
 }

--- a/resteasy-core/src/main/java/org/jboss/resteasy/util/DelegatingHttpRequest.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/util/DelegatingHttpRequest.java
@@ -143,4 +143,16 @@ public class DelegatingHttpRequest implements HttpRequest
    {
       return delegate.wasForwarded();
    }
+
+   @Override
+   public String getRemoteHost()
+   {
+      return delegate.getRemoteHost();
+   }
+
+   @Override
+   public String getRemoteAddress()
+   {
+      return delegate.getRemoteAddress();
+   }
 }

--- a/server-adapters/resteasy-jdk-http/src/main/java/org/jboss/resteasy/plugins/server/sun/http/HttpServerRequest.java
+++ b/server-adapters/resteasy-jdk-http/src/main/java/org/jboss/resteasy/plugins/server/sun/http/HttpServerRequest.java
@@ -139,4 +139,14 @@ public class HttpServerRequest extends BaseHttpRequest
    {
       return false;
    }
+
+   @Override
+   public String getRemoteHost() {
+       return exchange.getRemoteAddress().getHostName();
+   }
+
+   @Override
+   public String getRemoteAddress() {
+       return exchange.getRemoteAddress().getAddress().getHostAddress();
+   }
 }

--- a/server-adapters/resteasy-jdk-http/src/test/java/org/jboss/resteasy/test/HttpContextTest.java
+++ b/server-adapters/resteasy-jdk-http/src/test/java/org/jboss/resteasy/test/HttpContextTest.java
@@ -75,6 +75,12 @@ public class HttpContextTest
          Assert.assertEquals(200, response.getStatus());
          Assert.assertEquals("1234", response.readEntity(String.class));
       }
-   }
+
+      {
+          Response response = client.target(generateURL("/request")).request().get();
+          Assert.assertEquals(200, response.getStatus());
+          Assert.assertEquals("127.0.0.1/localhost", response.readEntity(String.class));
+       }
+}
 
 }

--- a/server-adapters/resteasy-jdk-http/src/test/java/org/jboss/resteasy/test/SimpleResource.java
+++ b/server-adapters/resteasy-jdk-http/src/test/java/org/jboss/resteasy/test/SimpleResource.java
@@ -1,7 +1,5 @@
 package org.jboss.resteasy.test;
 
-import org.jboss.logging.Logger;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.MatrixParam;
@@ -10,7 +8,11 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.spi.HttpRequest;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -69,5 +71,13 @@ public class SimpleResource
    public Response getHeader()
    {
       return Response.ok().header("header", "headervalue").build();
+   }
+
+   @GET
+   @Path("request")
+   @Produces("text/plain")
+   public String getRequest(@Context HttpRequest req)
+   {
+      return req.getRemoteAddress() + "/" + req.getRemoteHost();
    }
 }

--- a/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpRequest.java
+++ b/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpRequest.java
@@ -23,6 +23,7 @@ import javax.ws.rs.core.Response;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -399,5 +400,17 @@ public class NettyHttpRequest extends BaseHttpRequest
             resume(new ServiceUnavailableException());
          }
       }
+   }
+
+   @Override
+   public String getRemoteHost()
+   {
+      return ((InetSocketAddress)ctx.channel().remoteAddress()).getHostName();
+   }
+
+   @Override
+   public String getRemoteAddress()
+   {
+      return ((InetSocketAddress)ctx.channel().remoteAddress()).getAddress().getHostAddress();
    }
 }

--- a/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/NettyTest.java
+++ b/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/NettyTest.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.UriInfo;
 
 import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 import org.jboss.resteasy.plugins.server.netty.NettyContainer;
+import org.jboss.resteasy.spi.HttpRequest;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -110,6 +111,14 @@ public class NettyTest
       public String absolute(@Context UriInfo info)
       {
          return "uri: " + info.getRequestUri().toString();
+      }
+
+      @GET
+      @Path("request")
+      @Produces("text/plain")
+      public String getRequest(@Context HttpRequest req)
+      {
+         return req.getRemoteAddress() + "/" + req.getRemoteHost();
       }
    }
 
@@ -280,5 +289,13 @@ public class NettyTest
       client.close();
       Assert.assertEquals("HTTP/1.1 200 OK", statusLine);
       Assert.assertEquals(uri, response.subSequence(5, response.length()));
+   }
+
+   @Test
+   public void testRequest() throws Exception
+   {
+      WebTarget target = client.target(generateURL("/request"));
+      String val = target.request().get(String.class);
+      Assert.assertEquals("127.0.0.1/localhost", val);
    }
 }

--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpRequest.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpRequest.java
@@ -1,6 +1,8 @@
 package org.jboss.resteasy.plugins.server.vertx;
 
 import io.vertx.core.Context;
+import io.vertx.core.http.HttpServerRequest;
+
 import org.jboss.resteasy.core.AbstractAsynchronousResponse;
 import org.jboss.resteasy.core.AbstractExecutionContext;
 import org.jboss.resteasy.core.SynchronousDispatcher;
@@ -49,16 +51,18 @@ public class VertxHttpRequest extends BaseHttpRequest
    private VertxExecutionContext executionContext;
    private final Context context;
    private volatile boolean flushed;
+   private HttpServerRequest request;
 
-   public VertxHttpRequest(final Context context, final ResteasyHttpHeaders httpHeaders, final ResteasyUriInfo uri, final String httpMethod, final SynchronousDispatcher dispatcher, final VertxHttpResponse response, final boolean is100ContinueExpected)
+   public VertxHttpRequest(final Context context, final HttpServerRequest request, final ResteasyUriInfo uri, final SynchronousDispatcher dispatcher, final VertxHttpResponse response, final boolean is100ContinueExpected)
    {
       super(uri);
       this.context = context;
       this.is100ContinueExpected = is100ContinueExpected;
       this.response = response;
+      this.request = request;
       this.dispatcher = dispatcher;
-      this.httpHeaders = httpHeaders;
-      this.httpMethod = httpMethod;
+      this.httpHeaders = VertxUtil.extractHttpHeaders(request);
+      this.httpMethod = request.rawMethod();
       this.executionContext = new VertxExecutionContext(this, response, dispatcher);
    }
 
@@ -390,5 +394,17 @@ public class VertxHttpRequest extends BaseHttpRequest
             resume(new ServiceUnavailableException());
          }
       }
+   }
+
+   @Override
+   public String getRemoteHost()
+   {
+      return request.remoteAddress().host();
+   }
+
+   @Override
+   public String getRemoteAddress()
+   {
+      return request.remoteAddress().host();
    }
 }

--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxRequestHandler.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxRequestHandler.java
@@ -10,7 +10,6 @@ import org.jboss.resteasy.core.SynchronousDispatcher;
 import org.jboss.resteasy.plugins.server.embedded.SecurityDomain;
 import org.jboss.resteasy.plugins.server.vertx.i18n.LogMessages;
 import org.jboss.resteasy.plugins.server.vertx.i18n.Messages;
-import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
 import org.jboss.resteasy.spi.Failure;
 import org.jboss.resteasy.spi.ResteasyDeployment;
 import org.jboss.resteasy.specimpl.ResteasyUriInfo;
@@ -50,10 +49,9 @@ public class VertxRequestHandler implements Handler<HttpServerRequest>
       request.bodyHandler(buff -> {
          Context ctx = vertx.getOrCreateContext();
          ResteasyUriInfo uriInfo = VertxUtil.extractUriInfo(request, servletMappingPrefix);
-         ResteasyHttpHeaders headers = VertxUtil.extractHttpHeaders(request);
          HttpServerResponse response = request.response();
          VertxHttpResponse vertxResponse = new VertxHttpResponse(response, dispatcher.getProviderFactory(), request.method());
-         VertxHttpRequest vertxRequest = new VertxHttpRequest(ctx, headers, uriInfo, request.rawMethod(), dispatcher.getDispatcher(), vertxResponse, false);
+         VertxHttpRequest vertxRequest = new VertxHttpRequest(ctx, request, uriInfo, dispatcher.getDispatcher(), vertxResponse, false);
          if (buff.length() > 0)
          {
             ByteBufInputStream in = new ByteBufInputStream(buff.getByteBuf());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/request/ResteasyRequestTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/request/ResteasyRequestTest.java
@@ -1,0 +1,72 @@
+package org.jboss.resteasy.test.resource.request;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.spi.HttpResponseCodes;
+import org.jboss.resteasy.test.resource.request.resource.RequestResource;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @tpSubChapter Resource
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Tests for ResteasyRequest
+ * @tpSince RESTEasy 4.3.2
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ResteasyRequestTest {
+
+   static Client client;
+   static WebTarget requestWebTarget;
+
+   @BeforeClass
+   public static void before() throws Exception {
+      client = ClientBuilder.newClient();
+      requestWebTarget = client.target(generateURL("/request"));
+   }
+
+   @AfterClass
+   public static void close() {
+      client.close();
+   }
+
+   @Deployment
+   public static Archive<?> deploy() {
+      WebArchive war = TestUtil.prepareArchive(ResteasyRequestTest.class.getSimpleName());
+      return TestUtil.finishContainerPrepare(war, null, RequestResource.class);
+   }
+
+   private static String generateURL(String path) {
+      return PortProviderUtil.generateURL(path, ResteasyRequestTest.class.getSimpleName());
+   }
+
+   /**
+    * @tpTestDetails Checks ResteasyRequest
+    * @tpSince RESTEasy 4.3.2
+    */
+   @Test
+   public void testRequest() {
+      try {
+         Response response = requestWebTarget.request().get();
+         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+         Assert.assertEquals("127.0.0.1/127.0.0.1", response.readEntity(String.class));
+         response.close();
+      } catch (Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+   }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/request/resource/RequestResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/request/resource/RequestResource.java
@@ -1,0 +1,19 @@
+package org.jboss.resteasy.test.resource.request.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+
+import org.jboss.resteasy.spi.HttpRequest;
+
+@Path("/request")
+public class RequestResource
+{
+   @GET
+   @Produces("text/plain")
+   public String getRequest(@Context HttpRequest req)
+   {
+      return req.getRemoteAddress() + "/" + req.getRemoteHost();
+   }
+}


### PR DESCRIPTION
New interface ResteasyRequest extends JAX-RS Request with those methods
But it delegates to HttpRequest (perhaps we don't need both?)

This works, but we need to make some decisions:

- Do we keep `ResteasyRequest` as a subtype of JAX-RS `Request`, or do we tell users to inject RESTEasy's `HttpRequest` which has to have those methods anyway?
- Do we keep the `String getRemoteAddress/getRemoteHost` duo or go for something like `InetSocketAddress getRemoteAddress` like Netty has?

WDYT @patriot1burke @asoldano ?