### PR TITLE
[RESTEASY-2495] ParamConverter not being applied to HeaderParam

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/HeaderParamProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/HeaderParamProcessor.java
@@ -27,7 +27,8 @@ public class HeaderParamProcessor extends AbstractInvocationCollectionProcessor
    protected ClientInvocation apply(ClientInvocation invocation, Object... objects)
    {
       for (Object object : objects) {
-         invocation.getHeaders().header(paramName, object);
+         String value = invocation.getClientConfiguration().toString(object);
+         invocation.getHeaders().header(paramName, value);
       }
       return invocation;
    }


### PR DESCRIPTION
AbstractInvocationCollectionProcessor is processing Array and Collection of elements being ParamConverter aware. But with single values is delegating in final class to process the value. HeaderParamProcessor is not being aware of such transformation.

See https://issues.redhat.com/browse/RESTEASY-2495