### PR TITLE
Fix RESTEASY-2526 by using asyncutil lib for async loops

### DIFF
--- a/jboss-modules/build.xml
+++ b/jboss-modules/build.xml
@@ -31,6 +31,10 @@
             <maven-resource group="org.reactivestreams" artifact="reactive-streams"/>
         </module-def>
 
+        <module-def name="com.ibm.async.asyncutil">
+            <maven-resource group="com.ibm.async" artifact="asyncutil"/>
+        </module-def>
+
         <module-def name="org.eclipse.microprofile.restclient">
             <maven-resource group="org.eclipse.microprofile.rest.client" artifact="microprofile-rest-client-api"/>
         </module-def>

--- a/jboss-modules/pom.xml
+++ b/jboss-modules/pom.xml
@@ -25,6 +25,10 @@
             <artifactId>reactive-streams</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.ibm.async</groupId>
+            <artifactId>asyncutil</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>

--- a/jboss-modules/src/main/resources/modules/com/ibm/async/asyncutil/main/module.xml
+++ b/jboss-modules/src/main/resources/modules/com/ibm/async/asyncutil/main/module.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.5" name="com.ibm.async.asyncutil">
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+    </dependencies>
+</module>

--- a/jboss-modules/src/main/resources/modules/org/jboss/resteasy/resteasy-jaxrs/main/module.xml
+++ b/jboss-modules/src/main/resources/modules/org/jboss/resteasy/resteasy-jaxrs/main/module.xml
@@ -49,6 +49,7 @@
         <module name="org.jboss.resteasy.resteasy-validator-provider" optional="true" services="export" export="true"/>
         <module name="org.jboss.logging"/>
         <module name="org.reactivestreams"/>
+        <module name="com.ibm.async.asyncutil"/>
         <module name="org.eclipse.microprofile.restclient"/>
         <module name="org.eclipse.microprofile.config.api" export="true" optional="true"/> <!-- not really optional, just a workaround for WFLY12/13 missing MP Config API -->
         <module name="org.jboss.resteasy.resteasy-jaxrs-public" export="true"/>

--- a/resteasy-core/pom.xml
+++ b/resteasy-core/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.ibm.async</groupId>
+            <artifactId>asyncutil</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>provided</scope>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -101,6 +101,7 @@
         <version.org.springframework>5.2.0.RELEASE</version.org.springframework>
         <version.io.projectreactor>Dysprosium-SR2</version.io.projectreactor>
 
+        <version.asyncutil>0.1.0</version.asyncutil>
     </properties>
 
     <distributionManagement>
@@ -989,6 +990,11 @@
                 <version>${version.io.projectreactor}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.ibm.async</groupId>
+                <artifactId>asyncutil</artifactId>
+                <version>${version.asyncutil}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/server-adapters/resteasy-undertow/src/test/java/org/jboss/resteasy/test/undertow/AsyncIOResource.java
+++ b/server-adapters/resteasy-undertow/src/test/java/org/jboss/resteasy/test/undertow/AsyncIOResource.java
@@ -1,7 +1,18 @@
 package org.jboss.resteasy.test.undertow;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.io.input.NullInputStream;
+import org.jboss.resteasy.plugins.providers.FileRange;
 
 @Path("async-io")
 public class AsyncIOResource {
@@ -22,5 +33,24 @@ public class AsyncIOResource {
     @Path("slow-async-writer-on-worker-thread")
     public AsyncWriterData slowAsyncWriterOnWorkerThread() {
         return new AsyncWriterData(false, true);
+    }
+
+    @GET
+    @Path("io/{size}")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    public Response io(@PathParam("size") long size) {
+        return Response.ok(new NullInputStream(size)).build();
+    }
+
+    @GET
+    @Path("io/file-range/{size}")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    public Response fileRange(@PathParam("size") long size) throws IOException {
+        File file = File.createTempFile("empty-file", "");
+        file.deleteOnExit();
+        RandomAccessFile rFile = new RandomAccessFile(file, "rw");
+        rFile.setLength(size);
+        rFile.close();
+        return Response.ok(new FileRange(file, 0, size-1)).build();
     }
 }

--- a/server-adapters/resteasy-undertow/src/test/java/org/jboss/resteasy/test/undertow/AsyncIOTest.java
+++ b/server-adapters/resteasy-undertow/src/test/java/org/jboss/resteasy/test/undertow/AsyncIOTest.java
@@ -75,4 +75,26 @@ public class AsyncIOTest
       val = target.request().get(String.class);
       Assert.assertEquals("OK", val);
    }
+
+   @Test
+   public void testAsyncIoWrites() throws Exception
+   {
+       // 10M
+       WebTarget target = client.target(generateURL("/async-io/io/10000000"));
+       byte[] val = target.request().get(byte[].class);
+       Assert.assertEquals(10_000_000, val.length);
+       // 100M
+       target = client.target(generateURL("/async-io/io/100000000"));
+       val = target.request().get(byte[].class);
+       Assert.assertEquals(100_000_000, val.length);
+
+       // 10M
+       target = client.target(generateURL("/async-io/io/file-range/10000000"));
+       val = target.request().get(byte[].class);
+       Assert.assertEquals(10_000_000, val.length);
+       // 100M
+       target = client.target(generateURL("/async-io/io/file-range/100000000"));
+       val = target.request().get(byte[].class);
+       Assert.assertEquals(100_000_000, val.length);
+   }
 }


### PR DESCRIPTION
Proper fix for #2342, as described there.

This PR introduces a new (tiny) dependency that is required to properly implement loops using `CompletionStage`. I'm not sure if it's best to add a jboss modules for it, or include it in the jaxrs-all module.

Need guidance from @asoldano about this.