### PR TITLE
Travis-ci: added support for ppc64le build along with amd64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
+before_install:
+ - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then sudo apt update; sudo apt install maven ; mvn -version; fi
 install:
  - mvn -B clean; java -version
 script:
  - travis_wait 60 mvn -B -Ptravis,jboss-repository -fae -Dserver.version=$SERVER_VERSION ${ELYTRON:+-Delytron} install
 
 language: java
+arch:
+  - amd64
+  - ppc64le
 jdk:
   - openjdk8
 env:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjay-cpu/Resteasy/builds/186063826 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!