### PR TITLE
[RESTEASY-2771] Decode App Path portion of RequestURL

### DIFF
--- a/resteasy-core/pom.xml
+++ b/resteasy-core/pom.xml
@@ -62,6 +62,19 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.9.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <scope>provided</scope>

--- a/resteasy-core/src/test/java/org/jboss/resteasy/plugins/server/servlet/ServletUtilTest.java
+++ b/resteasy-core/src/test/java/org/jboss/resteasy/plugins/server/servlet/ServletUtilTest.java
@@ -1,0 +1,107 @@
+package org.jboss.resteasy.plugins.server.servlet;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.jboss.resteasy.specimpl.ResteasyUriInfo;
+import org.junit.Test;
+
+public class ServletUtilTest {
+
+   @Test
+   public void extractUriInfo_simple() {
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      when(request.getContextPath()).thenReturn("");
+      when(request.getQueryString()).thenReturn(null);
+      when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8000/app/resource"));
+      ResteasyUriInfo rui = ServletUtil.extractUriInfo(request, null);
+      assertEquals("", rui.getContextPath());
+      assertEquals("/app/resource", rui.getPath());
+   }
+
+   @Test
+   public void extractUriInfo_simpleWithContextRoot() {
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      when(request.getContextPath()).thenReturn("/contextRoot");
+      when(request.getQueryString()).thenReturn(null);
+      when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8000/contextRoot/app/resource"));
+      ResteasyUriInfo rui = ServletUtil.extractUriInfo(request, null);
+      assertEquals("/contextRoot", rui.getContextPath());
+      assertEquals("/app/resource", rui.getPath());
+   }
+
+   @Test
+   public void extractUriInfo_encoded()
+   {
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      when(request.getContextPath()).thenReturn("");
+      when(request.getQueryString()).thenReturn(null);
+      when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8000/app/resource!"));
+      ResteasyUriInfo rui = ServletUtil.extractUriInfo(request, null);
+      assertEquals("", rui.getContextPath());
+      assertEquals("/app/resource!", rui.getPath());
+
+      request = mock(HttpServletRequest.class);
+      when(request.getContextPath()).thenReturn("");
+      when(request.getQueryString()).thenReturn(null);
+      when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8000/app/resource%21"));
+      rui = ServletUtil.extractUriInfo(request, null);
+      assertEquals("", rui.getContextPath());
+      assertEquals("/app/resource!", rui.getPath());
+
+      request = mock(HttpServletRequest.class);
+      when(request.getContextPath()).thenReturn("");
+      when(request.getQueryString()).thenReturn(null);
+      when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8000/app!/resource"));
+      rui = ServletUtil.extractUriInfo(request, null);
+      assertEquals("", rui.getContextPath());
+      assertEquals("/app!/resource", rui.getPath());
+
+      request = mock(HttpServletRequest.class);
+      when(request.getContextPath()).thenReturn("");
+      when(request.getQueryString()).thenReturn(null);
+      when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8000/app%21/resource"));
+      rui = ServletUtil.extractUriInfo(request, null);
+      assertEquals("", rui.getContextPath());
+      assertEquals("/app!/resource", rui.getPath());
+   }
+
+   @Test
+   public void extractUriInfo_encodedWithContextRoot()
+   {
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      when(request.getContextPath()).thenReturn("/contextRoot");
+      when(request.getQueryString()).thenReturn(null);
+      when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8000/contextRoot/app/resource!"));
+      ResteasyUriInfo rui = ServletUtil.extractUriInfo(request, null);
+      assertEquals("/contextRoot", rui.getContextPath());
+      assertEquals("/app/resource!", rui.getPath());
+
+      request = mock(HttpServletRequest.class);
+      when(request.getContextPath()).thenReturn("/contextRoot");
+      when(request.getQueryString()).thenReturn(null);
+      when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8000/contextRoot/app/resource%21"));
+      rui = ServletUtil.extractUriInfo(request, null);
+      assertEquals("/contextRoot", rui.getContextPath());
+      assertEquals("/app/resource!", rui.getPath());
+
+      request = mock(HttpServletRequest.class);
+      when(request.getContextPath()).thenReturn("/contextRoot");
+      when(request.getQueryString()).thenReturn(null);
+      when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8000/contextRoot/app!/resource"));
+      rui = ServletUtil.extractUriInfo(request, null);
+      assertEquals("/contextRoot", rui.getContextPath());
+      assertEquals("/app!/resource", rui.getPath());
+
+      request = mock(HttpServletRequest.class);
+      when(request.getContextPath()).thenReturn("/contextRoot");
+      when(request.getQueryString()).thenReturn(null);
+      when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8000/contextRoot/app%21/resource"));
+      rui = ServletUtil.extractUriInfo(request, null);
+      assertEquals("/contextRoot", rui.getContextPath());
+      assertEquals("/app!/resource", rui.getPath());
+   }
+}


### PR DESCRIPTION
This resolves JIRA [RESTEASY-2771](https://issues.redhat.com/browse/RESTEASY-2771) by decoding the incoming servlet request URL.  Thus requests like `GET /app%21/resource` will match app/resource combinations like:

```
@ApplicationPath("app%21")
public MyApp1 extends Application {}
```

```
@ApplicationPath("app!")
public MyApp2 extends Application {}
```

```
@Path("resource")
public MyResource {

   @GET
   public String get() {
      return "Hello World!";
   }
}
```