### PR TITLE
[RESTEASY-2634] Fix HttpHeaders.getAcceptableLanguages

### DIFF
--- a/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/microprofile/client/header/HttpHeadersContextProvider.java
+++ b/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/microprofile/client/header/HttpHeadersContextProvider.java
@@ -129,7 +129,7 @@ public class HttpHeadersContextProvider implements HttpHeaders {
     public List<Locale> getAcceptableLanguages() {
         String accepts = getHeaderString(ACCEPT_LANGUAGE);
         if (accepts == null) {
-            return Collections.emptyList();
+            return Collections.singletonList(Locale.forLanguageTag("*"));
         }
 
         return parseToStream(accepts)

--- a/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/ResteasyHttpHeaders.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/ResteasyHttpHeaders.java
@@ -177,7 +177,7 @@ public class ResteasyHttpHeaders implements HttpHeaders
    {
       List<String> vals = requestHeaders.get(ACCEPT_LANGUAGE);
       if (vals == null || vals.isEmpty()) {
-         return Collections.emptyList();
+         return Collections.singletonList(Locale.forLanguageTag("*"));
       }
       List<WeightedLanguage> languages = new ArrayList<WeightedLanguage>();
       for (String v : vals) {


### PR DESCRIPTION
JAX-RS mandates that HttpHeaders.getAcceptableLanguages() returns a
single wildcard locale instance if no acceptable languages are defined.

I agree on the Apache License 2.0 terms.