### PR TITLE
[RESTEASY-2747] (3.11) Adding documentation about mutually exclusive usage of -Delytron and -Dts.standalone.microprofile properties

### DIFF
--- a/testsuite/README.MD
+++ b/testsuite/README.MD
@@ -97,6 +97,9 @@ the usage of `standalone-microprofile.xml` configuration file:
 
 > mvn clean verify -Dserver.home=PATH_TO_WIDLFLY_HOME -Dts.standalone.microprofile
 
+Please notice that the `-Dts.standalone.microprofile` property usage is not compatible with `-Delytron` property since both will try to set 
+a custom value for the server configuration file property, leading to unexpected results.
+
 ### Bootable jar testing
 Run testsuite or test against Bootable jar, not against Wildfly:
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RESTEASY-2747

The -Delytron and -Dts.standalone.microprofile properties are mutually exclusive because both the related profiles need to set the server configuration file property value to the one of a custom file.
Besides, elytron is the default when dealing with microprofile. Hence there's no need for any configuration to be added, which is what the elytron profile does.
This PR is for updating documentation accordingly.