### PR TITLE
Allow UnmodifiableMultivaluedMap to create EntrySet lazily

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/ResteasyHttpHeaders.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/ResteasyHttpHeaders.java
@@ -34,10 +34,20 @@ public class ResteasyHttpHeaders implements HttpHeaders
       this(requestHeaders, new HashMap<String, Cookie>());
    }
 
+   public ResteasyHttpHeaders(final MultivaluedMap<String, String> requestHeaders, final boolean eagerlyInitializeEntrySet)
+   {
+      this(requestHeaders, new HashMap<String, Cookie>(), eagerlyInitializeEntrySet);
+   }
+
    public ResteasyHttpHeaders(final MultivaluedMap<String, String> requestHeaders, final Map<String, Cookie> cookies)
    {
+      this(requestHeaders, cookies, true);
+   }
+
+   public ResteasyHttpHeaders(final MultivaluedMap<String, String> requestHeaders, final Map<String, Cookie> cookies, final boolean eagerlyInitializeEntrySet)
+   {
       this.requestHeaders = requestHeaders;
-      this.unmodifiableRequestHeaders = new UnmodifiableMultivaluedMap<>(requestHeaders);
+      this.unmodifiableRequestHeaders = new UnmodifiableMultivaluedMap<>(requestHeaders, eagerlyInitializeEntrySet);
       this.cookies = (cookies == null ? new HashMap<>() : cookies);
    }
 

--- a/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/UnmodifiableMultivaluedMap.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/UnmodifiableMultivaluedMap.java
@@ -20,21 +20,24 @@ public class UnmodifiableMultivaluedMap<K, V> implements MultivaluedMap<K, V>
 
    private final MultivaluedMap<K, V> delegate;
 
-   private final Set<java.util.Map.Entry<K, List<V>>> entrySet;
+   private volatile Set<java.util.Map.Entry<K, List<V>>> entrySet;
 
    public UnmodifiableMultivaluedMap(final MultivaluedMap<K, V> delegate)
    {
+      this(delegate, true);
+   }
+
+   public UnmodifiableMultivaluedMap(final MultivaluedMap<K, V> delegate, final boolean eagerlyInitializeEntrySet)
+   {
       this.delegate = delegate;
-      this.entrySet = buildEntrySet();
+      if (eagerlyInitializeEntrySet) {
+         this.entrySet = buildEntrySet();
+      }
    }
 
    private Set<java.util.Map.Entry<K, List<V>>> buildEntrySet()
    {
       Set<java.util.Map.Entry<K, List<V>>> entrySetDelegator = delegate.entrySet();
-      if (entrySetDelegator == null)
-      {
-         return null;
-      }
       Set<java.util.Map.Entry<K, List<V>>> entrySetToReturn = new HashSet<>();
       for (final java.util.Map.Entry<K, List<V>> entry : entrySetDelegator)
       {
@@ -116,6 +119,9 @@ public class UnmodifiableMultivaluedMap<K, V> implements MultivaluedMap<K, V>
    @Override
    public Set<Entry<K, List<V>>> entrySet()
    {
+      if (this.entrySet == null) {
+         this.entrySet = buildEntrySet();
+      }
       return this.entrySet;
    }
 

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/UnmodifiableMultivaluedMapTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/UnmodifiableMultivaluedMapTest.java
@@ -29,7 +29,7 @@ public class UnmodifiableMultivaluedMapTest
 {
 
    @Test
-   public void testNotModifiable()
+   public void testEagerlyCreatedNotModifiable()
    {
       MultivaluedMap<String, String> modifiableMultivaluedMap = new MultivaluedHashMap<>();
       modifiableMultivaluedMap.addAll("Hello", "Bonjour");
@@ -37,6 +37,22 @@ public class UnmodifiableMultivaluedMapTest
       UnmodifiableMultivaluedMap<String, String> unmodifiableMultivaluedMap = new UnmodifiableMultivaluedMap<>(
             modifiableMultivaluedMap);
 
+      doTest(unmodifiableMultivaluedMap);
+   }
+
+   @Test
+   public void testLazilyCreatedNotModifiable()
+   {
+      MultivaluedMap<String, String> modifiableMultivaluedMap = new MultivaluedHashMap<>();
+      modifiableMultivaluedMap.addAll("Hello", "Bonjour");
+
+      UnmodifiableMultivaluedMap<String, String> unmodifiableMultivaluedMap = new UnmodifiableMultivaluedMap<>(
+              modifiableMultivaluedMap, false);
+
+      doTest(unmodifiableMultivaluedMap);
+   }
+
+   private void doTest(UnmodifiableMultivaluedMap<String, String> unmodifiableMultivaluedMap) {
       try
       {
          unmodifiableMultivaluedMap.add("Forbidden", "Interdit");


### PR DESCRIPTION
Relates to: https://github.com/quarkusio/quarkus/issues/4345

Basically in a lot of the benchmarks the EntrySet of `UnmodifiableMultivaluedMap` is never queried, however without this patch it is always created.

During CPU profiling (using async-profiler) of Quarkus `0.24.0` which uses RESTEasy `4.3.1.Final`  I discovered entries like the following:

```
--- 220900450 ns (0.13%), 22 samples
  [ 0] ObjectSynchronizer::FastHashCode(Thread*, oopDesc*)
  [ 1] JVM_IHashCode
  [ 2] java.lang.Object.hashCode
  [ 3] java.util.HashMap.hash
  [ 4] java.util.HashMap.put
  [ 5] java.util.HashSet.add
  [ 6] org.jboss.resteasy.specimpl.UnmodifiableMultivaluedMap.buildEntrySet
  [ 7] org.jboss.resteasy.specimpl.UnmodifiableMultivaluedMap.<init>
  [ 8] org.jboss.resteasy.specimpl.ResteasyHttpHeaders.<init>
  [ 9] org.jboss.resteasy.specimpl.ResteasyHttpHeaders.<init>
  [10] org.jboss.resteasy.specimpl.ResteasyHttpHeaders.<init>
  [11] io.quarkus.resteasy.runtime.standalone.VertxUtil.extractHttpHeaders
  [12] io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.dispatch
  [13] io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.dispatchRequestContext
  [14] io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.lambda$handle$0
  [15] io.quarkus.resteasy.runtime.standalone.VertxRequestHandler$$Lambda$228.2111501191.handle
  [16] io.vertx.core.impl.ContextImpl.lambda$executeBlocking$2
  [17] io.vertx.core.impl.ContextImpl$$Lambda$240.1018596449.run
  [18] java.util.concurrent.ThreadPoolExecutor.runWorker
  [19] java.util.concurrent.ThreadPoolExecutor$Worker.run
  [20] io.netty.util.concurrent.FastThreadLocalRunnable.run
  [21] java.lang.Thread.run
```

With this PR those entries completely go away