### PR TITLE
[RESTEASY-2776] Add support of Optional types in BeanParams

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/InjectorFactoryImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/InjectorFactoryImpl.java
@@ -155,6 +155,11 @@ public class InjectorFactoryImpl implements InjectorFactory
    @Override
    public ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, String defaultName, Class type, Type genericType, Annotation[] annotations, boolean useDefault, ResteasyProviderFactory providerFactory)
    {
+      return OptionalInjections.wrap(genericType, innerType -> createParameterExtractor0(injectTargetClass, injectTarget, defaultName, genericType.equals(innerType) ? type : Types.getRawType(innerType), innerType, annotations, useDefault, providerFactory));
+   }
+
+   private ValueInjector createParameterExtractor0(Class injectTargetClass, AccessibleObject injectTarget, String defaultName, Class type, Type genericType, Annotation[] annotations, boolean useDefault, ResteasyProviderFactory providerFactory)
+   {
       DefaultValue defaultValue = findAnnotation(annotations, DefaultValue.class);
       boolean encode = findAnnotation(annotations, Encoded.class) != null || injectTarget.isAnnotationPresent(Encoded.class) || type.isAnnotationPresent(Encoded.class);
       String defaultVal = null;

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/OptionalInjectionTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/OptionalInjectionTest.java
@@ -31,7 +31,7 @@ public class OptionalInjectionTest {
 
     @Test
     public void testOptionalStringAbsent() throws Exception {
-        MockHttpRequest req = MockHttpRequest.get("/optional/string");
+        MockHttpRequest req = createMockHttpRequest("/optional/string");
         Assert.assertEquals("none", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
@@ -39,28 +39,28 @@ public class OptionalInjectionTest {
 
     @Test
     public void testOptionalStringPresent() throws Exception {
-        MockHttpRequest req = MockHttpRequest.get("/optional/string?value=88");
+        MockHttpRequest req = createMockHttpRequest("/optional/string?valueQ1=88");
         Assert.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
 
     @Test
     public void testOptionalHolderAbsent() throws Exception {
-        MockHttpRequest req = MockHttpRequest.get("/optional/holder");
+        MockHttpRequest req = createMockHttpRequest("/optional/holder");
         Assert.assertEquals("none", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
 
     @Test
     public void testOptionalHolderPresent() throws Exception {
-        MockHttpRequest req = MockHttpRequest.get("/optional/holder?value=88");
+        MockHttpRequest req = createMockHttpRequest("/optional/holder?valueQ2=88");
         Assert.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
 
     @Test
     public void testOptionalLongAbsent() throws Exception {
-        MockHttpRequest req = MockHttpRequest.post("/optional/long");
+        MockHttpRequest req = createMockHttpRequest("/optional/long", false);
         req.addFormHeader("notvalue", "badness");
         req.setInputStream(new ByteArrayInputStream(new byte[0]));
 
@@ -70,7 +70,7 @@ public class OptionalInjectionTest {
 
     @Test
     public void testMatrixParamAbsent() throws Exception {
-        MockHttpRequest httpRequest = MockHttpRequest.post("/optional/matrix");
+        MockHttpRequest httpRequest = createMockHttpRequest("/optional/matrix", false);
         Assert.assertEquals("42", registry
                 .getResourceInvoker(httpRequest)
                 .invoke(httpRequest, resp)
@@ -79,7 +79,7 @@ public class OptionalInjectionTest {
 
     @Test
     public void testMatrixParamPresent() throws Exception {
-        MockHttpRequest httpRequest = MockHttpRequest.post("/optional/matrix;value=24");
+        MockHttpRequest httpRequest = createMockHttpRequest("/optional/matrix;valueM=24", false);
         Assert.assertEquals("24", registry
                 .getResourceInvoker(httpRequest)
                 .invoke(httpRequest, resp)
@@ -93,7 +93,7 @@ public class OptionalInjectionTest {
 
     @Test(expected = NotFoundException.class)
     public void testPathParamNeverAbsentThrowsException() throws Exception {
-        MockHttpRequest httpRequest = MockHttpRequest.get("/optional/path/");
+        MockHttpRequest httpRequest = createMockHttpRequest("/optional/path/");
         registry.getResourceInvoker(httpRequest)
                 .invoke(httpRequest, resp)
                 .getEntity();
@@ -101,7 +101,7 @@ public class OptionalInjectionTest {
 
     @Test
     public void testHeaderParamAbsent() throws Exception {
-        MockHttpRequest httpRequest = MockHttpRequest.get("/optional/header");
+        MockHttpRequest httpRequest = createMockHttpRequest("/optional/header");
         Assert.assertEquals("42", registry
                 .getResourceInvoker(httpRequest)
                 .invoke(httpRequest, resp)
@@ -111,8 +111,8 @@ public class OptionalInjectionTest {
 
     @Test
     public void testHeaderParamPresent() throws Exception {
-        MockHttpRequest httpRequest = MockHttpRequest.get("/optional/header");
-        httpRequest.header("value", "24");
+        MockHttpRequest httpRequest = createMockHttpRequest("/optional/header");
+        httpRequest.header("valueH", "24");
         Assert.assertEquals("24", registry
                 .getResourceInvoker(httpRequest)
                 .invoke(httpRequest, resp)
@@ -121,7 +121,7 @@ public class OptionalInjectionTest {
 
     @Test
     public void testCookieParamAbsent() throws Exception {
-        MockHttpRequest httpRequest = MockHttpRequest.get("/optional/cookie");
+        MockHttpRequest httpRequest = createMockHttpRequest("/optional/cookie");
         Assert.assertEquals("42", registry
                 .getResourceInvoker(httpRequest)
                 .invoke(httpRequest, resp)
@@ -130,8 +130,8 @@ public class OptionalInjectionTest {
 
     @Test
     public void testCookieParamPresent() throws Exception {
-        MockHttpRequest httpRequest = MockHttpRequest.get("/optional/cookie");
-        httpRequest.cookie("value", "24");
+        MockHttpRequest httpRequest = createMockHttpRequest("/optional/cookie");
+        httpRequest.cookie("valueC", "24");
         Assert.assertEquals("24", registry
                 .getResourceInvoker(httpRequest)
                 .invoke(httpRequest, resp)
@@ -141,8 +141,8 @@ public class OptionalInjectionTest {
 
     @Test
     public void testOptionalLongPresent() throws Exception {
-        MockHttpRequest req = MockHttpRequest.post("/optional/long");
-        req.addFormHeader("value", "88");
+        MockHttpRequest req = createMockHttpRequest("/optional/long", false);
+        req.addFormHeader("valueF", "88");
 
         Assert.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
@@ -150,7 +150,7 @@ public class OptionalInjectionTest {
 
     @Test
     public void testOptionalIntAbsent() throws Exception {
-        MockHttpRequest req = MockHttpRequest.get("/optional/int");
+        MockHttpRequest req = createMockHttpRequest("/optional/int");
 
         Assert.assertEquals("424242", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
@@ -158,7 +158,7 @@ public class OptionalInjectionTest {
 
     @Test
     public void testOptionalIntPresent() throws Exception {
-        MockHttpRequest req = MockHttpRequest.get("/optional/int?value=88");
+        MockHttpRequest req = createMockHttpRequest("/optional/int?valueQ4=88");
 
         Assert.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
@@ -166,7 +166,7 @@ public class OptionalInjectionTest {
 
     @Test
     public void testOptionalDoubleAbsent() throws Exception {
-        MockHttpRequest req = MockHttpRequest.get("/optional/double");
+        MockHttpRequest req = createMockHttpRequest("/optional/double");
 
         Assert.assertEquals("4242.0", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
@@ -174,9 +174,37 @@ public class OptionalInjectionTest {
 
     @Test
     public void testOptionalDoublePresent() throws Exception {
-        MockHttpRequest req = MockHttpRequest.get("/optional/double?value=88.88");
+        MockHttpRequest req = createMockHttpRequest("/optional/double?valueQ3=88.88");
 
         Assert.assertEquals("88.88", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
+    }
+
+    /**
+     * Builds an instance of {@code MockHttpRequest} for {@code GET} calls, properly configured to make
+     * sure that all the {@code FormParam} are properly injected in all test cases otherwise we
+     * end up with a {@code NullPointerException}.
+     * @param uri the uri of the endpoint to test.
+     * @return an instance of {@code MockHttpRequest} properly configured.
+     * @throws Exception in case the provided uri is not properly formed.
+     */
+    private static MockHttpRequest createMockHttpRequest(String uri) throws Exception {
+        return createMockHttpRequest(uri, true);
+    }
+
+    /**
+     * Builds an instance of {@code MockHttpRequest} properly configured to make sure that all
+     * the {@code FormParam} are properly injected in all test cases otherwise we end up with
+     * a {@code NullPointerException}.
+     * @param uri the uri of the endpoint to test.
+     * @param isGet the flag indicating whether a GET call is expected otherwise a POST call will be
+     *              performed.
+     * @return an instance of {@code MockHttpRequest} properly configured.
+     * @throws Exception in case the provided uri is not properly formed.
+     */
+    private static MockHttpRequest createMockHttpRequest(String uri, boolean isGet) throws Exception {
+        MockHttpRequest req = isGet ? MockHttpRequest.get(uri) : MockHttpRequest.post(uri);
+        req.addFormHeader("foo", "bar");
+        return req;
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/OptionalResource.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/OptionalResource.java
@@ -1,14 +1,15 @@
 package org.jboss.resteasy.test.resource.resource;
 
-import org.jboss.resteasy.annotations.jaxrs.MatrixParam;
-
+import javax.ws.rs.BeanParam;
 import javax.ws.rs.CookieParam;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
+import javax.ws.rs.MatrixParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
@@ -17,33 +18,67 @@ import java.util.OptionalLong;
 
 @Path("/optional")
 public class OptionalResource {
+
+    @QueryParam("valueQ1")
+    Optional<String> queryParam1;
+    @QueryParam("valueQ2")
+    Optional<Holder<String>> queryParam2;
+    @FormParam("valueF")
+    OptionalLong formParam;
+    @QueryParam("valueQ3")
+    OptionalDouble queryParam3;
+    @QueryParam("valueQ4")
+    OptionalInt queryParam4;
+    @MatrixParam("valueM")
+    OptionalLong matrixParam;
+    @HeaderParam("valueH")
+    OptionalLong headerParam;
+    @CookieParam("valueC")
+    OptionalLong cookieParam;
+
+
     @Path("/string")
     @GET
-    public String string(@QueryParam("value") Optional<String> value) {
+    public String string(@QueryParam("valueQ1") Optional<String> value, @BeanParam Bean bean) {
+        if (!value.equals(queryParam1) || !value.equals(bean.queryParam1)) {
+            throw new IllegalStateException("Values are not equal");
+        }
         return value.orElse("none");
     }
 
     @Path("/holder")
     @GET
-    public String holder(@QueryParam("value") Optional<Holder<String>> value) {
+    public String holder(@QueryParam("valueQ2") Optional<Holder<String>> value, @BeanParam Bean bean) {
+        if (!value.equals(queryParam2) || !value.equals(bean.queryParam2)) {
+            throw new IllegalStateException("Values are not equal");
+        }
         return value.map(Holder::get).orElse("none");
     }
 
     @Path("/long")
     @POST
-    public String optLong(@FormParam("value") OptionalLong value) {
+    public String optLong(@FormParam("valueF") OptionalLong value, @BeanParam Bean bean) {
+        if (!value.equals(formParam) || !value.equals(bean.formParam)) {
+            throw new IllegalStateException("Values are not equal");
+        }
         return Long.toString(value.orElse(42));
     }
 
     @Path("/double")
     @GET
-    public String optDouble(@QueryParam("value") OptionalDouble value) {
+    public String optDouble(@QueryParam("valueQ3") OptionalDouble value, @BeanParam Bean bean) {
+        if (!value.equals(queryParam3) || !value.equals(bean.queryParam3)) {
+            throw new IllegalStateException("Values are not equal");
+        }
         return Double.toString(value.orElse(4242.0));
     }
 
     @Path("/int")
     @GET
-    public String optInt(@QueryParam("value") OptionalInt value) {
+    public String optInt(@QueryParam("valueQ4") OptionalInt value, @BeanParam Bean bean) {
+        if (!value.equals(queryParam4) || !value.equals(bean.queryParam4)) {
+            throw new IllegalStateException("Values are not equal");
+        }
         return Integer.toString(value.orElse(424242));
     }
 
@@ -60,19 +95,64 @@ public class OptionalResource {
         public static Holder<String> valueOf(String value) {
             return new Holder<>(value);
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Holder<?> holder = (Holder<?>) o;
+            return Objects.equals(value, holder.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
     }
 
     @Path("/matrix")
     @POST
-    public String matrix(@MatrixParam("value") OptionalLong value) {
+    public String matrix(@MatrixParam("valueM") OptionalLong value, @BeanParam Bean bean) {
+        if (!value.equals(matrixParam) || !value.equals(bean.matrixParam)) {
+            throw new IllegalStateException("Values are not equal");
+        }
         return Long.toString(value.orElse(42));
     }
 
     @Path("/header")
     @GET
-    public String header(@HeaderParam("value") OptionalLong value) { return Long.toString(value.orElse(42)); }
+    public String header(@HeaderParam("valueH") OptionalLong value, @BeanParam Bean bean) {
+        if (!value.equals(headerParam) || !value.equals(bean.headerParam)) {
+            throw new IllegalStateException("Values are not equal");
+        }
+        return Long.toString(value.orElse(42));
+    }
 
     @Path("/cookie")
     @GET
-    public String cookie(@CookieParam("value") OptionalLong value) { return Long.toString(value.orElse(42)); }
+    public String cookie(@CookieParam("valueC") OptionalLong value, @BeanParam Bean bean) {
+        if (!value.equals(cookieParam) || !value.equals(bean.cookieParam)) {
+            throw new IllegalStateException("Values are not equal");
+        }
+        return Long.toString(value.orElse(42));
+    }
+
+    public static class Bean {
+        @QueryParam("valueQ1")
+        Optional<String> queryParam1;
+        @QueryParam("valueQ2")
+        Optional<Holder<String>> queryParam2;
+        @FormParam("valueF")
+        OptionalLong formParam;
+        @QueryParam("valueQ3")
+        OptionalDouble queryParam3;
+        @QueryParam("valueQ4")
+        OptionalInt queryParam4;
+        @MatrixParam("valueM")
+        OptionalLong matrixParam;
+        @HeaderParam("valueH")
+        OptionalLong headerParam;
+        @CookieParam("valueC")
+        OptionalLong cookieParam;
+    }
 }


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/RESTEASY-2776

## Motivation

Up to now, we have no way to use Optional types in a BeanParam, if we do so we get an error `RESTEASY003875`.

## Modifications

* Adds the missing wrap call to the remaining methods `createParameterExtractor` to ensure that Optional types are supported in all cases
* Changes the `OptionalResource` to cover cases where params are directly injected into the resource but also into a BeanParam