### PR TITLE
SimpleViolationsContainer: adapt to hibernate-validator API changes

### DIFF
--- a/providers/resteasy-validator-provider/src/main/java/org/jboss/resteasy/plugins/validation/SimpleViolationsContainer.java
+++ b/providers/resteasy-validator-provider/src/main/java/org/jboss/resteasy/plugins/validation/SimpleViolationsContainer.java
@@ -115,7 +115,7 @@ public class SimpleViolationsContainer extends org.jboss.resteasy.api.validation
       {
          ConstraintDescriptorImpl<?> cdi1 = (ConstraintDescriptorImpl<?>) cv1.getConstraintDescriptor();
          ConstraintDescriptorImpl<?> cdi2 = (ConstraintDescriptorImpl<?>) cv2.getConstraintDescriptor();
-         if (cdi1.getElementType() != null ? !cdi1.getElementType().equals(cdi2.getElementType()) : cdi2.getElementType() != null) {
+         if (cdi1.getConstraintLocationKind() != null ? !cdi1.getConstraintLocationKind().equals(cdi2.getConstraintLocationKind()) : cdi2.getConstraintLocationKind() != null) {
             return false;
          }
       }


### PR DESCRIPTION
This change is needed as a part of
https://issues.redhat.com/browse/WFLY-11566 and requires hibernate-validator update 