### PR TITLE
Add test for https://github.com/resteasy/Resteasy/pull/2578

### DIFF
--- a/resteasy-client-microprofile-base/pom.xml
+++ b/resteasy-client-microprofile-base/pom.xml
@@ -39,9 +39,5 @@
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.reactivex.rxjava2</groupId>
-            <artifactId>rxjava</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/resteasy-client-microprofile-base/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
+++ b/resteasy-client-microprofile-base/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
@@ -20,6 +20,8 @@ import org.jboss.resteasy.microprofile.client.header.ClientHeaderProviders;
 import org.jboss.resteasy.microprofile.client.header.ClientHeadersRequestFilter;
 import org.jboss.resteasy.microprofile.client.impl.MpClient;
 import org.jboss.resteasy.microprofile.client.impl.MpClientBuilderImpl;
+import org.jboss.resteasy.microprofile.client.publisher.MpPublisherMessageBodyReader;
+//import org.jboss.resteasy.microprofile.client.publisher.MpPublisherMessageBodyReader;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.spi.ResteasyUriBuilder;
 
@@ -290,11 +292,13 @@ public class RestClientBuilderImpl implements RestClientBuilder {
         if (this.executorService != null) {
             resteasyClientBuilder.executorService(this.executorService);
         } else {
-            resteasyClientBuilder.executorService(Executors.newCachedThreadPool(), true);
+            this.executorService = Executors.newCachedThreadPool();
+            resteasyClientBuilder.executorService(executorService, true);
         }
         resteasyClientBuilder.register(DEFAULT_MEDIA_TYPE_FILTER);
         resteasyClientBuilder.register(METHOD_INJECTION_FILTER);
         resteasyClientBuilder.register(HEADERS_REQUEST_FILTER);
+        register(new MpPublisherMessageBodyReader(executorService));
         resteasyClientBuilder.sslContext(sslContext);
         resteasyClientBuilder.trustStore(trustStore);
         resteasyClientBuilder.keyStore(keyStore, keystorePassword);

--- a/resteasy-client-microprofile-base/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
+++ b/resteasy-client-microprofile-base/src/main/java/org/jboss/resteasy/microprofile/client/RestClientBuilderImpl.java
@@ -21,7 +21,6 @@ import org.jboss.resteasy.microprofile.client.header.ClientHeadersRequestFilter;
 import org.jboss.resteasy.microprofile.client.impl.MpClient;
 import org.jboss.resteasy.microprofile.client.impl.MpClientBuilderImpl;
 import org.jboss.resteasy.microprofile.client.publisher.MpPublisherMessageBodyReader;
-//import org.jboss.resteasy.microprofile.client.publisher.MpPublisherMessageBodyReader;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.spi.ResteasyUriBuilder;
 

--- a/resteasy-client-microprofile-base/src/main/java/org/jboss/resteasy/microprofile/client/publisher/MpPublisherMessageBodyReader.java
+++ b/resteasy-client-microprofile-base/src/main/java/org/jboss/resteasy/microprofile/client/publisher/MpPublisherMessageBodyReader.java
@@ -1,14 +1,9 @@
 package org.jboss.resteasy.microprofile.client.publisher;
 
-import io.reactivex.BackpressureStrategy;
-import io.reactivex.Flowable;
-import io.reactivex.FlowableEmitter;
-import io.reactivex.FlowableOnSubscribe;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Map;
 
@@ -20,7 +15,6 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.Provider;
 import javax.ws.rs.ext.Providers;
-import javax.ws.rs.sse.InboundSseEvent;
 
 import org.jboss.resteasy.plugins.providers.sse.SseConstants;
 import org.jboss.resteasy.plugins.providers.sse.SseEventInputImpl;
@@ -50,38 +44,6 @@ public class MpPublisherMessageBodyReader implements MessageBodyReader<Publisher
             }
         }
         SseEventInputImpl sseEventInput = new SseEventInputImpl(annotations, streamType, mediaType, httpHeaders, entityStream);
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        Flowable<?> flowable = Flowable.create(new FlowableOnSubscribe() {
-
-            @Override
-            public void subscribe(FlowableEmitter emitter) throws Exception {
-                Type typeArgument = null;
-                InboundSseEvent event;
-                if (genericType instanceof ParameterizedType) {
-                    typeArgument = ((ParameterizedType) genericType).getActualTypeArguments()[0];
-                    if (typeArgument.equals(InboundSseEvent.class)) {
-                        try {
-                            while ((event = sseEventInput.read(providers)) != null) {
-                                emitter.onNext(event);
-                            }
-                        } catch (Exception e) {
-                            emitter.onError(e);
-                        }
-                        emitter.onComplete();
-                    } else {
-                        try {
-                            while ((event = sseEventInput.read(providers)) != null) {
-                                emitter.onNext(event.readData((Class) typeArgument));
-                            }
-                        } catch (Exception e) {
-                            emitter.onError(e);
-                        }
-                        emitter.onComplete();
-                    }
-                }
-            }
-
-        }, BackpressureStrategy.BUFFER);
-        return flowable;
+        return new SSEPublisher<>(genericType, providers, sseEventInput);
     }
 }

