### PR TITLE
[RESTEASY-1986] Lower log level to DEBUG as the exception is rethrown

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/LogMessages.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/LogMessages.java
@@ -60,11 +60,11 @@ public interface LogMessages extends BasicLogger
    @LogMessage(level = Level.ERROR)
    @Message(id = BASE + 25, value = "Unknown exception while executing {0} {1}", format=Format.MESSAGE_FORMAT)
    void unknownException(String method, String path, @Cause Throwable cause);
-   
-   @LogMessage(level = Level.ERROR)
-   @Message(id = BASE + 30, value = "Failed to write event {0}", format=Format.MESSAGE_FORMAT)
-   void failedToWriteSseEvent(String event, @Cause Throwable cause);   
-   
+
+   @LogMessage(level = Level.DEBUG)
+   @Message(id = BASE + 30, value = "Failed to write event {0}", format = Format.MESSAGE_FORMAT)
+   void failedToWriteSseEvent(String event, @Cause Throwable cause);
+
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////
    //                                                  WARN                                                 //
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
RESTEASY-1986 backport to 3.6.1.Spx.

Issue: https://issues.redhat.com/browse/RESTEASY-2492
Upstream Issue: https://issues.redhat.com/browse/RESTEASY-1986
Upstream PR: https://github.com/resteasy/Resteasy/pull/1862