### PR TITLE
[RESTEASY-2749] (3.11) Remove mail layer tests when executing bootable JAR test profile

### DIFF
--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -264,7 +264,6 @@
                                         <layer>h2-default-datasource</layer>
                                         <layer>undertow-legacy-https</layer>
                                         <layer>ejb</layer>
-                                        <layer>mail</layer>
                                     </layers>
                                 </configuration>
                             </execution>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/EncodingMimeMultipartFormProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/EncodingMimeMultipartFormProviderTest.java
@@ -10,6 +10,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
@@ -32,7 +33,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 @Category({
-    ExpectedFailingWithStandaloneMicroprofileConfiguration.class    //  MP is missing javax.mail
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class, //  MP is missing javax.mail
+    NotForBootableJar.class //  no mail layer so far
 })
 public class EncodingMimeMultipartFormProviderTest {
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/MimeMultipartProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/MimeMultipartProviderTest.java
@@ -5,6 +5,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ProxyBuilder;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartOutput;
@@ -54,7 +55,8 @@ import java.util.Map;
 @RunWith(Arquillian.class)
 @RunAsClient
 @Category({
-    ExpectedFailingWithStandaloneMicroprofileConfiguration.class    //  MP is missing javax.mail
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class, //  MP is missing javax.mail
+    NotForBootableJar.class //  no mail layer so far
 })
 public class MimeMultipartProviderTest {
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RESTEASY-2749

This is to remove mail layer tests when executing bootable JAR test profile because so that it can be tested against EAP XP 2 feature pack, which currently does not provide such layer.