--- a/resteasy-client-microprofile-base/src/main/java/org/jboss/resteasy/microprofile/client/publisher/MpPublisherMessageBodyReader.java
+++ b/resteasy-client-microprofile-base/src/main/java/org/jboss/resteasy/microprofile/client/publisher/MpPublisherMessageBodyReader.java
@@ -6,6 +6,8 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.WebApplicationException;
@@ -23,10 +25,15 @@ import org.reactivestreams.Publisher;
 @Provider
 @Consumes(MediaType.SERVER_SENT_EVENTS)
 public class MpPublisherMessageBodyReader implements MessageBodyReader<Publisher<?>> {
-
     @Context
     protected Providers providers;
-
+    private ExecutorService executor;
+    public MpPublisherMessageBodyReader(final ExecutorService  ex) {
+       executor = ex;
+    }
+    public MpPublisherMessageBodyReader() {
+        executor = Executors.newCachedThreadPool();
+     }
     @Override
     public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         return Publisher.class.isAssignableFrom(type) && MediaType.SERVER_SENT_EVENTS_TYPE.isCompatible(mediaType);
@@ -44,6 +51,6 @@ public class MpPublisherMessageBodyReader implements MessageBodyReader<Publisher
             }
         }
         SseEventInputImpl sseEventInput = new SseEventInputImpl(annotations, streamType, mediaType, httpHeaders, entityStream);
-        return new SSEPublisher<>(genericType, providers, sseEventInput);
+        return new SSEPublisher<>(genericType, providers, sseEventInput, executor);
     }
 }

