### PR TITLE
Set response code to 500 if writing exception fails

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ServerResponseWriter.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ServerResponseWriter.java
@@ -121,6 +121,7 @@ public class ServerResponseWriter
 
          if (writer == null)
          {
+             response.setStatus(jaxrsResponse.getStatus()); //set the status to the response status anyway
              onWriteComplete.accept(new NoMessageBodyWriterFoundFailure(type, mt));
              return;
          }


### PR DESCRIPTION
Fix for https://github.com/quarkusio/quarkus/issues/8675

The root cause of the problem was not setting the content type, but it still should not return a 200 response if writing the error fails.