### PR TITLE
[RESTEASY-2581] Add profile to enable testing using Wildfly "standalone-microprofile.xml" configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 install:
  - mvn -B clean
 script:
- - travis_wait 60 mvn -B -Ptravis -fae -Dserver.version=$SERVER_VERSION ${ELYTRON:+-Delytron} install
+ - travis_wait 60 mvn -B -Ptravis -fae -Dserver.version=$SERVER_VERSION ${ELYTRON:+-Delytron} ${STANDALONE_MICROPROFILE:+-Dts.standalone.microprofile} install
 
 language: java
 jdk:
@@ -11,6 +11,7 @@ env:
   - SERVER_VERSION=18.0.1.Final
   - SERVER_VERSION=19.0.0.Final
   - SERVER_VERSION=19.0.0.Final ELYTRON=true
+  - SERVER_VERSION=19.0.0.Final STANDALONE_MICROPROFILE=true
 jobs:
   exclude:
     - jdk: openjdk11

--- a/testsuite/README.MD
+++ b/testsuite/README.MD
@@ -81,6 +81,15 @@ Run testsuite or test with the Wildfly with security manager enabled:
 
 > mvn clean verify -Dserver.home=PATH_TO_WIDLFLY_HOME -Dsecurity.manager
 
+### Use standalone-micoprofile.xml configuration
+Starting with Wildfly 19.0.0.Final, a set of new files were added to the 
+distribution in order to start the server up with a MicroProfile-oriented 
+configuration. 
+Passing the `-Dts.standalone.microprofile` property to Maven will force
+the usage of `standalone-microprofile.xml` configuration file:
+
+> mvn clean verify -Dserver.home=PATH_TO_WIDLFLY_HOME -Dts.standalone.microprofile
+
 ### Test logs
 Test logs are stored in ``/MODULE_NAME/target/surefire-reports/TEST_NAME-output.txt``
 

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/category/ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/category/ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11.java
@@ -1,0 +1,15 @@
+package org.jboss.resteasy.category;
+
+/**
+ * Marker interface for tests which are expected to fail because of SmallRye
+ * MicroProfile OpenAPI implementation issues, see:<br>
+ * - https://github.com/smallrye/smallrye-open-api/issues/290 <br>
+ * - https://github.com/smallrye/smallrye-open-api/issues/248 <br>
+ * and related fix:
+ * https://github.com/smallrye/smallrye-open-api/pull/251
+ * (there could be more issues/fixes about quite the same annotation scanning
+ * topics, though)
+ */
+public interface ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11 {
+
+}

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/category/ExpectedFailingWithStandaloneMicroprofileConfiguration.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/category/ExpectedFailingWithStandaloneMicroprofileConfiguration.java
@@ -1,0 +1,10 @@
+package org.jboss.resteasy.category;
+
+/**
+ * Marker interface for tests which are expected to fail when WildFly is using
+ * standalone-microprofile.xml configuration files.
+ *
+ */
+public interface ExpectedFailingWithStandaloneMicroprofileConfiguration {
+
+}

--- a/testsuite/integration-tests-spring/deployment/pom.xml
+++ b/testsuite/integration-tests-spring/deployment/pom.xml
@@ -147,6 +147,28 @@
                 </plugins>
             </build>
         </profile>
+        <!-- 
+            Test against MicroProfile config.
+            standalone-microprofile.xml is used to replace occurrences of
+            standalone-full.xml in Arquillian configuration (arquillian.xml)
+        -->
+        <profile>
+            <id>standalone.microprofile.profile</id>
+            <activation>
+                <property>
+                    <name>ts.standalone.microprofile</name>
+                </property>
+            </activation>
+            <properties>
+                <jboss.server.config.file.name>standalone-microprofile.xml</jboss.server.config.file.name>
+                <!--
+                    Excluding those tests that would need modules 
+                    which are in standalone-full.xml but not in 
+                    standalone-microprofile.xml
+                -->
+                <additional.surefire.excluded.groups>org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration</additional.surefire.excluded.groups>
+            </properties>
+        </profile>
     </profiles>
 
     <build>

--- a/testsuite/integration-tests-spring/inmodule/pom.xml
+++ b/testsuite/integration-tests-spring/inmodule/pom.xml
@@ -153,6 +153,28 @@
                 </plugins>
             </build>
         </profile>
+        <!-- 
+            Test against MicroProfile config.
+            standalone-microprofile.xml is used to replace occurrences of
+            standalone-full.xml in Arquillian configuration (arquillian.xml)
+        -->
+        <profile>
+            <id>standalone.microprofile.profile</id>
+            <activation>
+                <property>
+                    <name>ts.standalone.microprofile</name>
+                </property>
+            </activation>
+            <properties>
+                <jboss.server.config.file.name>standalone-microprofile.xml</jboss.server.config.file.name>
+                <!--
+                    Excluding those tests that would need modules 
+                    which are in standalone-full.xml but not in 
+                    standalone-microprofile.xml
+                -->
+                <additional.surefire.excluded.groups>org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration</additional.surefire.excluded.groups>
+            </properties>
+        </profile>
     </profiles>
 
     <build>

