### PR TITLE
[RESTEASY-2486] Fix for RestEasyClientBuilder http proxy not working

### DIFF
--- a/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
+++ b/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
@@ -55,6 +55,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder.*;
+
 public class RestClientBuilderImpl implements RestClientBuilder {
 
     private static final String RESTEASY_PROPERTY_PREFIX = "resteasy.";
@@ -197,17 +199,24 @@ public class RestClientBuilderImpl implements RestClientBuilder {
 
         List<String> noProxyHosts = Arrays.asList(
                 System.getProperty("http.nonProxyHosts", "localhost|127.*|[::1]").split("|"));
-        String proxyHost = System.getProperty("http.proxyHost");
+        String envProxyHost = System.getProperty("http.proxyHost");
 
         T actualClient;
         ResteasyClient client;
 
+        String userProxyHost = Optional.ofNullable(getConfiguration().getProperty(PROPERTY_PROXY_HOST)).filter(String.class::isInstance).map(String.class::cast).orElse(null);
+        Integer userProxyPort = Optional.ofNullable(getConfiguration().getProperty(PROPERTY_PROXY_PORT)).filter(Integer.class::isInstance).map(Integer.class::cast).orElse(null);
+        String userProxyScheme = Optional.ofNullable(getConfiguration().getProperty(PROPERTY_PROXY_SCHEME)).filter(String.class::isInstance).map(String.class::cast).orElse(null);
+
+
         ResteasyClientBuilder resteasyClientBuilder;
-        if (proxyHost != null && !noProxyHosts.contains(baseURI.getHost())) {
+        if (envProxyHost != null && !noProxyHosts.contains(baseURI.getHost())) {
             // Use proxy, if defined
             resteasyClientBuilder = builderDelegate.defaultProxy(
-                    proxyHost,
+                    envProxyHost,
                     Integer.parseInt(System.getProperty("http.proxyPort", "80")));
+        } else if (userProxyHost != null && userProxyPort != null) {
+            resteasyClientBuilder = builderDelegate.defaultProxy(userProxyHost, userProxyPort, userProxyScheme);
         } else {
             resteasyClientBuilder = builderDelegate;
         }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/URLConnectionClientEngineBuilder.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/URLConnectionClientEngineBuilder.java
@@ -29,6 +29,12 @@ public class URLConnectionClientEngineBuilder implements ClientHttpEngineBuilder
             clientEngine.setConnectTimeout((int) resteasyClientBuilder.getConnectionTimeout(TimeUnit.MILLISECONDS));
         }
 
+        if (resteasyClientBuilder.getDefaultProxyPort() > 0 && resteasyClientBuilder.getDefaultProxyHostname() != null) {
+            clientEngine.setProxyPort(resteasyClientBuilder.getDefaultProxyPort());
+            clientEngine.setProxyHost(resteasyClientBuilder.getDefaultProxyHostname());
+            clientEngine.setProxyScheme(resteasyClientBuilder.getDefaultProxyScheme());
+        }
+
         return clientEngine;
     }
 }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/URLConnectionEngine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/URLConnectionEngine.java
@@ -167,7 +167,7 @@ public class URLConnectionEngine implements ClientHttpEngine
    {
       Proxy proxy = null;
       if (this.proxyHost != null && this.proxyPort != null) {
-         new Proxy(Proxy.Type.HTTP, new InetSocketAddress(this.proxyHost, this.proxyPort));
+         proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(this.proxyHost, this.proxyPort));
       } else {
          proxy = Proxy.NO_PROXY;
       }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/URLConnectionEngine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/URLConnectionEngine.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.List;
 import java.util.Map;
 
@@ -34,6 +36,9 @@ public class URLConnectionEngine implements ClientHttpEngine
    protected HostnameVerifier hostnameVerifier;
    protected Integer readTimeout;
    protected Integer connectTimeout;
