### PR TITLE
[RESTEASY-2769] (3.14) Fixing Bouncycastle provisioning for Bootable JAR test executions

### DIFF
--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -255,6 +255,15 @@
                                             <includedPackages>
                                                 <package>org.jboss.resteasy.resteasy-rxjava2</package>
                                             </includedPackages>
+                                            <!--
+                                                Required for BC - this is needed to resemble what in
+                                                jboss-deployment-structure-bouncycastle.xml.
+                                                That deployment structure is used by some test cases and is expected
+                                                to reflect the server module working configuration.
+                                            -->
+                                            <includedPackages>
+                                                <package>org.bouncycastle</package>
+                                            </includedPackages>
                                         </feature-pack>
                                     </feature-packs>
                                     <layers>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RESTEASY-2769 for the `3.14` branch.

This is to comply with the EAP 7.3.x Bouncycastle module structure and to prevent the test deployment which use such configuration to fail Bootable JAR test executions.