### PR TITLE
Use bootable-jar with all modules in TS bootable jar profile

### DIFF
--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -245,7 +245,6 @@
                                     <log-time>true</log-time>
                                     <offline>true</offline>
                                     <plugin-options>
-                                        <jboss-maven-dist/>
                                         <jboss-fork-embedded>true</jboss-fork-embedded>
                                     </plugin-options>
                                     <feature-packs>


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RESTEASY-2686
related PR: https://github.com/resteasy/Resteasy/pull/2505

I checked bootable jar with latest WF snapshot and I found out, that bootable-jar server is using artifacts from `~/.m2` repo. So if server run is using wf, that was built to maven.repo.local, TS will be executed against wrong artifacts (becaues server won't use artifacts from custom maven repo, but from default repo `~/.m2`). TS execution with `-Dmaven.repo.local` doesn't help as well, because arquillian.xml doesn't use it by default.

This PR removes `<jboss-maven-dist/>` element from wildfly-jar-maven-plugin plugin. Without this changes, plugin builds bootable-jar without modules and modules are used from `~/.m2`. With this change (no jboss-maven-dist xml element), bootable jar is built with all modules, so `~/.m2` is not used.

See some test runs on jira comment.