### PR TITLE
[RESTEASY-629] Round down the datetime in seconds in evaluatePreconditions

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/RequestImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/specimpl/RequestImpl.java
@@ -162,9 +162,11 @@ public class RequestImpl implements Request
 
    public Response.ResponseBuilder ifModifiedSince(String strDate, Date lastModified)
    {
-      Date date = DateUtil.parseDate(strDate);
-
-      if (date.getTime() >= lastModified.getTime())
+      // The supported date formats have precision in seconds
+      // so the resulting date has precision in seconds
+      final Date date = DateUtil.parseDate(strDate);
+      // Compare timestamps with precision in seconds
+      if (date.getTime() >= getTimeWithPrecisionInSeconds(lastModified))
       {
          return Response.notModified();
       }
@@ -174,9 +176,11 @@ public class RequestImpl implements Request
 
    public Response.ResponseBuilder ifUnmodifiedSince(String strDate, Date lastModified)
    {
-      Date date = DateUtil.parseDate(strDate);
-
-      if (date.getTime() >= lastModified.getTime())
+      // The supported date formats have precision in seconds
+      // so the resulting date has precision in seconds
+      final Date date = DateUtil.parseDate(strDate);
+      // Compare timestamps with precision in seconds
+      if (date.getTime() >= getTimeWithPrecisionInSeconds(lastModified))
       {
          return null;
       }
@@ -237,5 +241,14 @@ public class RequestImpl implements Request
       return Response.status(SC_PRECONDITION_FAILED);
    }
 
+   /**
+    * @param date the date for which we want the timestamp rounded down.
+    * @return the number of milliseconds rounded down to the lowest thousand since
+    * January 1, 1970, 00:00:00 GMT represented by this date.
+    */
+   private static long getTimeWithPrecisionInSeconds(Date date)
+   {
+      return date.getTime() / 1_000L * 1_000L;
+   }
 
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/request/PreconditionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/request/PreconditionTest.java
@@ -91,6 +91,48 @@ public class PreconditionTest {
    }
 
    /**
+    * @tpTestDetails Sets header IF_UNMODIFIED_SINCE date is the second just before last modified
+    * @tpSince RESTEasy 4.6.0
+    */
+   @Test
+   public void testIfUnmodifiedSinceJustBeforeLastModified() {
+      WebTarget base = client.target(generateURL("/millis"));
+      try (Response response = base.request()
+          .header(HttpHeaderNames.IF_UNMODIFIED_SINCE, "Fri, 11 Dec 2020 22:47:14 GMT")
+          .get()) {
+         Assert.assertEquals(HttpResponseCodes.SC_PRECONDITION_FAILED, response.getStatus());
+      }
+   }
+
+   /**
+    * @tpTestDetails Sets header IF_UNMODIFIED_SINCE date is the second just after last modified
+    * @tpSince RESTEasy 4.6.0
+    */
+   @Test
+   public void testIfUnmodifiedSinceJustAfterLastModified() {
+      WebTarget base = client.target(generateURL("/millis"));
+      try (Response response = base.request()
+          .header(HttpHeaderNames.IF_UNMODIFIED_SINCE, "Fri, 11 Dec 2020 22:47:16 GMT")
+          .get()) {
+         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+      }
+   }
+
+   /**
+    * @tpTestDetails Sets header IF_UNMODIFIED_SINCE date is the same second as last modified
+    * @tpSince RESTEasy 4.6.0
+    */
+   @Test
+   public void testIfUnmodifiedSinceSameSecondAsLastModified() {
+      WebTarget base = client.target(generateURL("/millis"));
+      try (Response response = base.request()
+          .header(HttpHeaderNames.IF_UNMODIFIED_SINCE, "Fri, 11 Dec 2020 22:47:15 GMT")
+          .get()) {
+         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+      }
+   }
+
+   /**
     * @tpTestDetails Sets header IF_MODIFIED_SINCE date before last modified
     * @tpSince RESTEasy 3.0.16
     */
@@ -119,6 +161,48 @@ public class PreconditionTest {
          response.close();
       } catch (Exception e) {
          throw new RuntimeException(e);
+      }
+   }
+
+   /**
+    * @tpTestDetails Sets header IF_MODIFIED_SINCE date is the second just before last modified
+    * @tpSince RESTEasy 4.6.0
+    */
+   @Test
+   public void testIfModifiedSinceJustBeforeLastModified() {
+      WebTarget base = client.target(generateURL("/millis"));
+      try (Response response = base.request()
+          .header(HttpHeaderNames.IF_MODIFIED_SINCE, "Fri, 11 Dec 2020 22:47:14 GMT")
+          .get()) {
+         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+      }
+   }
+
+   /**
+    * @tpTestDetails Sets header IF_MODIFIED_SINCE date is the second just after last modified
+    * @tpSince RESTEasy 4.6.0
+    */
+   @Test
+   public void testIfModifiedSinceJustAfterLastModified() {
+      WebTarget base = client.target(generateURL("/millis"));
+      try (Response response = base.request()
+          .header(HttpHeaderNames.IF_MODIFIED_SINCE, "Fri, 11 Dec 2020 22:47:16 GMT")
+          .get()) {
+         Assert.assertEquals(HttpResponseCodes.SC_NOT_MODIFIED, response.getStatus());
+      }
+   }
+
+   /**
+    * @tpTestDetails Sets header IF_MODIFIED_SINCE date is the same second as last modified
+    * @tpSince RESTEasy 4.6.0
+    */
+   @Test
+   public void testIfModifiedSinceSameSecondAsLastModified() {
+      WebTarget base = client.target(generateURL("/millis"));
+      try (Response response = base.request()
+          .header(HttpHeaderNames.IF_MODIFIED_SINCE, "Fri, 11 Dec 2020 22:47:15 GMT")
+          .get()) {
+         Assert.assertEquals(HttpResponseCodes.SC_NOT_MODIFIED, response.getStatus());
       }
    }
 
