### PR TITLE
[3.11] [RESTEASY-2503] Throw ViolationException for EJBs with just parameter violations.

### DIFF
--- a/providers/resteasy-validator-provider/src/main/java/org/jboss/resteasy/plugins/validation/GeneralValidatorImpl.java
+++ b/providers/resteasy-validator-provider/src/main/java/org/jboss/resteasy/plugins/validation/GeneralValidatorImpl.java
@@ -1,5 +1,7 @@
 package org.jboss.resteasy.plugins.validation;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
@@ -10,6 +12,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.validation.Constraint;
 import javax.validation.ConstraintDeclarationException;
 import javax.validation.ConstraintDefinitionException;
 import javax.validation.ConstraintViolation;
@@ -217,7 +220,7 @@ public class GeneralValidatorImpl implements GeneralValidatorCDI
    public boolean isValidatable(Class<?> clazz)
    {
       // Called from resteasy-jaxrs.
-      if (cdiActive)
+      if (cdiActive && !(hasEJBScope(clazz) && hasNoClassOrFieldOrPropertyConstraints(clazz)))
       {
          return false;
       }
@@ -231,7 +234,8 @@ public class GeneralValidatorImpl implements GeneralValidatorCDI
       try
       {
          // Called from resteasy-jaxrs.
-         if (cdiActive && injectorFactory instanceof CdiInjectorFactory)
+         if (cdiActive && injectorFactory instanceof CdiInjectorFactory
+               && !(hasEJBScope(clazz) && hasNoClassOrFieldOrPropertyConstraints(clazz)))
          {
             return false;
          }
@@ -683,5 +687,139 @@ public class GeneralValidatorImpl implements GeneralValidatorCDI
    {
       Class<?> clazz = o.getClass();
       return clazz.getAnnotation(ApplicationScoped.class) != null;
+   }
+
+   private static boolean hasNoClassOrFieldOrPropertyConstraints(Class<?> clazz)
+   {
+      return !hasClassConstraint(clazz) && !hasFieldConstraint(clazz) && !hasPropertyConstraint(clazz);
+   }
+
+   private static boolean hasPropertyConstraint(Class<?> clazz)
+   {
+      for (Method method : clazz.getDeclaredMethods())
+      {
+         if (isGetter(method))
+         {
+            for (Annotation annotation : method.getAnnotations())
+            {
+               if (isConstraintAnnotation(annotation.annotationType()))
+               {
+                  return true;
+               }
+            }
+         }
+      }
+      for (Class<?> intf : clazz.getInterfaces())
+      {
+         if (hasPropertyConstraint(intf))
+         {
+            return true;
+         }
+      }
+      Class<?> superClass = clazz.getSuperclass();
+      if (superClass != null && !superClass.equals(Object.class))
+      {
+         return hasPropertyConstraint(superClass);
+      }
+      return false;
+   }
+
+   private static boolean hasFieldConstraint(Class<?> clazz)
+   {
+      for (Field field : clazz.getDeclaredFields())
+      {
+         for (Annotation annotation : field.getAnnotations())
+         {
+            if (isConstraintAnnotation(annotation.annotationType()))
+            {
+               return true;
+            }
+         }
+      }
+      Class<?> superClass = clazz.getSuperclass();
+      if (superClass != null && !superClass.equals(Object.class))
+      {
+         return hasFieldConstraint(superClass);
+      }
+      return false;
+   }
+
+   private static boolean hasClassConstraint(Class<?> clazz)
+   {
+      if (classHasConstraintAnnotation(clazz))
+      {
+         return true;
+      }
+      for (Class<?> intf : clazz.getInterfaces())
+      {
+         if (classHasConstraintAnnotation(intf))
+         {
+            return true;
+         }
+      }
+      Class<?> superClass = clazz.getSuperclass();
+      if (superClass != Object.class && superClass != null)
+      {
+         return hasClassConstraint(superClass);
+      }
+      return false;
+   }
+
+   private static boolean classHasConstraintAnnotation(Class<?> clazz)
+   {
+      for (Annotation annotation : clazz.getAnnotations())
+      {
+         if (isConstraintAnnotation(annotation.annotationType()))
+         {
+            return true;
+         }
+      }
+      return false;
+   }
+
+   private static boolean isConstraintAnnotation(Class<?> clazz)
+   {
+      return clazz.isAnnotation() && clazz.getAnnotation(Constraint.class) != null;
+   }
+
+   private static boolean hasEJBScope(Class<?> clazz)
+   {
+      return classHasAnnotations(clazz, new String[] {"javax.ejb.Stateless", "javax.ejb.Stateful", "javax.ejb.Singleton"});
+   }
+
+   private static boolean classHasAnnotations(Class<?> clazz, String[] names)
+   {
+      for (String name : names)
+      {
+         if (isAnnotationPresent(clazz, name))
+         {
+            return true;
+         }
+         for (Class<?> intf : clazz.getInterfaces())
+         {
+            if (isAnnotationPresent(intf, name))
+            {
+               return true;
+            }
+         }
+      }
+      Class<?> superClass = clazz.getSuperclass();
+      if (superClass != Object.class && superClass != null)
+      {
+         return classHasAnnotations(superClass, names);
+      }
+      return false;
+   }
+
+   private static boolean isAnnotationPresent(Class<?> clazz, String name)
+   {
+      for (Annotation annotation : clazz.getAnnotations())
+      {
+         if (annotation.annotationType().getName().equals(name))
+         {
+            return true;
+         }
+      }
+      return false;
    }
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
@@ -132,13 +132,22 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
       }
       if (validator != null)
       {
-         if (validator instanceof GeneralValidatorCDI)
+         Class<?> clazz = null;
+         if (resource != null && resource.getScannableClass() != null)
          {
-            isValidatable = GeneralValidatorCDI.class.cast(validator).isValidatable(getMethod().getDeclaringClass(), injector);
+            clazz = resource.getScannableClass();
          }
          else
          {
-            isValidatable = validator.isValidatable(getMethod().getDeclaringClass());
+            clazz = getMethod().getDeclaringClass();
+         }
+         if (validator instanceof GeneralValidatorCDI)
+         {
+            isValidatable = GeneralValidatorCDI.class.cast(validator).isValidatable(clazz, injector);
+         }
+         else
+         {
+            isValidatable = validator.isValidatable(clazz);
          }
          methodIsValidatable = validator.isMethodValidatable(getMethod());
       }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/EJBParameterViolationsOnlyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/EJBParameterViolationsOnlyTest.java
@@ -1,0 +1,136 @@
+package org.jboss.resteasy.test.validation.ejb;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.api.validation.Validation;
+import org.jboss.resteasy.api.validation.ViolationReport;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.test.validation.ejb.resource.EJBParameterViolationsOnlyAbstractDataObject;
+import org.jboss.resteasy.test.validation.ejb.resource.EJBParameterViolationsOnlyDataObject;
+import org.jboss.resteasy.test.validation.ejb.resource.EJBParameterViolationsOnlyResourceIntf;
+import org.jboss.resteasy.test.validation.ejb.resource.EJBParameterViolationsOnlySingletonResource;
+import org.jboss.resteasy.test.validation.ejb.resource.EJBParameterViolationsOnlyStatefulResource;
+import org.jboss.resteasy.test.validation.ejb.resource.EJBParameterViolationsOnlyStatelessResource;
+import org.jboss.resteasy.test.validation.ejb.resource.EJBParameterViolationsOnlyTestApplication;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+/**
+ * @tpSubChapter Test situation where EJBs have parameter violations but no class, field, or property violations.
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Regression test for RESTEASY-2503
+ * @tpSince RESTEasy 4.5
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class EJBParameterViolationsOnlyTest {
+
+   private static ResteasyClient client;
+   private static EJBParameterViolationsOnlyDataObject validDataObject;
+   private static EJBParameterViolationsOnlyDataObject invalidDataObject;
+
+   @Deployment
+   public static Archive<?> createTestArchive() {
+      WebArchive war = TestUtil.prepareArchive(EJBParameterViolationsOnlyTest.class.getSimpleName())
+            .addClasses(
+                  EJBParameterViolationsOnlyTestApplication.class,
+                  EJBParameterViolationsOnlyDataObject.class,
+                  EJBParameterViolationsOnlyAbstractDataObject.class,
+                  EJBParameterViolationsOnlyResourceIntf.class)
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+      return TestUtil.finishContainerPrepare(war, null,
+            EJBParameterViolationsOnlyStatelessResource.class,
+            EJBParameterViolationsOnlyStatefulResource.class,
+            EJBParameterViolationsOnlySingletonResource.class
+            );
+   }
+
+   private static String generateURL(String path) {
+      return PortProviderUtil.generateURL(path, EJBParameterViolationsOnlyTest.class.getSimpleName());
+   }
+
+   @BeforeClass
+   public static void beforeClass() {
+      client = (ResteasyClient)ClientBuilder.newClient();
+
+      // Create valid data object.
+      validDataObject = new EJBParameterViolationsOnlyDataObject();
+      validDataObject.setDirection("north");
+      validDataObject.setSpeed(10);
+
+      // Create data object with constraint violations.
+      invalidDataObject = new EJBParameterViolationsOnlyDataObject();
+      invalidDataObject.setDirection("north");
+      invalidDataObject.setSpeed(0);
+   }
+
+   @AfterClass
+   public static void afterClass() {
+      client.close();
+   }
+
+   /**
+    * @tpTestDetails Run tests for stateless EJB
+    * @tpSince RESTEasy 4.5
+    */
+   @Test
+   public void testStateless() throws Exception {
+      doValidationTest(client.target(generateURL("/app/stateless")));
+   }
+
+   /**
+   * @tpTestDetails Run tests for stateful EJB
+    * @tpSince RESTEasy 4.5
+    */
+   @Test
+   public void testStateful() throws Exception {
+      doValidationTest(client.target(generateURL("/app/stateful")));
+   }
+
+   /**
+   * @tpTestDetails Run tests for singleton EJB
+    * @tpSince RESTEasy 4.5
+    */
+   @Test
+   public void testSingleton() throws Exception {
+      doValidationTest(client.target(generateURL("/app/singleton")));
+   }
+
+   void doValidationTest(WebTarget target) throws Exception {
+      // Invoke with valid data object.
+      Invocation.Builder request = target.path("validation").request().accept(MediaType.TEXT_PLAIN);
+      Response response = request.post(Entity.entity(validDataObject, MediaType.APPLICATION_JSON), Response.class);
+      Assert.assertEquals(200, response.getStatus());
+
+      // Reset flag indicating method has been executed.
+      boolean used = target.path("used").request().get(boolean.class);
+      Assert.assertTrue(used);
+      target.path("reset").request().get();
+
+      // Invoke with invalid data object.
+      Response response2 = request.post(Entity.entity(invalidDataObject, MediaType.APPLICATION_JSON), Response.class);
+      Assert.assertEquals(400, response2.getStatus());
+      Assert.assertEquals("true", response2.getHeaderString(Validation.VALIDATION_HEADER));
+      ViolationReport report = response2.readEntity(ViolationReport.class);
+      TestUtil.countViolations(report, 0, 0, 0, 1, 0);
+      used = target.path("used").request().get(boolean.class);
+      Assert.assertFalse(used);
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/EJBParameterViolationsOnlyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/EJBParameterViolationsOnlyTest.java
@@ -36,7 +36,7 @@ import org.junit.runner.RunWith;
  * @tpSubChapter Test situation where EJBs have parameter violations but no class, field, or property violations.
  * @tpChapter Integration tests
  * @tpTestCaseDetails Regression test for RESTEASY-2503
- * @tpSince RESTEasy 4.5
+ * @tpSince RESTEasy 3.11.1
  */
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -88,7 +88,7 @@ public class EJBParameterViolationsOnlyTest {
 
    /**
     * @tpTestDetails Run tests for stateless EJB
-    * @tpSince RESTEasy 4.5
+    * @tpSince RESTEasy 3.11.1
     */
    @Test
    public void testStateless() throws Exception {
@@ -97,7 +97,7 @@ public class EJBParameterViolationsOnlyTest {
 
    /**
    * @tpTestDetails Run tests for stateful EJB
-    * @tpSince RESTEasy 4.5
+    * @tpSince RESTEasy 3.11.1
     */
    @Test
    public void testStateful() throws Exception {
@@ -106,7 +106,7 @@ public class EJBParameterViolationsOnlyTest {
 
    /**
    * @tpTestDetails Run tests for singleton EJB
-    * @tpSince RESTEasy 4.5
+    * @tpSince RESTEasy 3.11.1
     */
    @Test
    public void testSingleton() throws Exception {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/resource/EJBParameterViolationsOnlyAbstractDataObject.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/resource/EJBParameterViolationsOnlyAbstractDataObject.java
@@ -1,0 +1,17 @@
+package org.jboss.resteasy.test.validation.ejb.resource;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.Min;
+
+public abstract class EJBParameterViolationsOnlyAbstractDataObject implements Serializable
+{
+   private static final long serialVersionUID = 1L;
+
+   @Min(1)
+   protected int speed;
+
+   public abstract int getSpeed();
+
+   public abstract void setSpeed(int speed);
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/resource/EJBParameterViolationsOnlyDataObject.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/resource/EJBParameterViolationsOnlyDataObject.java
@@ -1,0 +1,29 @@
+package org.jboss.resteasy.test.validation.ejb.resource;
+
+import javax.validation.constraints.NotNull;
+
+public class EJBParameterViolationsOnlyDataObject extends EJBParameterViolationsOnlyAbstractDataObject
+{
+    @NotNull
+    private String direction;
+
+    public int getSpeed()
+    {
+        return speed;
+    }
+
+    public String getDirection()
+    {
+        return direction;
+    }
+
+    public void setSpeed(int number)
+    {
+        this.speed = number;
+    }
+
+    public void setDirection(String direction)
+    {
+        this.direction = direction;
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/resource/EJBParameterViolationsOnlyResourceIntf.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/resource/EJBParameterViolationsOnlyResourceIntf.java
@@ -1,0 +1,28 @@
+package org.jboss.resteasy.test.validation.ejb.resource;
+
+import javax.ejb.Remote;
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Remote
+@Produces(MediaType.TEXT_PLAIN)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface EJBParameterViolationsOnlyResourceIntf
+{
+   @POST
+   @Path("validation")
+   String testValidation(@Valid EJBParameterViolationsOnlyDataObject payload);
+
+   @GET
+   @Path("used")
+   boolean used();
+
+   @GET
+   @Path("reset")
+   void reset();
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/resource/EJBParameterViolationsOnlySingletonResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/resource/EJBParameterViolationsOnlySingletonResource.java
@@ -1,0 +1,27 @@
+package org.jboss.resteasy.test.validation.ejb.resource;
+
+import javax.ejb.Singleton;
+import javax.ws.rs.Path;
+
+@Singleton
+@Path("singleton")
+public class EJBParameterViolationsOnlySingletonResource implements EJBParameterViolationsOnlyResourceIntf
+{
+   private static boolean executionFlag;
+
+   @Override
+   public String testValidation(EJBParameterViolationsOnlyDataObject payload) {
+      executionFlag = true;
+      return payload.getDirection();
+   }
+
+   @Override
+   public boolean used() {
+      return executionFlag;
+   }
+
+   @Override
+   public void reset() {
+      executionFlag = false;
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/resource/EJBParameterViolationsOnlyStatefulResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/resource/EJBParameterViolationsOnlyStatefulResource.java
@@ -1,0 +1,27 @@
+package org.jboss.resteasy.test.validation.ejb.resource;
+
+import javax.ejb.Stateful;
+import javax.ws.rs.Path;
+
+@Stateful
+@Path("stateful")
+public class EJBParameterViolationsOnlyStatefulResource implements EJBParameterViolationsOnlyResourceIntf
+{
+   private static boolean executionFlag;
+
+   @Override
+   public String testValidation(EJBParameterViolationsOnlyDataObject payload) {
+      executionFlag = true;
+      return payload.getDirection();
+   }
+
+   @Override
+   public boolean used() {
+      return executionFlag;
+   }
+
+   @Override
+   public void reset() {
+      executionFlag = false;
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/resource/EJBParameterViolationsOnlyStatelessResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/resource/EJBParameterViolationsOnlyStatelessResource.java
@@ -1,0 +1,27 @@
+package org.jboss.resteasy.test.validation.ejb.resource;
+
+import javax.ejb.Stateless;
+import javax.ws.rs.Path;
+
+@Stateless
+@Path("stateless")
+public class EJBParameterViolationsOnlyStatelessResource implements EJBParameterViolationsOnlyResourceIntf
+{
+   private static boolean executionFlag;
+
+   @Override
+   public String testValidation(EJBParameterViolationsOnlyDataObject payload) {
+      executionFlag = true;
+      return payload.getDirection();
+   }
+
+   @Override
+   public boolean used() {
+      return executionFlag;
+   }
+
+   @Override
+   public void reset() {
+      executionFlag = false;
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/resource/EJBParameterViolationsOnlyTestApplication.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/resource/EJBParameterViolationsOnlyTestApplication.java
@@ -1,0 +1,9 @@
+package org.jboss.resteasy.test.validation.ejb.resource;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("app")
+public class EJBParameterViolationsOnlyTestApplication extends Application
+{
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/validation/NoFieldValidationEJBTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/validation/NoFieldValidationEJBTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
  * @tpSubChapter Internal validation methods
  * @tpChapter Unit tests
  * @tpTestCaseDetails Test constraint finding methods in GeneralValidatorImpl
- * @tpSince RESTEasy 4.6
+ * @tpSince RESTEasy 3.11.1
  */
 public class NoFieldValidationEJBTest {
 
@@ -122,7 +122,7 @@ public class NoFieldValidationEJBTest {
 
    /**
     * @tpTestDetails Find class constraints
-    * @tpSince RESTEasy 4.5
+    * @tpSince RESTEasy 3.11.1
     */
    @Test
    public void testClassConstraints() throws Exception {
@@ -169,7 +169,7 @@ public class NoFieldValidationEJBTest {
 
    /**
     * @tpTestDetails Find field constraints
-    * @tpSince RESTEasy 4.5
+    * @tpSince RESTEasy 3.11.1
     */
    @Test
    public void testFieldConstraints() throws Exception {
@@ -226,7 +226,7 @@ public class NoFieldValidationEJBTest {
 
    /**
     * @tpTestDetails Find property constraints
-    * @tpSince RESTEasy 4.5
+    * @tpSince RESTEasy 3.11.1
     */
    @Test
    public void testPropertyConstraints() throws Exception {

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/validation/NoFieldValidationEJBTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/validation/NoFieldValidationEJBTest.java
@@ -1,0 +1,269 @@
+package org.jboss.resteasy.test.providers.validation;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.constraints.Min;
+
+import org.jboss.resteasy.plugins.validation.GeneralValidatorImpl;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @tpSubChapter Internal validation methods
+ * @tpChapter Unit tests
+ * @tpTestCaseDetails Test constraint finding methods in GeneralValidatorImpl
+ * @tpSince RESTEasy 4.6
+ */
+public class NoFieldValidationEJBTest {
+
+   private static Method hasNoClassOrFieldOrPropertyConstraints;
+   private static Method hasClassConstraint;
+   private static Method hasFieldConstraint;
+   private static Method hasPropertyConstraint;
+   private static Method isConstraintAnnotation;
+   private static Method isGetter;
+   private static Method classHasAnnotations;
+
+   @BeforeClass
+   public static void beforeClass()
+   {
+      try
+      {
+         hasNoClassOrFieldOrPropertyConstraints = GeneralValidatorImpl.class.getDeclaredMethod("hasNoClassOrFieldOrPropertyConstraints", Class.class);
+         hasClassConstraint = GeneralValidatorImpl.class.getDeclaredMethod("hasClassConstraint", Class.class);
+         hasFieldConstraint = GeneralValidatorImpl.class.getDeclaredMethod("hasFieldConstraint", Class.class);
+         hasPropertyConstraint = GeneralValidatorImpl.class.getDeclaredMethod("hasPropertyConstraint", Class.class);
+         isConstraintAnnotation = GeneralValidatorImpl.class.getDeclaredMethod("isConstraintAnnotation", Class.class);
+         isGetter = GeneralValidatorImpl.class.getDeclaredMethod("isGetter", Method.class);
+         classHasAnnotations = GeneralValidatorImpl.class.getDeclaredMethod("classHasAnnotations", Class.class, String[].class);
+
+         hasNoClassOrFieldOrPropertyConstraints.setAccessible(true);
+         hasClassConstraint.setAccessible(true);
+         hasFieldConstraint.setAccessible(true);
+         hasPropertyConstraint.setAccessible(true);
+         isConstraintAnnotation.setAccessible(true);
+         isGetter.setAccessible(true);
+         classHasAnnotations.setAccessible(true);
+      }
+      catch (Exception e)
+      {
+         //
+      }
+   }
+
+   @Constraint(validatedBy = ClassConstraintValidator.class)
+   @Target({TYPE})
+   @Retention(RUNTIME)
+   public @interface ClassConstraint {
+      int value();
+   }
+
+   public class ClassConstraintValidator implements ConstraintValidator<ClassConstraint, Object> {
+      int size;
+
+      public void initialize(ClassConstraint constraintAnnotation) {
+         size = constraintAnnotation.value();
+      }
+
+      @Override
+      public boolean isValid(Object value, ConstraintValidatorContext context) {
+         return true;
+      }
+   }
+
+   //////////////////////////////////////////////////////////////////////////////////////
+   ///// Constraint annotations
+   //////////////////////////////////////////////////////////////////////////////////////
+   @Test
+   public void testConstraintAnnotations()
+   {
+   }
+
+   //////////////////////////////////////////////////////////////////////////////////////
+   ///// Class constraints
+   //////////////////////////////////////////////////////////////////////////////////////
+
+   @ClassConstraint(3)
+   public interface Ic_w {}
+
+   public interface Ic_wo {}
+
+   @ClassConstraint(3)
+   public static class Cc_w {}
+
+   public static class Cc_wo {}
+
+   @ClassConstraint(3)
+   public static class CIc_w_wo implements Ic_wo {}
+
+   public static class CIc_wo_w implements Ic_w {}
+
+   public static class CIc_wo_wwo implements Ic_w, Ic_wo {}
+
+   public static class CIc_wo_wo implements Ic_wo {}
+
+   @ClassConstraint(3)
+   public static class SCc_w_wo extends Cc_wo {}
+
+   public static class SCc_wo_w extends Cc_w {}
+
+   public static class SCc_wo_wo extends Cc_wo {}
+
+   public static class SCc_wo_wo_w extends Cc_wo implements Ic_w {}
+
+   /**
+    * @tpTestDetails Find class constraints
+    * @tpSince RESTEasy 4.5
+    */
+   @Test
+   public void testClassConstraints() throws Exception {
+      Assert.assertTrue(isInited());
+      Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, Ic_w.class)));
+      Assert.assertTrue(Boolean.FALSE.equals(hasClassConstraint.invoke(null, Ic_wo.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, Cc_w.class)));
+      Assert.assertTrue(Boolean.FALSE.equals(hasClassConstraint.invoke(null, Cc_wo.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, CIc_w_wo.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, CIc_wo_wwo.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, CIc_wo_w.class)));
+      Assert.assertTrue(Boolean.FALSE.equals(hasClassConstraint.invoke(null, CIc_wo_wo.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, SCc_w_wo.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, SCc_wo_w.class)));
+      Assert.assertTrue(Boolean.FALSE.equals(hasClassConstraint.invoke(null, SCc_wo_wo.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, SCc_wo_wo_w.class)));
+   }
+
+   //////////////////////////////////////////////////////////////////////////////////////
+   ///// Field constraints
+   //////////////////////////////////////////////////////////////////////////////////////
+
+   public static class Cf_w
+   {
+      @Min(3) int n;
+   }
+
+   public static class Cf_wo
+   {
+   }
+
+   public static class SCf_wo_w extends Cf_w
+   {
+   }
+
+   public static class SCf_w_wo extends Cf_wo
+   {
+      @Min(3) int n;
+   }
+
+   public static class SCf_wo_wo extends Cf_wo
+   {
+   }
+
+   /**
+    * @tpTestDetails Find field constraints
+    * @tpSince RESTEasy 4.5
+    */
+   @Test
+   public void testFieldConstraints() throws Exception {
+      Assert.assertTrue(isInited());
+      Assert.assertTrue(Boolean.TRUE.equals(hasFieldConstraint.invoke(null, Cf_w.class)));
+      Assert.assertTrue(Boolean.FALSE.equals(hasFieldConstraint.invoke(null, Cf_wo.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasFieldConstraint.invoke(null, SCf_wo_w.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasFieldConstraint.invoke(null, SCf_w_wo.class)));
+      Assert.assertTrue(Boolean.FALSE.equals(hasFieldConstraint.invoke(null, SCf_wo_wo.class)));
+   }
+
+   //////////////////////////////////////////////////////////////////////////////////////
+   ///// Property constraints
+   //////////////////////////////////////////////////////////////////////////////////////
+   public interface Ip_w
+   {
+      @Min(3)
+      int getN();
+   }
+
+   public interface Ip_wo {}
+
+   public static class Cp_w
+   {
+      @Min(3)
+      public int getN() {return 4;}
+   }
+
+   public static class Cp_wo {}
+
+   public static class CIp_w_wo implements Ip_wo
+   {
+      @Min(3)
+      public int getN() {return 4;}
+   }
+
+   public abstract static class CIp_wo_w implements Ip_w {}
+
+   public abstract static class CIp_wo_wwo implements Ip_w, Ip_wo {}
+
+   public static class CIp_wo_wo implements Ip_wo {}
+
+   public static class SCp_w_wo extends Cp_wo
+   {
+      @Min(3)
+      public int getN() {return 4;}
+   }
+
+   public static class SCp_wo_w extends Cp_w {}
+
+   public static class SCp_wo_wo extends Cp_wo {}
+
+   public abstract static class SCp_wo_wo_w extends Cp_wo implements Ip_w {}
+
+   /**
+    * @tpTestDetails Find property constraints
+    * @tpSince RESTEasy 4.5
+    */
+   @Test
+   public void testPropertyConstraints() throws Exception {
+      Assert.assertTrue(isInited());
+      Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, Ip_w.class)));
+      Assert.assertTrue(Boolean.FALSE.equals(hasPropertyConstraint.invoke(null, Ip_wo.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, Cp_w.class)));
+      Assert.assertTrue(Boolean.FALSE.equals(hasPropertyConstraint.invoke(null, Cp_wo.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, CIp_w_wo.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, CIp_wo_wwo.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, CIp_wo_w.class)));
+      Assert.assertTrue(Boolean.FALSE.equals(hasPropertyConstraint.invoke(null, CIp_wo_wo.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, SCp_w_wo.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, SCp_wo_w.class)));
+      Assert.assertTrue(Boolean.FALSE.equals(hasPropertyConstraint.invoke(null, SCc_wo_wo.class)));
+      Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, SCp_wo_wo_w.class)));
+   }
+
+   //////////////////////////////////////////////////////////////////////////////////////
+   ///// Testing GeneralValidatorImpl.classHasAnnotations()
+   //////////////////////////////////////////////////////////////////////////////////////
+   @Test
+   public void testClassAnnotations() throws Exception {
+      Assert.assertEquals(Boolean.TRUE, classHasAnnotations.invoke(null, SCc_wo_wo_w.class, new String[] {ClassConstraint.class.getName()}));
+      Assert.assertEquals(Boolean.FALSE, classHasAnnotations.invoke(null, SCc_wo_wo_w.class, new String[] {Min.class.getName()}));
+   }
+
+   //////////////////////////////////////////////////////////////////////////////////////
+   ///// Private methods
+   //////////////////////////////////////////////////////////////////////////////////////
+   private static boolean isInited()
+   {
+      return hasNoClassOrFieldOrPropertyConstraints != null
+            && hasClassConstraint != null
+            && hasFieldConstraint != null
+            && hasPropertyConstraint != null
+            && isConstraintAnnotation != null
+            && isGetter != null;
+   }
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/RESTEASY-2503

This is the cheery-pick of https://github.com/resteasy/Resteasy/pull/2324 to `3.11` branch for `WildFly master` and `EAP 7.3` unless we have plan to upgrade Resteasy to 3.12 in both streams.