### PR TITLE
[RESTEASY-2798] Save accesses to volatile member

### DIFF
--- a/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/PatchMethodFilter.java
+++ b/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/PatchMethodFilter.java
@@ -201,18 +201,21 @@ public class PatchMethodFilter implements ContainerRequestFilter
 
    private ObjectMapper getObjectMapper()
    {
-      if (objectMapper == null)
+      ObjectMapper currentObjectMapper = objectMapper;
+      if (currentObjectMapper == null)
       {
          synchronized (this)
          {
-            if (objectMapper == null)
+            currentObjectMapper = objectMapper;
+            if (currentObjectMapper == null)
             {
                ObjectMapper contextMapper = getContextObjectMapper();
-               objectMapper = (contextMapper == null) ? new ObjectMapper() : contextMapper;
+               currentObjectMapper = (contextMapper == null) ? new ObjectMapper() : contextMapper;
+               this.objectMapper = currentObjectMapper;
             }
          }
       }
-      return objectMapper;
+      return currentObjectMapper;
    }
 
    private ObjectMapper getContextObjectMapper()

--- a/providers/json-binding/src/main/java/org/jboss/resteasy/plugins/providers/jsonb/AbstractJsonBindingProvider.java
+++ b/providers/json-binding/src/main/java/org/jboss/resteasy/plugins/providers/jsonb/AbstractJsonBindingProvider.java
@@ -21,27 +21,31 @@ public class AbstractJsonBindingProvider extends JsonBindingProvider {
 
    @Context
    javax.ws.rs.ext.Providers providers;
-   private volatile Jsonb jsonbObj = null;
+   private volatile Jsonb jsonbObj;
 
    protected Jsonb getJsonb(Class<?> type) {
       ContextResolver<Jsonb> contextResolver = providers.getContextResolver(Jsonb.class, MediaType.APPLICATION_JSON_TYPE);
       if (contextResolver != null)
       {
          return contextResolver.getContext(type);
-      } else
+      }
+      else
       {
-         if (jsonbObj == null)
+         Jsonb currentJsonbObj = jsonbObj;
+         if (currentJsonbObj == null)
          {
             synchronized (this)
             {
-               if (jsonbObj == null) {
+               currentJsonbObj = jsonbObj;
+               if (currentJsonbObj == null) {
                   JsonProviderImpl jProviderImpl = new JsonProviderImpl();
                   JsonBindingBuilder jbBuilder = new JsonBindingBuilder();
-                  jsonbObj = jbBuilder.withProvider(jProviderImpl).build();
+                  currentJsonbObj = jbBuilder.withProvider(jProviderImpl).build();
+                  this.jsonbObj = currentJsonbObj;
                }
             }
          }
-         return jsonbObj;
+         return currentJsonbObj;
       }
    }
 

--- a/providers/resteasy-validator-provider/src/main/java/org/jboss/resteasy/plugins/validation/AbstractValidatorContextResolver.java
+++ b/providers/resteasy-validator-provider/src/main/java/org/jboss/resteasy/plugins/validation/AbstractValidatorContextResolver.java
@@ -60,7 +60,7 @@ public class AbstractValidatorContextResolver
             }
          }
       }
-      return validatorFactory;
+      return tmpValidatorFactory;
    }
 
    BootstrapConfiguration getConfig()

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpAsyncClient4Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ApacheHttpAsyncClient4Engine.java
@@ -261,7 +261,7 @@ public class ApacheHttpAsyncClient4Engine implements AsyncClientHttpEngine, Clos
       private ResultFuture<T> future;
       private SharedInputStream sharedStream;
 
