### PR TITLE
Using GitHub Actions for CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,37 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest ]
+        java: ['1.8', '11']
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Build with Maven Java ${{ matrix.java }}
+        run: mvn clean install -fae

--- a/resteasy-client-jetty/src/test/java/org/jboss/resteasy/test/client/jetty/JettyClientEngineTest.java
+++ b/resteasy-client-jetty/src/test/java/org/jboss/resteasy/test/client/jetty/JettyClientEngineTest.java
@@ -90,7 +90,7 @@ public class JettyClientEngineTest {
          .get();
 
       assertEquals(200, response.getStatus());
-      assertEquals("Success\n", response.readEntity(String.class));
+      assertEquals("Success" + System.lineSeparator(), response.readEntity(String.class));
    }
 
    @Test
@@ -117,7 +117,7 @@ public class JettyClientEngineTest {
 
       Response response = cs.toCompletableFuture().get();
       assertEquals(200, response.getStatus());
-      assertEquals("Success\n", response.readEntity(String.class));
+      assertEquals("Success" + System.lineSeparator(), response.readEntity(String.class));
    }
 
    @Test
@@ -143,7 +143,7 @@ public class JettyClientEngineTest {
          .get(String.class);
 
       String response = cs.toCompletableFuture().get();
-      assertEquals("Success\n", response);
+      assertEquals("Success" + System.lineSeparator(), response);
    }
 
    @Test
