### PR TITLE
Back port couple of fixes for PatchMethodFitler

### DIFF
--- a/docbook/reference/en/en-US/modules/Installation_Configuration.xml
+++ b/docbook/reference/en/en-US/modules/Installation_Configuration.xml
@@ -742,6 +742,19 @@ public class MyApplication extends Application
                                 will not occur.
                             </entry>
 </row>
+                        <row>
+                            <entry>
+                                resteasy.patchfilter.disabled
+                            </entry>
+                            <entry>
+                                false
+                            </entry>
+                            <entry>
+                                Turns off the default patch filter to handle JSON patch and JSON Merge Patch request. 
+                                A customerized patch method filter can be provided to serve the JSON patch and JSON merge
+                                patch request instead.
+                            </entry>
+                        </row>
                     </tbody>
                 </tgroup>
             </table>

--- a/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/PatchMethodFilter.java
+++ b/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/PatchMethodFilter.java
@@ -19,8 +19,10 @@ import javax.ws.rs.ext.Providers;
 
 import org.jboss.resteasy.core.ResourceInvoker;
 import org.jboss.resteasy.core.ResourceMethodInvoker;
+import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.specimpl.MultivaluedTreeMap;
 import org.jboss.resteasy.spi.ApplicationException;
+import org.jboss.resteasy.spi.ResteasyConfiguration;
 import org.jboss.resteasy.spi.Failure;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
@@ -65,6 +67,16 @@ public class PatchMethodFilter implements ContainerRequestFilter
             && (MediaType.APPLICATION_JSON_PATCH_JSON_TYPE.isCompatible(requestContext.getMediaType())
             || APPLICATION_JSON_MERGE_PATCH_JSON_TYPE.isCompatible(requestContext.getMediaType())))
       {
+         ResteasyConfiguration context = ResteasyProviderFactory.getContextData(ResteasyConfiguration.class);
+         boolean disabled = false;
+         if (context == null) {
+            disabled = Boolean.getBoolean(ResteasyContextParameters.RESTEASY_PATCH_FILTER_DISABLED);
+         } else {
+            disabled = Boolean.parseBoolean(context.getParameter(ResteasyContextParameters.RESTEASY_PATCH_FILTER_DISABLED));
+         }
+         if (disabled) {
+            return;
+         }
          HttpRequest request = ResteasyProviderFactory.getContextData(HttpRequest.class);
          HttpResponse response = ResteasyProviderFactory.getContextData(HttpResponse.class);
          request.setHttpMethod("GET");

--- a/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/PatchMethodFilter.java
+++ b/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/PatchMethodFilter.java
@@ -10,7 +10,6 @@ import javax.annotation.Priority;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Context;
@@ -110,23 +109,8 @@ public class PatchMethodFilter implements ContainerRequestFilter
          }
          ResourceMethodInvoker methodInvoker = (ResourceMethodInvoker) resourceInovker;
          Object object;
