### PR TITLE
[RESTEASY-2550] Skip null parameters being processed by ParamConverte…

### DIFF
--- a/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/microprofile/client/ProxyInvocationHandler.java
+++ b/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/microprofile/client/ProxyInvocationHandler.java
@@ -98,9 +98,13 @@ public class ProxyInvocationHandler implements InvocationHandler {
 
                 int index = 0;
                 for (Object arg : args) {
+                    // ParamConverter's are not allowed to be passed null values. If we have a null value do not process
+                    // it through the provider.
+                    if (arg == null) {
+                        continue;
+                    }
 
                     if (parameterAnnotations[index].length > 0) { // does a parameter converter apply?
-
                         ParamConverter<?> converter = ((ParamConverterProvider) p).getConverter(arg.getClass(), null, parameterAnnotations[index]);
                         if (converter != null) {
                             Type[] genericTypes = getGenericTypes(converter.getClass());

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/i18n/Messages.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/i18n/Messages.java
@@ -141,4 +141,7 @@ public interface Messages
 
    @Message(id = BASE + 185, value = "Unable to set http proxy")
    String unableToSetHttpProxy();
+
+   @Message(id = BASE + 190, value = "Parameter annotated with %s cannot be null")
+   String nullParameter(String annotation);
 }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/webtarget/PathParamProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/webtarget/PathParamProcessor.java
@@ -1,7 +1,11 @@
 package org.jboss.resteasy.client.jaxrs.internal.proxy.processors.webtarget;
 
+import org.jboss.resteasy.client.jaxrs.i18n.Messages;
 import org.jboss.resteasy.client.jaxrs.internal.proxy.processors.WebTargetProcessor;
 
+import java.util.Objects;
+
+import javax.ws.rs.PathParam;
 import javax.ws.rs.client.WebTarget;
 
 /**
@@ -28,6 +32,6 @@ public class PathParamProcessor implements WebTargetProcessor
    @Override
    public WebTarget build(WebTarget target, Object param)
    {
-      return target.resolveTemplate(paramName, param, encodeSlashInPath);
+      return target.resolveTemplate(paramName, Objects.requireNonNull(param, Messages.MESSAGES.nullParameter(PathParam.class.getSimpleName())), encodeSlashInPath);
    }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HelloClient.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HelloClient.java
@@ -6,6 +6,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 
 import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
 import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
@@ -22,6 +23,14 @@ public interface HelloClient {
     @GET
     @Path("/hello")
     String hello();
+
+    @GET
+    @Path("/null-path-param/{value}")
+    String nullPathParam(@PathParam("value") String value);
+
+    @GET
+    @Path("/null-query-param/")
+    String nullQueryParam(@QueryParam("value") String value);
 
     @GET
     @Path("some/{id}")

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HelloResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HelloResource.java
@@ -9,6 +9,7 @@ import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.Assert;
@@ -27,6 +28,19 @@ public class HelloResource {
     @Path("/hello")
     public String hello() {
        return "Hello";
+    }
+
+    @GET
+    @Produces("text/plain")
+    @Path("/null-path-param/{value}")
+    public String nullPathParam(@PathParam("value") final String value) {
+        return value;
+    }
+
+    @GET
+    @Path("/null-query-param/")
+    public String nullQueryParam(@QueryParam("value") String value) {
+        return value;
     }
 
     @GET

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProxyTest.java
@@ -2,9 +2,14 @@ package org.jboss.resteasy.test.microprofile.restclient;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.net.URL;
+import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -12,6 +17,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import javax.ws.rs.ext.Provider;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -51,6 +59,7 @@ public class RestClientProxyTest
       war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
       war.addClass(PortProviderUtil.class);
       war.addClass(Category.class);
+      war.addClasses(TestParamConverter.class, TestParamConverterProvider.class);
       war.addAsManifestResource(new StringAsset("Dependencies: org.eclipse.microprofile.restclient,org.jboss.resteasy.resteasy-rxjava2 services\n"), "MANIFEST.MF");
       return TestUtil.finishContainerPrepare(war, null);
    }
@@ -153,5 +162,108 @@ public class RestClientProxyTest
       Assert.assertTrue("Waiting for event to be delivered has timed out.", waitResult);
       assertTrue(value.get() instanceof WebApplicationException);
       assertEquals(Response.Status.NOT_FOUND.getStatusCode(), ((WebApplicationException)value.get()).getResponse().getStatus());
+   }
+
+   @Test
+   public void testNullPathParam() throws Exception {
+      RestClientBuilder builder = RestClientBuilder.newBuilder();
+      RestClientBuilder resteasyBuilder = new BuilderResolver().newBuilder();
+      assertEquals(resteasyBuilder.getClass(), builder.getClass());
+      HelloClient client = builder
+              .baseUrl(new URL(generateURL("")))
+              .build(HelloClient.class);
+
+      assertNotNull(client);
+      assertEquals("testPath", client.nullPathParam("testPath"));
+      try {
+         client.nullPathParam(null);
+         fail("A null path parameter should not be allowed");
+      } catch (NullPointerException e) {
+         // Given the generic error we want to ensure we're getting an NPE from the correct spot. We'll validate this
+         // via the message id.
+         final String msg = e.getLocalizedMessage();
+         final String msgId = "RESTEASY004690";
+         assertTrue(String.format("Expected message to start with %s: %s", msgId, msg), msg.startsWith(msgId));
+      }
+   }
+
+   @Test
+   public void testNullPathParamWithConverter() throws Exception {
+      RestClientBuilder builder = RestClientBuilder.newBuilder();
+      RestClientBuilder resteasyBuilder = new BuilderResolver().newBuilder();
+      assertEquals(resteasyBuilder.getClass(), builder.getClass());
+      HelloClient client = builder
+              .baseUrl(new URL(generateURL("")))
+              .register(TestParamConverterProvider.class)
+              .build(HelloClient.class);
+
+      assertNotNull(client);
+      assertEquals("testPath", client.nullPathParam("testPath"));
+      try {
+         client.nullPathParam(null);
+         fail("A null path parameter should not be allowed");
+      } catch (NullPointerException e) {
+         // Given the generic error we want to ensure we're getting an NPE from the correct spot. We'll validate this
+         // via the message id.
+         final String msg = e.getLocalizedMessage();
+         final String msgId = "RESTEASY004690";
+         assertTrue(String.format("Expected message to start with %s: %s", msgId, msg), msg.startsWith(msgId));
+      }
+   }
+
+   @Test
+   public void testNullQueryParam() throws Exception {
+      RestClientBuilder builder = RestClientBuilder.newBuilder();
+      RestClientBuilder resteasyBuilder = new BuilderResolver().newBuilder();
+      assertEquals(resteasyBuilder.getClass(), builder.getClass());
+      HelloClient client = builder
+              .baseUrl(new URL(generateURL("")))
+              .build(HelloClient.class);
+
+      assertNotNull(client);
+      assertEquals("testPath", client.nullQueryParam("testPath"));
+      assertNull(client.nullQueryParam(null));
+   }
+
+   @Test
+   public void testNullQueryParamWithConverter() throws Exception {
+      RestClientBuilder builder = RestClientBuilder.newBuilder();
+      RestClientBuilder resteasyBuilder = new BuilderResolver().newBuilder();
+      assertEquals(resteasyBuilder.getClass(), builder.getClass());
+      HelloClient client = builder
+              .baseUrl(new URL(generateURL("")))
+              .register(TestParamConverterProvider.class)
+              .build(HelloClient.class);
+
+      assertNotNull(client);
+      assertEquals("testPath", client.nullQueryParam("testPath"));
+      assertNull(client.nullQueryParam(null));
+   }
+
+   public static class TestParamConverter implements ParamConverter<String> {
+
+      @Override
+      public String fromString(final String value) {
+         return value;
+      }
+
+      @Override
+      public String toString(final String value) {
+         return value.toString();
+      }
+   }
+
+   @Provider
+   public static class TestParamConverterProvider implements ParamConverterProvider {
+      private final TestParamConverter converter = new TestParamConverter();
+
+      @Override
+      @SuppressWarnings("unchecked")
+      public <T> ParamConverter<T> getConverter(final Class<T> rawType, final Type genericType, final Annotation[] annotations) {
+         if (Objects.equals(rawType, CharSequence.class)) {
+            return (ParamConverter<T>) converter;
+         }
+         return null;
+      }
    }
 }


### PR DESCRIPTION
…r's. Also throw an NPE if a parameter annotated with @PathParam it not allowed.

Backport of #2377 for 3.11 branch

Issue: https://issues.redhat.com/browse/JBEAP-21181

Upstream Issue: https://issues.redhat.com/browse/RESTEASY-2550
Upstream PR: #2377