@@ -242,7 +242,7 @@ public class JettyClientEngineTest {
    @Test
    public void testFilterBufferReplay() throws Exception {
       final String greeting = "Success";
-      final byte[] expected = (greeting + '\n').getBytes(StandardCharsets.UTF_8);
+      final byte[] expected = (greeting + System.lineSeparator()).getBytes(StandardCharsets.UTF_8);
       server.setHandler(new AbstractHandler() {
          @Override
          public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/server-adapters/resteasy-jdk-http/src/test/java/org/jboss/resteasy/test/HttpContextTest.java
+++ b/server-adapters/resteasy-jdk-http/src/test/java/org/jboss/resteasy/test/HttpContextTest.java
@@ -8,6 +8,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
+import java.util.regex.Pattern;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -79,7 +80,9 @@ public class HttpContextTest
       {
           Response response = client.target(generateURL("/request")).request().get();
           Assert.assertEquals(200, response.getStatus());
-          Assert.assertEquals("127.0.0.1/localhost", response.readEntity(String.class));
+          final String val = response.readEntity(String.class);
+          final String pattern = "^127.0.0.1/.+";
+          Assert.assertTrue(String.format("Expected value '%s' to match pattern '%s'", val, pattern), Pattern.matches(pattern, val));
        }
 }
 

--- a/server-adapters/resteasy-jdk-http/src/test/java/org/jboss/resteasy/test/HttpContextTest.java
+++ b/server-adapters/resteasy-jdk-http/src/test/java/org/jboss/resteasy/test/HttpContextTest.java
@@ -8,6 +8,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import javax.ws.rs.client.Client;
@@ -46,6 +47,8 @@ public class HttpContextTest
    {
       contextBuilder.cleanup();
       httpServer.stop(0);
+      // TODO (jrp) this needs to be removed, just attempting to rule out a race condition
+      TimeUnit.SECONDS.sleep(2L);
    }
 
    @Test

--- a/server-adapters/resteasy-jdk-http/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
+++ b/server-adapters/resteasy-jdk-http/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
@@ -2,6 +2,8 @@ package org.jboss.resteasy.test.security;
 
 import static org.jboss.resteasy.test.TestPortProvider.createProxy;
 import static org.jboss.resteasy.test.TestPortProvider.generateURL;
+import static org.jboss.resteasy.test.TestPortProvider.getHost;
+import static org.jboss.resteasy.test.TestPortProvider.getPort;
 
 import java.util.List;
 
@@ -289,7 +291,7 @@ public class BasicAuthTest
          {
             // Generate BASIC scheme object and add it to the local auth cache
             BasicScheme basicAuth = new BasicScheme();
-            HttpHost targetHost = new HttpHost("localhost", 8081);
+            HttpHost targetHost = new HttpHost(getHost(), getPort());
             authCache.put(targetHost, basicAuth);
 
             // Add AuthCache to the execution context

--- a/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/NettyTest.java
+++ b/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/NettyTest.java
@@ -9,6 +9,7 @@ import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.Socket;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.HttpMethod;
@@ -296,6 +297,7 @@ public class NettyTest
    {
       WebTarget target = client.target(generateURL("/request"));
       String val = target.request().get(String.class);
-      Assert.assertEquals("127.0.0.1/localhost", val);
+      final String pattern = "^127.0.0.1/.+";
+      Assert.assertTrue(String.format("Expected value '%s' to match pattern '%s'", val, pattern), Pattern.matches(pattern, val));
    }
 }

--- a/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/SniTest.java
+++ b/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/SniTest.java
@@ -101,7 +101,7 @@ public class SniTest
    }
 
    private String callRestService(Client client) {
-      WebTarget target = client.target("https://localhost:8081/test");
+      WebTarget target = client.target(String.format("https://%s:%d/test", TestPortProvider.getHost(), TestPortProvider.getPort()));
       return target.request().get(String.class);
    }
 

--- a/server-adapters/resteasy-vertx/src/test/java/org/jboss/resteasy/test/DynamicFeatureTest.java
+++ b/server-adapters/resteasy-vertx/src/test/java/org/jboss/resteasy/test/DynamicFeatureTest.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.annotation.Annotation;
+import java.util.concurrent.TimeUnit;
 
 import static org.jboss.resteasy.test.TestPortProvider.generateURL;
 
@@ -179,6 +180,8 @@ public class DynamicFeatureTest
       VertxResteasyDeployment deployment = new VertxResteasyDeployment();
       deployment.getActualProviderClasses().add(AddDynamicFeature.class);
       deployment.getActualResourceClasses().add(Resource.class);
+      // TODO (jrp) this needs to be removed, just attempting to rule out a race condition
+      TimeUnit.SECONDS.sleep(2L);
       VertxContainer.start(deployment);
       client = ClientBuilder.newClient();
    }

--- a/server-adapters/resteasy-vertx/src/test/java/org/jboss/resteasy/test/VertxTest.java
+++ b/server-adapters/resteasy-vertx/src/test/java/org/jboss/resteasy/test/VertxTest.java
@@ -9,6 +9,7 @@ import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.Socket;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -314,6 +315,7 @@ public class VertxTest
    {
       WebTarget target = client.target(generateURL("/request"));
       String val = target.request().get(String.class);
-      Assert.assertEquals("127.0.0.1/127.0.0.1", val);
+      final String pattern = "^127.0.0.1/.+";
+      Assert.assertTrue(String.format("Expected value '%s' to match pattern '%s'", val, pattern), Pattern.matches(pattern, val));
    }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/request/ResteasyRequestTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/request/ResteasyRequestTest.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.test.resource.request;
 
+import java.util.regex.Pattern;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -63,7 +64,9 @@ public class ResteasyRequestTest {
       try {
          Response response = requestWebTarget.request().get();
          Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
-         Assert.assertEquals("127.0.0.1/127.0.0.1", response.readEntity(String.class));
+         final String val = response.readEntity(String.class);
+         final String pattern = "^127.0.0.1/.+";
+         Assert.assertTrue(String.format("Expected value '%s' to match pattern '%s'", val, pattern), Pattern.matches(pattern, val));
          response.close();
       } catch (Exception e) {
          throw new RuntimeException(e);


### PR DESCRIPTION
@ronsigal @asoldano What do you guys think about this? It's not testing the two versions of WildFly like Travis currently does, but it does add testing for Windows. We could enable it to test on multiple versions of WildFly too.

One thing I have noticed is on Windows, especially Java 8 and the `resteasy-jdk-http` tests, fail with a "Bind address already in use". I assume this may be some kind of race for the socket actually closing. I can't duplicate it on my Windows VM at all so I'd be tempted to skip it on Windows CI. Thoughts?