-         try
-         {
-            object = methodInvoker.invokeDryRun(request, response);
-         }
-         catch (Exception e)
-         {
-            if (e.getCause() instanceof WebApplicationException)
-            {
-               throw e;
-            }
-            else
-            {
-               LogMessages.LOGGER.errorPatchTarget(requestContext.getUriInfo().getRequestUri().toString());
-               throw new ProcessingException("Unexpected error to get the json patch/merge target", e);
-            }
-         }
          try{
+            object = methodInvoker.invokeDryRun(request, response);
             ByteArrayOutputStream tmpOutputStream = new ByteArrayOutputStream();
             MessageBodyWriter msgBodyWriter = ResteasyProviderFactory.getInstance().getMessageBodyWriter(
                   object.getClass(), object.getClass(), methodInvoker.getMethodAnnotations(),

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/servlet/ResteasyContextParameters.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/plugins/server/servlet/ResteasyContextParameters.java
@@ -52,6 +52,6 @@ public interface ResteasyContextParameters
    String JAX_RS_2_0_REQUEST_MATCHING = "jaxrs.2.0.request.matching";
 
    String RESTEASY_PREFER_JACKSON_OVER_JSONB = "resteasy.preferJacksonOverJsonB";
-
+   String RESTEASY_PATCH_FILTER_DISABLED = "resteasy.patchfilter.disabled";
    String RESTEASY_STATISTICS_ENABLED = "resteasy.statistics.enabled";
 }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/LogMessages.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/LogMessages.java
@@ -68,10 +68,6 @@ public interface LogMessages extends BasicLogger
    @Message(id = BASE + 40, value = "GET method returns the patch/merge json object target for request {0} not found", format = Format.MESSAGE_FORMAT)
    void patchTargetMethodNotFound(String requestURI);
 
-   @LogMessage(level = Level.ERROR)
-   @Message(id = BASE + 41, value = "Failed to get the patch/merge target for request {0}", format = Format.MESSAGE_FORMAT)
-   void errorPatchTarget(String requestURI);
-
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////
    //                                                  WARN                                                 //
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/LogMessages.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/LogMessages.java
@@ -64,6 +64,13 @@ public interface LogMessages extends BasicLogger
    @LogMessage(level = Level.DEBUG)
    @Message(id = BASE + 30, value = "Failed to write event {0}", format = Format.MESSAGE_FORMAT)
    void failedToWriteSseEvent(String event, @Cause Throwable cause);
+   @LogMessage(level = Level.ERROR)
+   @Message(id = BASE + 40, value = "GET method returns the patch/merge json object target for request {0} not found", format = Format.MESSAGE_FORMAT)
+   void patchTargetMethodNotFound(String requestURI);
+
+   @LogMessage(level = Level.ERROR)
+   @Message(id = BASE + 41, value = "Failed to get the patch/merge target for request {0}", format = Format.MESSAGE_FORMAT)
+   void errorPatchTarget(String requestURI);
 
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////
    //                                                  WARN                                                 //

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/patch/StudentPatchTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/patch/StudentPatchTest.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.test.resource.patch;
 
 import javax.json.Json;
+import javax.json.JsonObject;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -86,4 +87,28 @@ public class StudentPatchTest {
       Assert.assertEquals("Expected school is null", null, patchedStudent.getSchool());
       Assert.assertEquals("Add gender", "male", patchedStudent.getGender());
    }
+
+   @Test
+   public void testMergePatchStudent() throws Exception {
+      ResteasyClient client = ((ResteasyClientBuilder)ClientBuilder.newBuilder()).connectionPoolSize(10).build();
+      WebTarget base = client.target(generateURL("/students"));
+      Student newStudent = new Student().setId(2L).setFirstName("Alice").setSchool("school2");
+      Response response = base.request().post(Entity.<Student>entity(newStudent, MediaType.APPLICATION_JSON_TYPE));
+      Student s = response.readEntity(Student.class);
+      Assert.assertNotNull("Add student failed", s);
+      Assert.assertEquals("Alice", s.getFirstName());
+      Assert.assertNull("Last name is not null", s.getLastName());
+      Assert.assertEquals("school2", s.getSchool());
+      Assert.assertNull("Gender is not null", s.getGender());
+      WebTarget patchTarget = client.target(generateURL("/students/2"));
+      JsonObject object = Json.createObjectBuilder().add("lastName", "Green").addNull("school").build();
+      Response result = patchTarget.request().build(HttpMethod.PATCH, Entity.entity(object, "application/merge-patch+json")).invoke();
+      Student patchedStudent = result.readEntity(Student.class);
+      Assert.assertEquals("Expected lastname is changed to Green", "Green", patchedStudent.getLastName());
+      Assert.assertEquals("Expected firstname is Alice", "Alice", patchedStudent.getFirstName());
+      Assert.assertEquals("Expected school is null", null, patchedStudent.getSchool());
+      Assert.assertEquals("Expected gender is null", null, patchedStudent.getGender());
+      client.close();
+   }
+
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/patch/StudentPatchTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/patch/StudentPatchTest.java
@@ -1,5 +1,8 @@
 package org.jboss.resteasy.test.resource.patch;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.ws.rs.HttpMethod;
@@ -11,10 +14,12 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.utils.PortProviderUtil;
 import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
@@ -30,7 +35,8 @@ import org.junit.runner.RunWith;
 public class StudentPatchTest {
 
    static Client client;
-
+   static final String PATCH_DEPLOYMENT = "Patch";
+   static final String DISABLED_PATCH_DEPLOYMENT = "DisablePatch";
    @BeforeClass
    public static void setup() {
       client = ClientBuilder.newClient();
@@ -42,10 +48,18 @@ public class StudentPatchTest {
       client = null;
    }
 
-   @Deployment
+   @Deployment(name=PATCH_DEPLOYMENT, order = 1)
    public static Archive<?> deploy() {
       WebArchive war = TestUtil.prepareArchive(StudentPatchTest.class.getSimpleName());
       return TestUtil.finishContainerPrepare(war, null, StudentResource.class, Student.class);
+   }
+
+   @Deployment(name=DISABLED_PATCH_DEPLOYMENT, order = 2)
+   public static Archive<?> createDisablePatchFilterDeployment() {
+       WebArchive war = TestUtil.prepareArchive(DISABLED_PATCH_DEPLOYMENT);
+       Map<String, String> contextParam = new HashMap<>();
+       contextParam.put(ResteasyContextParameters.RESTEASY_PATCH_FILTER_DISABLED, "true");
+       return TestUtil.finishContainerPrepare(war, contextParam, StudentResource.class, Student.class);
    }
 
    private String generateURL(String path) {
@@ -53,7 +67,7 @@ public class StudentPatchTest {
    }
 
    @Test
-   //@Ignore
+   @OperateOnDeployment(PATCH_DEPLOYMENT)
    public void testPatchStudent() throws Exception {
       ResteasyClient client = new ResteasyClientBuilder().connectionPoolSize(10).build();
 
@@ -89,6 +103,7 @@ public class StudentPatchTest {
    }
 
    @Test
+   @OperateOnDeployment(PATCH_DEPLOYMENT)
    public void testMergePatchStudent() throws Exception {
       ResteasyClient client = ((ResteasyClientBuilder)ClientBuilder.newBuilder()).connectionPoolSize(10).build();
       WebTarget base = client.target(generateURL("/students"));
@@ -108,6 +123,31 @@ public class StudentPatchTest {
       Assert.assertEquals("Expected firstname is Alice", "Alice", patchedStudent.getFirstName());
       Assert.assertEquals("Expected school is null", null, patchedStudent.getSchool());
       Assert.assertEquals("Expected gender is null", null, patchedStudent.getGender());
+      client.close();
+   }
+   @Test
+   @OperateOnDeployment(DISABLED_PATCH_DEPLOYMENT)
+   public void testPatchDisabled() throws Exception {
+      ResteasyClient client = ((ResteasyClientBuilder)ClientBuilder.newBuilder()).connectionPoolSize(10).build();
+
+      WebTarget base = client.target(PortProviderUtil.generateURL("/students", DISABLED_PATCH_DEPLOYMENT));
+      //add a student, first name is Taylor and school is school1, other fields is null.
+      Student newStudent = new Student().setId(1L).setFirstName("Taylor").setSchool("school1");
+      Response response = base.request().post(Entity.<Student>entity(newStudent, MediaType.APPLICATION_JSON_TYPE));
+      Student s = response.readEntity(Student.class);
+      Assert.assertNotNull("Add student failed", s);
+      Assert.assertEquals("Taylor", s.getFirstName());
+      Assert.assertNull("Last name is not null", s.getLastName());
+      Assert.assertEquals("school1", s.getSchool());
+      Assert.assertNull("Gender is not null", s.getGender());
+
+      WebTarget patchTarget = client.target(PortProviderUtil.generateURL("/students/1", DISABLED_PATCH_DEPLOYMENT));
+      javax.json.JsonArray patchRequest = Json.createArrayBuilder()
+            .add(Json.createObjectBuilder().add("op", "copy").add("from", "/firstName").add("path", "/lastName").build())
+            .add(Json.createObjectBuilder().add("op", "replace").add("path", "/firstName").add("value", "John").build())
+            .build();
+      Response res = patchTarget.request().build(HttpMethod.PATCH, Entity.entity(patchRequest, MediaType.APPLICATION_JSON_PATCH_JSON)).invoke();
+      Assert.assertEquals("Http 400 is expected", 400, res.getStatus());
       client.close();
    }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/patch/StudentResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/patch/StudentResource.java
@@ -25,6 +25,7 @@ public class StudentResource
 
    @GET
    @Path("/{id}")
+   @Consumes(MediaType.APPLICATION_JSON)
    @Produces(MediaType.APPLICATION_JSON)
    public Student getStudent(@PathParam("id") long id)
    {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/patch/StudentResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/patch/StudentResource.java
@@ -72,5 +72,18 @@ public class StudentResource
       studentsMap.put(id, student);
       return student;
    }
+   @PATCH
+   @Path("/{id}")
+   @Consumes("application/merge-patch+json")
+   @Produces(MediaType.APPLICATION_JSON)
+   public Student mergePatchStudent(@PathParam("id") long id, Student student)
+   {
+      if (studentsMap.get(id) == null)
+      {
+         throw new NotFoundException();
+      }
+      studentsMap.put(id, student);
+      return student;
+   }
 
 }


### PR DESCRIPTION
This PR backport  these changes:
[RESTEASY-2165]:Add json merge patch support
[RESTEASY-2496]:Add configuration parameter to disable PatchMethodFitler
[RESTEASY-2280]:PatchMethodFilter GET requires Consumes APPLICATION_JSON_PATCH_JSON