### PR TITLE
How to run a single microprofile-ck test

### DIFF
--- a/testsuite/README.MD
+++ b/testsuite/README.MD
@@ -53,6 +53,9 @@ To run the testsuite with failing tests included for testing purposes:
 ### Single test
 > mvn surefire:test@default-test -Dserver.home=PATH_TO_WIDLFLY_HOME -Dtest=NAME_OF_THE_TEST_CLASS -fn
 
+When running `microprofile-tck` tests, use the following in order to activate WireMock:
+> mvn wiremock:run -Dparams="--port=8765" -Ddir="target/classes" surefire:test@default-test -Dserver.home=PATH_TO_WIDLFLY_HOME -Dtest=NAME_OF_THE_TEST_CLASS -fn
+
 ### Speciality single test JsonBindingTest and JsonBindingAnnotationsJacksonTest
 To run test JsonBindingTest requires the use of a speciality surefire syntax.
 > mvn surefire:test@jsonb-test  -Dserver.home=PATH_TO_WIDLFLY_HOME -Dtest=JsonBindingTest -fn


### PR DESCRIPTION
The README suggests to run a single test like this `mvn surefire:test@default-test ...`
the problem is that directly invoking the execution-id `surefire:test@default-test` makes it impossible to automatically start the `wiremock-maven-plugin` in the case of `microprofile-tck` tests;

In facts, running `mvn help:effective-pom` from testsuite/microprofile-tck:
```
 <plugin>
        <artifactId>maven-surefire-plugin</artifactId>
        <version>2.19.1</version>
        <executions>
          <execution>
            <id>default-test</id>
            <phase>test</phase>
            <goals>
              <goal>test</goal>
            </goals>
```
we see it's actually invoking this which the `default-test` execution;