### PR TITLE
RESTEASY-828 Issue with injected ServletContext in Resteasy/SpringMVC setup

### DIFF
--- a/resteasy-spring/src/main/java/org/jboss/resteasy/springmvc/ResteasySpringDispatcherServlet.java
+++ b/resteasy-spring/src/main/java/org/jboss/resteasy/springmvc/ResteasySpringDispatcherServlet.java
@@ -1,0 +1,23 @@
+package org.jboss.resteasy.springmvc;
+
+import org.jboss.resteasy.core.ResteasyContext;
+import org.springframework.web.servlet.DispatcherServlet;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+
+public class ResteasySpringDispatcherServlet extends DispatcherServlet {
+   @Override
+   protected void doDispatch(HttpServletRequest request, HttpServletResponse response) throws Exception {
+      try {
+         ServletContext servletContext = this.getServletContext();
+         Map<Class<?>, Object> map = ResteasyContext.getContextDataMap();
+         map.put(ServletContext.class, servletContext);
+         super.doDispatch(request, response);
+      } finally {
+         ResteasyContext.popContextData(ServletContext.class);
+      }
+   }
+}

--- a/testsuite/integration-tests-spring/inmodule/pom.xml
+++ b/testsuite/integration-tests-spring/inmodule/pom.xml
@@ -306,4 +306,24 @@
         </plugins>
     </build>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-core</artifactId>
+            <version>${version.resteasy.testsuite}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-depchain</artifactId>
+            <scope>test</scope>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/RESTEasy828Test.java
+++ b/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/RESTEasy828Test.java
@@ -1,0 +1,118 @@
+package org.jboss.resteasy.test.spring.inmodule;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.spi.HttpResponseCodes;
+import org.jboss.resteasy.springmvc.ResteasySpringDispatcherServlet;
+import org.jboss.resteasy.test.spring.inmodule.resource.RESTEasy828Resource;
+
+import org.jboss.resteasy.utils.PermissionUtil;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import java.io.File;
+import java.io.FilePermission;
+import java.lang.reflect.ReflectPermission;
+import java.util.PropertyPermission;
+import java.util.logging.LoggingPermission;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class RESTEasy828Test {
+
+   static Client client;
+   private static final String ERROR_MESSAGE = "Got unexpected entity from the server";
+
+   private String generateURL(String path) {
+      return PortProviderUtil.generateURL(path, RESTEasy828Test.class.getSimpleName());
+   }
+
+   @Before
+   public void init() {
+      client = ClientBuilder.newClient();
+   }
+
+   @After
+   public void after() throws Exception {
+      client.close();
+   }
+
+   @Deployment
+   private static Archive<?> deploy() {
+      WebArchive archive = ShrinkWrap.create(WebArchive.class, RESTEasy828Test.class.getSimpleName() + ".war")
+              .addAsWebInfResource(RESTEasy828Test.class.getPackage(), "resteasy828/web.xml", "web.xml");
+      archive.addAsWebInfResource(RESTEasy828Test.class.getPackage(),
+              "resteasy828/applicationContext.xml", "applicationContext.xml");
+
+      archive.addClass(RESTEasy828Resource.class);
+
+      archive.addAsLibraries(Maven
+              .resolver()
+              .loadPomFromFile("pom.xml")
+              .resolve("org.springframework:spring-webmvc")
+              .withTransitivity()
+              .asFile());
+
+      archive.addAsLibraries(Maven
+              .resolver()
+              .loadPomFromFile("pom.xml")
+              .resolve("org.jboss.resteasy:resteasy-spring")
+              .withTransitivity()
+              .asFile());
+
+      archive.addAsLibraries(Maven
+              .resolver()
+              .loadPomFromFile("pom.xml")
+              .resolve("org.jboss.resteasy:resteasy-core")
+              .withTransitivity()
+              .asFile());
+
+      archive.addAsLibraries(Maven
+              .resolver()
+              .loadPomFromFile("pom.xml")
+              .resolve("org.jboss.resteasy:resteasy-core-spi")
+              .withTransitivity()
+              .asFile());
+
+
+      archive.as(ZipExporter.class).exportTo(
+              new File("/tmp/RESTEasy828Test.war"), true);
+
+      // Permission needed for "arquillian.debug" to run
+      // "suppressAccessChecks" required for access to arquillian-core.jar
+      // remaining permissions needed to run springframework
+      archive.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
+              new PropertyPermission("arquillian.*", "read"),
+              new ReflectPermission("suppressAccessChecks"),
+              new RuntimePermission("accessDeclaredMembers"),
+              new FilePermission("<<ALL FILES>>", "read"),
+              new LoggingPermission("control", "")
+      ), "permissions.xml");
+
+
+      return archive;
+   }
+
+   @Test
+   public void testResteasy828() throws InterruptedException {
+      WebTarget target = client.target(generateURL("/resteasy828"));
+      Response response = target.request().get();
+      Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+      Assert.assertNotNull(target.request().get(String.class));
+   }
+}

