### PR TITLE
[RESTEASY-2622] Follow up at avoiding a NullPointerException of the M…

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpAsyncClient4Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpAsyncClient4Engine.java
@@ -21,6 +21,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.ResponseProcessingException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
@@ -769,7 +770,10 @@ public class ApacheHttpAsyncClient4Engine implements AsyncClientHttpEngine, Clos
       {
          byte[] requestContent = requestContent(request);
          ByteArrayEntity entity = new ByteArrayEntity(requestContent);
-         entity.setContentType(new BasicHeader(HTTP.CONTENT_TYPE, request.getHeaders().getMediaType().toString()));
+         final MediaType mediaType = request.getHeaders().getMediaType();
+         if (mediaType != null) {
+            entity.setContentType(new BasicHeader(HTTP.CONTENT_TYPE, mediaType.toString()));
+         }
          commitHeaders(request, httpRequest);
          ((HttpEntityEnclosingRequest) httpRequest).setEntity(entity);
       }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43Engine.java
@@ -555,13 +555,13 @@ public class ManualClosingApacheHttpClient43Engine implements ApacheHttpClientEn
          if (mediaType != null) {
             entityToBuildByteArray
                     .setContentType(new BasicHeader(HTTP.CONTENT_TYPE, mediaType.toString()));
-            entityToBuild = entityToBuildByteArray;
          }
+         entityToBuild = entityToBuildByteArray;
       }
-      else if (mediaType != null)
+      else
       {
          entityToBuild = new FileExposingFileEntity(memoryManagedOutStream.getFile(),
-               request.getHeaders().getMediaType().toString());
+               mediaType == null ? null : mediaType.toString());
       }
       if (request.isChunked())
       {


### PR DESCRIPTION
…ediaType associated with request headers is null.

https://issues.redhat.com/browse/RESTEASY-2622