--- a/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/SpringMvcHttpResponseCodesTest.java
+++ b/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/SpringMvcHttpResponseCodesTest.java
@@ -10,6 +10,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
@@ -168,6 +169,7 @@ public class SpringMvcHttpResponseCodesTest {
     * @tpSince RESTEasy 3.1.0
     */
    @Test
+   @Category(ExpectedFailingWithStandaloneMicroprofileConfiguration.class)
    public void testNotAuthorizedException() {
       Response response = nonAutorizedClient.target(generateURL("/secured/json")).request()
             .post(Entity.entity("{\"name\":\"Zack\"}", MediaType.APPLICATION_JSON_TYPE));
@@ -180,7 +182,7 @@ public class SpringMvcHttpResponseCodesTest {
     * @tpSince RESTEasy 3.1.0
     */
    @Test
-   @Category(NotForForwardCompatibility.class)
+   @Category({NotForForwardCompatibility.class, ExpectedFailingWithStandaloneMicroprofileConfiguration.class})
    public void testForbiddenException() {
       Response response = userAuthorizedClient.target(generateURL("/secured/json")).request()
             .post(Entity.entity("{\"name\":\"Zack\"}", MediaType.APPLICATION_JSON_TYPE));
@@ -188,7 +190,7 @@ public class SpringMvcHttpResponseCodesTest {
    }
 
    @Test
-   @Category(NotForForwardCompatibility.class)
+   @Category({NotForForwardCompatibility.class, ExpectedFailingWithStandaloneMicroprofileConfiguration.class})
    public void testOK() {
       Response response = authorizedClient.target(generateURL("/secured/json")).request()
             .post(Entity.entity("{\"name\":\"Zack\"}", MediaType.APPLICATION_JSON_TYPE));

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -181,6 +181,28 @@
                 </plugins>
             </build>
         </profile>
+        <!-- 
+            Test against MicroProfile config.
+            standalone-microprofile.xml is used to replace occurrences of
+            standalone-full.xml in Arquillian configuration (arquillian.xml)
+        -->
+        <profile>
+            <id>standalone.microprofile.profile</id>
+            <activation>
+                <property>
+                    <name>ts.standalone.microprofile</name>
+                </property>
+            </activation>
+            <properties>
+                <jboss.server.config.file.name>standalone-microprofile.xml</jboss.server.config.file.name>
+                <!--
+                    Excluding those tests that would need modules 
+                    which are in standalone-full.xml but not in 
+                    standalone-microprofile.xml
+                -->
+                <additional.surefire.excluded.groups>org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration,org.jboss.resteasy.category.ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11</additional.surefire.excluded.groups>
+            </properties>
+        </profile>
     </profiles>
 
     <dependencies>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/AsynchronousCdiTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/AsynchronousCdiTest.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.test.cdi.basic.resource.AsynchronousResource;
 import org.jboss.resteasy.test.cdi.basic.resource.AsynchronousStateless;
 import org.jboss.resteasy.test.cdi.basic.resource.AsynchronousStatelessLocal;
@@ -15,6 +16,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Client;
@@ -60,6 +62,9 @@ public class AsynchronousCdiTest {
     * @tpSince RESTEasy 3.0.16
     */
    @Test
+   @Category({
+       ExpectedFailingWithStandaloneMicroprofileConfiguration.class}   //  java.lang.NoClassDefFoundError: javax/ejb/AsyncResult (MP is missing EJB3)
+   )
    public void testAsynchJaxRs() throws Exception {
       Client client = ClientBuilder.newClient();
       WebTarget base = client.target(generateURL("/asynch/simple"));

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/CDIResourceTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/CDIResourceTest.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.test.ContainerConstants;
 import org.jboss.resteasy.util.HttpResponseCodes;
 import org.jboss.resteasy.utils.PermissionUtil;
@@ -21,6 +22,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.BufferedReader;
@@ -48,6 +50,9 @@ import org.jboss.resteasy.test.cdi.basic.resource.resteasy1082.TestServlet;
 
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class    //  java.lang.ClassNotFoundException: javax.faces.webapp.FacesServlet (MP is missing JSF)
+})
 public class CDIResourceTest {
 
    protected static final Logger logger = LogManager.getLogger(CDIResourceTest.class.getName());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/EJBTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/EJBTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.cdi.basic;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.test.cdi.basic.resource.EJBApplication;
 import org.jboss.resteasy.test.cdi.basic.resource.EJBBook;
 import org.jboss.resteasy.test.cdi.basic.resource.EJBBookReader;
@@ -26,6 +27,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
@@ -52,6 +54,10 @@ import static org.junit.Assert.assertEquals;
  * @tpSince RESTEasy 3.0.16
  */
 @RunWith(Arquillian.class)
+
+@Category({
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class // MP is missing EJB3
+})
 public class EJBTest {
 
    private static Logger log = Logger.getLogger(EJBTest.class);
@@ -76,6 +82,7 @@ public class EJBTest {
          .addClasses(EJBBookReader.class, EJBBookReaderImpl.class)
          .addClasses(EJBBookWriterImpl.class)
          .addClasses(EJBResourceParent.class, EJBLocalResource.class, EJBRemoteResource.class, EJBBookResource.class)
+         .addClass(ExpectedFailingWithStandaloneMicroprofileConfiguration.class)
          .setWebXML(EJBTest.class.getPackage(), "ejbtest_web.xml")
          .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
       // Arquillian in the deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/EjbExceptionUnwrapTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/EjbExceptionUnwrapTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.cdi.basic;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.test.cdi.basic.resource.EjbExceptionUnwrapFooException;
 import org.jboss.resteasy.test.cdi.basic.resource.EjbExceptionUnwrapFooExceptionMapper;
 import org.jboss.resteasy.test.cdi.basic.resource.EjbExceptionUnwrapFooResource;
@@ -20,6 +21,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Client;
@@ -109,6 +111,9 @@ public class EjbExceptionUnwrapTest {
     * @tpSince RESTEasy 3.0.16
     */
    @Test
+   @Category({
+      ExpectedFailingWithStandaloneMicroprofileConfiguration.class  //  fails because /basic is not found (MP is missing EJB3)
+   })
    public void testLocatingResource() throws Exception {
       {
          Response response = client.target(generateURL("/locating/basic")).request().get();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/OutOfBandTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/OutOfBandTest.java
@@ -10,6 +10,7 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.test.cdi.basic.resource.OutOfBandResource;
 import org.jboss.resteasy.test.cdi.basic.resource.OutOfBandResourceIntf;
 import org.jboss.resteasy.util.HttpResponseCodes;
@@ -19,9 +20,10 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-/**
+/**MDBInjectionTest.java
  * @tpSubChapter CDI
  * @tpChapter Integration tests
  * @tpTestCaseDetails Regression test for RESTEASY-1049.
@@ -29,12 +31,16 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class
+})
 public class OutOfBandTest {
 
    @Deployment
    public static Archive<?> createTestArchive() {
       WebArchive war = TestUtil.prepareArchive("RESTEASY-1008")
             .addClasses(OutOfBandResourceIntf.class, OutOfBandResource.class)
+            .addClass(ExpectedFailingWithStandaloneMicroprofileConfiguration.class)
             .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
       return war;
    }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/SingletonTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/SingletonTest.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.test.cdi.basic.resource.SingletonLocalIF;
 import org.jboss.resteasy.test.cdi.basic.resource.SingletonRootResource;
 import org.jboss.resteasy.test.cdi.basic.resource.SingletonSubResource;
@@ -18,6 +19,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Client;
@@ -33,6 +35,9 @@ import javax.ws.rs.core.Response;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class // java.lang.NoClassDefFoundError: javax/ejb/EJBException (MP is missing EJB3)
+})
 public class SingletonTest {
    static Client client;
    protected static final Logger logger = LogManager.getLogger(SingletonTest.class.getName());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/ejb/EJBCDIValidationEJBProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/ejb/EJBCDIValidationEJBProxyTest.java
@@ -12,6 +12,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.api.validation.ViolationReport;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.test.cdi.ejb.resource.EJBCDIValidationEJBProxyGreeterResource;
 import org.jboss.resteasy.test.cdi.ejb.resource.EJBCDIValidationEJBProxyGreeting;
 import org.jboss.resteasy.utils.PermissionUtil;
@@ -24,6 +25,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -34,6 +36,9 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class // MP is missing EJB3
+})
 public class EJBCDIValidationEJBProxyTest {
 
    private static final String VALID_REQUEST = "{\n"
@@ -50,6 +55,7 @@ public class EJBCDIValidationEJBProxyTest {
    public static Archive<?> createTestArchive() {
       WebArchive war = TestUtil.prepareArchive(EJBCDIValidationEJBProxyTest.class.getSimpleName());
       war.addClass(EJBCDIValidationEJBProxyGreeting.class);
+      war.addClass(ExpectedFailingWithStandaloneMicroprofileConfiguration.class);
       war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
       war.setWebXML(EJBCDIValidationEJBProxyTest.class.getPackage(), "web.xml");
       war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/ejb/EJBCDIValidationTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/ejb/EJBCDIValidationTest.java
@@ -13,6 +13,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.api.validation.ViolationReport;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.test.cdi.ejb.resource.EJBCDIValidationApplication;
 import org.jboss.resteasy.test.cdi.ejb.resource.EJBCDIValidationSingletonResource;
 import org.jboss.resteasy.test.cdi.ejb.resource.EJBCDIValidationStatefulResource;
@@ -27,6 +28,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -41,13 +43,14 @@ public class EJBCDIValidationTest {
 
    private static Client client;
 
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> createTestArchive() {
       WebArchive war = TestUtil.prepareArchive(EJBCDIValidationTest.class.getSimpleName());
       war.addClasses(EJBCDIValidationApplication.class)
       .addClasses(EJBCDIValidationStatelessResource.class)
       .addClasses(EJBCDIValidationStatefulResource.class)
       .addClasses(EJBCDIValidationSingletonResource.class)
+      .addClass(ExpectedFailingWithStandaloneMicroprofileConfiguration.class)
       .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
       war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
               new HibernateValidatorPermission("accessPrivateMembers")
@@ -74,6 +77,7 @@ public class EJBCDIValidationTest {
     * @tpSince RESTEasy 4.0.0
     */
    @Test
+   @Category({ExpectedFailingWithStandaloneMicroprofileConfiguration.class})
    public void testStateless() {
       // Expect property, parameter violations.
       WebTarget base = client.target(generateURL("/rest/stateless/"));
@@ -134,6 +138,7 @@ public class EJBCDIValidationTest {
     * @tpSince RESTEasy 4.0.0
     */
    @Test
+   @Category({ExpectedFailingWithStandaloneMicroprofileConfiguration.class})
    public void testSingleton() {
       doTestSingleton(1); // Expect property violation when EJB resource gets created.
       doTestSingleton(0); // EJB resource has been created: expect no property violation.

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionJpaEnumTypeTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionJpaEnumTypeTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.cdi.injection;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.cdi.injection.resource.ApplicationUser;
@@ -16,6 +17,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.WebTarget;
@@ -32,6 +34,9 @@ import javax.ws.rs.core.MediaType;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class // Weld would complain as no impementations are available for injected beans
+})
 public class InjectionJpaEnumTypeTest {
 
    @Deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionTest.java
@@ -24,6 +24,7 @@ import org.hibernate.validator.HibernateValidatorPermission;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBook;
@@ -59,6 +60,7 @@ import org.junit.BeforeClass;
 import org.junit.AfterClass;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -71,6 +73,9 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class // MP is missing jboss.naming.context.java.jboss.exported.jms.RemoteConnectionFactory
+})
 public class InjectionTest extends AbstractInjectionTestBase {
    protected static final Logger log = LogManager.getLogger(InjectionTest.class.getName());
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/MDBInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/MDBInjectionTest.java
@@ -16,6 +16,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBook;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBookBag;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBookBagLocal;
@@ -49,6 +50,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -60,6 +62,9 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class // MP is missing jboss.naming.context.java.jboss.exported.jms.RemoteConnectionFactory
+})
 public class MDBInjectionTest extends AbstractInjectionTestBase {
    protected static final Logger log = LogManager.getLogger(MDBInjectionTest.class.getName());
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/ReverseInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/ReverseInjectionTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.cdi.injection;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBook;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBookBag;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBookBagLocal;
@@ -47,6 +48,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.jms.Connection;
@@ -79,7 +81,6 @@ import java.util.logging.LoggingPermission;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
 /**
  * @tpSubChapter CDI
  * @tpChapter Integration tests
@@ -93,6 +94,9 @@ import static org.junit.Assert.assertTrue;
  * @tpSince RESTEasy 3.0.16
  */
 @RunWith(Arquillian.class)
+@Category({
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class // MP is missing jboss.naming.context.java.jboss.exported.jms.RemoteConnectionFactory
+})
 public class ReverseInjectionTest extends AbstractInjectionTestBase {
    private static Logger log = Logger.getLogger(ReverseInjectionTest.class);
 
@@ -146,6 +150,7 @@ public class ReverseInjectionTest extends AbstractInjectionTestBase {
             .addClasses(ReverseInjectionEJBHolderRemote.class, ReverseInjectionEJBHolderLocal.class, ReverseInjectionEJBHolder.class)
             .addClasses(ReverseInjectionResource.class)
             .addClasses(CDIInjectionNewBean.class, CDIInjectionStereotypedApplicationScope.class, CDIInjectionStereotypedDependentScope.class)
+            .addClass(ExpectedFailingWithStandaloneMicroprofileConfiguration.class)
             .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
             .addAsResource(ReverseInjectionTest.class.getPackage(), "persistence.xml", "META-INF/persistence.xml");
       // Arquillian in the deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/TimerInterceptorTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/TimerInterceptorTest.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.test.cdi.interceptors.resource.TimerInterceptorResource;
 import org.jboss.resteasy.test.cdi.interceptors.resource.TimerInterceptorResourceIntf;
 import org.jboss.resteasy.test.cdi.util.UtilityProducer;
@@ -14,6 +15,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Client;
@@ -31,6 +33,9 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class // java.lang.NoClassDefFoundError: javax/ejb/Timer (MP is missing EJB3)
+})
 public class TimerInterceptorTest {
    protected static final Logger log = LogManager.getLogger(TimerInterceptorTest.class.getName());
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ParameterListTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ParameterListTest.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11;
 import org.jboss.resteasy.client.ClientRequest; //@cs-: clientrequest (Old client test)
 import org.jboss.resteasy.client.ClientResponse; //@cs-: clientresponse (Old client test)
 import org.jboss.resteasy.client.ProxyFactory;
@@ -20,6 +21,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Client;
@@ -37,6 +39,9 @@ import java.util.TreeSet;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11.class // MP OpenAPI JAX-RS annotations scanner fails on deployment resources with a NPE
+})
 public class ParameterListTest extends ClientTestBase{
 
    protected static final Logger logger = LogManager.getLogger(ParameterListTest.class.getName());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/GenericProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/GenericProxyTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.client.proxy;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
@@ -24,6 +25,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Entity;
@@ -42,6 +44,9 @@ import static org.jboss.resteasy.test.client.proxy.resource.GenericEntities.Gene
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11.class // MP OpenAPI JAX-RS annotations scanner fails on deployment resources with a NPE
+})
 public class GenericProxyTest {
    private static ResteasyClient client;
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/ProxyWithGenericReturnTypeTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/ProxyWithGenericReturnTypeTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.client.proxy;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11;
 import org.jboss.resteasy.client.ClientRequest; //@cs-: clientrequest (Old client test)
 import org.jboss.resteasy.client.ClientResponse; //@cs-: clientresponse (Old client test)
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
@@ -19,6 +20,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.WebTarget;
@@ -34,6 +36,9 @@ import java.util.List;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11.class // MP OpenAPI JAX-RS annotations scanner fails on deployment resources with a NPE
+})
 public class ProxyWithGenericReturnTypeTest {
 
    @Deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/AnnotationInheritanceGenericsTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/AnnotationInheritanceGenericsTest.java
@@ -4,6 +4,7 @@ import org.hamcrest.Matchers;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11;
 import org.jboss.resteasy.test.core.basic.resource.AnnotationInheritanceGenericsAbstract;
 import org.jboss.resteasy.test.core.basic.resource.AnnotationInheritanceGenericsEntity;
 import org.jboss.resteasy.test.core.basic.resource.AnnotationInheritanceGenericsImpl;
@@ -14,6 +15,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.HttpMethod;
@@ -35,6 +37,9 @@ import java.util.Collection;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11.class // MP OpenAPI JAX-RS annotations scanner fails on deployment resources with a NPE
+})
 public class AnnotationInheritanceGenericsTest {
 
    private static final String TEST_NAME = AnnotationInheritanceGenericsTest.class.getSimpleName();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/form/Resteasy1405Test.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/form/Resteasy1405Test.java
@@ -23,6 +23,7 @@ import javax.xml.bind.Marshaller;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 import org.jboss.resteasy.test.form.resteasy1405.ByFieldForm;
@@ -49,7 +50,10 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Category({NotForForwardCompatibility.class})
+@Category({
+    NotForForwardCompatibility.class,
+    ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11.class // MP OpenAPI JAX-RS annotations scanner fails on deployment resources with a NPE
+})
 public class Resteasy1405Test
 {
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/EncodingMimeMultipartFormProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/EncodingMimeMultipartFormProviderTest.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
@@ -20,6 +21,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -29,6 +31,9 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class    //  MP is missing javax.mail
+})
 public class EncodingMimeMultipartFormProviderTest {
 
    private static final String TEST_URI = generateURL("/encoding-mime");

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/MimeMultipartProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/MimeMultipartProviderTest.java
@@ -4,6 +4,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.client.jaxrs.ProxyBuilder;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartOutput;
@@ -21,6 +22,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.activation.DataHandler;
@@ -51,6 +53,9 @@ import java.util.Map;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class    //  MP is missing javax.mail
+})
 public class MimeMultipartProviderTest {
 
    private static Logger logger = Logger.getLogger(MimeMultipartProviderTest.class);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcastTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcastTest.java
@@ -4,6 +4,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.providers.sse.resource.SseBroadcastResource;
 import org.jboss.resteasy.utils.PortProviderUtil;
@@ -13,6 +14,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Client;
@@ -49,6 +51,9 @@ public class SseBroadcastTest {
     * @tpSince RESTEasy 3.5.0
     */
    @Test
+   @Category({
+      ExpectedFailingWithStandaloneMicroprofileConfiguration.class  // server broadcaster of SseBroadcastResource.java does not get created
+   })
    public void testBroadcasterMultipleSinks() throws Exception {
       final CountDownLatch latch = new CountDownLatch(3);
       final AtomicInteger errors = new AtomicInteger(0);
@@ -116,6 +121,9 @@ public class SseBroadcastTest {
     * @tpSince RESTEasy 3.5.0
     */
    @Test
+   @Category({
+      ExpectedFailingWithStandaloneMicroprofileConfiguration.class  // server broadcaster dpoes not get created
+   })
    public void testBroadcasterOnCloseCallbackCloseBroadsCasterOnServer() throws Exception {
       final CountDownLatch latch = new CountDownLatch(1);
       final AtomicInteger errors = new AtomicInteger(0);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseReconnectTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseReconnectTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.providers.sse;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.test.providers.sse.resource.SseReconnectResource;
 import org.jboss.resteasy.util.HttpResponseCodes;
 import org.jboss.resteasy.utils.PortProviderUtil;
@@ -11,6 +12,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.ServiceUnavailableException;
@@ -30,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({ExpectedFailingWithStandaloneMicroprofileConfiguration.class})
 public class SseReconnectTest {
 
    @Deployment
@@ -90,6 +93,9 @@ public class SseReconnectTest {
     * @tpSince RESTEasy 3.5.0
     */
    @Test
+   @Category({
+      ExpectedFailingWithStandaloneMicroprofileConfiguration.class  // server reconnection in SseReconnectResource.java gets HTTP 503
+   })
    public void testSseEndpointUnavailable() throws Exception {
       final CountDownLatch latch = new CountDownLatch(1);
       final AtomicInteger errors = new AtomicInteger(0);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/ParameterSubResTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/ParameterSubResTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.resource.basic;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.resource.basic.resource.ApplicationScopeObject;
 import org.jboss.resteasy.test.resource.basic.resource.MultiInterfaceResLocatorResource;
@@ -30,6 +31,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Client;
@@ -44,6 +46,9 @@ import java.util.logging.LoggingPermission;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11.class // MP OpenAPI JAX-RS annotations scanner fails on deployment resources with a NPE
+})
 public class ParameterSubResTest {
 
    static Client client;
@@ -63,6 +68,7 @@ public class ParameterSubResTest {
       war.addClass(RequestScopedObject.class);
       war.addClass(ParameterSubResSub.class);
       war.addClass(ParameterSubResSubImpl.class);
+      war.addClass(ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11.class);
       war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
       war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
             new LoggingPermission("control", "")

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/FormParamTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/FormParamTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.resource.param;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11;
 import org.jboss.resteasy.test.resource.param.resource.FormParamBasicResource;
 import org.jboss.resteasy.test.resource.param.resource.FormParamEntityPrototype;
 import org.jboss.resteasy.test.resource.param.resource.FormParamEntityThrowsIllegaArgumentException;
@@ -18,6 +19,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Client;
@@ -34,6 +36,9 @@ import javax.ws.rs.core.Response;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11.class // MP OpenAPI JAX-RS annotations scanner fails on deployment resources with a NPE
+})
 public class FormParamTest {
    static Client client;
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/MultiValuedParamCustomClassTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/MultiValuedParamCustomClassTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.resource.param;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.resource.param.resource.MultiValuedParamPersonResource;
@@ -18,6 +19,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import javax.ws.rs.core.Response;
 
@@ -30,6 +32,9 @@ import javax.ws.rs.core.Response;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11.class // MP OpenAPI JAX-RS annotations scanner fails on deployment resources with a NPE
+})
 public class MultiValuedParamCustomClassTest {
 
    @Deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/MultiValuedParamDateNoProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/MultiValuedParamDateNoProxyTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.resource.param;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
@@ -28,6 +29,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Entity;
@@ -35,7 +37,6 @@ import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
-
 /**
  * @tpSubChapter Parameters
  * @tpChapter Integration tests
@@ -46,6 +47,9 @@ import javax.ws.rs.core.Response;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11.class // MP OpenAPI JAX-RS annotations scanner fails on deployment resources with a NPE
+})
 public class MultiValuedParamDateNoProxyTest {
 
    @Deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/MultiValuedParamDateProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/MultiValuedParamDateProxyTest.java
@@ -9,6 +9,7 @@ import java.util.TreeSet;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.resource.param.resource.CookieParamWrapper;
@@ -39,6 +40,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -51,6 +53,9 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11.class // MP OpenAPI JAX-RS annotations scanner fails on deployment resources with a NPE
+})
 public class MultiValuedParamDateProxyTest {
 
    @Deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/path/LocatorSubResourceReturningThisTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/path/LocatorSubResourceReturningThisTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.resource.path;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11;
 import org.jboss.resteasy.test.resource.path.resource.LocatorSubResourceReturningThisParamEntityPrototype;
 import org.jboss.resteasy.test.resource.path.resource.LocatorSubResourceReturningThisParamEntityWithConstructor;
 import org.jboss.resteasy.utils.PortProviderUtil;
@@ -13,6 +14,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.DefaultValue;
@@ -32,6 +34,9 @@ import javax.ws.rs.core.Response;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11.class // MP OpenAPI JAX-RS annotations scanner fails on deployment resources with a StackOverflowError
+})
 public class LocatorSubResourceReturningThisTest {
 
    @Path("resource")

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
@@ -11,6 +11,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.category.ExpectedFailingOnWildFly18;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.category.NotForForwardCompatibility;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
@@ -50,7 +51,7 @@ import java.util.Hashtable;
 @ServerSetup({BasicAuthTest.SecurityDomainSetup.class})
 @RunWith(Arquillian.class)
 @RunAsClient
-@Category({ExpectedFailingOnWildFly18.class}) //WFLY-12655
+@Category({ExpectedFailingOnWildFly18.class})   //WFLY-12655
 public class BasicAuthTest {
 
    private static final String WRONG_RESPONSE = "Wrong response content.";
@@ -136,6 +137,10 @@ public class BasicAuthTest {
     * @tpSince RESTEasy 3.0.16
     */
    @Test
+   @Category({
+        // MP is missing security, setup fails: "operation" => "add","address" => [("subsystem" => "security"),("security-domain" => "jaxrsSecDomain")]} failed
+        ExpectedFailingWithStandaloneMicroprofileConfiguration.class
+   })
    public void testProxy() throws Exception {
       BasicAuthBaseProxy proxy = authorizedClient.target(generateURL("/")).proxyBuilder(BasicAuthBaseProxy.class).build();
       Assert.assertEquals(WRONG_RESPONSE, proxy.get(), "hello");
@@ -147,6 +152,10 @@ public class BasicAuthTest {
     * @tpSince RESTEasy 3.0.16
     */
    @Test
+   @Category({
+        // MP is missing security, setup fails: "operation" => "add","address" => [("subsystem" => "security"),("security-domain" => "jaxrsSecDomain")]} failed
+        ExpectedFailingWithStandaloneMicroprofileConfiguration.class
+   })
    public void testProxyFailure() throws Exception {
       BasicAuthBaseProxy proxy = noAutorizationClient.target(generateURL("/")).proxyBuilder(BasicAuthBaseProxy.class).build();
       try {
@@ -163,6 +172,10 @@ public class BasicAuthTest {
     * @tpSince RESTEasy 3.0.16
     */
    @Test
+   @Category({
+        // MP is missing security, setup fails: "operation" => "add","address" => [("subsystem" => "security"),("security-domain" => "jaxrsSecDomain")]} failed
+        ExpectedFailingWithStandaloneMicroprofileConfiguration.class
+   })
    public void testSecurity() throws Exception {
       // authorized client
       {
@@ -217,6 +230,10 @@ public class BasicAuthTest {
     * @tpSince RESTEasy 3.0.16
     */
    @Test
+   @Category({
+        // MP is missing security, setup fails: "operation" => "add","address" => [("subsystem" => "security"),("security-domain" => "jaxrsSecDomain")]} failed
+        ExpectedFailingWithStandaloneMicroprofileConfiguration.class
+   })
    public void testSecurityFailure() throws Exception {
       {
             Response response = noAutorizationClient.target(generateURL("/secured")).request().get();
@@ -262,7 +279,11 @@ public class BasicAuthTest {
     * @tpSince RESTEasy 3.1.1
     */
    @Test
-   @Category(NotForForwardCompatibility.class)
+   @Category({
+        NotForForwardCompatibility.class,
+        // MP is missing security, setup fails: "operation" => "add","address" => [("subsystem" => "security"),("security-domain" => "jaxrsSecDomain")]} failed
+        ExpectedFailingWithStandaloneMicroprofileConfiguration.class
+   })
    public void testContentTypeWithForbiddenMessage() {
       Response response = unauthorizedClient.target(generateURL("/secured/denyWithContentType")).request().get();
       Assert.assertEquals(HttpResponseCodes.SC_FORBIDDEN, response.getStatus());
@@ -275,6 +296,10 @@ public class BasicAuthTest {
     * @tpSince RESTEasy 3.1.1
     */
    @Test
+   @Category({
+        // MP is missing security, setup fails: "operation" => "add","address" => [("subsystem" => "security"),("security-domain" => "jaxrsSecDomain")]} failed
+        ExpectedFailingWithStandaloneMicroprofileConfiguration.class
+   })
    public void testContentTypeWithUnauthorizedMessage() {
       Response response = noAutorizationClient.target(generateURL("/secured/denyWithContentType")).request().get();
       Assert.assertEquals(HttpResponseCodes.SC_UNAUTHORIZED, response.getStatus());
@@ -287,6 +312,10 @@ public class BasicAuthTest {
      * @tpSince RESTEasy 3.7.0
      */
     @Test
+    @Category({
+        // MP is missing security, setup fails: "operation" => "add","address" => [("subsystem" => "security"),("security-domain" => "jaxrsSecDomain")]} failed
+        ExpectedFailingWithStandaloneMicroprofileConfiguration.class
+    })
     public void testWithClientRequestFilterAuthorizedUser() {
         Response response = authorizedClientUsingRequestFilter.target(generateURL("/secured/authorized")).request().get();
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
@@ -298,6 +327,10 @@ public class BasicAuthTest {
      * @tpSince RESTEasy 3.7.0
      */
     @Test
+    @Category({
+        // MP is missing security, setup fails: "operation" => "add","address" => [("subsystem" => "security"),("security-domain" => "jaxrsSecDomain")]} failed
+        ExpectedFailingWithStandaloneMicroprofileConfiguration.class
+    })
     public void testWithClientRequestFilterWrongPassword(){
         Response response = unauthorizedClientUsingRequestFilterWithWrongPassword.target(generateURL("/secured/authorized")).request().get();
         Assert.assertEquals(HttpResponseCodes.SC_UNAUTHORIZED, response.getStatus());
@@ -309,6 +342,10 @@ public class BasicAuthTest {
      * @tpSince RESTEasy 3.7.0
      */
     @Test
+    @Category({
+        // MP is missing security, setup fails: "operation" => "add","address" => [("subsystem" => "security"),("security-domain" => "jaxrsSecDomain")]} failed
+        ExpectedFailingWithStandaloneMicroprofileConfiguration.class
+    })
     public void testWithClientRequestFilterUnauthorizedUser() {
         Response response = unauthorizedClientUsingRequestFilter.target(generateURL("/secured/authorized")).request().get();
         Assert.assertEquals(HttpResponseCodes.SC_FORBIDDEN, response.getStatus());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SecurityContextTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SecurityContextTest.java
@@ -5,6 +5,7 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.client.jaxrs.BasicAuthentication;
 import org.jboss.resteasy.setup.AbstractUsersRolesSecurityDomainSetup;
 import org.jboss.resteasy.test.security.resource.SecurityContextResource;
@@ -18,6 +19,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.CommandFailedException;
 import javax.ws.rs.client.Client;
@@ -38,6 +40,9 @@ import java.nio.file.Paths;
 @ServerSetup({SecurityContextTest.SecurityDomainSetup.class})
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class
+})
 public class SecurityContextTest {
 
    private static final String USERNAME = "bill";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/TwoSecurityDomainsTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/TwoSecurityDomainsTest.java
@@ -11,6 +11,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.category.ExpectedFailingOnWildFly18;
+import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
@@ -46,7 +47,10 @@ import java.util.Hashtable;
 @ServerSetup({TwoSecurityDomainsTest.SecurityDomainSetup1.class, TwoSecurityDomainsTest.SecurityDomainSetup2.class})
 @RunWith(Arquillian.class)
 @RunAsClient
-@Category({ExpectedFailingOnWildFly18.class}) //WFLY-12655
+@Category({
+    ExpectedFailingOnWildFly18.class,               //WFLY-12655
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class
+})
 public class TwoSecurityDomainsTest {
 
    private static ResteasyClient authorizedClient;


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RESTEASY-2581, parallel to https://github.com/resteasy/Resteasy/pull/2399 which is for branch `3.11`.

Basically, this PR introduces a new profile which - like for what happens in Wildfly TS - would use the `standalone-microprofile.xml` config file to start the server up.
Then, when running tests by passing a new property - namely `-Dts.standalone.microprofile` to activate the above mentioned profile, some tests in `integration-tests` and `integration-tests-spring/inmodule` TS modules will fail.
Hence, two new JUint `Category` interfaces have been added:

* `ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11`: skips tests that _seem_ to fail because of the SmallRye MP OpenAPI implementation used in Wildfly 19 (further investigation to confirm this is needed)
* `ExpectedFailingWithStandaloneMicroprofileConfiguration`: skips tests that fail because of missing subsystems in Wildfly when `standalone-microprofile.xml` is used.

Commands to verify that TS is running fine with the new profile:
```
$ export SERVER_VERSION=19.0.0.Final
$ mvn -B -am -pl integration-tests -fae -Dserver.version=$SERVER_VERSION install -Dts.standalone.microprofile
```
 