### PR TITLE
[RESTEASY-2767] Make the Eclipse MicroProfile Config API optional.

### DIFF
--- a/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/WhiteListPolymorphicTypeValidatorBuilder.java
+++ b/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/WhiteListPolymorphicTypeValidatorBuilder.java
@@ -2,10 +2,9 @@ package org.jboss.resteasy.plugins.providers.jackson;
 
 import java.util.StringTokenizer;
 
-import org.eclipse.microprofile.config.Config;
-import org.jboss.resteasy.microprofile.config.ResteasyConfigProvider;
-
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import org.jboss.resteasy.spi.config.Configuration;
+import org.jboss.resteasy.spi.config.ConfigurationFactory;
 
 public class WhiteListPolymorphicTypeValidatorBuilder extends BasicPolymorphicTypeValidator.Builder
 {
@@ -15,7 +14,7 @@ public class WhiteListPolymorphicTypeValidatorBuilder extends BasicPolymorphicTy
 
    public WhiteListPolymorphicTypeValidatorBuilder() {
       super();
-      Config c = ResteasyConfigProvider.getConfig();
+      Configuration c = ConfigurationFactory.getInstance().getConfiguration();
       String allowIfBaseType = c.getOptionalValue(BASE_TYPE_PROP, String.class).orElse(null);
       if (allowIfBaseType != null) {
          StringTokenizer st = new StringTokenizer(allowIfBaseType, ",", false);

--- a/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/Mime4JWorkaround.java
+++ b/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/Mime4JWorkaround.java
@@ -30,7 +30,7 @@ import org.apache.james.mime4j.storage.StorageProvider;
 import org.apache.james.mime4j.storage.ThresholdStorageProvider;
 import org.apache.james.mime4j.stream.BodyDescriptorBuilder;
 import org.apache.james.mime4j.stream.MimeConfig;
-import org.jboss.resteasy.microprofile.config.ResteasyConfigProvider;
+import org.jboss.resteasy.spi.config.ConfigurationFactory;
 
 /**
  * Copy code from org.apache.james.mime4j.message.DefaultMessageBuilder.parseMessage().
@@ -57,7 +57,7 @@ public class Mime4JWorkaround {
             BodyDescriptorBuilder bdb = new DefaultBodyDescriptorBuilder(null, strict ? DefaultFieldParser.getParser() : LenientFieldParser.getParser(), mon);
 
             StorageProvider storageProvider;
-            if (ResteasyConfigProvider.getConfig().getOptionalValue(DefaultStorageProvider.DEFAULT_STORAGE_PROVIDER_PROPERTY, String.class).orElse(null) != null) {
+            if (ConfigurationFactory.getInstance().getConfiguration().getOptionalValue(DefaultStorageProvider.DEFAULT_STORAGE_PROVIDER_PROPERTY, String.class).orElse(null) != null) {
                 storageProvider = DefaultStorageProvider.getInstance();
             } else {
                 StorageProvider backend = new CustomTempFileStorageProvider();

--- a/resteasy-client-api/pom.xml
+++ b/resteasy-client-api/pom.xml
@@ -45,11 +45,6 @@
             <artifactId>jakarta.json</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.microprofile.config</groupId>
-            <artifactId>microprofile-config-api</artifactId>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/WebApplicationExceptionWrapper.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/WebApplicationExceptionWrapper.java
@@ -35,8 +35,8 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.resteasy.spi.config.Configuration;
+import org.jboss.resteasy.spi.config.ConfigurationFactory;
 import org.jboss.resteasy.spi.ResteasyDeployment;
 
 /**
@@ -58,7 +58,7 @@ public interface WebApplicationExceptionWrapper<T extends WebApplicationExceptio
      * wrapping feature is turned off
      */
     static WebApplicationException wrap(final WebApplicationException e) {
-        final Config config = ConfigProvider.getConfig();
+        final Configuration config = ConfigurationFactory.getInstance().getConfiguration();
         final boolean originalBehavior = config.getOptionalValue("resteasy.original.webapplicationexception.behavior", boolean.class).orElse(false);
         final boolean serverSide = ResteasyDeployment.onServer();
         if (originalBehavior || !serverSide) {

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43Engine.java
@@ -24,7 +24,7 @@ import org.jboss.resteasy.client.jaxrs.i18n.Messages;
 import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
 import org.jboss.resteasy.client.jaxrs.internal.FinalizedClientResponse;
-import org.jboss.resteasy.microprofile.config.ResteasyConfigProvider;
+import org.jboss.resteasy.spi.config.ConfigurationFactory;
 import org.jboss.resteasy.util.CaseInsensitiveMap;
 
 import javax.net.ssl.HostnameVerifier;
@@ -117,7 +117,7 @@ public class ManualClosingApacheHttpClient43Engine implements ApacheHttpClientEn
     * <br>
     * Defaults to JVM temp directory.
     */
-   protected File fileUploadTempFileDir = new File(ResteasyConfigProvider.getConfig().getOptionalValue("java.io.tmpdir", String.class).orElse(null));
+   protected File fileUploadTempFileDir = new File(ConfigurationFactory.getInstance().getConfiguration().getOptionalValue("java.io.tmpdir", String.class).orElse(null));
 
    public ManualClosingApacheHttpClient43Engine()
    {

--- a/resteasy-core-spi/pom.xml
+++ b/resteasy-core-spi/pom.xml
@@ -98,6 +98,18 @@
                 <groupId>com.atlassian.maven.plugins</groupId>
                 <artifactId>clover-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <test.config.prop>sys-prop-value</test.config.prop>
+                    </systemPropertyVariables>
+                    <environmentVariables>
+                        <TEST_CONFIG_ENV>env-value</TEST_CONFIG_ENV>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URL;
+import java.util.NoSuchElementException;
 
 import javax.validation.ElementKind;
 import javax.ws.rs.core.MediaType;
@@ -844,4 +845,10 @@ public interface Messages
 
    @Message(id = BASE + 13, value = "Error creating array from %s")
    String errorCreatingArray(String s);
+
+   @Message(id = BASE + 2043, value = "Value %s cannot be converted to type %s with property name %s")
+   IllegalArgumentException cannotConvertParameter(Object value, Class<?> type, String name);
+
+   @Message(id = BASE + 2044, value = "Property %s not found")
+   NoSuchElementException propertyNotFound(String name);
 }

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/config/Configuration.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/config/Configuration.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.spi.config;
+
+import java.util.Optional;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public interface Configuration {
+
+    /**
+     * Returns the resolved value for the specified type of the named property.
+     *
+     * @param name the name of the parameter
+     * @param type the type to convert the value to
+     * @param <T>  the property type
+     *
+     * @return the resolved optional value
+     *
+     * @throws IllegalArgumentException if the type is not supported
+     */
+    <T> Optional<T> getOptionalValue(String name, Class<T> type);
+
+    /**
+     * Returns the resolved value for the specified type of the named property.
+     *
+     * @param name the name of the parameter
+     * @param type the type to convert the value to
+     * @param <T>  the property type
+     *
+     * @return the resolved value
+     *
+     * @throws IllegalArgumentException         if the type is not supported
+     * @throws java.util.NoSuchElementException if there is no property associated with the name
+     */
+    <T> T getValue(String name, Class<T> type);
+}

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/config/ConfigurationFactory.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/config/ConfigurationFactory.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.spi.config;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ServiceLoader;
+
+import org.jboss.resteasy.spi.ResteasyConfiguration;
+
+/**
+ * A factory which returns the {@link Configuration}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public interface ConfigurationFactory {
+
+    /**
+     * Returns a new factory. The factory with the lowest {@linkplain #priority() priority} will be selected.
+     *
+     * @return the new factory
+     *
+     * @throws RuntimeException if the service loader could not find a factory
+     */
+    static ConfigurationFactory getInstance() {
+        if (System.getSecurityManager() == null) {
+            final ServiceLoader<ConfigurationFactory> loader = ServiceLoader.load(ConfigurationFactory.class);
+            ConfigurationFactory current = null;
+            for (ConfigurationFactory factory : loader) {
+                if (current == null) {
+                    current = factory;
+                } else if (factory.priority() < current.priority()) {
+                    current = factory;
+                }
+            }
+            return current == null ? () -> Integer.MAX_VALUE : current;
+        }
+        return AccessController.doPrivileged((PrivilegedAction<ConfigurationFactory>) () -> {
+            final ServiceLoader<ConfigurationFactory> loader = ServiceLoader.load(ConfigurationFactory.class);
+            ConfigurationFactory current = null;
+            for (ConfigurationFactory factory : loader) {
+                if (current == null) {
+                    current = factory;
+                } else if (factory.priority() < current.priority()) {
+                    current = factory;
+                }
+            }
+            return current == null ? () -> Integer.MAX_VALUE : current;
+        });
+    }
+
+    /**
+     * Returns the configuration for the current context.
+     *
+     * @return the configuration
+     */
+    default Configuration getConfiguration() {
+        return getConfiguration(null);
+    }
+
+    /**
+     * Returns the configuration for the current context.
+     *
+     * @param config a {@linkplain ResteasyConfiguration configuration} used to resolve default values, if {@code null}
+     *               a default resolver will be used
+     *
+     * @return the configuration
+     */
+    default Configuration getConfiguration(final ResteasyConfiguration config) {
+        return new DefaultConfiguration(config);
+    }
+
+    /**
+     * The ranking priority for the this factory. The lowest priority will be the one selected.
+     *
+     * @return the priority
+     */
+    int priority();
+}

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/config/DefaultConfiguration.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/config/DefaultConfiguration.java
@@ -1,0 +1,179 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.spi.config;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
+import org.jboss.resteasy.spi.ResteasyConfiguration;
+
+/**
+ * A default configuration which first attempts to use the Eclipse MicroProfile Config API. If not present on the class
+ * path the {@linkplain ResteasyConfiguration configuration} is used to resolve the value, followed by system properties
+ * and then environment variables if not found in the previous search.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class DefaultConfiguration implements Configuration {
+    private static final Function<String, String> DEFAULT_RESOLVER = new Resolver(null);
+    private static final Method GET_CONFIG;
+    private static final Method GET_OPTIONAL_VALUE;
+    private static final Method GET_VALUE;
+
+    static {
+        Method getConfig;
+        Method getOptionalValue;
+        Method getValue;
+        try {
+            final ClassLoader classLoader = getClassLoader();
+            final Class<?> configProvider = Class.forName("org.eclipse.microprofile.config.ConfigProvider", false, classLoader);
+            getConfig = configProvider.getDeclaredMethod("getConfig", ClassLoader.class);
+            final Class<?> config = Class.forName("org.eclipse.microprofile.config.Config", false, classLoader);
+            getOptionalValue = config.getDeclaredMethod("getOptionalValue", String.class, Class.class);
+            getValue = config.getDeclaredMethod("getValue", String.class, Class.class);
+        } catch (Throwable ignore) {
+            getConfig = null;
+            getOptionalValue = null;
+            getValue = null;
+        }
+        GET_CONFIG = getConfig;
+        GET_OPTIONAL_VALUE = getOptionalValue;
+        GET_VALUE = getValue;
+    }
+
+    private final Function<String, String> resolver;
+
+    /**
+     * Creates a new configuration which uses system properties to resolve the values if the Eclipse MicroProfile Config
+     * is not on the class path.
+     */
+    public DefaultConfiguration() {
+        this(null);
+    }
+
+    /**
+     * Creates a new configuration which uses the {@linkplain ResteasyConfiguration configuration} to resolve the values
+     * if the Eclipse MicroProfile Config is not on the class path.
+     *
+     * @param config the resolver
+     */
+    public DefaultConfiguration(final ResteasyConfiguration config) {
+        this.resolver = config == null ? DEFAULT_RESOLVER : new Resolver(config);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Optional<T> getOptionalValue(final String name, final Class<T> type) {
+        if (GET_CONFIG != null) {
+            try {
+                final Object config = GET_CONFIG.invoke(null, getClassLoader());
+                return (Optional<T>) GET_OPTIONAL_VALUE.invoke(config, name, type);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                LogMessages.LOGGER.debugf(e, "Failed to invoke the configuration API method %s.", GET_OPTIONAL_VALUE);
+            }
+        }
+        final String value = resolver.apply(name);
+        if (value == null) {
+            return Optional.empty();
+        }
+        final Object typedValue;
+        if (type == String.class) {
+            typedValue = type.cast(value);
+        } else if (type == Boolean.class || type == boolean.class) {
+            typedValue = Boolean.valueOf(value);
+        } else if (type == Character.class || type == char.class) {
+            if (value.isEmpty()) {
+                return Optional.empty();
+            }
+            typedValue = value.charAt(0);
+        } else if (type == Byte.class || type == byte.class) {
+            typedValue = Byte.valueOf(value.trim());
+        } else if (type == Short.class || type == short.class) {
+            typedValue = Short.valueOf(value);
+        } else if (type == Integer.class || type == int.class) {
+            typedValue = Integer.valueOf(value);
+        } else if (type == Long.class || type == long.class) {
+            typedValue = Long.valueOf(value);
+        } else if (type == Float.class || type == float.class) {
+            typedValue = Float.valueOf(value);
+        } else if (type == Double.class || type == double.class) {
+            typedValue = Double.valueOf(value);
+        } else if (type == BigDecimal.class) {
+            typedValue = new BigDecimal(value);
+        } else if (type.isEnum()) {
+            typedValue = Enum.valueOf(type.asSubclass(Enum.class), value);
+        } else {
+            throw Messages.MESSAGES.cannotConvertParameter(value, type, name);
+        }
+        return (Optional<T>) Optional.of(typedValue);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getValue(final String name, final Class<T> type) {
+        if (GET_CONFIG != null) {
+            try {
+                final Object config = GET_CONFIG.invoke(null, getClassLoader());
+                return (T) GET_VALUE.invoke(config, name, type);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                LogMessages.LOGGER.debugf(e, "Failed to invoke the configuration API method %s.", GET_VALUE);
+            }
+        }
+        return getOptionalValue(name, type).orElseThrow(() -> Messages.MESSAGES.propertyNotFound(name));
+    }
+
+    private static ClassLoader getClassLoader() {
+        if (System.getSecurityManager() == null) {
+            final ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+            return tccl != null ? tccl : DefaultConfiguration.class.getClassLoader();
+        }
+        return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> {
+            final ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+            return tccl != null ? tccl : DefaultConfiguration.class.getClassLoader();
+        });
+    }
+
+    private static class Resolver implements Function<String, String> {
+        private final ResteasyConfiguration config;
+
+        private Resolver(final ResteasyConfiguration config) {
+            this.config = config;
+        }
+
+        @Override
+        public String apply(final String name) {
+            String value = config == null ? null : config.getInitParameter(name);
+            if (value == null) {
+                value = System.getProperty(name);
+                if (value == null) {
+                    value = System.getenv(name);
+                }
+            }
+            return value;
+        }
+    }
+}

--- a/resteasy-core-spi/src/test/java/org/jboss/resteasy/spi/config/ConfigurationTestCase.java
+++ b/resteasy-core-spi/src/test/java/org/jboss/resteasy/spi/config/ConfigurationTestCase.java
@@ -1,0 +1,127 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.spi.config;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class ConfigurationTestCase {
+
+    private static final Set<Property<?>> EXPECTED_CONVERSIONS = new HashSet<>();
+
+    private enum TestEnum {
+        TEST
+    }
+
+    @BeforeClass
+    public static void configureProperties() {
+        EXPECTED_CONVERSIONS.add(Property.of("test.string", String.class, "test string value"));
+        EXPECTED_CONVERSIONS.add(Property.of("test.Boolean", Boolean.class, Boolean.TRUE));
+        EXPECTED_CONVERSIONS.add(Property.of("test.boolean", boolean.class, true));
+        EXPECTED_CONVERSIONS.add(Property.of("test.byte", byte.class, (byte) 98));
+        EXPECTED_CONVERSIONS.add(Property.of("test.Byte", Byte.class, Byte.valueOf("98")));
+        EXPECTED_CONVERSIONS.add(Property.of("test.short", short.class, Short.valueOf("5")));
+        EXPECTED_CONVERSIONS.add(Property.of("test.Short", Short.class, Short.parseShort("6")));
+        EXPECTED_CONVERSIONS.add(Property.of("test.int", int.class, 10));
+        EXPECTED_CONVERSIONS.add(Property.of("test.Integer", Integer.class, 11));
+        EXPECTED_CONVERSIONS.add(Property.of("test.long", long.class, 15L));
+        EXPECTED_CONVERSIONS.add(Property.of("test.Long", Long.class, Long.valueOf("16")));
+        EXPECTED_CONVERSIONS.add(Property.of("test.float", float.class, 5.0f));
+        EXPECTED_CONVERSIONS.add(Property.of("test.Float", Float.class, 5.5f));
+        EXPECTED_CONVERSIONS.add(Property.of("test.double", double.class, 10.0d));
+        EXPECTED_CONVERSIONS.add(Property.of("test.Double", Double.class, 10.5d));
+        EXPECTED_CONVERSIONS.add(Property.of("test.big.decimal", BigDecimal.class, new BigDecimal("20.00")));
+        EXPECTED_CONVERSIONS.add(Property.of("test.enum", TestEnum.class, TestEnum.TEST));
+
+        for (Property<?> property : EXPECTED_CONVERSIONS) {
+            TestResteasyConfiguration.PROPS.put(property.name, String.valueOf(property.expectedValue));
+        }
+    }
+
+    @Test
+    public void testDefaultConfiguration() {
+        final Configuration configuration = new DefaultConfiguration();
+
+        Assert.assertTrue("Expected the system property test.config.prop to be present",
+                configuration.getOptionalValue("test.config.prop", String.class).isPresent());
+
+        Assert.assertTrue("Expected the environment variable TEST_CONFIG_ENV tobe present",
+                configuration.getOptionalValue("TEST_CONFIG_ENV", String.class).isPresent());
+
+        Assert.assertFalse("Did not expect the property test.config.invalid to exist",
+                configuration.getOptionalValue("test.config.invalid", String.class).isPresent());
+
+        Assert.assertEquals("Expected the system property value sys-prop-value", "sys-prop-value",
+                configuration.getValue("test.config.prop", String.class));
+
+        Assert.assertEquals("Expected the environment variable value env-value", "env-value",
+                configuration.getValue("TEST_CONFIG_ENV", String.class));
+
+        Assert.assertThrows("Expected a NoSuchElementException", NoSuchElementException.class,
+                () -> configuration.getValue("test.config.invalid", String.class));
+
+    }
+
+    @Test
+    public void testConfigurationFactory() {
+        Assert.assertEquals(TestConfigurationFactory.class, ConfigurationFactory.getInstance().getClass());
+    }
+
+    @Test
+    public void testConversions() {
+        final Configuration configuration = ConfigurationFactory.getInstance().getConfiguration();
+
+        for (Property<?> property : EXPECTED_CONVERSIONS) {
+            Assert.assertEquals(property.expectedValue, configuration.getValue(property.name, property.type));
+            final Optional<?> optional = configuration.getOptionalValue(property.name, property.type);
+            Assert.assertTrue(String.format("Expected property %s to be present", property.name), optional.isPresent());
+            Assert.assertEquals(property.expectedValue, optional.get());
+        }
+        Assert.assertThrows(IllegalArgumentException.class, () -> configuration.getOptionalValue("test.string", Date.class));
+        Assert.assertThrows(IllegalArgumentException.class, () -> configuration.getValue("test.string", Date.class));
+    }
+
+    private static class Property<T> {
+        final String name;
+        final Class<T> type;
+        final T expectedValue;
+
+        private Property(final String name, final Class<T> type, final T expectedValue) {
+            this.name = name;
+            this.type = type;
+            this.expectedValue = expectedValue;
+        }
+
+        static <T> Property<T> of(final String name, final Class<T> type, final T expectedValue) {
+            return new Property<>(name, type, expectedValue);
+        }
+    }
+}

--- a/resteasy-core-spi/src/test/java/org/jboss/resteasy/spi/config/TestConfigurationFactory.java
+++ b/resteasy-core-spi/src/test/java/org/jboss/resteasy/spi/config/TestConfigurationFactory.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.spi.config;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class TestConfigurationFactory implements ConfigurationFactory {
+
+    @Override
+    public Configuration getConfiguration() {
+        return new DefaultConfiguration(TestResteasyConfiguration.INSTANCE);
+    }
+
+    @Override
+    public int priority() {
+        return 300;
+    }
+}

--- a/resteasy-core-spi/src/test/java/org/jboss/resteasy/spi/config/TestResteasyConfiguration.java
+++ b/resteasy-core-spi/src/test/java/org/jboss/resteasy/spi/config/TestResteasyConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.spi.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.resteasy.spi.ResteasyConfiguration;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class TestResteasyConfiguration implements ResteasyConfiguration {
+
+    static final Map<String, String> PROPS = new HashMap<>();
+
+    static final TestResteasyConfiguration INSTANCE = new TestResteasyConfiguration();
+
+    @Override
+    public String getParameter(final String name) {
+        return PROPS.get(name);
+    }
+
+    @Override
+    public Set<String> getParameterNames() {
+        return PROPS.keySet();
+    }
+
+    @Override
+    public String getInitParameter(final String name) {
+        return PROPS.get(name);
+    }
+
+    @Override
+    public Set<String> getInitParameterNames() {
+        return PROPS.keySet();
+    }
+}

--- a/resteasy-core-spi/src/test/resources/META-INF/services/org.jboss.resteasy.spi.config.ConfigurationFactory
+++ b/resteasy-core-spi/src/test/resources/META-INF/services/org.jboss.resteasy.spi.config.ConfigurationFactory
@@ -1,0 +1,20 @@
+#
+# JBoss, Home of Professional Open Source.
+#
+# Copyright 2020 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.jboss.resteasy.spi.config.TestConfigurationFactory

--- a/resteasy-core/pom.xml
+++ b/resteasy-core/pom.xml
@@ -132,6 +132,7 @@
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
             <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.smallrye.config</groupId>

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyDeploymentImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyDeploymentImpl.java
@@ -1,8 +1,6 @@
 package org.jboss.resteasy.core;
 
-import org.eclipse.microprofile.config.Config;
 import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
-import org.jboss.resteasy.microprofile.config.ResteasyConfigProvider;
 import org.jboss.resteasy.plugins.interceptors.RoleBasedSecurityFeature;
 import org.jboss.resteasy.plugins.providers.JaxrsServerFormUrlEncodedProvider;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
@@ -11,6 +9,7 @@ import org.jboss.resteasy.plugins.server.resourcefactory.JndiComponentResourceFa
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
+import org.jboss.resteasy.spi.config.ConfigurationFactory;
 import org.jboss.resteasy.spi.Dispatcher;
 import org.jboss.resteasy.spi.InjectorFactory;
 import org.jboss.resteasy.spi.PropertyInjector;
@@ -320,11 +319,11 @@ public class ResteasyDeploymentImpl implements ResteasyDeployment
 
       Object tracingText;
       Object thresholdText;
+      Object context = getDefaultContextObjects() == null ? null : getDefaultContextObjects().get(ResteasyConfiguration.class);
 
-      Config config = ResteasyConfigProvider.getConfig();
+      org.jboss.resteasy.spi.config.Configuration config = ConfigurationFactory.getInstance().getConfiguration((ResteasyConfiguration) context);
       tracingText = config.getOptionalValue(ResteasyContextParameters.RESTEASY_TRACING_TYPE, String.class).orElse(null);
       thresholdText = config.getOptionalValue(ResteasyContextParameters.RESTEASY_TRACING_THRESHOLD, String.class).orElse(null);
-      Object context = getDefaultContextObjects() == null ? null : getDefaultContextObjects().get(ResteasyConfiguration.class);
 
       if (tracingText != null) {
          providerFactory.property(ResteasyContextParameters.RESTEASY_TRACING_TYPE, tracingText);

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/config/DefaultConfigurationFactory.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/config/DefaultConfigurationFactory.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.core.config;
+
+import org.jboss.resteasy.core.ResteasyContext;
+import org.jboss.resteasy.spi.ResteasyConfiguration;
+import org.jboss.resteasy.spi.config.Configuration;
+import org.jboss.resteasy.spi.config.ConfigurationFactory;
+import org.jboss.resteasy.spi.config.DefaultConfiguration;
+
+/**
+ * A default configuration factory with a priority of 500.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class DefaultConfigurationFactory implements ConfigurationFactory {
+
+    @Override
+    public Configuration getConfiguration() {
+        final ResteasyConfiguration configuration = ResteasyContext.getContextData(ResteasyConfiguration.class);
+        return configuration == null ? new DefaultConfiguration() : new DefaultConfiguration(configuration);
+    }
+
+    @Override
+    public int priority() {
+        return 500;
+    }
+}

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/registry/SegmentNode.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/registry/SegmentNode.java
@@ -2,11 +2,11 @@ package org.jboss.resteasy.core.registry;
 
 import org.jboss.resteasy.core.ResourceLocatorInvoker;
 import org.jboss.resteasy.core.ResourceMethodInvoker;
-import org.jboss.resteasy.microprofile.config.ResteasyConfigProvider;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
 import org.jboss.resteasy.specimpl.ResteasyUriInfo;
+import org.jboss.resteasy.spi.config.ConfigurationFactory;
 import org.jboss.resteasy.spi.DefaultOptionsMethodException;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponseCodes;
@@ -504,9 +504,9 @@ public class SegmentNode
       String[] mm = matchingMethods(sortList);
       if (mm != null)
       {
-         boolean isFailFast = Boolean.valueOf(ResteasyConfigProvider.getConfig().getOptionalValue(
-                         ResteasyContextParameters.RESTEASY_FAIL_FAST_ON_MULTIPLE_RESOURCES_MATCHING,String.class)
-                         .orElse("false"));
+         boolean isFailFast = ConfigurationFactory.getInstance().getConfiguration().getOptionalValue(
+                 ResteasyContextParameters.RESTEASY_FAIL_FAST_ON_MULTIPLE_RESOURCES_MATCHING, boolean.class)
+                 .orElse(false);
          if(isFailFast) {
             throw new RuntimeException(Messages.MESSAGES
                     .multipleMethodsMatchFailFast(requestToString(request), mm));

--- a/resteasy-core/src/main/java/org/jboss/resteasy/microprofile/config/ResteasyConfigProvider.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/microprofile/config/ResteasyConfigProvider.java
@@ -5,6 +5,12 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigBuilder;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 
+/**
+ * @see org.jboss.resteasy.spi.config.Configuration
+ * @see org.jboss.resteasy.spi.config.ConfigurationFactory
+ * @deprecated Use the {@link org.jboss.resteasy.spi.config.Configuration}
+ */
+@Deprecated
 public final class ResteasyConfigProvider
 {
    public static Config getConfig() {

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/RegisterBuiltin.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/RegisterBuiltin.java
@@ -2,10 +2,10 @@ package org.jboss.resteasy.plugins.providers;
 
 import org.jboss.resteasy.core.ThreadLocalResteasyProviderFactory;
 import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
-import org.jboss.resteasy.microprofile.config.ResteasyConfigProvider;
 import org.jboss.resteasy.plugins.interceptors.GZIPDecodingInterceptor;
 import org.jboss.resteasy.plugins.interceptors.GZIPEncodingInterceptor;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
+import org.jboss.resteasy.spi.config.ConfigurationFactory;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
 import javax.ws.rs.RuntimeType;
@@ -185,7 +185,7 @@ public class RegisterBuiltin
       return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
          @Override
          public Boolean run() {
-            final String value = ResteasyConfigProvider.getConfig().getOptionalValue("resteasy.allowGzip", String.class).orElse(null);
+            final String value = ConfigurationFactory.getInstance().getConfiguration().getOptionalValue("resteasy.allowGzip", String.class).orElse(null);
             if ("".equals(value)) return Boolean.FALSE;
             return Boolean.parseBoolean(value);
          }

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/ConfigurationBootstrap.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/ConfigurationBootstrap.java
@@ -1,11 +1,12 @@
 package org.jboss.resteasy.plugins.server.servlet;
 
 import org.jboss.resteasy.core.ResteasyDeploymentImpl;
-import org.jboss.resteasy.microprofile.config.ResteasyConfigProvider;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
+import org.jboss.resteasy.spi.config.Configuration;
 import org.jboss.resteasy.spi.ResteasyConfiguration;
 import org.jboss.resteasy.spi.ResteasyDeployment;
+import org.jboss.resteasy.spi.config.DefaultConfiguration;
 import org.jboss.resteasy.util.HttpHeaderNames;
 
 import javax.ws.rs.core.Application;
@@ -25,6 +26,7 @@ import java.util.Map;
 public abstract class ConfigurationBootstrap implements ResteasyConfiguration
 {
    private ResteasyDeployment deployment = new ResteasyDeploymentImpl();
+   private final Configuration config = new DefaultConfiguration(this);
 
 
    public ResteasyDeployment createDeployment()
@@ -349,9 +351,7 @@ public abstract class ConfigurationBootstrap implements ResteasyConfiguration
    {
       String propName = null;
       if (System.getSecurityManager() == null) {
-         propName = ResteasyConfigProvider.getConfig()
-                 .getOptionalValue(name, String.class)
-                 .orElse(null);
+         propName = config.getOptionalValue(name, String.class).orElse(null);
 
       } else {
 
@@ -359,9 +359,7 @@ public abstract class ConfigurationBootstrap implements ResteasyConfiguration
             propName = AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
                @Override
                public String run() throws Exception {
-                  return ResteasyConfigProvider.getConfig()
-                          .getOptionalValue(name, String.class)
-                          .orElse(null);
+                  return config.getOptionalValue(name, String.class).orElse(null);
                }
             });
          } catch (PrivilegedActionException pae) {

--- a/resteasy-core/src/main/java/org/jboss/resteasy/util/PortProvider.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/util/PortProvider.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.util;
 
-import org.jboss.resteasy.microprofile.config.ResteasyConfigProvider;
+import org.jboss.resteasy.spi.config.Configuration;
+import org.jboss.resteasy.spi.config.ConfigurationFactory;
 
 /**
  * Utility class that provides a port number for the Resteasy embedded container.
@@ -31,8 +32,9 @@ public class PortProvider
     */
    public static int getPort()
    {
+      final Configuration configuration = ConfigurationFactory.getInstance().getConfiguration();
       int port = -1;
-      String property =  ResteasyConfigProvider.getConfig().getOptionalValue(ENV_VAR_NAME, String.class).orElse(null);
+      String property =  configuration.getOptionalValue(ENV_VAR_NAME, String.class).orElse(null);
       if (property != null)
       {
          try
@@ -46,7 +48,7 @@ public class PortProvider
 
       if (port == -1)
       {
-         property = ResteasyConfigProvider.getConfig().getOptionalValue(PROPERTY_NAME, String.class).orElse(null);
+         property = configuration.getOptionalValue(PROPERTY_NAME, String.class).orElse(null);
          if (property != null)
          {
             try
@@ -74,8 +76,9 @@ public class PortProvider
     */
    public static String getHost()
    {
+      final Configuration configuration = ConfigurationFactory.getInstance().getConfiguration();
       String host = null;
-      String property = ResteasyConfigProvider.getConfig().getOptionalValue(ENV_VAR_HOSTNAME, String.class).orElse(null);
+      String property = configuration.getOptionalValue(ENV_VAR_HOSTNAME, String.class).orElse(null);
       if (property != null)
       {
          host = property;
@@ -83,7 +86,7 @@ public class PortProvider
 
       if (host == null)
       {
-         property = ResteasyConfigProvider.getConfig().getOptionalValue(PROPERTY_HOSTNAME, String.class).orElse(null);
+         property = configuration.getOptionalValue(PROPERTY_HOSTNAME, String.class).orElse(null);
          if (property != null)
          {
             host = property;

--- a/resteasy-core/src/main/resources/META-INF/services/org.jboss.resteasy.spi.config.ConfigurationFactory
+++ b/resteasy-core/src/main/resources/META-INF/services/org.jboss.resteasy.spi.config.ConfigurationFactory
@@ -1,0 +1,20 @@
+#
+# JBoss, Home of Professional Open Source.
+#
+# Copyright 2020 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.jboss.resteasy.core.config.DefaultConfigurationFactory


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-2767

This is an alternate to the approach  in #2590 which fully makes the Eclipse MicroProfile Config optional for RESTEasy.