+   protected String proxyHost;
+   protected Integer proxyPort;
+   protected String proxyScheme;
 
    /**
     * {@inheritDoc}
@@ -160,7 +165,14 @@ public class URLConnectionEngine implements ClientHttpEngine
     */
    protected HttpURLConnection createConnection(final ClientInvocation request) throws IOException
    {
-      HttpURLConnection connection = (HttpURLConnection) request.getUri().toURL().openConnection();
+      Proxy proxy = null;
+      if (this.proxyHost != null && this.proxyPort != null) {
+         new Proxy(Proxy.Type.HTTP, new InetSocketAddress(this.proxyHost, this.proxyPort));
+      } else {
+         proxy = Proxy.NO_PROXY;
+      }
+
+      HttpURLConnection connection = (HttpURLConnection) request.getUri().toURL().openConnection(proxy);
       connection.setRequestMethod(request.getMethod());
 
       if (this.connectTimeout != null)
@@ -268,5 +280,17 @@ public class URLConnectionEngine implements ClientHttpEngine
    public void setReadTimeout(Integer readTimeout)
    {
       this.readTimeout = readTimeout;
+   }
+
+   public void setProxyHost(String proxyHost) {
+      this.proxyHost = proxyHost;
+   }
+
+   public void setProxyPort(Integer proxyPort) {
+      this.proxyPort = proxyPort;
+   }
+
+   public void setProxyScheme(String proxyScheme) {
+      this.proxyScheme = proxyScheme;
    }
 }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.java
@@ -385,12 +385,14 @@ public class ResteasyClientBuilderImpl extends ResteasyClientBuilder
       }
 
       boolean resetProxy = false;
+      boolean hasSetupNewProxy = false;
       if (this.defaultProxy == null) {
          resetProxy = true;
          // check for proxy config parameters
          setProxyIfNeeded(config);
+         hasSetupNewProxy = this.defaultProxy != null;
       }
-      ClientHttpEngine engine = httpEngine != null ? httpEngine : new ClientHttpEngineBuilder43().resteasyClientBuilder(this).build();
+      ClientHttpEngine engine = httpEngine != null && !hasSetupNewProxy ? httpEngine : new ClientHttpEngineBuilder43().resteasyClientBuilder(this).build();
       if (resetProxy) {
          this.defaultProxy = null;
       }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.java
@@ -385,14 +385,12 @@ public class ResteasyClientBuilderImpl extends ResteasyClientBuilder
       }
 
       boolean resetProxy = false;
-      boolean hasSetupNewProxy = false;
       if (this.defaultProxy == null) {
          resetProxy = true;
          // check for proxy config parameters
          setProxyIfNeeded(config);
-         hasSetupNewProxy = this.defaultProxy != null;
       }
-      ClientHttpEngine engine = httpEngine != null && !hasSetupNewProxy ? httpEngine : new ClientHttpEngineBuilder43().resteasyClientBuilder(this).build();
+      ClientHttpEngine engine = httpEngine != null ? httpEngine : new ClientHttpEngineBuilder43().resteasyClientBuilder(this).build();
       if (resetProxy) {
          this.defaultProxy = null;
       }


### PR DESCRIPTION
I observed an issue using Quarkus, which uses the RestEasy REST Client, for which I have opened an issue here:

https://github.com/quarkusio/quarkus/issues/6522

It concerns an issue where the http-proxy setup with a `RestClientBuilder` would not work, i.e. the settings are completely ignored in the following setup:

```
 MyRestClient build = RestClientBuilder.newBuilder()
                .baseUri(UriBuilder.fromUri("http://localhost:3001").build())
                .property(PROPERTY_PROXY_HOST, "localhost") //ignored
                .property(PROPERTY_PROXY_PORT, 3002) //ignored
                .property(PROPERTY_PROXY_SCHEME, "http") //ignored
                .build(MyRestClient.class);
```

The change concerns this part of `ResteasyClientBuilderImpl`:

```
 boolean resetProxy = false;
      if (this.defaultProxy == null) {
         resetProxy = true;
         // check for proxy config parameters
         setProxyIfNeeded(config);
      }
      ClientHttpEngine engine = httpEngine != null ? httpEngine : new ClientHttpEngineBuilder43().resteasyClientBuilder(this).build();
      if (resetProxy) {
         this.defaultProxy = null;
      }
```
This small PR checks if a new proxy has been setup, and if it has, it allows the creation of a new http client engine.


The rationale behind this is that during custom initialization using a `RestClientBuilder`, the httpEngine had already been setup previously, so even if the `setProxyIfNeeded()` was called to set the `defaultProxy` inside the builder instance, the next lines would only take into account if an existing instance of the `httpEngine` is present - which, according to my test cases, was always the case. Therefore, the proxy settings would be discarded since the old instance of the `httpEngine` would always be used.

I have tested it using my scenarios with Quarkus, but I don't have the chance to perform all necessary checks, as I am not familiar with the architecture of the rest of the Resteasy implementation. This part of the code just seemed a bit unintentional so I thought I may as well give it a shot, hoping that my assumptions are correct.