### PR TITLE
Performance improvements

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/MultivaluedMapImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/MultivaluedMapImpl.java
@@ -16,7 +16,7 @@ public class MultivaluedMapImpl<K, V> extends HashMap<K, List<V>> implements Mul
 {
    public void putSingle(K key, V value)
    {
-      List<V> list = new ArrayList<V>();
+      List<V> list = new ArrayList<V>(2);
       list.add(value);
       put(key, list);
    }
@@ -75,7 +75,7 @@ public class MultivaluedMapImpl<K, V> extends HashMap<K, List<V>> implements Mul
    {
       List<V> list = get(key);
       if (list == null)
-         put(key, list = new ArrayList<V>());
+         put(key, list = new ArrayList<V>(2));
       return list;
    }
 

--- a/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/ResteasyUriInfo.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/ResteasyUriInfo.java
@@ -81,17 +81,6 @@ public class ResteasyUriInfo implements UriInfo
       this.matchingPath = initData.getMatchingPath();
    }
 
-   private void processUris() {
-      requestURI = URI.create(absoluteString);
-      absolutePath = queryIdx < 0 ? requestURI : URI.create(absoluteString.substring(0, queryIdx));
-      baseURI = absolutePath;
-      String tmpContextPath = contextPath;
-      if (!tmpContextPath.endsWith("/")) tmpContextPath += "/";
-      if (!tmpContextPath.startsWith("/")) tmpContextPath = "/" + tmpContextPath;
-      String baseString = absoluteString.substring(0, pathStart);
-      baseString += tmpContextPath;
-      baseURI = URI.create(baseString);
-   }
 
    protected void initialize(CharSequence absoluteUri, String queryString, String contextPath)
    {
@@ -273,8 +262,7 @@ public class ResteasyUriInfo implements UriInfo
     */
    public void setRequestUri(URI relative)
    {
-      if (baseURI == null) processUris();
-      setUri(baseURI, relative);
+      setUri(getBaseUri(), relative);
    }
 
    public String getPath()
@@ -301,7 +289,9 @@ public class ResteasyUriInfo implements UriInfo
 
    public URI getRequestUri()
    {
-      if (requestURI == null) processUris();
+      if (requestURI == null) {
+          requestURI = URI.create(absoluteString);
+      }
       return requestURI;
    }
 
@@ -312,7 +302,9 @@ public class ResteasyUriInfo implements UriInfo
 
    public URI getAbsolutePath()
    {
-      if (absolutePath == null) processUris();
+      if (absolutePath == null) {
+          absolutePath = queryIdx < 0 ? getRequestUri() : URI.create(absoluteString.substring(0, queryIdx));
+      }
       return absolutePath;
    }
 
@@ -323,7 +315,14 @@ public class ResteasyUriInfo implements UriInfo
 
    public URI getBaseUri()
    {
-      if (baseURI == null) processUris();
+       if (baseURI == null) {
+         String tmpContextPath = contextPath;
+         if (!tmpContextPath.endsWith("/")) tmpContextPath += "/";
+         if (!tmpContextPath.startsWith("/")) tmpContextPath = "/" + tmpContextPath;
+         String baseString = absoluteString.substring(0, pathStart);
+         baseString += tmpContextPath;
+         baseURI = URI.create(baseString);
+      }
       return baseURI;
    }
 

--- a/resteasy-core/src/main/java/org/jboss/resteasy/util/Encode.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/util/Encode.java
@@ -214,6 +214,9 @@ public class Encode
 
    public static String decodePath(String path)
    {
+      if (path.indexOf('%') == -1) {
+          return path;
+      }
       Matcher matcher = encodedCharsMulti.matcher(path);
       int start=0;
       StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
- Avoid unnecessary use of URI.create - rather do more lazily
- Multivalued maps will 99% of the time have 1 or maybe 2 entries for a key so don't allocate memory for 10
- Avoid unnecessary matcher creation when decoding when a string does not contain % in it - which is the more likely case for URI's to Rest resources

These changes increase throughput by about 2% on a simple Rest service and were found doing some hotspot analysis on load tests on Quarkus.