-      private volatile boolean hasResult;
+      private boolean hasResult;
       private volatile T result;
       private volatile Exception exception;
       private volatile boolean completed;

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientImpl.java
@@ -26,9 +26,9 @@ import java.util.concurrent.ScheduledExecutorService;
  */
 public class ResteasyClientImpl implements ResteasyClient
 {
-   protected volatile ClientHttpEngine httpEngine;
-   protected volatile ExecutorService asyncInvocationExecutor;
-   protected volatile ScheduledExecutorService scheduledExecutorService;
+   protected final ClientHttpEngine httpEngine;
+   protected final ExecutorService asyncInvocationExecutor;
+   protected final ScheduledExecutorService scheduledExecutorService;
    protected ClientConfiguration configuration;
    protected boolean closed;
    protected boolean cleanupExecutor;
@@ -46,10 +46,7 @@ public class ResteasyClientImpl implements ResteasyClient
 
    protected ResteasyClientImpl(final ClientHttpEngine httpEngine, final ExecutorService asyncInvocationExecutor, final boolean cleanupExecutor, final ClientConfiguration configuration)
    {
-      this.cleanupExecutor = cleanupExecutor;
-      this.httpEngine = httpEngine;
-      this.asyncInvocationExecutor = asyncInvocationExecutor;
-      this.configuration = configuration;
+      this(httpEngine, asyncInvocationExecutor, cleanupExecutor, null, configuration);
    }
 
    public ClientHttpEngine httpEngine()

--- a/resteasy-client/src/main/java/org/jboss/resteasy/plugins/providers/sse/client/SseEventSourceImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/plugins/providers/sse/client/SseEventSourceImpl.java
@@ -258,11 +258,12 @@ public class SseEventSourceImpl implements SseEventSource
       {
          return;
       }
-      if (response != null)
+      final ClientResponse clientResponse = response;
+      if (clientResponse != null)
       {
          try
          {
-            response.releaseConnection(false);
+            clientResponse.releaseConnection(false);
          }
          catch (IOException e)
          {
@@ -329,11 +330,12 @@ public class SseEventSourceImpl implements SseEventSource
             {
                request = requestBuilder.build(verb, entity);
             }
-            response = (ClientResponse) request.invoke();
-            if (Family.SUCCESSFUL.equals(response.getStatusInfo().getFamily()))
+            final ClientResponse clientResponse = (ClientResponse) request.invoke();
+            response = clientResponse;
+            if (Family.SUCCESSFUL.equals(clientResponse.getStatusInfo().getFamily()))
             {
                onConnection();
-               eventInput = response.readEntity(SseEventInputImpl.class);
+               eventInput = clientResponse.readEntity(SseEventInputImpl.class);
                //if 200<= response code <300 and response contentType is null, fail the connection.
                if (eventInput == null && !alwaysReconnect)
                {
@@ -345,9 +347,9 @@ public class SseEventSourceImpl implements SseEventSource
             {
                //Let's buffer the entity in case the response contains an entity the user would like to retrieve from the exception.
                //This will also ensure that the connection is correctly closed.
-               response.bufferEntity();
+               clientResponse.bufferEntity();
                //Throw an instance of WebApplicationException depending on the response.
-               ClientInvocation.handleErrorStatus(response);
+               ClientInvocation.handleErrorStatus(clientResponse);
             }
          }
          catch (ServiceUnavailableException ex)

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -124,11 +124,11 @@ public abstract class ResteasyProviderFactory extends RuntimeDelegate implements
                   instance = result = newInstance(); //TODO use reflection directly, to avoid circular dependency
                }
                if (registerBuiltinByDefault)
-                  instance.registerBuiltin();
+                  result.registerBuiltin();
             }
          }
       }
