### PR TITLE
[RESTEASY-2694] (3.14) Adding support for running test suite against bootable JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <surefire.system.args>-Xms512m -Xmx512m ${modular.jdk.args}</surefire.system.args>
         <!-- Plugins versions -->
         <version.org.jacoco.plugin>0.7.9</version.org.jacoco.plugin>
+        <version.org.wildfly.jar.plugin>2.0.0.Beta8</version.org.wildfly.jar.plugin>
         <version.surefire.plugin>2.19.1</version.surefire.plugin>
         <version.javadoc.plugin>3.0.1</version.javadoc.plugin>
     </properties>
@@ -226,6 +227,11 @@
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${version.org.jacoco.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-jar-maven-plugin</artifactId>
+                    <version>${version.org.wildfly.jar.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -16,7 +16,7 @@
     <description>RESTEasy dependencies BOM</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dep.arquillian-bom.version>1.1.15.Final</dep.arquillian-bom.version>
+        <dep.arquillian-bom.version>1.6.0.Final</dep.arquillian-bom.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.10.5</version.com.fasterxml.jackson>
@@ -80,7 +80,7 @@
         <version.org.wildfly.core.wildfly-cli>7.0.0.Final</version.org.wildfly.core.wildfly-cli>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.wildfly-arquillian-container-managed>2.2.0.Final</version.org.wildfly.wildfly-arquillian-container-managed>
-        <version.org.wildfly.wildfly-arquillian-container-remote>2.1.1.Final</version.org.wildfly.wildfly-arquillian-container-remote>
+        <version.org.wildfly.wildfly-arquillian-container-bootable>3.0.0.Beta3</version.org.wildfly.wildfly-arquillian-container-bootable>
         <version.org.yaml.snakeyaml>1.26</version.org.yaml.snakeyaml>
         <version.weld.api>3.1.SP3 </version.weld.api>
         <version.weld>3.1.5.Final</version.weld>
@@ -893,9 +893,15 @@
             </dependency>
             <dependency>
                 <groupId>org.wildfly.arquillian</groupId>
-                <artifactId>wildfly-arquillian-container-remote</artifactId>
-                <version>${version.org.wildfly.wildfly-arquillian-container-remote}</version>
+                <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                <version>${version.org.wildfly.wildfly-arquillian-container-bootable}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.sasl</groupId>
+                        <artifactId>jboss-sasl</artifactId>
+                    </exclusion>
+                    <!-- TODO remove this exclusion once this depends on Jakarta Inject -->
+                    <!-- superseded by jakarta.inject:jakarta.inject-api -->
                     <exclusion>
                         <groupId>javax.inject</groupId>
                         <artifactId>javax.inject</artifactId>

--- a/testsuite/README.MD
+++ b/testsuite/README.MD
@@ -90,6 +90,19 @@ the usage of `standalone-microprofile.xml` configuration file:
 
 > mvn clean verify -Dserver.home=PATH_TO_WIDLFLY_HOME -Dts.standalone.microprofile
 
+### Bootable jar testing
+Run testsuite or test against Bootable jar, not against Wildfly:
+
+> mvn clean verify -Dts.bootable -Ddefault=false -Ddisable.microprofile.tests -Dserver.version=21.0.0.Beta1-SNAPSHOT -Dserver.home=not-needed-for-bootable.jar 
+
+Please notice that when running integration tests against a bootable JAR, the following applies:
+
+* `-Dtestsuite.wildfly.galleon.pack.group.id` can be used to set the Group Id for the WildFly Galleon feature pack 
+artifact (e.g. org.jboss.eap would use a productized version), the default being `org.wildfly`
+* `-Dserver.version` will be used to set the version for the WildFly Galleon feature pack artifact
+* `-Dserver.home` must be set to some literal (like in the above example) since this prevents the `download` profile
+from being executed and the server distribution to be downloaded and unpacked consequently. 
+
 ### Test logs
 Test logs are stored in ``/MODULE_NAME/target/surefire-reports/TEST_NAME-output.txt``
 

--- a/testsuite/arquillian-utils/pom.xml
+++ b/testsuite/arquillian-utils/pom.xml
@@ -30,6 +30,20 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <dependencies>
@@ -38,6 +52,14 @@
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-depchain</artifactId>
             <type>pom</type>
+            <exclusions>
+                <!-- TODO remove this exclusion once this depends on Jakarta Inject -->
+                <!-- superseded by jakarta.inject:jakarta.inject-api -->
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -130,6 +152,12 @@
                 <exclusion>
                     <groupId>org.sonatype.aether</groupId>
                     <artifactId>aether-api</artifactId>
+                </exclusion>
+                <!-- TODO remove this exclusion once this depends on Jakarta Inject -->
+                <!-- superseded by jakarta.inject:jakarta.inject-api -->
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/category/NotForBootableJar.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/category/NotForBootableJar.java
@@ -1,0 +1,7 @@
+package org.jboss.resteasy.category;
+
+/**
+ * Marker interface for tests which are expected to fail with bootable jar.
+ */
+public interface NotForBootableJar {
+}

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -203,6 +203,152 @@
                 <microprofile.excluded.groups>org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration,org.jboss.resteasy.category.ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11</microprofile.excluded.groups>
             </properties>
         </profile>
+        
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Disable the standard copy-based provisioning -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>initialize-basedirs</id>
+                                <phase>none</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <executions>
+                            <!-- Package a jaxrs-server layer with a few other layers -->
+                            <execution>
+                                <id>bootable-jar-observability-packaging</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <output-file-name>jaxrs-server.jar</output-file-name>
+                                    <hollowJar>true</hollowJar>
+                                    <record-state>false</record-state>
+                                    <log-time>true</log-time>
+                                    <plugin-options>
+                                        <jboss-fork-embedded>true</jboss-fork-embedded>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.wildfly.galleon.pack.group.id}</groupId>
+                                            <artifactId>wildfly-galleon-pack</artifactId>
+                                            <version>${server.version}</version>
+                                            <!-- Required for rxjava -->
+                                            <includedPackages>
+                                                <package>org.jboss.resteasy.resteasy-rxjava2</package>
+                                            </includedPackages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <layers>
+                                        <layer>jaxrs-server</layer>
+                                        <layer>microprofile-config</layer>
+                                        <layer>datasources</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>undertow-legacy-https</layer>
+                                        <layer>ejb</layer>
+                                        <layer>mail</layer>
+                                    </layers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <install.dir>${project.build.directory}/wildfly</install.dir>
+                                <bootable.jar>${project.build.directory}/jaxrs-server.jar</bootable.jar>
+                                <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
+                                <container.management.port.managed>${container.management.port.managed}</container.management.port.managed>
+                                <securityManagerArg>${securityManagerArg}</securityManagerArg>
+                                <additionalJvmArgs>${additionalJvmArgs}</additionalJvmArgs>
+                                <ipv6>false</ipv6>
+                                <ipv6ArquillianSettings></ipv6ArquillianSettings>
+                                <node>127.0.0.1</node>
+                                <project.version>${project.version}</project.version>
+                                <version.resteasy.testsuite>${version.resteasy.testsuite}</version.resteasy.testsuite>
+                                <security.provider>${security.provider}</security.provider>
+                                <modular.jdk.args>${modular.jdk.args}</modular.jdk.args>
+                                <container.base.dir.managed>${container.base.dir.managed}</container.base.dir.managed>
+                                <container.offset.managed>0</container.offset.managed>
+                                <container.qualifier.managed>${container.qualifier.managed}</container.qualifier.managed>
+                                <container.qualifier.managed.encoding>${container.qualifier.managed.encoding}</container.qualifier.managed.encoding>
+                                <container.offset.managed.encoding>${container.offset.managed.encoding}</container.offset.managed.encoding>
+                                <container.management.port.managed.encoding>${container.management.port.managed.encoding}</container.management.port.managed.encoding>
+                            </systemPropertyVariables>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>disable-jsonb-client</id>
+                                <phase>none</phase>
+                            </execution>
+
+                            <execution>
+                                <id>default-test-bootable-jar</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes>
+                                        <!-- Tests requires excluding JsonBindingProvider-->
+                                        <exclude>**/JsonBindingAnnotationsJacksonTest.java</exclude>
+                                        <exclude>**/SseJsonEventTest</exclude>
+                                        <!-- Tests without proper arquillian container in arquillian-bootable.xml -->
+                                        <exclude>**/*Gzip*</exclude>
+                                        <exclude>**/SslServerWithCorrectCertificateTest.java</exclude>
+                                        <exclude>**/SslServerWithWildcardHostnameCertificateTest.java</exclude>
+                                        <exclude>**/SslServerWithWrongHostnameCertificateTest.java</exclude>
+                                        <exclude>**/SslSniHostNamesTest.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+
+                            <!-- execution with excluded JSON-B -->
+                            <execution>
+                                <id>disable-jsonb-client-bootable-jar</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <includes>
+                                        <!-- TODO JsonBindingAnnotationsJacksonTest may be included here as well with additional changes-->
+                                        <include>**/SseJsonEventTest.java</include>
+                                    </includes>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>org.jboss.resteasy:resteasy-json-binding-provider</classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <dependencies>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cache/ServerCacheInterceptorTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cache/ServerCacheInterceptorTest.java
@@ -8,6 +8,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.category.ExpectedFailingOnWildFly19;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.plugins.cache.server.InfinispanCache;
@@ -38,7 +39,10 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Category({ExpectedFailingOnWildFly19.class})
+@Category({
+        ExpectedFailingOnWildFly19.class,
+        NotForBootableJar.class // related resteasy-cache-core module is not delivered by WF, so it's not necessary to check it with bootable jar
+})
 public class ServerCacheInterceptorTest {
 
    private static ResteasyClient clientA;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/CDIResourceTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/CDIResourceTest.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.test.ContainerConstants;
 import org.jboss.resteasy.util.HttpResponseCodes;
 import org.jboss.resteasy.utils.PermissionUtil;
@@ -51,7 +52,11 @@ import org.jboss.resteasy.test.cdi.basic.resource.resteasy1082.TestServlet;
 @RunWith(Arquillian.class)
 @RunAsClient
 @Category({
-    ExpectedFailingWithStandaloneMicroprofileConfiguration.class    //  java.lang.ClassNotFoundException: javax.faces.webapp.FacesServlet (MP is missing JSF)
+    // java.lang.ClassNotFoundException: javax.faces.webapp.FacesServlet (MP is missing JSF)
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class,
+    // this test doesn't use Arquillian, so additional bootable-jar support needs to be added here
+    // in order to have this test functional on bootable jar
+    NotForBootableJar.class
 })
 public class CDIResourceTest {
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionTest.java
@@ -25,6 +25,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBook;
@@ -74,7 +75,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 @Category({
-    ExpectedFailingWithStandaloneMicroprofileConfiguration.class // MP is missing jboss.naming.context.java.jboss.exported.jms.RemoteConnectionFactory
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class, // MP is missing jboss.naming.context.java.jboss.exported.jms.RemoteConnectionFactory
+    NotForBootableJar.class // needs ejb + standalone-full when creating the bootable and inherit all default packages, this creates a 250MB bootable JAR which is useless
 })
 public class InjectionTest extends AbstractInjectionTestBase {
    protected static final Logger log = LogManager.getLogger(InjectionTest.class.getName());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/MDBInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/MDBInjectionTest.java
@@ -17,6 +17,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBook;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBookBag;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBookBagLocal;
@@ -63,7 +64,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 @Category({
-    ExpectedFailingWithStandaloneMicroprofileConfiguration.class // MP is missing jboss.naming.context.java.jboss.exported.jms.RemoteConnectionFactory
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class, // MP is missing jboss.naming.context.java.jboss.exported.jms.RemoteConnectionFactory
+    NotForBootableJar.class // needs ejb + standalone-full
 })
 public class MDBInjectionTest extends AbstractInjectionTestBase {
    protected static final Logger log = LogManager.getLogger(MDBInjectionTest.class.getName());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/ReverseInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/ReverseInjectionTest.java
@@ -4,6 +4,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBook;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBookBag;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBookBagLocal;
@@ -95,7 +96,8 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(Arquillian.class)
 @Category({
-    ExpectedFailingWithStandaloneMicroprofileConfiguration.class // MP is missing jboss.naming.context.java.jboss.exported.jms.RemoteConnectionFactory
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class, // MP is missing jboss.naming.context.java.jboss.exported.jms.RemoteConnectionFactory
+    NotForBootableJar.class // needs ejb + standalone-full
 })
 public class ReverseInjectionTest extends AbstractInjectionTestBase {
    private static Logger log = Logger.getLogger(ReverseInjectionTest.class);
@@ -151,6 +153,7 @@ public class ReverseInjectionTest extends AbstractInjectionTestBase {
             .addClasses(ReverseInjectionResource.class)
             .addClasses(CDIInjectionNewBean.class, CDIInjectionStereotypedApplicationScope.class, CDIInjectionStereotypedDependentScope.class)
             .addClass(ExpectedFailingWithStandaloneMicroprofileConfiguration.class)
+            .addClass(NotForBootableJar.class)
             .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
             .addAsResource(ReverseInjectionTest.class.getPackage(), "persistence.xml", "META-INF/persistence.xml");
       // Arquillian in the deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
@@ -15,12 +15,14 @@ import javax.ws.rs.core.FeatureContext;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.utils.PermissionUtil;
 import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -29,6 +31,7 @@ import org.junit.runner.RunWith;
  * @tpSince RESTEasy 3.0.17
  */
 @RunWith(Arquillian.class)
+@Category(NotForBootableJar.class)  // no log check support for bootable-jar in RESTEasy TS so far
 public class ClientBuilderTest {
 
    @SuppressWarnings(value = "unchecked")
@@ -36,6 +39,7 @@ public class ClientBuilderTest {
    public static Archive<?> deploy() {
       WebArchive war = TestUtil.prepareArchive(ClientBuilderTest.class.getSimpleName());
       war.addClass(TestUtil.class);
+      war.addClass(NotForBootableJar.class);
       // Arquillian in the deployment and use of TestUtil
       war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(new ReflectPermission("suppressAccessChecks"),
             new FilePermission(TestUtil.getStandaloneDir(DEFAULT_CONTAINER_QUALIFIER) + File.separator + "log" +

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/DuplicateDeploymentTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/DuplicateDeploymentTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.test.core.basic.resource.DuplicateDeploymentReader;
 import org.jboss.resteasy.test.core.basic.resource.DuplicateDeploymentResource;
 import org.jboss.resteasy.utils.TestUtil;
@@ -14,7 +15,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
-
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALIFIER;
@@ -27,6 +28,7 @@ import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALI
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class)  // no log check support for bootable-jar in RESTEasy TS so far
 public class DuplicateDeploymentTest {
    private static int initWarningCount = 0;
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/logging/DebugLoggingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/logging/DebugLoggingTest.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.core.logging.resource.DebugLoggingEndPoint;
@@ -23,6 +24,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 
@@ -43,6 +45,9 @@ import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALI
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category({
+        NotForBootableJar.class  // no log check support for bootable-jar in RESTEasy TS so far
+})
 public class DebugLoggingTest {
 
    static ResteasyClient client;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/ResourceClassProcessorErrorTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/ResourceClassProcessorErrorTest.java
@@ -6,6 +6,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.test.core.spi.resource.ResourceClassProcessorErrorImplementation;
 import org.jboss.resteasy.test.core.spi.resource.ResourceClassProcessorPureEndPoint;
 import org.jboss.resteasy.utils.LogCounter;
@@ -15,6 +16,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -28,6 +30,7 @@ import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALI
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class) // no log check support for bootable-jar in RESTEasy TS so far
 public class ResourceClassProcessorErrorTest {
 
    private static final String DEPLOYMENT_NAME = "deployment_name";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/crypto/CryptoTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/crypto/CryptoTest.java
@@ -5,6 +5,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.security.KeyTools;
 import org.jboss.resteasy.security.smime.EnvelopedInput;
@@ -28,6 +29,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Client;
@@ -58,6 +60,7 @@ import java.util.Base64;
 @SuppressWarnings(value = "unchecked")
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class) // RESTEasy crypto module is private in WF so it's not necessary to test this with bootable jar
 public class CryptoTest {
    private static final String ERROR_CONTENT_MSG = "Wrong content of response";
    private static final String ERROR_CORE_MSG = "Wrong BouncyCastleProvider and RESTEasy integration";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/DuplicateProviderRegistrationTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/DuplicateProviderRegistrationTest.java
@@ -2,6 +2,7 @@ package org.jboss.resteasy.test.providers.custom;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.test.ContainerConstants;
 import org.jboss.resteasy.test.providers.custom.resource.DuplicateProviderRegistrationFeature;
 import org.jboss.resteasy.test.providers.custom.resource.DuplicateProviderRegistrationFilter;
@@ -12,6 +13,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Client;
@@ -34,6 +36,7 @@ import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALI
  * @tpSince RESTEasy 3.0.17
  */
 @RunWith(Arquillian.class)
+@Category(NotForBootableJar.class)  // no log check support for bootable-jar in RESTEasy TS so far
 public class DuplicateProviderRegistrationTest {
 
    private static final String RESTEASY_002155_ERR_MSG = "Wrong count of RESTEASY002155 warning message";
@@ -44,6 +47,7 @@ public class DuplicateProviderRegistrationTest {
       WebArchive war = TestUtil.prepareArchive(DuplicateProviderRegistrationTest.class.getSimpleName());
       war.addClasses(DuplicateProviderRegistrationFeature.class, DuplicateProviderRegistrationFilter.class,
             TestUtil.class, DuplicateProviderRegistrationInterceptor.class, ContainerConstants.class);
+      war.addClass(NotForBootableJar.class);
       // Arquillian in the deployment, test reads the server.log
       war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
             new ReflectPermission("suppressAccessChecks"),

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/MissingProducerTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/MissingProducerTest.java
@@ -3,11 +3,13 @@ package org.jboss.resteasy.test.providers.custom;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALIFIER;
@@ -20,6 +22,7 @@ import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALI
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class) // no log check support for bootable-jar in RESTEasy TS so far
 public class MissingProducerTest {
    private static final String ERR_MSG = "Warning was not logged";
    private static int initLogMsg1Count = parseLog1();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jsonb/basic/JsonBindingDebugLoggingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jsonb/basic/JsonBindingDebugLoggingTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.providers.jsonb.basic;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.test.ContainerConstants;
 import org.jboss.resteasy.test.providers.jsonb.basic.resource.DebugLoggingServerSetup;
@@ -20,6 +21,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.ProcessingException;
@@ -48,6 +50,7 @@ import static org.hamcrest.Matchers.greaterThan;
  */
 @RunWith(Arquillian.class)
 @ServerSetup({DebugLoggingServerSetup.class}) // TBD: remove debug logging activation?
+@Category(NotForBootableJar.class) // no log check support for bootable-jar in RESTEasy TS so far
 public class JsonBindingDebugLoggingTest {
 
    static ResteasyClient client;
@@ -59,6 +62,7 @@ public class JsonBindingDebugLoggingTest {
       war.addClass(JsonBindingDebugLoggingItemCorruptedGet.class);
       war.addClass(JsonBindingDebugLoggingItemCorruptedSet.class);
       war.addClasses(LogCounter.class, PortProviderUtil.class, TestUtil.class);
+      war.addClass(NotForBootableJar.class);
       war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(
               new ReflectPermission("suppressAccessChecks"),
               new RuntimePermission("accessDeclaredMembers"),

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/EncodingMimeMultipartFormProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/EncodingMimeMultipartFormProviderTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 @Category({
-    ExpectedFailingWithStandaloneMicroprofileConfiguration.class    //  MP is missing javax.mail
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class,    //  MP is missing javax.mail
 })
 public class EncodingMimeMultipartFormProviderTest {
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/MimeMultipartProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/MimeMultipartProviderTest.java
@@ -54,7 +54,7 @@ import java.util.Map;
 @RunWith(Arquillian.class)
 @RunAsClient
 @Category({
-    ExpectedFailingWithStandaloneMicroprofileConfiguration.class    //  MP is missing javax.mail
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class,    //  MP is missing javax.mail
 })
 public class MimeMultipartProviderTest {
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/DuplicitePathTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/DuplicitePathTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.test.response.resource.DuplicitePathDupliciteApplicationOne;
@@ -21,6 +22,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.WebTarget;
@@ -39,6 +41,7 @@ import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALI
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class) // no log check support for bootable-jar in RESTEasy TS so far
 public class DuplicitePathTest {
    static ResteasyClient client;
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
@@ -12,6 +12,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.category.ExpectedFailingOnWildFly18;
 import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
@@ -51,7 +52,10 @@ import java.util.Hashtable;
 @ServerSetup({BasicAuthTest.SecurityDomainSetup.class})
 @RunWith(Arquillian.class)
 @RunAsClient
-@Category({ExpectedFailingOnWildFly18.class})   //WFLY-12655
+@Category({
+        ExpectedFailingOnWildFly18.class, //WFLY-12655
+        NotForBootableJar.class // requires different security configuration
+})
 public class BasicAuthTest {
 
    private static final String WRONG_RESPONSE = "Wrong response content.";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SecurityContextTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SecurityContextTest.java
@@ -6,6 +6,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.BasicAuthentication;
 import org.jboss.resteasy.setup.AbstractUsersRolesSecurityDomainSetup;
 import org.jboss.resteasy.test.security.resource.SecurityContextResource;
@@ -41,7 +42,8 @@ import java.nio.file.Paths;
 @RunWith(Arquillian.class)
 @RunAsClient
 @Category({
-    ExpectedFailingWithStandaloneMicroprofileConfiguration.class
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class,
+    NotForBootableJar.class // requires different security configuration
 })
 public class SecurityContextTest {
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/TwoSecurityDomainsTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/TwoSecurityDomainsTest.java
@@ -12,6 +12,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.category.ExpectedFailingOnWildFly18;
 import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
@@ -49,7 +50,8 @@ import java.util.Hashtable;
 @RunAsClient
 @Category({
     ExpectedFailingOnWildFly18.class,               //WFLY-12655
-    ExpectedFailingWithStandaloneMicroprofileConfiguration.class
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class,
+    NotForBootableJar.class // requires different security configuration
 })
 public class TwoSecurityDomainsTest {
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/warning/SubResourceWarningTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/warning/SubResourceWarningTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.warning;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.test.core.interceptors.resource.TestResource1;
 import org.jboss.resteasy.test.core.interceptors.resource.TestResource2;
 import org.jboss.resteasy.test.core.interceptors.resource.TestSubResource;
@@ -14,6 +15,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 
@@ -27,6 +29,7 @@ import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALI
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class) // no log check support for bootable-jar in RESTEasy TS so far
 public class SubResourceWarningTest {
 
    // check server.log msg count before app is deployed.  Deploying causes messages to be logged.

--- a/testsuite/integration-tests/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration-tests/src/test/resources/arquillian-bootable.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <defaultProtocol type="Servlet 3.0" />
+
+    <group qualifier="integration-tests" default="true">
+        <container qualifier="${container.qualifier.managed}" default="true">
+            <configuration>
+                <property name="installDir">${install.dir}</property>
+                <property name="jarFile">${bootable.jar}</property>
+
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} -Djboss.socket.binding.port-offset=${container.offset.managed}</property>
+                <property name="jbossArguments">${securityManagerArg}</property>
+                <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
+                     In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node}</property>
+                <property name="managementPort">${container.management.port.managed}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">8787 ${container.management.port.managed}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+        <container qualifier="${container.qualifier.managed.encoding}">
+            <configuration>
+                <property name="installDir">${install.dir}-encoding</property>
+                <property name="jarFile">${bootable.jar}</property>
+
+                <!-- Forcing file.encoding=us-ascii in order to test RESTEASY-2171 -->
+                <property name="javaVmArguments">-Dorg.jboss.resteasy.port=15080 -Dfile.encoding=us-ascii -server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} -Djboss.socket.binding.port-offset=7000
+                </property>
+                <property name="jbossArguments">${securityManagerArg}</property>
+                <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
+                     In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node}</property>
+                <property name="managementPort">${container.management.port.managed.encoding}</property>
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">8787 ${container.management.port.managed.encoding}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+    </group>
+
+</arquillian>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -76,6 +76,22 @@
 
     <profiles>
         <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <properties>
+                <additional.surefire.excluded.groups>org.jboss.resteasy.category.NotForBootableJar</additional.surefire.excluded.groups>
+                <testsuite.wildfly.galleon.pack.group.id>org.wildfly</testsuite.wildfly.galleon.pack.group.id>
+            </properties>
+            <modules>
+                <module>arquillian-utils</module>
+                <module>integration-tests</module>
+            </modules>
+        </profile>
+        <profile>
             <id>default</id>
             <activation>
                 <property>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RESTEASY-2694 for the 3.14 branch.

Same failures as for the 3.13 branch [1] when running against WFLY 21 Beta1 are reported at the moment, due to https://issues.redhat.com/browse/WFCORE-5143.

[1]
https://github.com/resteasy/Resteasy/pull/2526