--- a/resteasy-client-microprofile-base/src/main/java/org/jboss/resteasy/microprofile/client/publisher/SSEPublisher.java
+++ b/resteasy-client-microprofile-base/src/main/java/org/jboss/resteasy/microprofile/client/publisher/SSEPublisher.java
@@ -1,0 +1,280 @@
+package org.jboss.resteasy.microprofile.client.publisher;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.plugins.providers.sse.SseEventInputImpl;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import javax.ws.rs.ext.Providers;
+import javax.ws.rs.sse.InboundSseEvent;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Publisher implementation emitting server-sent-event downstream.
+ *
+ * @param <T> the type of event.
+ */
+@SuppressWarnings("ReactiveStreamsPublisherImplementation")
+public class SSEPublisher<T> implements Publisher<T> {
+
+    private static final Runnable CLEARED = () -> {
+        // sentinel indicating we are done.
+    };
+
+    private final SseEventInputImpl input;
+    private final Type genericType;
+    private final Providers providers;
+
+    private static final Logger LOGGER = Logger.getLogger(SSEPublisher.class);
+
+    public SSEPublisher(final Type genericType, final Providers providers, final SseEventInputImpl input) {
+        this.genericType = genericType;
+        this.input = input;
+        this.providers = providers;
+    }
+
+    @Override
+    public void subscribe(final Subscriber<? super T> downstream) {
+        SSEProcessor<? super T> processor = new SSEProcessor<>(downstream,
+                512); // TODO should retrieve this value from the configuration.
+        downstream.onSubscribe(processor);
+        pump(processor, input);
+    }
+
+    /**
+     * Reads the server-sent event from the {@code input} and pass them to the processor.
+     * The processor handles the downstream requests and buffer/drop items according to them.
+     *
+     * @param processor the stream
+     * @param input     the SSE input
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private void pump(final SSEProcessor processor, final SseEventInputImpl input) {
+        Type typeArgument;
+        InboundSseEvent event;
+        if (genericType instanceof ParameterizedType) {
+            typeArgument = ((ParameterizedType) genericType).getActualTypeArguments()[0];
+            if (typeArgument.equals(InboundSseEvent.class)) {
+                try {
+                    while ((event = input.read(providers)) != null) {
+                        processor.emit(event);
+                    }
+                } catch (Exception e) {
+                    processor.onError(e);
+                    return;
+                }
+                processor.onCompletion();
+            } else {
+                try {
+                    while ((event = input.read(providers)) != null) {
+                        processor.emit(event.readData((Class) typeArgument));
+                    }
+                } catch (Exception e) {
+                    processor.onError(e);
+                    return;
+                }
+                processor.onCompletion();
+            }
+        }
+    }
+
+    /**
+     * Processor receiving SSE items from the source and dealing with downstream requests.
+     * The items are buffers, and older events are dropped if the buffer is full.
+     *
+     * @param <T> the type of event
+     */
+    private static class SSEProcessor<T> implements Subscription {
+        private final AtomicLong requested = new AtomicLong();
+        private final Subscriber<T> downstream;
+
+        private final Queue<T> queue;
+        private final int bufferSize;
+        private Throwable failure;
+        private volatile boolean done;
+        private final AtomicInteger wip = new AtomicInteger();
+        private final AtomicReference<Runnable> onTermination;
+
+        SSEProcessor(final Subscriber<T> downstream, final int bufferSize) {
+            this.downstream = downstream;
+            this.bufferSize = bufferSize;
+            this.queue = new SpscLinkedArrayQueue<>(bufferSize);
+            this.onTermination = new AtomicReference<>();
+        }
+
+        public void emit(T t) {
+            if (done || isCancelled()) {
+                return;
+            }
+
+            if (t == null) {
+                throw new NullPointerException("Reactive Streams Rule 2.13 violated: The received item is `null`");
+            }
+
+            if (queue.size() == bufferSize) {
+                T item = queue.poll();
+                LOGGER.debugf("Dropping server-sent-event '%s' due to lack of downstream requests", item);
+            }
+            queue.offer(t);
+
+            drain();
+        }
+
+        @Override
+        public void request(long n) {
+            if (n > 0) {
+                Subscriptions.add(requested, n);
+                drain();
+            } else {
+                cancel();
+                downstream.onError(new IllegalArgumentException(
+                        "Reactive Streams Rule 3.9 violated: request must be positive, but was " + n));
+            }
+        }
+
+        @Override
+        public final void cancel() {
+            cleanup();
+        }
+
+        public boolean isCancelled() {
+            return onTermination.get() == CLEARED;
+        }
+
+        void drain() {
+            if (wip.getAndIncrement() != 0) {
+                return;
+            }
+
+            int missed = 1;
+            final Queue<T> q = queue;
+
+            do {
+                long requests = requested.get();
+                long emitted = 0L;
+
+                while (emitted != requests) {
+                    // Be sure to clear the queue after cancellation or termination.
+                    if (isCancelled()) {
+                        q.clear();
+                        return;
+                    }
+
+                    boolean d = done;
+                    T event = q.poll();
+                    boolean empty = event == null;
+
+                    // No event and done - completing.
+                    if (d && empty) {
+                        if (failure != null) {
+                            sendErrorToDownstream(failure);
+                        } else {
+                            sendCompletionToDownstream();
+                        }
+                        return;
+                    }
+
+                    if (empty) {
+                        break;
+                    }
+
+                    // Passing the item downstream, and incrementing the emitted counter.
+                    try {
+                        downstream.onNext(event);
+                    } catch (Throwable x) {
+                        cancel();
+                    }
+                    emitted++;
+                }
+
+                // We have emitted all the items we could possibly do without violating the protocol.
+                if (emitted == requests) {
+                    // Be sure to clear the queue after cancellation or termination.
+                    if (isCancelled()) {
+                        q.clear();
+                        return;
+                    }
+
+                    // Re-check for completion.
+                    boolean d = done;
+                    boolean empty = q.isEmpty();
+                    if (d && empty) {
+                        if (failure != null) {
+                            sendErrorToDownstream(failure);
+                        } else {
+                            sendCompletionToDownstream();
+                        }
+                        return;
+                    }
+                }
+
+                // Update `requested`
+                if (emitted != 0) {
+                    Subscriptions.produced(requested, emitted);
+                }
+
+                missed = wip.addAndGet(-missed);
+            } while (missed != 0);
+        }
+
+        protected void onCompletion() {
+            done = true;
+            drain();
+        }
+
+        protected void onError(Throwable e) {
+            if (done || isCancelled()) {
+                return;
+            }
+
+            if (e == null) {
+                throw new NullPointerException("Reactive Streams Rule 2.13 violated: The received error is `null`");
+            }
+
+            this.failure = e;
+            done = true;
+
+            drain();
+        }
+
+        private void cleanup() {
+            Runnable action = onTermination.getAndSet(CLEARED);
+            if (action != null && action != CLEARED) {
+                action.run();
+            }
+        }
+
+        private void sendCompletionToDownstream() {
+            if (isCancelled()) {
+                return;
+            }
+
+            try {
+                downstream.onComplete();
+            } finally {
+                cleanup();
+            }
+        }
+
+        private void sendErrorToDownstream(Throwable e) {
+            if (e == null) {
+                e = new NullPointerException("Reactive Streams Rule 2.13 violated: The received error is `null`");
+            }
+            if (isCancelled()) {
+                return;
+            }
+            try {
+                downstream.onError(e);
+            } finally {
+                cleanup();
+            }
+        }
+    }
+
+}