@@ -498,7 +582,7 @@ public class PreconditionTest {
    }
 
    /**
-    * @tpTestDetails Response if IF_MATH is missing
+    * @tpTestDetails Response if IF_MATCH is missing
     * @tpSince RESTEasy 3.0.17
     */
    @Test
@@ -512,7 +596,7 @@ public class PreconditionTest {
    }
 
    /**
-    * @tpTestDetails Response if IF_MATH is missing and IF_NONE_MATCH don't match
+    * @tpTestDetails Response if IF_MATCH is missing and IF_NONE_MATCH don't match
     * @tpSince RESTEasy 3.0.17
     */
    @Test

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/request/resource/PreconditionLastModifiedResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/request/resource/PreconditionLastModifiedResource.java
@@ -5,7 +5,9 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
+import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 @Path("/")
 public class PreconditionLastModifiedResource {
@@ -19,5 +21,24 @@ public class PreconditionLastModifiedResource {
       }
 
       return Response.ok("foo", "text/plain").build();
+   }
+
+   @Path("millis")
+   @GET
+   public Response doGetWithMillis(@Context Request request) {
+      final Calendar lastModified = new Calendar.Builder()
+          .setDate(2020, Calendar.DECEMBER, 11)
+          .setTimeOfDay(22, 47, 15, 999)
+          .setTimeZone(TimeZone.getTimeZone("GMT"))
+          .build();
+      final Response.ResponseBuilder responseBuilder = request.evaluatePreconditions(lastModified.getTime());
+      if (responseBuilder == null) {
+         // Last modified date didn't match, send new content
+         return Response.ok("new content", "text/plain")
+             .lastModified(lastModified.getTime())
+             .build();
+      }
+      // Sending 304 not modified
+      return responseBuilder.build();
    }
 }


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/RESTEASY-629

## Motivation

The method `evaluatePreconditions(Date)` is not useable as it is now when the input date has milliseconds because it will be compared with a date without milliseconds so it will always return `null` indicating that the content has changed which is incorrect.

## Modifications:

* Trims the milliseconds from the input date before comparing the dates in order to compare dates with the same precision
* Adds the corresponding integration tests