### PR TITLE
[RESTEASY-2495] made HeaderParamProcessor aware of ParamConverter and…

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/HeaderParamProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/invocation/HeaderParamProcessor.java
@@ -27,7 +27,8 @@ public class HeaderParamProcessor extends AbstractInvocationCollectionProcessor
    protected ClientInvocation apply(ClientInvocation invocation, Object... objects)
    {
       for (Object object : objects) {
-         invocation.getHeaders().header(paramName, object);
+         String value = invocation.getClientConfiguration().toString(object);
+         invocation.getHeaders().header(paramName, value);
       }
       return invocation;
    }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/HeaderParamParamConverterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/HeaderParamParamConverterTest.java
@@ -1,0 +1,56 @@
+package org.jboss.resteasy.test.resource.param;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.test.resource.param.resource.HeaderParamMyClass;
+import org.jboss.resteasy.test.resource.param.resource.HeaderParamParamConverterProvider;
+import org.jboss.resteasy.test.resource.param.resource.HeaderParamParamConverterTestService;
+import org.jboss.resteasy.test.resource.param.resource.HeaderParamParamConverterTestServiceImpl;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import javax.ws.rs.client.ClientBuilder;
+
+/**
+ * Provides a ParamConverter for an input parameter using annotation @HeaderParam
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class HeaderParamParamConverterTest {
+    private static String testSimpleName = HeaderParamParamConverterTest.class.getSimpleName();
+    @Deployment
+    public static Archive<?> deploy() {
+        WebArchive war = TestUtil.prepareArchive(testSimpleName);
+        war.addClasses(HeaderParamMyClass.class,
+                HeaderParamParamConverterProvider.class,
+                HeaderParamParamConverterTestServiceImpl.class,
+                HeaderParamParamConverterTestService.class);
+        return TestUtil.finishContainerPrepare(war, null, null);
+    }
+
+    private String generateURL(String path) {
+        return PortProviderUtil.generateURL(path, testSimpleName);
+    }
+    private static String generateBaseUrl() {
+        return PortProviderUtil.generateBaseUrl(testSimpleName);
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        HeaderParamMyClass header = new HeaderParamMyClass();
+        header.setValue("someValue");
+        // test
+        ResteasyClient proxyClient = (ResteasyClient) ClientBuilder.newClient();
+        HeaderParamParamConverterTestService service = proxyClient.target(generateBaseUrl())
+                .proxyBuilder(HeaderParamParamConverterTestService .class).build();
+
+        Assert.assertTrue(service.test(header));
+        proxyClient.close();
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/resource/HeaderParamMyClass.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/resource/HeaderParamMyClass.java
@@ -1,0 +1,18 @@
+package org.jboss.resteasy.test.resource.param.resource;
+
+public class HeaderParamMyClass {
+    private String header = "badValue";
+
+    public HeaderParamMyClass(){
+
+    }
+
+    public void setValue(String v) {
+        header = v;
+    }
+
+    @Override
+    public String toString() {
+        return header;
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/resource/HeaderParamParamConverterProvider.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/resource/HeaderParamParamConverterProvider.java
@@ -1,0 +1,38 @@
+package org.jboss.resteasy.test.resource.param.resource;
+
+import java.lang.annotation.Annotation;
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import javax.ws.rs.ext.Provider;
+import java.lang.reflect.Type;
+
+@Provider
+public class HeaderParamParamConverterProvider implements ParamConverterProvider {
+    public static class MyClassConverter implements ParamConverter<HeaderParamMyClass> {
+        @Override
+        public HeaderParamMyClass fromString(String value) {
+            final HeaderParamMyClass result = new HeaderParamMyClass();
+            result.setValue(value + "-MORE");
+            return result;
+        }
+        @Override
+        public String toString(HeaderParamMyClass value) {
+            return "paramConverter";
+        }
+    }
+
+    public HeaderParamParamConverterProvider () {
+    }
+
+    @Override
+    public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType,
+                                              Annotation[] annotations) {
+        final ParamConverter<T> result;
+        if (rawType.isAssignableFrom(HeaderParamMyClass .class)) {
+            result = (ParamConverter<T>)new MyClassConverter();
+        } else {
+            result = null;
+        }
+        return result;
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/resource/HeaderParamParamConverterTestService.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/resource/HeaderParamParamConverterTestService.java
@@ -1,0 +1,11 @@
+package org.jboss.resteasy.test.resource.param.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.HeaderParam;
+
+@Path("/")
+public interface HeaderParamParamConverterTestService {
+    @GET
+    boolean test(@HeaderParam("test-header") HeaderParamMyClass someValue);
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/resource/HeaderParamParamConverterTestServiceImpl.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/resource/HeaderParamParamConverterTestServiceImpl.java
@@ -1,0 +1,13 @@
+package org.jboss.resteasy.test.resource.param.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+
+@Path("/")
+public class HeaderParamParamConverterTestServiceImpl implements HeaderParamParamConverterTestService{
+    @GET
+    public boolean test(@HeaderParam("test-header") HeaderParamMyClass someValue){
+        return "someValue-MORE".equals(someValue.toString());
+    }
+}


### PR DESCRIPTION
… provided testcase
This PR replaces https://github.com/resteasy/Resteasy/pull/2292.
2292 only provides the fix in HeaderParamProcessor.  A testcase was
requested but never provided.  This PR provides the original fix
and a testcase.