### PR TITLE
[RESTEASY-2776] Add some documentation about Optional types in BeanParams

### DIFF
--- a/docbook/reference/en/en-US/modules/_OptionalParam.xml
+++ b/docbook/reference/en/en-US/modules/_OptionalParam.xml
@@ -38,4 +38,34 @@ public String optDouble(@QueryParam("value") OptionalDouble value) {
     <para>
         As the list shown above, those parameter types support the Java-provided <code>Optional</code> types. Please note that the <code>@PathParam</code> is an exception for which <code>Optional</code> is not available. The reason is that <code>Optional</code> for the <code>@PathParam</code> use case would just be a NO-OP, since an element of the path cannot be omitted.
     </para>
+
+    <para>
+      The <code>Optional</code> types can also be used as type of the fields of a <code>@BeanParam</code>'s class.
+    </para>
+
+    <para>Here is an example of endpoint with a <code>@BeanParam</code>:</para>
+
+    <programlisting><![CDATA[@Path("/double")
+@GET
+public String optDouble(@BeanParam Bean bean) {
+    return Double.toString(bean.value.orElse(4242.0));
+}]]></programlisting>
+
+  <para>The corresponding class <code>Bean</code>:</para>
+
+  <programlisting><![CDATA[public class Bean {
+    @QueryParam("value")
+    OptionalDouble value;
+}]]></programlisting>
+
+  <para> Finally, the <code>Optional</code> types can be used directly as type of the fields of a JAX-RS resource class.</para>
+
+  <para>Here is an example of a JAX-RS resource class with an <code>Optional</code> type:</para>
+
+  <programlisting><![CDATA[@RequestScoped
+public class OptionalResource {
+    @QueryParam("value")
+    Optional<String> value;
+    ...
+}]]></programlisting>
 </chapter>


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/RESTEASY-2776 (doc part)

## Motivation

Some documentation was needed to describe the new feature https://issues.redhat.com/browse/RESTEASY-2776

## Modifications:

* Adds a new section in the documentation about `OptionalParam`