### PR TITLE
[RESTEASY-2749] (3.14) Remove mail layer tests when executing bootable JAR test profile

### DIFF
--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -264,7 +264,6 @@
                                         <layer>h2-default-datasource</layer>
                                         <layer>undertow-legacy-https</layer>
                                         <layer>ejb</layer>
-                                        <layer>mail</layer>
                                     </layers>
                                 </configuration>
                             </execution>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/EncodingMimeMultipartFormProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/EncodingMimeMultipartFormProviderTest.java
@@ -10,6 +10,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
@@ -32,7 +33,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 @Category({
-    ExpectedFailingWithStandaloneMicroprofileConfiguration.class,    //  MP is missing javax.mail
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class, //  MP is missing javax.mail
+    NotForBootableJar.class //  no mail layer so far
 })
 public class EncodingMimeMultipartFormProviderTest {
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/MimeMultipartProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/MimeMultipartProviderTest.java
@@ -5,6 +5,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ProxyBuilder;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartOutput;
@@ -54,7 +55,8 @@ import java.util.Map;
 @RunWith(Arquillian.class)
 @RunAsClient
 @Category({
-    ExpectedFailingWithStandaloneMicroprofileConfiguration.class,    //  MP is missing javax.mail
+    ExpectedFailingWithStandaloneMicroprofileConfiguration.class, //  MP is missing javax.mail
+    NotForBootableJar.class //  no mail layer so far
 })
 public class MimeMultipartProviderTest {
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RESTEASY-2749 for the 3.14 branch, by cherry-picking https://github.com/resteasy/Resteasy/pull/2585/commits/b958515c29d402a4e38761e2655c1749f8ccbdc5.

This is to remove the mail layer tests when executing the bootable JAR test profile so that it can ready in advance (as requested in https://github.com/resteasy/Resteasy/pull/2585#pullrequestreview-526102363) to be tested against next versions of EAP XP 2 feature pack which would depend on RESTEasy 3.14.x, in case those will not yet provide such layer.

EAP XP 2 base (7.3.x) is currently using RESTEasy 3.11.x so the changes in here have been tested _just_ against WildFly 21 - as it was done when the `ts.bootable` profile was added, see https://github.com/resteasy/Resteasy/pull/2558 and the only failures logged locally are most likely related to changes in https://github.com/resteasy/Resteasy/pull/2586 which should be back ported here as well.