### PR TITLE
[RESTEASY-2748] (3.11) Fixing Bouncycastle test deployment structure

### DIFF
--- a/testsuite/integration-tests/src/test/resources/jboss-deployment-structure-bouncycastle.xml
+++ b/testsuite/integration-tests/src/test/resources/jboss-deployment-structure-bouncycastle.xml
@@ -2,10 +2,7 @@
 <jboss-deployment-structure>
     <deployment>
         <dependencies>
-            <module name="org.bouncycastle.bcmail" services="import"/>
-            <module name="org.bouncycastle.bcpg" services="import"/>
-            <module name="org.bouncycastle.bcpkix" services="import"/>
-            <module name="org.bouncycastle.bcprov" services="import"/>
+            <module name="org.bouncycastle" services="import"/>
         </dependencies>
     </deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RESTEASY-2748

This is to comply with the EAP 7.3.x Bouncycastle module structure and to prevent the test deployment which use such configuration to fail.