### PR TITLE
[RESTEASY-2683] NPE in ApacheHttpClient43Test because cache is null in MediaTypeMap

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/MediaTypeMap.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/MediaTypeMap.java
@@ -550,8 +550,8 @@ public class MediaTypeMap<T>
       CachedMediaTypeAndClass cacheEntry = null;
       if (useCache)
       {
+         cacheEntry = new CachedMediaTypeAndClass(type, accept);
          if (classCache != null) {
-            cacheEntry = new CachedMediaTypeAndClass(type, accept);
             cached = classCache.get(cacheEntry);
             if (cached != null) return cached;
          }
@@ -576,14 +576,14 @@ public class MediaTypeMap<T>
       cached = convert(matches);
       if (useCache) {
          Map<CachedMediaTypeAndClass, List<T>> cache = classCache;
-         if (classCache == null) {
+         if (cache == null) {
             synchronized (this)
             {
                if (classCache == null)
                {
-                  cache = new HashMap<>();
-                  classCache = cache;
+                  classCache = new HashMap<>();
                }
+               cache = classCache;
             }
          }
          cache.put(cacheEntry, cached);


### PR DESCRIPTION
The `cache` can result in null at initialization. I'm changing to always set the `cache` to `classCache` no matter if it was created by the same thread or by any another one. I also used a ConcurrentHashMap instead of normal HashMap.

I'm not protecting the setting part in `mergeEverything`, if you think it's necessary to protect it too just let me know.