### PR TITLE
CompletionStageResponseTest intermittent failures

### DIFF
--- a/server-adapters/resteasy-vertx/src/test/java/org/jboss/resteasy/test/async/AsyncRequestFilter.java
+++ b/server-adapters/resteasy-vertx/src/test/java/org/jboss/resteasy/test/async/AsyncRequestFilter.java
@@ -17,8 +17,8 @@ import java.util.concurrent.Executors;
 
 public abstract class AsyncRequestFilter implements ContainerRequestFilter {
 
-   private String name;
-   private String callbackException;
+   private final String name;
+   private volatile String callbackException;
    private static final Logger LOG = Logger.getLogger(AsyncRequestFilter.class);
 
    public AsyncRequestFilter(final String name)

--- a/server-adapters/resteasy-vertx/src/test/java/org/jboss/resteasy/test/async/AsyncResponseFilter.java
+++ b/server-adapters/resteasy-vertx/src/test/java/org/jboss/resteasy/test/async/AsyncResponseFilter.java
@@ -19,8 +19,8 @@ import java.util.concurrent.Executors;
 
 public abstract class AsyncResponseFilter implements ContainerResponseFilter {
 
-   private String name;
-   private String callbackException;
+   private final String name;
+   private volatile String callbackException;
    private static final Logger LOG = Logger.getLogger(AsyncRequestFilter.class);
 
    public AsyncResponseFilter(final String name)

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncRequestFilter.java
@@ -18,8 +18,8 @@ import org.jboss.resteasy.spi.HttpRequest;
 
 public abstract class AsyncRequestFilter implements ContainerRequestFilter {
 
-   private String name;
-   private String callbackException;
+   private final String name;
+   private volatile String callbackException;
    private static final Logger LOG = Logger.getLogger(AsyncRequestFilter.class);
 
    public AsyncRequestFilter(final String name)

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/AsyncResponseFilter.java
@@ -20,8 +20,8 @@ import org.jboss.resteasy.spi.ResteasyAsynchronousResponse;
 
 public abstract class AsyncResponseFilter implements ContainerResponseFilter {
 
-   private String name;
-   private String callbackException;
+   private final String name;
+   private volatile String callbackException;
    private static final Logger LOG = Logger.getLogger(AsyncRequestFilter.class);
 
    public AsyncResponseFilter(final String name)

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/CallbackSecondSettingCompletionCallback.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/CallbackSecondSettingCompletionCallback.java
@@ -4,7 +4,7 @@ import javax.ws.rs.container.CompletionCallback;
 
 public class CallbackSecondSettingCompletionCallback implements CompletionCallback {
 
-   private static String throwableName;
+   private static volatile String throwableName;
    public static final String NULL = "NULL";
    public static final String OUTOFORDER = "CallbackSecondSettingCompletionCallback is not second";
    public static final String NONAME = "No name has been set yet";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/CallbackSettingCompletionCallback.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/resource/CallbackSettingCompletionCallback.java
@@ -4,7 +4,7 @@ import javax.ws.rs.container.CompletionCallback;
 
 public class CallbackSettingCompletionCallback implements CompletionCallback {
 
-   private static String throwableName;
+   private static volatile String throwableName;
    public static final String NULL = "NULL";
    public static final String NONAME = "No name has been set yet";
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/CompletionStageResponseTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/CompletionStageResponseTest.java
@@ -89,7 +89,7 @@ public class CompletionStageResponseTest {
       Assert.assertEquals(CompletionStageResponseResource.HELLO, entity);
 
       // make sure the completion callback was called with no error
-      request = client.target(generateURL("/callback-called-no-error")).request();
+      request = client.target(generateURL("/callback-called-no-error?p=text")).request();
       response = request.get();
       Assert.assertEquals(200, response.getStatus());
       response.close();
@@ -176,7 +176,7 @@ public class CompletionStageResponseTest {
       Assert.assertEquals(CompletionStageResponseResource.EXCEPTION, entity);
 
       // make sure the completion callback was called with with an error
-      request = client.target(generateURL("/callback-called-with-error")).request();
+      request = client.target(generateURL("/callback-called-with-error?p=exception/delay")).request();
       response = request.get();
       Assert.assertEquals(200, response.getStatus());
       response.close();
@@ -197,7 +197,7 @@ public class CompletionStageResponseTest {
       Assert.assertEquals(CompletionStageResponseResource.EXCEPTION, entity);
 
       // make sure the completion callback was called with with an error
-      request = client.target(generateURL("/callback-called-with-error")).request();
+      request = client.target(generateURL("/callback-called-with-error?p=exception/delay-wrapped")).request();
       response = request.get();
       Assert.assertEquals(200, response.getStatus());
       response.close();
@@ -218,7 +218,7 @@ public class CompletionStageResponseTest {
       response.close();
 
       // make sure the completion callback was called with with an error
-      request = client.target(generateURL("/callback-called-with-error")).request();
+      request = client.target(generateURL("/callback-called-with-error?p=exception/immediate/runtime")).request();
       response = request.get();
       Assert.assertEquals(200, response.getStatus());
       response.close();
@@ -239,7 +239,7 @@ public class CompletionStageResponseTest {
       response.close();
 
       // make sure the completion callback was called with with an error
-      request = client.target(generateURL("/callback-called-with-error")).request();
+      request = client.target(generateURL("/callback-called-with-error?p=exception/immediate/notruntime")).request();
       response = request.get();
       Assert.assertEquals(200, response.getStatus());
       response.close();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/PublisherResponseNoStreamTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/PublisherResponseNoStreamTest.java
@@ -81,7 +81,7 @@ public class PublisherResponseNoStreamTest {
       Assert.assertEquals("[\"one\",\"two\"]", entity);
 
       // make sure the completion callback was called with no error
-      request = client.target(generateURL("/callback-called-no-error")).request();
+      request = client.target(generateURL("/callback-called-no-error/text")).request();
       response = request.get();
       Assert.assertEquals(200, response.getStatus());
       response.close();
@@ -101,7 +101,7 @@ public class PublisherResponseNoStreamTest {
       Assert.assertEquals("Got it", entity);
 
       // make sure the completion callback was called with with an error
-      request = client.target(generateURL("/callback-called-with-error")).request();
+      request = client.target(generateURL("/callback-called-with-error/text-error-immediate")).request();
       response = request.get();
       Assert.assertEquals(200, response.getStatus());
       response.close();
@@ -121,7 +121,7 @@ public class PublisherResponseNoStreamTest {
       Assert.assertEquals("Got it", entity);
 
       // make sure the completion callback was called with with an error
-      request = client.target(generateURL("/callback-called-with-error")).request();
+      request = client.target(generateURL("/callback-called-with-error/text-error-deferred")).request();
       response = request.get();
       Assert.assertEquals(200, response.getStatus());
       response.close();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/PublisherResponseTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/PublisherResponseTest.java
@@ -103,7 +103,7 @@ public class PublisherResponseTest {
       Assert.assertEquals(Arrays.asList(new String[] {"one", "two"}), list);
 
       // make sure the completion callback was called with no error
-      Builder request = client.target(generateURL("/callback-called-no-error")).request();
+      Builder request = client.target(generateURL("/callback-called-no-error/text")).request();
       Response response = request.get();
       Assert.assertEquals(200, response.getStatus());
       response.close();
@@ -129,7 +129,7 @@ public class PublisherResponseTest {
       Assert.assertEquals("Got it", cee.getResponse().readEntity(String.class));
 
       // make sure the completion callback was called with with an error
-      Builder request = client.target(generateURL("/callback-called-with-error")).request();
+      Builder request = client.target(generateURL("/callback-called-with-error/text-error-immediate")).request();
       Response response = request.get();
       Assert.assertEquals(200, response.getStatus());
       response.close();
@@ -150,7 +150,7 @@ public class PublisherResponseTest {
       Assert.assertEquals("Got it", entity);
 
       // make sure the completion callback was called with with an error
-      request = client.target(generateURL("/callback-called-with-error")).request();
+      request = client.target(generateURL("/callback-called-with-error/text-error-deferred")).request();
       response = request.get();
       Assert.assertEquals(200, response.getStatus());
       response.close();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/SingleProvider.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/SingleProvider.java
@@ -16,7 +16,7 @@ public class SingleProvider implements AsyncResponseProvider<Single<?>>
 
    private static class SingleAdaptor<T> extends CompletableFuture<T>
    {
-      private Disposable subscription;
+      private final Disposable subscription;
 
       SingleAdaptor(final Single<T> observable)
       {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/AsyncResponseCallback.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/AsyncResponseCallback.java
@@ -8,7 +8,7 @@ import javax.ws.rs.container.CompletionCallback;
 public class AsyncResponseCallback implements CompletionCallback {
 
    private static CountDownLatch latch;
-   private static Throwable error;
+   private static volatile Throwable error;
 
    public AsyncResponseCallback()
    {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/AsyncResponseCallback.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/AsyncResponseCallback.java
@@ -1,5 +1,7 @@
 package org.jboss.resteasy.test.response.resource;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -7,32 +9,36 @@ import javax.ws.rs.container.CompletionCallback;
 
 public class AsyncResponseCallback implements CompletionCallback {
 
-   private static CountDownLatch latch;
-   private static volatile Throwable error;
+   private static Map<String, CountDownLatch> latches = new ConcurrentHashMap<String, CountDownLatch>();
+   private static Map<String, Throwable> errors = new ConcurrentHashMap<String, Throwable>();
+   private final String s;
 
-   public AsyncResponseCallback()
+   public AsyncResponseCallback(final String s)
    {
-      latch = new CountDownLatch(1);
-      error = null;
+      this.s = s;
+      latches.put(s, new CountDownLatch(1));
+      errors.remove(s);
    }
 
    @Override
    public void onComplete(Throwable throwable)
    {
-      latch.countDown();
-      error = throwable;
+      latches.get(s).countDown();
+      if (throwable != null)
+         errors.put(s, throwable);
    }
 
-   public static void assertCalled(boolean withError)
+   public static void assertCalled(String s, boolean withError)
    {
       boolean called = false;
       try {
-         called = latch.await(10, TimeUnit.SECONDS);
+         called = latches.get(s).await(10, TimeUnit.SECONDS);
       } catch (Exception e) {
          //ignore
       }
       if(!called)
          throw new AssertionError("Not called");
+      Throwable error = errors.get(s);
       if(withError && error == null
             || !withError && error != null)
          throw new AssertionError("Error mismatch");

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/CompletionStageResponseResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/CompletionStageResponseResource.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import org.jboss.resteasy.annotations.jaxrs.QueryParam;
 import org.jboss.resteasy.spi.HttpRequest;
 
 import io.reactivex.Single;
@@ -27,7 +28,7 @@ public class CompletionStageResponseResource {
    @Path("text")
    @Produces("text/plain")
    public CompletionStage<String> text(@Context HttpRequest req) {
-      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback());
+      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback("text"));
       CompletableFuture<String> cs = new CompletableFuture<>();
       ExecutorService executor = Executors.newSingleThreadExecutor();
       executor.submit(
@@ -116,7 +117,7 @@ public class CompletionStageResponseResource {
    @Path("exception/delay")
    @Produces("text/plain")
    public CompletionStage<String> exceptionDelay(@Context HttpRequest req) {
-      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback());
+      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback("exception/delay"));
       CompletableFuture<String> cs = new CompletableFuture<>();
       ExecutorService executor = Executors.newSingleThreadExecutor();
       executor.submit(
@@ -138,7 +139,7 @@ public class CompletionStageResponseResource {
    @Path("exception/delay-wrapped")
    @Produces("text/plain")
    public CompletionStage<String> exceptionDelayWrapped(@Context HttpRequest req) {
-      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback());
+      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback("exception/delay-wrapped"));
       CompletableFuture<String> cs = CompletableFuture.completedFuture("OK");
       ExecutorService executor = Executors.newSingleThreadExecutor();
       return cs.thenApplyAsync(text -> {
@@ -156,7 +157,7 @@ public class CompletionStageResponseResource {
    @Path("exception/immediate/runtime")
    @Produces("text/plain")
    public CompletionStage<String> exceptionImmediateRuntime(@Context HttpRequest req) {
-      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback());
+      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback("exception/immediate/runtime"));
       throw new RuntimeException(EXCEPTION + ": expect stacktrace");
    }
 
@@ -164,21 +165,21 @@ public class CompletionStageResponseResource {
    @Path("exception/immediate/notruntime")
    @Produces("text/plain")
    public CompletionStage<String> exceptionImmediateNotRuntime(@Context HttpRequest req) throws Exception {
-      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback());
+      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback("exception/immediate/notruntime"));
       throw new Exception( EXCEPTION + ": expect stacktrace");
    }
 
    @GET
    @Path("callback-called-no-error")
-   public String callbackCalledNoError() {
-      AsyncResponseCallback.assertCalled(false);
+   public String callbackCalledNoError(@QueryParam String p) {
+      AsyncResponseCallback.assertCalled(p, false);
       return "OK";
    }
 
    @GET
    @Path("callback-called-with-error")
-   public String callbackCalledWithError() {
-      AsyncResponseCallback.assertCalled(true);
+   public String callbackCalledWithError(@QueryParam String p) {
+      AsyncResponseCallback.assertCalled(p, true);
       return "OK";
    }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/CompletionStageResponseResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/CompletionStageResponseResource.java
@@ -123,7 +123,7 @@ public class CompletionStageResponseResource {
             new Runnable() {
                public void run() {
                   try {
-                     Thread.sleep(1500L); // make sure that response will be created after end-point method ends
+                     Thread.sleep(3000L); // make sure that response will be created after end-point method ends
                   } catch (InterruptedException e) {
                      throw new RuntimeException(e);
                   }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/PublisherResponseNoStreamResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/PublisherResponseNoStreamResource.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.reactivestreams.Publisher;
 
@@ -24,7 +25,7 @@ public class PublisherResponseNoStreamResource {
    @Path("text")
    @Produces("application/json")
    public Publisher<String> text(@Context HttpRequest req) {
-      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback());
+      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback("text"));
       return Flowable.fromArray("one", "two");
    }
 
@@ -42,9 +43,9 @@ public class PublisherResponseNoStreamResource {
    }
 
    @GET
-   @Path("callback-called-no-error")
-   public String callbackCalledNoError() {
-      AsyncResponseCallback.assertCalled(false);
+   @Path("callback-called-no-error/{p}")
+   public String callbackCalledNoError(@PathParam String p) {
+      AsyncResponseCallback.assertCalled(p, false);
       return "OK";
    }
 
@@ -52,7 +53,7 @@ public class PublisherResponseNoStreamResource {
    @Path("text-error-immediate")
    @Produces("application/json")
    public Publisher<String> textErrorImmediate(@Context HttpRequest req) {
-      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback());
+      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback("text-error-immediate"));
       throw new AsyncResponseException();
    }
 
@@ -60,14 +61,14 @@ public class PublisherResponseNoStreamResource {
    @Path("text-error-deferred")
    @Produces("application/json")
    public Publisher<String> textErrorDeferred(@Context HttpRequest req) {
-      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback());
+      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback("text-error-deferred"));
       return Flowable.error(new AsyncResponseException());
    }
 
    @GET
-   @Path("callback-called-with-error")
-   public String callbackCalledWithError() {
-      AsyncResponseCallback.assertCalled(true);
+   @Path("callback-called-with-error/{p}")
+   public String callbackCalledWithError(@PathParam String p) {
+      AsyncResponseCallback.assertCalled(p, true);
       return "OK";
    }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/PublisherResponseResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/resource/PublisherResponseResource.java
@@ -11,6 +11,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.Stream;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.reactivestreams.Publisher;
 
@@ -27,7 +28,7 @@ public class PublisherResponseResource {
    @Produces("application/json")
    @Stream
    public Publisher<String> text(@Context HttpRequest req) {
-      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback());
+      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback("text"));
       return Flowable.fromArray("one", "two");
    }
 
@@ -46,9 +47,9 @@ public class PublisherResponseResource {
    }
 
    @GET
-   @Path("callback-called-no-error")
-   public String callbackCalledNoError() {
-      AsyncResponseCallback.assertCalled(false);
+   @Path("callback-called-no-error/{p}")
+   public String callbackCalledNoError(@PathParam String p) {
+      AsyncResponseCallback.assertCalled(p, false);
       return "OK";
    }
 
@@ -57,7 +58,7 @@ public class PublisherResponseResource {
    @Produces("application/json")
    @Stream
    public Publisher<String> textErrorImmediate(@Context HttpRequest req) {
-      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback());
+      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback("text-error-immediate"));
       throw new AsyncResponseException();
    }
 
@@ -66,14 +67,14 @@ public class PublisherResponseResource {
    @Produces("application/json")
    @Stream
    public Publisher<String> textErrorDeferred(@Context HttpRequest req) {
-      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback());
+      req.getAsyncContext().getAsyncResponse().register(new AsyncResponseCallback("text-error-deferred"));
       return Flowable.error(new AsyncResponseException());
    }
 
    @GET
-   @Path("callback-called-with-error")
-   public String callbackCalledWithError() {
-      AsyncResponseCallback.assertCalled(true);
+   @Path("callback-called-with-error/{p}")
+   public String callbackCalledWithError(@PathParam String p) {
+      AsyncResponseCallback.assertCalled(p, true);
       return "OK";
    }
 


### PR DESCRIPTION
A bunch of changes in test classes to prevent concurrency related issues that might be causing the intermittent failure of org.jboss.resteasy.test.response.CompletionStageResponseTest and similar tests.