### PR TITLE
[RESTEASY-2642] Add doPrivs to sys prop checks

### DIFF
--- a/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
+++ b/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
@@ -43,7 +43,9 @@ import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.security.AccessController;
 import java.security.KeyStore;
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -193,8 +195,8 @@ public class RestClientBuilderImpl implements RestClientBuilder {
         ClassLoader classLoader = aClass.getClassLoader();
 
         List<String> noProxyHosts = Arrays.asList(
-                System.getProperty("http.nonProxyHosts", "localhost|127.*|[::1]").split("\\|"));
-        String envProxyHost = System.getProperty("http.proxyHost");
+                getSystemProperty("http.nonProxyHosts", "localhost|127.*|[::1]").split("\\|"));
+        String envProxyHost = getSystemProperty("http.proxyHost", null);
 
         T actualClient;
         ResteasyClient client;
@@ -204,7 +206,7 @@ public class RestClientBuilderImpl implements RestClientBuilder {
             // Use proxy, if defined in the env variables
             resteasyClientBuilder = builderDelegate.defaultProxy(
                     envProxyHost,
-                    Integer.parseInt(System.getProperty("http.proxyPort", "80")));
+                    Integer.parseInt(getSystemProperty("http.proxyPort", "80")));
         } else {
             // Search for proxy settings passed in the client builder, if passed and use them if found
             String userProxyHost = Optional.ofNullable(getConfiguration().getProperty(PROPERTY_PROXY_HOST))
@@ -288,7 +290,7 @@ public class RestClientBuilderImpl implements RestClientBuilder {
      */
     private boolean useURLConnection() {
         if (useURLConnection == null) {
-            String defaultToURLConnection = System.getProperty("org.jboss.resteasy.microprofile.defaultToURLConnectionHttpClient", "false");
+            String defaultToURLConnection = getSystemProperty("org.jboss.resteasy.microprofile.defaultToURLConnectionHttpClient", "false");
             useURLConnection = defaultToURLConnection.toLowerCase().equals("true");
         }
         return useURLConnection;
@@ -606,6 +608,10 @@ public class RestClientBuilderImpl implements RestClientBuilder {
 
     ResteasyClientBuilder getBuilderDelegate() {
         return builderDelegate;
+    }
+
+    private String getSystemProperty(String key, String def) {
+        return AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty(key, def));
     }
 
     private final MpClientBuilderImpl builderDelegate;

--- a/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
+++ b/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
@@ -611,6 +611,9 @@ public class RestClientBuilderImpl implements RestClientBuilder {
     }
 
     private String getSystemProperty(String key, String def) {
+        if (System.getSecurityManager() == null) {
+            return System.getProperty(key, def);
+        }
         return AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty(key, def));
     }
 

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java
@@ -22,8 +22,10 @@ public class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate
 
    private static Map<String, MediaType> map = new ConcurrentHashMap<String, MediaType>();
    private static Map<MediaType, String> reverseMap = new ConcurrentHashMap<MediaType, String>();
-   private static final int MAX_MT_CACHE_SIZE = AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
-      Integer.getInteger("org.jboss.resteasy.max_mediatype_cache_size", 200));
+   private static final int MAX_MT_CACHE_SIZE = System.getSecurityManager() == null
+      ? Integer.getInteger("org.jboss.resteasy.max_mediatype_cache_size", 200)
+      : AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
+         Integer.getInteger("org.jboss.resteasy.max_mediatype_cache_size", 200));
 
    public Object fromString(String type) throws IllegalArgumentException
    {

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java
@@ -6,6 +6,8 @@ import org.jboss.resteasy.util.HeaderParameterParser;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.RuntimeDelegate;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -20,8 +22,8 @@ public class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate
 
    private static Map<String, MediaType> map = new ConcurrentHashMap<String, MediaType>();
    private static Map<MediaType, String> reverseMap = new ConcurrentHashMap<MediaType, String>();
-   private static final int MAX_MT_CACHE_SIZE =
-       Integer.getInteger("org.jboss.resteasy.max_mediatype_cache_size", 200);
+   private static final int MAX_MT_CACHE_SIZE = AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
+      Integer.getInteger("org.jboss.resteasy.max_mediatype_cache_size", 200));
 
    public Object fromString(String type) throws IllegalArgumentException
    {


### PR DESCRIPTION
This PR wraps calls to `System.getProperty(...)` and `Integer.getInteger(...)` in doPriv blocks to ensure that they will work with a Java 2 security manager enabled.