### PR TITLE
Fix bootable jar profile for branch 3.11

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -94,7 +94,7 @@
             <id>default</id>
             <activation>
                 <property>
-                    <name>!forward.compatibility</name>
+                    <name>!ts.bootable</name>
                 </property>
             </activation>
             <modules>


### PR DESCRIPTION
At present, because of the use of property `forward.compatibility` for mutual exclusive profiles `default` and `forward.compatibility` we cannot exclude test modules `integration-tests`, `integration-tests-spring`, `microprofile-tck` from being executed for bootable jar