### PR TITLE
RESTEASY-2454: Remove finalize from ClientResponse to improve gc

### DIFF
--- a/profiling-tests/src/test/java/org/jboss/resteasy/test/profiling/InMemoryClientEngine.java
+++ b/profiling-tests/src/test/java/org/jboss/resteasy/test/profiling/InMemoryClientEngine.java
@@ -23,6 +23,7 @@ import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
 import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
 import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
+import org.jboss.resteasy.client.jaxrs.internal.FinalizedClientResponse;
 import org.jboss.resteasy.spi.Dispatcher;
 import org.jboss.resteasy.core.SynchronousDispatcher;
 import org.jboss.resteasy.core.SynchronousExecutionContext;
@@ -185,7 +186,7 @@ public class InMemoryClientEngine implements ClientHttpEngine
       return null;
    }
 
-   public static class InMemoryClientResponse extends ClientResponse
+   public static class InMemoryClientResponse extends FinalizedClientResponse
    {
       private InputStream stream;
 

--- a/resteasy-client-jetty/src/main/java/org/jboss/resteasy/client/jaxrs/engines/jetty/JettyClientResponse.java
+++ b/resteasy-client-jetty/src/main/java/org/jboss/resteasy/client/jaxrs/engines/jetty/JettyClientResponse.java
@@ -4,10 +4,10 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
-import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
+import org.jboss.resteasy.client.jaxrs.internal.FinalizedClientResponse;
 import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
 
-class JettyClientResponse extends ClientResponse {
+class JettyClientResponse extends FinalizedClientResponse {
    private final Runnable cancel;
    private InputStream stream;
 

--- a/resteasy-client-reactor-netty/src/test/java/org/jboss/resteasy/client/jaxrs/engines/ReactorNettyClientHttpEngineByteBufReleaseTest.java
+++ b/resteasy-client-reactor-netty/src/test/java/org/jboss/resteasy/client/jaxrs/engines/ReactorNettyClientHttpEngineByteBufReleaseTest.java
@@ -162,7 +162,7 @@ public class ReactorNettyClientHttpEngineByteBufReleaseTest {
 
     @Test
     public void testLeakDetectionOnMissingClientResponseClose() throws Exception {
-        final Client client = setupClient(Duration.ofSeconds(2), false);
+        final Client client = setupClient(Duration.ofSeconds(10), false);
         for(int i=0; i < CALL_COUNT; i++) {
             final Response response = client
                 .target("/hello")
@@ -170,7 +170,7 @@ public class ReactorNettyClientHttpEngineByteBufReleaseTest {
                 .rx()
                 .get()
                 .toCompletableFuture()
-                .get();
+                .get(10, TimeUnit.SECONDS);
         }
         // It's a ByteBuf leak that is actually asserted here on missing close on response.
         assertThat(errContent.toString(), containsString("LEAK"));
@@ -179,14 +179,14 @@ public class ReactorNettyClientHttpEngineByteBufReleaseTest {
 
     @Test
     public void testRestEasyClientResponseWithFinalize() throws Exception {
-        final Client client = setupClient(Duration.ofSeconds(2), true);
+        final Client client = setupClient(Duration.ofSeconds(10), true);
         final Response response = client
                 .target("/hello")
                 .request()
                 .rx()
                 .get()
                 .toCompletableFuture()
-                .get();
+                .get(10, TimeUnit.SECONDS);
 
         assertNotNull(response.getClass().getDeclaredMethod("finalize"));
         assertTrue(response.getClass().getSimpleName().contains("FinalizedRestEasyClientResponse"));
@@ -194,14 +194,15 @@ public class ReactorNettyClientHttpEngineByteBufReleaseTest {
 
     @Test(expected = java.lang.NoSuchMethodException.class)
     public void testDefaultRestEasyClientResponseWithoutFinalize() throws Exception {
-        final Client client = setupClient(Duration.ofSeconds(2));
+        final Client client = setupClient(Duration.ofSeconds(10));
         final Response response = client
                 .target("/hello")
                 .request()
                 .rx()
                 .get()
                 .toCompletableFuture()
-                .get();
+                .get(10, TimeUnit.SECONDS);
+
         response.getClass().getDeclaredMethod("finalize");
     }
 

--- a/resteasy-client-reactor-netty/src/test/java/org/jboss/resteasy/client/jaxrs/engines/ReactorNettyClientHttpEngineTest.java
+++ b/resteasy-client-reactor-netty/src/test/java/org/jboss/resteasy/client/jaxrs/engines/ReactorNettyClientHttpEngineTest.java
@@ -560,6 +560,16 @@ public class ReactorNettyClientHttpEngineTest {
         assertEquals(200, response.getStatus());
         assertEquals(HELLO_WORLD, response.readEntity(String.class));
     }
+    @Test
+    public void testFinalizeResponse() throws Exception {
+        final Client timeoutClient = setupClient(HttpClient.create(), Duration.ofMillis(100));
+
+        final CompletionStage<Response> completionStage = timeoutClient.target(url("/hello")).request().rx().get();
+        final Response response = completionStage.toCompletableFuture().get();
+        assertEquals(200, response.getStatus());
+        assertEquals(HELLO_WORLD, response.readEntity(String.class));
+    }
+
 
     private static String incrementAge(final String json) {
         final int length = json.length();

--- a/resteasy-client-vertx/src/main/java/org/jboss/resteasy/client/jaxrs/engines/vertx/VertxClientHttpEngine.java
+++ b/resteasy-client-vertx/src/main/java/org/jboss/resteasy/client/jaxrs/engines/vertx/VertxClientHttpEngine.java
@@ -33,6 +33,8 @@ import java.util.concurrent.Future;
 
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpHeaders;
+import org.jboss.resteasy.client.jaxrs.internal.FinalizedClientResponse;
+import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
 import org.jboss.resteasy.util.CaseInsensitiveMap;
 
 public class VertxClientHttpEngine implements AsyncClientHttpEngine {
@@ -258,12 +260,12 @@ public class VertxClientHttpEngine implements AsyncClientHttpEngine {
 
         InputStreamAdapter adapter = new InputStreamAdapter(clientResponse, 4 * 1024);
 
-        class RestEasyClientResponse extends ClientResponse {
+        class RestEasyClientResponse extends FinalizedClientResponse {
 
             private InputStream is;
 
             private RestEasyClientResponse(final ClientConfiguration configuration) {
-                super(configuration);
+                super(configuration, RESTEasyTracingLogger.empty());
                 this.is = adapter;
             }
 

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpAsyncClient4Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpAsyncClient4Engine.java
@@ -57,6 +57,7 @@ import org.jboss.resteasy.client.jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
 import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
+import org.jboss.resteasy.client.jaxrs.internal.FinalizedClientResponse;
 import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
 import org.jboss.resteasy.util.CaseInsensitiveMap;
 
@@ -667,7 +668,7 @@ public class ApacheHttpAsyncClient4Engine implements AsyncClientHttpEngine, Clos
    /**
     * ClientResponse with surefire releaseConnection
     */
-   private static class ConnectionResponse extends ClientResponse
+   private static class ConnectionResponse extends FinalizedClientResponse
    {
 
       private InputStream connection;

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43Engine.java
@@ -23,6 +23,7 @@ import org.jboss.resteasy.client.jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.client.jaxrs.i18n.Messages;
 import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
+import org.jboss.resteasy.client.jaxrs.internal.FinalizedClientResponse;
 import org.jboss.resteasy.microprofile.config.ResteasyConfigProvider;
 import org.jboss.resteasy.util.CaseInsensitiveMap;
 
@@ -289,7 +290,7 @@ public class ManualClosingApacheHttpClient43Engine implements ApacheHttpClientEn
          cleanUpAfterExecute(httpMethod);
       }
 
-      ClientResponse response = new ClientResponse(request.getClientConfiguration(), request.getTracingLogger())
+      ClientResponse response = new FinalizedClientResponse(request.getClientConfiguration(), request.getTracingLogger())
       {
          InputStream stream;
 

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/URLConnectionEngine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/URLConnectionEngine.java
@@ -4,6 +4,7 @@ import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
 import org.jboss.resteasy.client.jaxrs.i18n.Messages;
 import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
+import org.jboss.resteasy.client.jaxrs.internal.FinalizedClientResponse;
 import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
 import org.jboss.resteasy.util.CaseInsensitiveMap;
 
@@ -58,7 +59,7 @@ public class URLConnectionEngine implements ClientHttpEngine
       }
 
       //Creating response with stream content
-      ClientResponse response = new ClientResponse(request.getClientConfiguration(), RESTEasyTracingLogger.empty())
+      ClientResponse response = new FinalizedClientResponse(request.getClientConfiguration(), RESTEasyTracingLogger.empty())
       {
          private InputStream stream;
 

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/AbortedResponse.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/AbortedResponse.java
@@ -23,7 +23,7 @@ import java.util.Map;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class AbortedResponse extends ClientResponse
+public class AbortedResponse extends FinalizedClientResponse
 {
    @SuppressWarnings("unchecked")
    public AbortedResponse(final ClientConfiguration configuration,final Response response)

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientResponse.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientResponse.java
@@ -148,18 +148,6 @@ public abstract class ClientResponse extends BuiltResponse
    }
 
    @Override
-   // This method is synchronized to protect against premature calling of finalize by the GC
-   protected synchronized void finalize() throws Throwable
-   {
-      if (isClosed()) return;
-      try {
-         close();
-      }
-      catch (Exception ignored) {
-      }
-   }
-
-   @Override
    protected HeaderValueProcessor getHeaderValueProcessor()
    {
       return configuration;

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/FinalizedClientResponse.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/FinalizedClientResponse.java
@@ -1,0 +1,29 @@
+package org.jboss.resteasy.client.jaxrs.internal;
+
+import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
+
+/**
+ * A class that adds a {@link Object#finalize) method to the {@link ClientResponse} as a last ditch backstop to prevent
+ * leaking resources with ill-behaved clients.  Use of finalize could incur a significant performance penalty.
+ */
+public abstract class FinalizedClientResponse extends ClientResponse {
+
+    protected FinalizedClientResponse(final ClientConfiguration configuration,
+                                      final RESTEasyTracingLogger tracingLogger)
+    {
+        super(configuration, tracingLogger);
+    }
+
+    @Override
+    // This method is synchronized to protect against premature calling of finalize by the GC
+    protected synchronized void finalize() throws Throwable
+    {
+        if (isClosed()) return;
+        try {
+            close();
+        }
+        catch (Exception ignored) {
+        }
+    }
+
+}


### PR DESCRIPTION
To improve gc remove finalize from ClientResponse and re-add finalize
at the specific client implementation
Make finalize addition configurable with the ReactorNettyClientHttpEngine RestEasyClientReponse.