### PR TITLE
[WFLY-13790] get rid of jsonb object singleton, letting any deploymen…

### DIFF
--- a/providers/json-binding/src/main/java/org/jboss/resteasy/plugins/providers/jsonb/AbstractJsonBindingProvider.java
+++ b/providers/json-binding/src/main/java/org/jboss/resteasy/plugins/providers/jsonb/AbstractJsonBindingProvider.java
@@ -21,7 +21,7 @@ public class AbstractJsonBindingProvider extends JsonBindingProvider {
 
    @Context
    javax.ws.rs.ext.Providers providers;
-   private static Jsonb jsonbObj = null;
+   private volatile Jsonb jsonbObj = null;
 
    protected Jsonb getJsonb(Class<?> type) {
       ContextResolver<Jsonb> contextResolver = providers.getContextResolver(Jsonb.class, MediaType.APPLICATION_JSON_TYPE);
@@ -32,9 +32,14 @@ public class AbstractJsonBindingProvider extends JsonBindingProvider {
       {
          if (jsonbObj == null)
          {
-            JsonProviderImpl jProviderImpl = new JsonProviderImpl();
-            JsonBindingBuilder jbBuilder = new JsonBindingBuilder();
-            jsonbObj = jbBuilder.withProvider(jProviderImpl).build();
+            synchronized (this)
+            {
+               if (jsonbObj == null) {
+                  JsonProviderImpl jProviderImpl = new JsonProviderImpl();
+                  JsonBindingBuilder jbBuilder = new JsonBindingBuilder();
+                  jsonbObj = jbBuilder.withProvider(jProviderImpl).build();
+               }
+            }
          }
          return jsonbObj;
       }


### PR DESCRIPTION
…t have its own instance; use double-checked locking for initializing the object

This is a cherry-pick of PR: https://github.com/resteasy/Resteasy/pull/2539 to `3.11` branch for the downstream issue.