--- a/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/RESTEasy828Test.java
+++ b/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/RESTEasy828Test.java
@@ -4,15 +4,12 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.spi.HttpResponseCodes;
-import org.jboss.resteasy.springmvc.ResteasySpringDispatcherServlet;
 import org.jboss.resteasy.test.spring.inmodule.resource.RESTEasy828Resource;
 
 import org.jboss.resteasy.utils.PermissionUtil;
 import org.jboss.resteasy.utils.PortProviderUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.junit.After;
@@ -25,7 +22,6 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
-import java.io.File;
 import java.io.FilePermission;
 import java.lang.reflect.ReflectPermission;
 import java.util.PropertyPermission;
@@ -36,7 +32,6 @@ import java.util.logging.LoggingPermission;
 public class RESTEasy828Test {
 
    static Client client;
-   private static final String ERROR_MESSAGE = "Got unexpected entity from the server";
 
    private String generateURL(String path) {
       return PortProviderUtil.generateURL(path, RESTEasy828Test.class.getSimpleName());
@@ -48,7 +43,7 @@ public class RESTEasy828Test {
    }
 
    @After
-   public void after() throws Exception {
+   public void after() {
       client.close();
    }
 
@@ -89,9 +84,6 @@ public class RESTEasy828Test {
               .withTransitivity()
               .asFile());
 
-
-      archive.as(ZipExporter.class).exportTo(
-              new File("/tmp/RESTEasy828Test.war"), true);
 
       // Permission needed for "arquillian.debug" to run
       // "suppressAccessChecks" required for access to arquillian-core.jar

--- a/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/resource/RESTEasy828Resource.java
+++ b/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/resource/RESTEasy828Resource.java
@@ -1,0 +1,17 @@
+package org.jboss.resteasy.test.spring.inmodule.resource;
+
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+
+@Component
+@Path("/resteasy828")
+public class RESTEasy828Resource {
+   @GET
+   public String get(@Context ServletContext context) {
+      return context.getClass().toString();
+   }
+}

--- a/testsuite/integration-tests-spring/inmodule/src/test/resources/org/jboss/resteasy/test/spring/inmodule/resteasy828/applicationContext.xml
+++ b/testsuite/integration-tests-spring/inmodule/src/test/resources/org/jboss/resteasy/test/spring/inmodule/resteasy828/applicationContext.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
+  <import resource="classpath:springmvc-resteasy.xml"/>
+
+  <context:component-scan base-package="org.jboss.resteasy.test.spring.inmodule.resource"/>
+
+</beans>

--- a/testsuite/integration-tests-spring/inmodule/src/test/resources/org/jboss/resteasy/test/spring/inmodule/resteasy828/web.xml
+++ b/testsuite/integration-tests-spring/inmodule/src/test/resources/org/jboss/resteasy/test/spring/inmodule/resteasy828/web.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         id="WebApp_ID" version="2.5" metadata-complete="true">
+
+    <display-name>resteasy828</display-name>
+
+    <servlet>
+        <description>ResteasyContextInjection</description>
+        <display-name>resteasy828</display-name>
+        <servlet-name>resteasy828</servlet-name>
+        <servlet-class>org.jboss.resteasy.springmvc.ResteasySpringDispatcherServlet</servlet-class>
+        <init-param>
+            <param-name>contextConfigLocation</param-name>
+            <param-value>WEB-INF/applicationContext.xml</param-value>
+        </init-param>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>resteasy828</servlet-name>
+        <url-pattern>/</url-pattern>
+    </servlet-mapping>
+</web-app>
+


### PR DESCRIPTION
The default Spring `DispatcherServlet` doesn't push the  `ServletContext` into `ResteasyContext` properly, however using `DispatcherServlet` is a convenient way to configure `springframework`, so we need to provided a `ResteasySpringDispatcherServlet` for users to use.

Please note using `DispatcherServlet` is not the only way to configure the RESTEasy/Spring integration, and we also have the other ways such as:

- Using the `resteasy-spring-boot` project to eliminate the manual configuration with Spring/SpringMVC: https://github.com/resteasy/resteasy-spring-boot
- Totally configuring the `web.xml` manually to setup spring container properly and don't use `DispatcherServlet` at all(which is very verbose and not the standard way described in document), and here is the example: https://github.com/resteasy/Resteasy/blob/master/testsuite/integration-tests-spring/inmodule/src/test/resources/org/jboss/resteasy/test/spring/inmodule/web.xml

So the addition of `ResteasySpringDispatcherServlet` is just for the scenario when using Spring/SpringMVC by configuration `DispatcherServlet`, which is described as the standard way to do the configuration in document.

For more detail discussions please check here:

* https://issues.jboss.org/browse/RESTEASY-828

For the document of the `ResteasySpringDispatcherServlet`, it will be tracked by this issue: 

* https://issues.jboss.org/browse/RESTEASY-2392


 
