### PR TITLE
feat: use the method parameter name if annotation configuration is not provided

### DIFF
--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
@@ -728,6 +728,10 @@ public class ResourceBuilder
          resourceClassBuilder.resourceMethods.add(method);
          return resourceClassBuilder;
       }
+
+      public DefaultResourceMethod getMethod() {
+         return method;
+      }
    }
 
    public static class FieldParameterBuilder extends ParameterBuilder<FieldParameterBuilder>

--- a/resteasy-spring-web/src/main/java/org/jboss/resteasy/spi/metadata/SpringResourceBuilder.java
+++ b/resteasy-spring-web/src/main/java/org/jboss/resteasy/spi/metadata/SpringResourceBuilder.java
@@ -368,14 +368,21 @@ public class SpringResourceBuilder extends ResourceBuilder {
 
         @Override
         public ResourceMethodParameterBuilder param(int i) {
-            return new SpringResourceMethodParameterBuilder(this, getLocator().getParams()[i]);
+            String defaultName = null;
+            if (this.getMethod().getAnnotatedMethod().getParameters()[i].isNamePresent()) {
+                defaultName = this.getMethod().getAnnotatedMethod().getParameters()[i].getName();
+            }
+            return new SpringResourceMethodParameterBuilder(this, getLocator().getParams()[i], defaultName);
         }
     }
 
     private static class SpringResourceMethodParameterBuilder extends ResourceMethodParameterBuilder {
 
-        SpringResourceMethodParameterBuilder(final ResourceMethodBuilder method, final MethodParameter param) {
+        final String defaultName;
+
+        SpringResourceMethodParameterBuilder(final ResourceMethodBuilder method, final MethodParameter param, final String defaultName) {
             super(method, param);
+            this.defaultName = defaultName;
         }
 
         @Override
@@ -454,6 +461,9 @@ public class SpringResourceBuilder extends ResourceBuilder {
                 parameter.setParamType(Parameter.ParamType.CONTEXT);
             } else {
                 parameter.setParamType(Parameter.ParamType.UNKNOWN);
+            }
+            if (parameter.getParamName().isEmpty() && (defaultName != null)){
+                parameter.setParamName(defaultName);
             }
         }
     }

--- a/testsuite/integration-tests-spring-web/deployment/pom.xml
+++ b/testsuite/integration-tests-spring-web/deployment/pom.xml
@@ -253,6 +253,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/testsuite/integration-tests-spring-web/deployment/src/test/java/org/jboss/resteasy/test/spring/web/deployment/resource/TestController.java
+++ b/testsuite/integration-tests-spring-web/deployment/src/test/java/org/jboss/resteasy/test/spring/web/deployment/resource/TestController.java
@@ -20,7 +20,7 @@ public class TestController {
     public static final String CONTROLLER_PATH = "spring";
 
     @GetMapping("/hello")
-    public String string(@RequestParam(name = "name") String name) {
+    public String string(@RequestParam String name) {
         return "hello " + name;
     }
 
@@ -29,18 +29,28 @@ public class TestController {
         return "hello " + name;
     }
 
+    @GetMapping("/hello3")
+    public String stringWithNameValue(@RequestParam(name = "name") String name) {
+        return "hello " + name;
+    }
+
     @GetMapping("/int/{num}")
     public Integer intPathVariable(@PathVariable("num") Integer number) {
         return number + 1;
     }
 
+    @GetMapping("/{msg}")
+    public String stringPathVariable(@PathVariable("msg") String message) {
+        return message;
+    }
+
     @GetMapping(path = "/json/{message}")
-    public SomeClass json(@PathVariable("message") String message) {
+    public SomeClass json(@PathVariable String message) {
         return new SomeClass(message);
     }
 
     @RequestMapping(path = "/json2/{message}", produces = MediaType.APPLICATION_JSON)
-    public SomeClass jsonFromRequestMapping(@PathVariable("message") String message) {
+    public SomeClass jsonFromRequestMapping(@PathVariable String message) {
         return new SomeClass(message);
     }
 


### PR DESCRIPTION
if no annotation values (for "name" or "value") are supplied the method parameter name will be used
Related to Quarkus [#3992](https://github.com/quarkusio/quarkus/issues/3992) issue

Could you @geoand please review this and forward it to someone else if necessary?