### PR TITLE
[RESTEASY-2797] Add support PATCH MockHttpRequest

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/mock/MockHttpRequest.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/mock/MockHttpRequest.java
@@ -122,6 +122,13 @@ public class MockHttpRequest extends BaseHttpRequest
       request.httpMethod = "PUT";
       return request;
    }
+   
+   public static MockHttpRequest patch(String uri) throws URISyntaxException
+   {
+      MockHttpRequest request = initWithUri(uri);
+      request.httpMethod = "PATCH";
+      return request;
+   }
 
    public static MockHttpRequest delete(String uri) throws URISyntaxException
    {

--- a/resteasy-core/src/main/java/org/jboss/resteasy/mock/MockHttpRequest.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/mock/MockHttpRequest.java
@@ -122,7 +122,6 @@ public class MockHttpRequest extends BaseHttpRequest
       request.httpMethod = "PUT";
       return request;
    }
-   
    public static MockHttpRequest patch(String uri) throws URISyntaxException
    {
       MockHttpRequest request = initWithUri(uri);


### PR DESCRIPTION
In MockHttpRequest the PATCH verb is not supported immediately.
Though PATCH can be used with a workaround, it would be much clear if it explicitlty supported by it's own function.