### PR TITLE
Only upload archives for failed runs. Also fix the name to not end with ".zip"

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,14 +38,14 @@ jobs:
       - name: Build with Maven Java ${{ matrix.java }} on WildFly ${{ matrix.wildfly-version }}
         run: mvn clean install -fae '-Dserver.version=${{ matrix.wildfly-version }}'
       - uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
-          name: surefire-reports-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.wildfly-version }}.zip
+          name: surefire-reports-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.wildfly-version }}
           path: '**/surefire-reports/*.txt'
       - uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
-          name: server-logs-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.wildfly-version }}.zip
+          name: server-logs-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.wildfly-version }}
           path: '**/server.log'
 
   build-java-docs:


### PR DESCRIPTION
After some thought I'm wondering if we really want to add archived logs for successful jobs. It adds unneeded archives and clutters the UI. Also just keeps down on the size of retained data.

This is definitely not required so feel free to close it if we'd rather keep all the archives.