--- a/resteasy-client-microprofile-base/src/main/java/org/jboss/resteasy/microprofile/client/publisher/SpscLinkedArrayQueue.java
+++ b/resteasy-client-microprofile-base/src/main/java/org/jboss/resteasy/microprofile/client/publisher/SpscLinkedArrayQueue.java
@@ -1,0 +1,298 @@
+package org.jboss.resteasy.microprofile.client.publisher;
+
+import java.util.AbstractQueue;
+import java.util.Iterator;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+/**
+ * A single-producer single-consumer array-backed queue which can allocate new arrays in case the consumer is slower
+ * than the producer.
+ * <p>
+ * Code inspired from https://github.com/JCTools/JCTools/blob/master/jctools-core/src/main/java/org/jctools/queues/atomic.
+ *
+ * @param <E> the element type of the queue
+ */
+public final class SpscLinkedArrayQueue<E> extends AbstractQueue<E> implements Queue<E> {
+    private static final int MAX_LOOK_AHEAD_STEP = 4096;
+    private final AtomicLong producerIndex = new AtomicLong();
+
+    private int producerLookAheadStep;
+    private long producerLookAhead;
+
+    private final int producerMask;
+
+    private AtomicReferenceArray<Object> producerBuffer;
+    private final int consumerMask;
+    private AtomicReferenceArray<Object> consumerBuffer;
+    private final AtomicLong consumerIndex = new AtomicLong();
+
+    private static final Object HAS_NEXT = new Object();
+
+    public SpscLinkedArrayQueue(final int bufferSize) {
+        int p2capacity = roundToPowerOfTwo(Math.max(8, bufferSize));
+        int mask = p2capacity - 1;
+        AtomicReferenceArray<Object> buffer = new AtomicReferenceArray<>(p2capacity + 1);
+        producerBuffer = buffer;
+        producerMask = mask;
+        adjustLookAheadStep(p2capacity);
+        consumerBuffer = buffer;
+        consumerMask = mask;
+        producerLookAhead = mask - 1L; // we know it's all empty to start with
+        soProducerIndex(0L);
+    }
+
+    /**
+     * Find the next larger positive power of two value up from the given value. If value is a power of two then
+     * this value will be returned.
+     *
+     * @param value from which next positive power of two will be found.
+     * @return the next positive power of 2 or this value if it is a power of 2.
+     */
+    public static int roundToPowerOfTwo(final int value) {
+        return 1 << (32 - Integer.numberOfLeadingZeros(value - 1));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation is correct for single producer thread use only.
+     */
+    @Override
+    public boolean offer(final E e) {
+        if (null == e) {
+            throw new NullPointerException("Null is not a valid element");
+        }
+        // local load of field to avoid repeated loads after volatile reads
+        final AtomicReferenceArray<Object> buffer = producerBuffer;
+        final long index = lpProducerIndex();
+        final int mask = producerMask;
+        final int offset = calcWrappedOffset(index, mask);
+        if (index < producerLookAhead) {
+            return writeToQueue(buffer, e, index, offset);
+        } else {
+            final int lookAheadStep = producerLookAheadStep;
+            // go around the buffer or resize if full (unless we hit max capacity)
+            int lookAheadElementOffset = calcWrappedOffset(index + lookAheadStep, mask);
+            if (null == lvElement(buffer, lookAheadElementOffset)) { // LoadLoad
+                producerLookAhead = index + lookAheadStep - 1; // joy, there's plenty of room
+                return writeToQueue(buffer, e, index, offset);
+            } else if (null == lvElement(buffer, calcWrappedOffset(index + 1, mask))) { // buffer is not full
+                return writeToQueue(buffer, e, index, offset);
+            } else {
+                resize(buffer, index, offset, e, mask); // add a buffer and link old to new
+                return true;
+            }
+        }
+    }
+
+    private boolean writeToQueue(final AtomicReferenceArray<Object> buffer, final E e, final long index,
+            final int offset) {
+        soElement(buffer, offset, e); // StoreStore
+        soProducerIndex(index + 1); // this ensures atomic write of long on 32bit platforms
+        return true;
+    }
+
+    private void resize(final AtomicReferenceArray<Object> oldBuffer, final long currIndex, final int offset, final E e,
+            final long mask) {
+        final int capacity = oldBuffer.length();
+        final AtomicReferenceArray<Object> newBuffer = new AtomicReferenceArray<>(capacity);
+        producerBuffer = newBuffer;
+        producerLookAhead = currIndex + mask - 1;
+        soElement(newBuffer, offset, e); // StoreStore
+        soNext(oldBuffer, newBuffer);
+        soElement(oldBuffer, offset, HAS_NEXT); // new buffer is visible after element is
+        // inserted
+        soProducerIndex(currIndex + 1); // this ensures correctness on 32bit platforms
+    }
+
+    private void soNext(AtomicReferenceArray<Object> curr, AtomicReferenceArray<Object> next) {
+        soElement(curr, calcDirectOffset(curr.length() - 1), next);
+    }
+
+    @SuppressWarnings("unchecked")
+    private AtomicReferenceArray<Object> lvNextBufferAndUnlink(AtomicReferenceArray<Object> curr, int nextIndex) {
+        int nextOffset = calcDirectOffset(nextIndex);
+        AtomicReferenceArray<Object> nextBuffer = (AtomicReferenceArray<Object>) lvElement(curr, nextOffset);
+        soElement(curr, nextOffset, null); // Avoid GC nepotism
+        return nextBuffer;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation is correct for single consumer thread use only.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public E poll() {
+        // local load of field to avoid repeated loads after volatile reads
+        final AtomicReferenceArray<Object> buffer = consumerBuffer;
+        final long index = lpConsumerIndex();
+        final int mask = consumerMask;
+        final int offset = calcWrappedOffset(index, mask);
+        final Object e = lvElement(buffer, offset); // LoadLoad
+        boolean isNextBuffer = e == HAS_NEXT;
+        if (null != e && !isNextBuffer) {
+            soElement(buffer, offset, null); // StoreStore
+            soConsumerIndex(index + 1); // this ensures correctness on 32bit platforms
+            return (E) e;
+        } else if (isNextBuffer) {
+            return newBufferPoll(lvNextBufferAndUnlink(buffer, mask + 1), index, mask);
+        }
+
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private E newBufferPoll(AtomicReferenceArray<Object> nextBuffer, final long index, final int mask) {
+        consumerBuffer = nextBuffer;
+        final int offsetInNew = calcWrappedOffset(index, mask);
+        final E n = (E) lvElement(nextBuffer, offsetInNew); // LoadLoad
+        if (null != n) {
+            soElement(nextBuffer, offsetInNew, null); // StoreStore
+            soConsumerIndex(index + 1); // this ensures correctness on 32bit platforms
+        }
+        return n;
+    }
+
+    @SuppressWarnings("unchecked")
+    public E peek() {
+        final AtomicReferenceArray<Object> buffer = consumerBuffer;
+        final long index = lpConsumerIndex();
+        final int mask = consumerMask;
+        final int offset = calcWrappedOffset(index, mask);
+        final Object e = lvElement(buffer, offset); // LoadLoad
+        if (e == HAS_NEXT) {
+            return newBufferPeek(lvNextBufferAndUnlink(buffer, mask + 1), index, mask);
+        }
+
+        return (E) e;
+    }
+
+    @SuppressWarnings("unchecked")
+    private E newBufferPeek(AtomicReferenceArray<Object> nextBuffer, final long index, final int mask) {
+        consumerBuffer = nextBuffer;
+        final int offsetInNew = calcWrappedOffset(index, mask);
+        return (E) lvElement(nextBuffer, offsetInNew); // LoadLoad
+    }
+
+    @Override
+    public void clear() {
+        //noinspection StatementWithEmptyBody
+        while (poll() != null || !isEmpty()) {
+        }
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        throw new UnsupportedOperationException();
+    }
+
+    public int size() {
+        /*
+         * It is possible for a thread to be interrupted or reschedule between the read of the producer and
+         * consumer indices, therefore protection is required to ensure size is within valid range. In the
+         * event of concurrent polls/offers to this method the size is OVER estimated as we read consumer
+         * index BEFORE the producer index.
+         */
+        long after = lvConsumerIndex();
+        while (true) {
+            final long before = after;
+            final long currentProducerIndex = lvProducerIndex();
+            after = lvConsumerIndex();
+            if (before == after) {
+                return (int) (currentProducerIndex - after);
+            }
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return lvProducerIndex() == lvConsumerIndex();
+    }
+
+    private void adjustLookAheadStep(int capacity) {
+        producerLookAheadStep = Math.min(capacity / 4, MAX_LOOK_AHEAD_STEP);
+    }
+
+    private long lvProducerIndex() {
+        return producerIndex.get();
+    }
+
+    private long lvConsumerIndex() {
+        return consumerIndex.get();
+    }
+
+    private long lpProducerIndex() {
+        return producerIndex.get();
+    }
+
+    private long lpConsumerIndex() {
+        return consumerIndex.get();
+    }
+
+    private void soProducerIndex(long v) {
+        producerIndex.lazySet(v);
+    }
+
+    private void soConsumerIndex(long v) {
+        consumerIndex.lazySet(v);
+    }
+
+    private static int calcWrappedOffset(long index, int mask) {
+        return calcDirectOffset((int) index & mask);
+    }
+
+    private static int calcDirectOffset(int index) {
+        return index;
+    }
+
+    private static void soElement(AtomicReferenceArray<Object> buffer, int offset, Object e) {
+        buffer.lazySet(offset, e);
+    }
+
+    private static Object lvElement(AtomicReferenceArray<Object> buffer, int offset) {
+        return buffer.get(offset);
+    }
+
+    /**
+     * Offer two elements at the same time.
+     * <p>
+     * Don't use the regular offer() with this at all!
+     *
+     * @param first  the first value, not null
+     * @param second the second value, not null
+     * @return true if the queue accepted the two new values
+     */
+    public boolean offer(E first, E second) {
+        final AtomicReferenceArray<Object> buffer = producerBuffer;
+        final long p = lvProducerIndex();
+        final int m = producerMask;
+
+        int pi = calcWrappedOffset(p + 2, m);
+
+        if (null == lvElement(buffer, pi)) {
+            pi = calcWrappedOffset(p, m);
+            soElement(buffer, pi + 1, second);
+            soElement(buffer, pi, first);
+            soProducerIndex(p + 2);
+        } else {
+            final int capacity = buffer.length();
+            final AtomicReferenceArray<Object> newBuffer = new AtomicReferenceArray<>(capacity);
+            producerBuffer = newBuffer;
+
+            pi = calcWrappedOffset(p, m);
+            soElement(newBuffer, pi + 1, second); // StoreStore
+            soElement(newBuffer, pi, first);
+            soNext(buffer, newBuffer);
+
+            soElement(buffer, pi, HAS_NEXT); // new buffer is visible after element is
+
+            soProducerIndex(p + 2); // this ensures correctness on 32bit platforms
+        }
+
+        return true;
+    }
+}

--- a/resteasy-client-microprofile-base/src/main/java/org/jboss/resteasy/microprofile/client/publisher/Subscriptions.java
+++ b/resteasy-client-microprofile-base/src/main/java/org/jboss/resteasy/microprofile/client/publisher/Subscriptions.java
@@ -1,0 +1,82 @@
+package org.jboss.resteasy.microprofile.client.publisher;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class Subscriptions {
+
+    /**
+     * Atomically adds the positive value n to the requested value in the AtomicLong and
+     * caps the result at Long.MAX_VALUE and returns the previous value.
+     *
+     * @param requested the AtomicLong holding the current requested value
+     * @param requests the value to add, must be positive (not verified)
+     * @return the original value before the add
+     */
+    public static long add(AtomicLong requested, long requests) {
+        for (;;) {
+            long r = requested.get();
+            if (r == Long.MAX_VALUE) {
+                return Long.MAX_VALUE;
+            }
+            long u = add(r, requests);
+            if (requested.compareAndSet(r, u)) {
+                return r;
+            }
+        }
+    }
+
+    /**
+     * Adds two long values and caps the sum at Long.MAX_VALUE.
+     *
+     * @param a the first value
+     * @param b the second value
+     * @return the sum capped at Long.MAX_VALUE
+     */
+    public static long add(long a, long b) {
+        long u = a + b;
+        if (u < 0L) {
+            return Long.MAX_VALUE;
+        }
+        return u;
+    }
+
+
+    /**
+     * Concurrent subtraction bound to 0, mostly used to decrement a request tracker by
+     * the amount produced by the operator.
+     *
+     * @param requested the atomic long keeping track of requests
+     * @param amount delta to subtract
+     * @return value after subtraction or zero
+     */
+    public static long produced(AtomicLong requested, long amount) {
+        long r;
+        long u;
+        do {
+            r = requested.get();
+            if (r == 0 || r == Long.MAX_VALUE) {
+                return r;
+            }
+            u = subOrZero(r, amount);
+        } while (!requested.compareAndSet(r, u));
+
+        return u;
+    }
+
+    /**
+     * Cap a subtraction to 0
+     *
+     * @param a left operand
+     * @param b right operand
+     * @return Subtraction result or 0 if overflow
+     */
+    public static long subOrZero(long a, long b) {
+        long res = a - b;
+        if (res < 0L) {
+            return 0;
+        }
+        return res;
+    }
+
+
+}

--- a/resteasy-client-microprofile-base/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
+++ b/resteasy-client-microprofile-base/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
@@ -1,1 +1,0 @@
-org.jboss.resteasy.microprofile.client.publisher.MpPublisherMessageBodyReader

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -584,6 +584,9 @@
                                 <goal>test</goal>
                             </goals>
                             <configuration>
+                                <systemPropertyVariables>
+                                    <resteasy.microprofile.sseclient.buffersize>5</resteasy.microprofile.sseclient.buffersize>
+                                </systemPropertyVariables>
                                 <excludes>
                                     <!-- Tests requires excluding JsonBindingProvider-->
                                     <exclude>**/JsonBindingAnnotationsJacksonTest.java</exclude>
@@ -601,6 +604,9 @@
                                 <goal>test</goal>
                             </goals>
                             <configuration>
+                                <systemPropertyVariables>
+                                    <resteasy.microprofile.sseclient.buffersize>5</resteasy.microprofile.sseclient.buffersize>
+                                </systemPropertyVariables>
                                 <includes>
                                     <include>**/JsonBindingAnnotationsJacksonTest.java</include>
                                     <include>**/SseJsonEventTest.java</include>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/MPSseClient.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/MPSseClient.java
@@ -1,0 +1,18 @@
+package org.jboss.resteasy.test.microprofile.restclient;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.reactivestreams.Publisher;
+
+@RegisterRestClient(baseUri = "http://localhost:8080/SsePublisherClientTest")
+public interface MPSseClient {
+
+    @GET
+    @Path("/events")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    Publisher<String> getStrings();
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/SsePublisherClientTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/SsePublisherClientTest.java
@@ -1,0 +1,104 @@
+package org.jboss.resteasy.test.microprofile.restclient;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.resteasy.microprofile.client.BuilderResolver;
+import org.jboss.resteasy.test.microprofile.restclient.resource.MPSseResource;
+import org.jboss.resteasy.test.providers.sse.ExecutorServletContextListener;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class SsePublisherClientTest {
+    @ArquillianResource
+    URL url;
+
+    @Deployment
+    public static Archive<?> deploy()
+    {
+        WebArchive war = TestUtil.prepareArchive(SsePublisherClientTest.class.getSimpleName());
+        return TestUtil.finishContainerPrepare(war, null, MPSseResource.class, ExecutorServletContextListener.class);
+    }
+
+    private String generateURL(String path)
+    {
+       return PortProviderUtil.generateURL(path, SsePublisherClientTest.class.getSimpleName());
+    }
+
+    @Test
+    public void testSseClient() throws Exception
+    {
+       RestClientBuilder builder = RestClientBuilder.newBuilder();
+       RestClientBuilder resteasyBuilder = new BuilderResolver().newBuilder();
+       assertEquals(resteasyBuilder.getClass(), builder.getClass());
+       MPSseClient client = builder.baseUrl(new URL(generateURL(""))).build(MPSseClient.class);
+       Publisher<String> publisher = client.getStrings();
+       CountDownLatch resultsLatch = new CountDownLatch(12);
+       StringSubscriber subscriber = new StringSubscriber(12, resultsLatch);
+       publisher.subscribe(subscriber);
+       assertTrue(resultsLatch.await(30, TimeUnit.SECONDS));
+       assertNull(subscriber.throwable);
+    }
+
+    private static class StringSubscriber implements Subscriber<String>, AutoCloseable {
+
+        final Set<String> eventStrings = new HashSet<>();
+        final CountDownLatch eventLatch;
+        Throwable throwable;
+        Subscription subscription;
+        long requestedEvents;
+
+        StringSubscriber(final long requestedEvents, final CountDownLatch eventLatch) {
+            this.requestedEvents = requestedEvents;
+            this.eventLatch = eventLatch;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            subscription = s;
+            s.request(requestedEvents);
+        }
+
+        @Override
+        public void onNext(String s) {
+            eventStrings.add(s);
+            eventLatch.countDown();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            throwable = t;
+        }
+
+        @Override
+        public void onComplete() {
+        }
+
+        @Override
+        public void close() throws Exception {
+            subscription.cancel();
+        }
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/resource/MPSseResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/resource/MPSseResource.java
@@ -1,0 +1,52 @@
+package org.jboss.resteasy.test.microprofile.restclient.resource;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.sse.Sse;
+import javax.ws.rs.sse.SseEventSink;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.test.providers.sse.ExecutorServletContextListener;
+
+@Path("/")
+public class MPSseResource {
+
+    @Context
+    private Sse sse;
+
+    @Context
+    private ServletContext servletContext;
+    private static final Logger logger = Logger.getLogger(MPSseResource.class);
+
+    @GET
+    @Path("/events")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    public void eventStream(@Context SseEventSink sink) throws IOException {
+        if (sink == null) {
+            throw new IllegalStateException("No client connected.");
+        }
+        ExecutorService service = (ExecutorService) servletContext.getAttribute(ExecutorServletContextListener.TEST_EXECUTOR);
+        service.execute(new Thread() {
+            public void run() {
+
+                try {
+
+                    for (int i = 0; i < 12; i++) {
+                        sink.send(sse.newEvent("msg" + i));
+                        Thread.sleep(10);
+                    }
+                } catch (final InterruptedException e) {
+                    logger.error(e.getMessage(), e);
+                }
+
+            }
+        });
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/resource/MPSseResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/resource/MPSseResource.java
@@ -12,7 +12,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.sse.Sse;
 import javax.ws.rs.sse.SseEventSink;
 
-import org.jboss.logging.Logger;
 import org.jboss.resteasy.test.providers.sse.ExecutorServletContextListener;
 
 @Path("/")
@@ -23,7 +22,6 @@ public class MPSseResource {
 
     @Context
     private ServletContext servletContext;
-    private static final Logger logger = Logger.getLogger(MPSseResource.class);
 
     @GET
     @Path("/events")
@@ -33,19 +31,9 @@ public class MPSseResource {
             throw new IllegalStateException("No client connected.");
         }
         ExecutorService service = (ExecutorService) servletContext.getAttribute(ExecutorServletContextListener.TEST_EXECUTOR);
-        service.execute(new Thread() {
-            public void run() {
-
-                try {
-
-                    for (int i = 0; i < 12; i++) {
-                        sink.send(sse.newEvent("msg" + i));
-                        Thread.sleep(10);
-                    }
-                } catch (final InterruptedException e) {
-                    logger.error(e.getMessage(), e);
-                }
-
+        service.execute(() -> {
+            for (int i = 0; i < 12; i++) {
+                sink.send(sse.newEvent("msg" + i));
             }
         });
     }


### PR DESCRIPTION
This PR is rebased with https://github.com/resteasy/Resteasy/pull/2578 and changes  the following things: 
1. Add executor to SSEPublisher to avoid block the Publisher emit
2. Add system property "resteasy.microprofile.sseclient.buffersize" to configure the Subscription queue size.
3. Add test for https://github.com/resteasy/Resteasy/pull/2578 and configure the Subscription queue size to 5 to check the overflow behavior.