### PR TITLE
[RESTEASY-2812] Fix MediaType cache poisoning with trailing semi-colon

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java
@@ -69,11 +69,11 @@ public class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate<M
           result = internalParse(type);
           final int size = map.size();
           if (size >= MAX_MT_CACHE_SIZE) {
-              map.clear();
-              reverseMap.clear();
+              clearCache();
           }
+          final String normalisedType = internalToString(result);
           map.put(type, result);
-          reverseMap.put(result, type);
+          reverseMap.put(result, normalisedType);
       }
       return result;
    }
@@ -159,8 +159,7 @@ public class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate<M
           result = internalToString(type);
           final int size = reverseMap.size();
           if (size >= MAX_MT_CACHE_SIZE) {
-             reverseMap.clear();
-             map.clear();
+             clearCache();
           }
           reverseMap.put(type, result);
           map.put(result, type);
@@ -168,7 +167,7 @@ public class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate<M
       return result;
    }
 
-   private String internalToString(MediaType type)
+   private static String internalToString(MediaType type)
    {
       StringBuilder buf = new StringBuilder();
 
@@ -182,5 +181,11 @@ public class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate<M
          else buf.append(val);
       }
       return buf.toString();
+   }
+
+   static void clearCache()
+   {
+      map.clear();
+      reverseMap.clear();
    }
 }

--- a/resteasy-core/src/test/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegateTest.java
+++ b/resteasy-core/src/test/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegateTest.java
@@ -1,0 +1,72 @@
+package org.jboss.resteasy.plugins.delegates;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.core.MediaType;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MediaTypeHeaderDelegateTest {
+
+  private MediaTypeHeaderDelegate delegate;
+
+  @Before
+  public void setUp() throws Exception {
+    delegate = new MediaTypeHeaderDelegate();
+
+    // We need to clear the cache here since the cache is static and will be reused between tests.
+    // This will not work if these tests are run in parallel.
+    MediaTypeHeaderDelegate.clearCache();
+  }
+
+  @Test
+  public void testParseStripsTrailingSemicolonWhenParsingDodgyContentType() {
+    MediaTypeHeaderDelegate.parse("application/json;");
+
+    assertEquals("application/json", delegate.toString(new MediaType("application", "json")));
+  }
+
+  @Test
+  public void testParseHandlesMediaTypeWithCharset() {
+    MediaTypeHeaderDelegate.parse("application/json; charset=utf-8");
+
+    assertEquals("application/json;charset=utf-8", delegate.toString(new MediaType("application", "json", "utf-8")));
+  }
+
+  @Test
+  public void testParseHandlesMediaTypeWithCharsetAndAnotherParameter() {
+    MediaTypeHeaderDelegate.parse("application/json; charset=utf-8; a=bobbytables");
+
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put("charset", "utf-8");
+    parameters.put("a", "bobbytables");
+    assertEquals("application/json;a=bobbytables;charset=utf-8", delegate.toString(new MediaType("application", "json", parameters)));
+  }
+
+  @Test
+  public void testParseHandlesMediaTypeWithCharsetAndAnotherParameterAndTrailingSemiColon() {
+    MediaTypeHeaderDelegate.parse("application/json; charset=utf-8; a=bobbytables;");
+
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put("charset", "utf-8");
+    parameters.put("a", "bobbytables");
+    assertEquals("application/json;a=bobbytables;charset=utf-8", delegate.toString(new MediaType("application", "json", parameters)));
+  }
+
+  @Test
+  public void initialisedDelegateCacheShouldNotBePoisonedByMediaTypeWithTrailingSemiColon() {
+    // Seed the cache by asking to parse a valid
+    MediaTypeHeaderDelegate.parse("application/json");
+
+    // Verify that getting retrieving the media type returns the expected media type
+    assertEquals("application/json", delegate.toString(new MediaType("application", "json")));
+
+    // Poison the cache with a trailing semi-colon
+    MediaTypeHeaderDelegate.parse("application/json;");
+
+    // Verify that getting retrieving the media type returns the expected media type
+    assertEquals("application/json", delegate.toString(new MediaType("application", "json")));
+  }
+}


### PR DESCRIPTION
The `MediaTypeHeaderDelegate` holds a static cache mapping string
representations of Media Types (e.g. application/json) to their
`javax.ws.rs.core.MediaType` equivalent. The reduces repeated parsing of
the same, or similar, Media Types; increasing performance of most
service calls by a small amount.

The class boils down to two methods: `parse(String)` and
`toString(MediaType)`. These two methods are not symmetric since the
parse method may receive additional sections in the Media Type string
(e.g. "application/json; charset=utf-8"). However, it is expected
that when passing a bare Media Type within the additional sections, it
should be symmetric.

Hence: `parse("application/json") == MediaType("application", "json");`

The cache introduces a bug, however, if the `parse` method is called
with a Media Type with a trailing semi-colon. This is technically not
valid for a `Content-Type` but it still can exist. When this happens,
the cache is effectively poisoned as `toString(MediaType("application",
"json"))` 
will now return "application/json;".

The fix here is to use `internalToString` to normalise the type being
put into the `reverseMap`. The `map` has to stay the same.