### PR TITLE
RESTEASY-2648 Upgrade json-patch to 1.13

### DIFF
--- a/jboss-modules/build.xml
+++ b/jboss-modules/build.xml
@@ -109,13 +109,13 @@
         </module-def>
 
         <module-def name="com.github.fge.jackson-coreutils">
-            <maven-resource group="com.github.fge" artifact="jackson-coreutils"/>
-            <maven-resource group="com.github.fge" artifact="msg-simple"/>
-            <maven-resource group="com.github.fge" artifact="btf"/>
+            <maven-resource group="com.github.java-json-tools" artifact="jackson-coreutils"/>
+            <maven-resource group="com.github.java-json-tools" artifact="msg-simple"/>
+            <maven-resource group="com.github.java-json-tools" artifact="btf"/>
         </module-def>
 
         <module-def name="com.github.fge.json-patch">
-            <maven-resource group="com.github.fge" artifact="json-patch"/>
+            <maven-resource group="com.github.java-json-tools" artifact="json-patch"/>
         </module-def>
 
         <module-def name="org.jboss.resteasy.resteasy-jaxb-provider">

--- a/providers/jackson2/pom.xml
+++ b/providers/jackson2/pom.xml
@@ -69,7 +69,7 @@
             <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.fge</groupId>
+            <groupId>com.github.java-json-tools</groupId>
             <artifactId>json-patch</artifactId>
             <exclusions>
                 <exclusion>
@@ -78,32 +78,7 @@
 		        </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.code.findbugs</groupId>
-                    <artifactId>jsr305</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.checkerframework</groupId>
-                    <artifactId>checker-compat-qual</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.errorprone</groupId>
-                    <artifactId>error_prone_annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.j2objc</groupId>
-                    <artifactId>j2objc-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>animal-sniffer-annotations</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -82,7 +82,7 @@
         <version.org.wildfly.security.wildfly-elytron>1.7.0.Final</version.org.wildfly.security.wildfly-elytron>
         <version.weld.api>3.0.SP4</version.weld.api>
         <version.weld>3.0.5.Final</version.weld>
-        <version.json.patch>1.9</version.json.patch>
+        <version.json.patch>1.13</version.json.patch>
 
         <!-- MicroProfile versions -->
         <version.microprofile.restclient>1.4.1</version.microprofile.restclient>
@@ -905,7 +905,7 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>com.github.fge</groupId>
+                <groupId>com.github.java-json-tools</groupId>
                 <artifactId>json-patch</artifactId>
                 <version>${version.json.patch}</version>
             </dependency>


### PR DESCRIPTION
Upgrades json-patch to 1.13.
as a biggest bonus (and main reason for doing this) we get rid of guava dependency in jackson provider.