### PR TITLE
3.14.fix

### DIFF
--- a/testsuite/integration-tests-spring/deployment/pom.xml
+++ b/testsuite/integration-tests-spring/deployment/pom.xml
@@ -166,7 +166,7 @@
                     which are in standalone-full.xml but not in 
                     standalone-microprofile.xml
                 -->
-                <microprofile.excluded.groups>org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration</microprofile.excluded.groups>
+                <microprofile.excluded.groups>,org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration</microprofile.excluded.groups>
             </properties>
         </profile>
     </profiles>

--- a/testsuite/integration-tests-spring/inmodule/pom.xml
+++ b/testsuite/integration-tests-spring/inmodule/pom.xml
@@ -172,7 +172,7 @@
                     which are in standalone-full.xml but not in 
                     standalone-microprofile.xml
                 -->
-                <microprofile.excluded.groups>org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration</microprofile.excluded.groups>
+                <microprofile.excluded.groups>,org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration</microprofile.excluded.groups>
             </properties>
         </profile>
     </profiles>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -200,7 +200,7 @@
                     which are in standalone-full.xml but not in 
                     standalone-microprofile.xml
                 -->
-                <microprofile.excluded.groups>org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration,org.jboss.resteasy.category.ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11</microprofile.excluded.groups>
+                <microprofile.excluded.groups>,org.jboss.resteasy.category.ExpectedFailingWithStandaloneMicroprofileConfiguration,org.jboss.resteasy.category.ExpectedFailingBecauseOfSmallRyeMicroprofileOpenApi11</microprofile.excluded.groups>
             </properties>
         </profile>
         

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -47,7 +47,7 @@
                         <jboss.server.config.file.name>${jboss.server.config.file.name}</jboss.server.config.file.name>
                         <security.provider>${security.provider}</security.provider>
                     </systemPropertyVariables>
-                    <excludedGroups>org.jboss.resteasy.category.ExpectedFailing,${additional.surefire.excluded.groups},${microprofile.excluded.groups}</excludedGroups>
+                    <excludedGroups>org.jboss.resteasy.category.ExpectedFailing${additional.surefire.excluded.groups}${microprofile.excluded.groups}</excludedGroups>
                 </configuration>
             </plugin>
             <plugin>
@@ -83,7 +83,7 @@
                 </property>
             </activation>
             <properties>
-                <additional.surefire.excluded.groups>org.jboss.resteasy.category.NotForBootableJar</additional.surefire.excluded.groups>
+                <additional.surefire.excluded.groups>,org.jboss.resteasy.category.NotForBootableJar</additional.surefire.excluded.groups>
                 <testsuite.wildfly.galleon.pack.group.id>org.wildfly</testsuite.wildfly.galleon.pack.group.id>
             </properties>
             <modules>
@@ -125,7 +125,7 @@
                 </property>
             </activation>
             <properties>
-                <microprofile.excluded.groups>org.jboss.resteasy.category.MicroProfileDependent</microprofile.excluded.groups>
+                <microprofile.excluded.groups>,org.jboss.resteasy.category.MicroProfileDependent</microprofile.excluded.groups>
             </properties>
         </profile>
         <profile>
@@ -159,7 +159,7 @@
                 </property>
             </activation>
             <properties>
-                <additional.surefire.excluded.groups>org.jboss.resteasy.category.ExpectedFailingOnWildFly20</additional.surefire.excluded.groups>
+                <additional.surefire.excluded.groups>,org.jboss.resteasy.category.ExpectedFailingOnWildFly20</additional.surefire.excluded.groups>
             </properties>
         </profile>
         <profile>
@@ -171,7 +171,7 @@
                 </property>
             </activation>
             <properties>
-                <additional.surefire.excluded.groups>org.jboss.resteasy.category.ExpectedFailingOnWildFly19</additional.surefire.excluded.groups>
+                <additional.surefire.excluded.groups>,org.jboss.resteasy.category.ExpectedFailingOnWildFly19</additional.surefire.excluded.groups>
             </properties>
         </profile>
         <profile>
@@ -183,7 +183,7 @@
                 </property>
             </activation>
             <properties>
-                <additional.surefire.excluded.groups>org.jboss.resteasy.category.ExpectedFailingOnWildFly18</additional.surefire.excluded.groups>
+                <additional.surefire.excluded.groups>,org.jboss.resteasy.category.ExpectedFailingOnWildFly18</additional.surefire.excluded.groups>
             </properties>
         </profile>
         <!-- If resteasy.version is specified, it will be used for tests instead of the project.version -->


### PR DESCRIPTION
Having e.g. `<excludedGroups>someclass1,,someclass3</excludedGroups>` causes `someclass3` to be ignored