### PR TITLE
[RESTEASY-2300] Blank Host Name still throws exception

### DIFF
--- a/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyUtil.java
+++ b/server-adapters/resteasy-netty/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyUtil.java
@@ -28,6 +28,9 @@ public class NettyUtil
    public static ResteasyUriInfo extractUriInfo(HttpRequest request, String contextPath, String protocol)
    {
       String host = HttpHeaders.getHost(request, "unknown");
+      if ("".equals(host)) {
+         host = "unknown";
+      }
       String uri = request.getUri();
 
       String uriString = protocol + "://" + host + uri;

--- a/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyUtil.java
+++ b/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyUtil.java
@@ -27,6 +27,9 @@ public class NettyUtil
    public static ResteasyUriInfo extractUriInfo(HttpRequest request, String contextPath, String protocol)
    {
       String host = HttpHeaders.getHost(request, "unknown");
+      if ("".equals(host)) {
+         host = "unknown";
+      }
       String uri = request.getUri();
 
       String uriString;

--- a/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/HeaderEmptyHostTest.java
+++ b/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/HeaderEmptyHostTest.java
@@ -1,0 +1,70 @@
+package org.jboss.resteasy.test;
+
+import org.jboss.resteasy.plugins.server.netty.NettyContainer;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.Socket;
+import java.util.stream.Collectors;
+
+/**
+ * RESTEASY-2300
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
+ */
+public class HeaderEmptyHostTest
+{
+   @Path("/emptyhost")
+   public static class Resource
+   {
+      @Context
+      UriInfo uriInfo;
+
+      @GET
+      @Path("/test")
+      public String hello()
+      {
+         return "uriInfo: " + uriInfo.getRequestUri().toString();
+      }
+   }
+
+   @BeforeClass
+   public static void setup() throws Exception
+   {
+      NettyContainer.start().getRegistry().addPerRequestResource(Resource.class);
+   }
+
+   @AfterClass
+   public static void end() throws Exception
+   {
+      NettyContainer.stop();
+   }
+
+   @Test
+   public void testEmptyHostHeader() throws Exception
+   {
+      try (Socket client = new Socket(TestPortProvider.getHost(), TestPortProvider.getPort())) {
+         try (PrintWriter out = new PrintWriter(client.getOutputStream(), true)) {
+            final String uri = "/emptyhost/test";
+            out.printf("GET %s HTTP/1.1\r\n", uri);
+            out.print("Host: \r\n");
+            out.print("Connection: close\r\n");
+            out.print("\r\n");
+            out.flush();
+            String response = new BufferedReader(new InputStreamReader(client.getInputStream())).lines().collect(Collectors.joining("\n"));
+            Assert.assertNotNull(response);
+            Assert.assertTrue(response.contains("HTTP/1.1 200 OK"));
+            Assert.assertTrue(response.contains("uriInfo: http://unknown" + uri));
+         }
+      }
+   }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/HeaderEmptyHostTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/HeaderEmptyHostTest.java
@@ -1,0 +1,60 @@
+package org.jboss.resteasy.test.client;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.test.client.resource.HeaderEmptyHostResource;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.Socket;
+import java.net.URL;
+import java.util.stream.Collectors;
+
+/**
+ * RESTEASY-2300 and UNDERTOW-1614
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class HeaderEmptyHostTest extends ClientTestBase {
+    private static Logger logger = Logger.getLogger(HeaderEmptyHostTest.class);
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+        WebArchive war = TestUtil.prepareArchive(HeaderEmptyHostTest.class.getSimpleName());
+        return TestUtil.finishContainerPrepare(war, null, HeaderEmptyHostResource.class);
+    }
+
+    @ArquillianResource
+    URL url;
+
+    @Test
+    public void testEmptyHost() throws Exception {
+        try (Socket client = new Socket(url.getHost(), url.getPort())) {
+            try (PrintWriter out = new PrintWriter(client.getOutputStream(), true)) {
+                final String uri = "/HeaderEmptyHostTest/headeremptyhostresource";
+                out.printf("GET %s HTTP/1.1\r\n", uri);
+                out.print("Host: \r\n");
+                out.print("Connection: close\r\n");
+                out.print("\r\n");
+                out.flush();
+                String response = new BufferedReader(new InputStreamReader(client.getInputStream())).lines().collect(Collectors.joining("\n"));
+                logger.info("response = " + response);
+                Assert.assertNotNull(response);
+                Assert.assertTrue(response.contains("HTTP/1.1 200 OK"));
+                Assert.assertTrue(response.contains("uriInfo: http://" + url.getHost() + ":" + url.getPort() + uri));
+            }
+        }
+    }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/resource/HeaderEmptyHostResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/resource/HeaderEmptyHostResource.java
@@ -1,0 +1,25 @@
+package org.jboss.resteasy.test.client.resource;
+
+import org.jboss.logging.Logger;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+@Path("/headeremptyhostresource")
+public class HeaderEmptyHostResource {
+    private static Logger logger = Logger.getLogger(HeaderEmptyHostResource.class);
+
+    @Context
+    UriInfo uriInfo;
+
+    @GET
+    @Produces("text/plain")
+    public String getUriInfo() {
+        logger.info("uriInfo = " + uriInfo.getRequestUri());
+        return "uriInfo: " + uriInfo.getRequestUri().toString();
+    }
+
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/RESTEASY-2300
Upstream PR: https://github.com/resteasy/Resteasy/pull/2436 https://github.com/resteasy/Resteasy/pull/2435