-      return instance;
+      return result;
    }
 
    public static ResteasyProviderFactory newInstance()

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/AsyncResponseConsumer.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/AsyncResponseConsumer.java
@@ -334,8 +334,8 @@ public abstract class AsyncResponseConsumer
    private static class AsyncRawStreamingResponseConsumer extends AsyncStreamResponseConsumer
    {
       private boolean sentEntity;
-      private volatile boolean onCompleteReceived = false;
-      private volatile boolean sendingEvent = false;
+      private boolean onCompleteReceived;
+      private volatile boolean sendingEvent;
 
       AsyncRawStreamingResponseConsumer(final ResourceMethodInvoker method, final AsyncStreamProvider<?> asyncStreamProvider)
       {
@@ -485,8 +485,8 @@ public abstract class AsyncResponseConsumer
    {
       private SseImpl sse;
       private SseEventSink sseEventSink;
-      private volatile boolean onCompleteReceived = false;
-      private volatile boolean sendingEvent = false;
+      private boolean onCompleteReceived;
+      private volatile boolean sendingEvent;
 
       private AsyncGeneralStreamingSseResponseConsumer(final ResourceMethodInvoker method, final AsyncStreamProvider<?> asyncStreamProvider)
       {

--- a/resteasy-core/src/main/java/org/jboss/resteasy/microprofile/config/FilterConfigSourceImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/microprofile/config/FilterConfigSourceImpl.java
@@ -54,19 +54,22 @@ public class FilterConfigSourceImpl implements ResteasyConfigSource {
 
    @Override
    public String getName() {
-      if (name == null) {
+      String currentName = name;
+      if (currentName == null) {
          synchronized(this) {
-            if (name == null) {
+            currentName = name;
+            if (currentName == null) {
                ServletContext servletContext = ResteasyContext.getContextData(ServletContext.class);
                FilterConfig filterConfig = ResteasyContext.getContextData(FilterConfig.class);
                StringBuilder sb = new StringBuilder();
-               name = sb.append(servletContext != null ? servletContext.getServletContextName() : null).append(":")
+               currentName = sb.append(servletContext != null ? servletContext.getServletContextName() : null).append(":")
                      .append(filterConfig != null ? filterConfig.getFilterName() : null)
                      .append(":FilterConfigSource").toString();
+               this.name = currentName;
             }
          }
       }
-      return name;
+      return currentName;
    }
 
    @Override

--- a/resteasy-core/src/main/java/org/jboss/resteasy/microprofile/config/ServletConfigSourceImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/microprofile/config/ServletConfigSourceImpl.java
@@ -53,19 +53,22 @@ public class ServletConfigSourceImpl implements ResteasyConfigSource {
 
    @Override
    public String getName() {
-      if (name == null) {
+      String currentName = name;
+      if (currentName == null) {
          synchronized(this) {
-            if (name == null) {
+            currentName = name;
+            if (currentName == null) {
                ServletContext servletContext = ResteasyContext.getContextData(ServletContext.class);
                ServletConfig servletConfig = ResteasyContext.getContextData(ServletConfig.class);
                StringBuilder sb = new StringBuilder();
-               name = sb.append(servletContext != null ? servletContext.getServletContextName() : null).append(":")
+               currentName = sb.append(servletContext != null ? servletContext.getServletContextName() : null).append(":")
                      .append(servletConfig != null ? servletConfig.getServletName() : null)
                      .append(":ServletConfigSource").toString();
+               this.name = currentName;
             }
          }
       }
-      return name;
+      return currentName;
    }
 
    @Override

--- a/resteasy-core/src/main/java/org/jboss/resteasy/microprofile/config/ServletContextConfigSourceImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/microprofile/config/ServletContextConfigSourceImpl.java
@@ -53,17 +53,20 @@ public class ServletContextConfigSourceImpl implements ResteasyConfigSource {
 
    @Override
    public String getName() {
-      if (name == null) {
+      String currentName = name;
+      if (currentName == null) {
          synchronized(this) {
-            if (name == null) {
+            currentName = name;
+            if (currentName == null) {
                ServletContext servletContext = ResteasyContext.getContextData(ServletContext.class);
                StringBuilder sb = new StringBuilder();
-               name = sb.append(servletContext != null ? servletContext.getServletContextName() : null)
+               currentName = sb.append(servletContext != null ? servletContext.getServletContextName() : null)
                      .append(":ServletContextConfigSource").toString();
+               this.name = currentName;
             }
          }
       }
-      return name;
+      return currentName;
    }
 
    @Override

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/DocumentProvider.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/DocumentProvider.java
@@ -54,14 +54,12 @@ public class DocumentProvider extends AbstractEntityProvider<Document> implement
    }
 
    private void lazyInit() {
-      boolean init = this.init;
       if (!init) {
          synchronized (this) {
-            init = this.init;
             if (!init) {
-               this.init = true;
                this.documentBuilder = DocumentBuilderFactory.newInstance();
                this.transformerFactory = TransformerFactory.newInstance();
+               this.init = true;
             }
          }
       }

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/JndiComponentResourceFactory.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/resourcefactory/JndiComponentResourceFactory.java
@@ -44,7 +44,6 @@ public class JndiComponentResourceFactory implements ResourceFactory
 
    public Object createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory)
    {
-      if (reference != null) return reference;
       Object ref = reference;
       if (ref == null)
       {

--- a/resteasy-core/src/main/java/org/jboss/resteasy/util/snapshot/SnapshotMap.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/util/snapshot/SnapshotMap.java
@@ -56,7 +56,8 @@ public class SnapshotMap<K,V> implements ConcurrentMap<K, V> {
     }
 
     private boolean delegateUpdate() {
-        return !snapFirst && delegate != null && !lockSnapshots && this.delegate != Collections.EMPTY_MAP;
+        Map<K, V> currentDelegate;
+        return !snapFirst && (currentDelegate = delegate) != null && !lockSnapshots && currentDelegate != Collections.EMPTY_MAP;
     }
 
     @Override


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/RESTEASY-2798

## Motivation

Accessing to a volatile member has a cost in term of performances so it could be interesting to reduce the total amount of accesses to volatile member when it is possible.

## Modifications:

* Lazy initializes by relying on a local variable to reduce volatile reads
* Use a local variable instead of doing several volatile reads within the same method
* Remove the modifier `volatile` from member fields that are only read and write in synchronized blocks
* Replace the modifier `volatile` by `final` when the fields are not modified
* Remove the modifier `volatile` from member fields that are read and write in pair with another `volatile` member field by relying on piggybacking