### PR TITLE
TS updates

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest ]
         java: ['1.8', '11']
-        wildfly-version: ['20.0.1.Final', '21.0.1.Final']
+        wildfly-version: ['22.0.1.Final', '23.0.2.Final']
 
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ language: java
 jdk:
   - openjdk8
 env:
-  - SERVER_VERSION=21.0.1.Final ELYTRON=true
-  - SERVER_VERSION=21.0.1.Final STANDALONE_MICROPROFILE=true
+  - SERVER_VERSION=23.0.2.Final ELYTRON=true
+  - SERVER_VERSION=23.0.2.Final STANDALONE_MICROPROFILE=true
 jobs:
 addons:
   hosts:

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -357,6 +357,45 @@
                 </plugins>
             </build>
         </profile>
+
+        <!--
+            By default, ${version.resteasy.testsuite} version for RESTEasy restclient is used.
+            But use.mp.from.project.profile allows to use ${project.version} version for RESTEasy restclient.
+                This is useful for test runs where we test resteasy version without RESTEasy restclient available.
+                In this case, tests with RESTEasy restclient are used for compatibility testing only.
+        -->
+        <profile>
+            <id>not.use.mp.from.project.profile</id>
+            <activation>
+                <property>
+                    <name>!ts.use.mp.from.project</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-client-microprofile</artifactId>
+                    <version>${version.resteasy.testsuite}</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>use.mp.from.project.profile</id>
+            <activation>
+                <property>
+                    <name>ts.use.mp.from.project</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-client-microprofile</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <dependencies>
@@ -397,13 +436,6 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>${version.resteasy.testsuite}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client-microprofile</artifactId>
             <version>${version.resteasy.testsuite}</version>
             <scope>provided</scope>
         </dependency>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/AsynchronousCdiTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/AsynchronousCdiTest.java
@@ -47,7 +47,7 @@ public class AsynchronousCdiTest {
       return PortProviderUtil.generateURL(path, AsynchronousCdiTest.class.getSimpleName());
    }
 
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> createTestArchive() {
       WebArchive war = TestUtil.prepareArchive(AsynchronousCdiTest.class.getSimpleName());
       war.addClasses(UtilityProducer.class)

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionTest.java
@@ -119,7 +119,7 @@ public class InjectionTest extends AbstractInjectionTestBase {
    private static int invocationCounter;
 
    @SuppressWarnings(value = "unchecked")
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> createTestArchive() throws Exception {
       initQueue();
       WebArchive war = TestUtil.prepareArchive(InjectionTest.class.getSimpleName());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/MDBInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/MDBInjectionTest.java
@@ -73,7 +73,7 @@ public class MDBInjectionTest extends AbstractInjectionTestBase {
    static Client client;
 
    @SuppressWarnings(value = "unchecked")
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> createTestArchive() throws Exception {
       initQueue();
       WebArchive war = TestUtil.prepareArchive(MDBInjectionTest.class.getSimpleName());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/TimerInterceptorTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/TimerInterceptorTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertEquals;
 public class TimerInterceptorTest {
    protected static final Logger log = LogManager.getLogger(TimerInterceptorTest.class.getName());
 
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> createTestArchive() {
       WebArchive war = TestUtil.prepareArchive(TimerInterceptorTest.class.getSimpleName())
             .addClasses(UtilityProducer.class, PortProviderUtil.class)

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/resource/ClientWebApplicationExceptionMicroProfileProxyResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/resource/ClientWebApplicationExceptionMicroProfileProxyResource.java
@@ -10,7 +10,6 @@ import org.jboss.resteasy.client.exception.ResteasyWebApplicationException;
 import org.jboss.resteasy.client.exception.WebApplicationExceptionWrapper;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.test.client.exception.ClientWebApplicationExceptionMicroProfileProxyTest;
 import org.jboss.resteasy.test.client.exception.ClientWebApplicationExceptionTest;
 import org.jboss.resteasy.utils.PortProviderUtil;
@@ -19,25 +18,19 @@ import org.junit.Assert;
 @Path("test")
 public class ClientWebApplicationExceptionMicroProfileProxyResource {
 
-   private static ClientWebApplicationExceptionProxyResourceInterface proxy;
+   private static ClientWebApplicationExceptionProxyResourceInterface oldBehaviorProxy;
+   private static ClientWebApplicationExceptionProxyResourceInterface newBehaviorProxy;
 
    static {
       ResteasyClient client = (ResteasyClient) ResteasyClientBuilder.newClient();
-      proxy = client.target(generateURL("/app/test/")).proxy(ClientWebApplicationExceptionProxyResourceInterface.class);
+      oldBehaviorProxy = client.target(PortProviderUtil.generateURL("/app/test/", ClientWebApplicationExceptionMicroProfileProxyTest.oldBehaviorDeploymentName))
+              .proxy(ClientWebApplicationExceptionProxyResourceInterface.class);
+      newBehaviorProxy = client.target(PortProviderUtil.generateURL("/app/test/", ClientWebApplicationExceptionMicroProfileProxyTest.newBehaviorDeploymentName))
+              .proxy(ClientWebApplicationExceptionProxyResourceInterface.class);
    }
 
    private static String generateURL(String path) {
       return PortProviderUtil.generateURL(path, ClientWebApplicationExceptionMicroProfileProxyTest.class.getSimpleName());
-   }
-
-   /**
-    * Sets the System property ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR
-    * @param value value property is set to
-    */
-   @GET
-   @Path("behavior/{value}")
-   public void setBehavior(@PathParam("value") String value) {
-      System.setProperty(ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR, value);
    }
 
    /**
@@ -68,30 +61,58 @@ public class ClientWebApplicationExceptionMicroProfileProxyResource {
 
    /**
     * Uses a proxy to call oldException() to get an HTTP response derived from a WebApplicationException.
-    * Based on that response, the proxy will throw either a WebApplicationException or WebApplicationExceptionWrapper,
-    * depending on the value of ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR.
+    * The proxy will throw a WebApplicationException because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is true.
     *
     * @param i determines element of oldExceptions to be thrown by oldException()
     * @throws Exception
     */
    @GET
-   @Path("nocatch/old/{i}")
-   public String noCatchOld(@PathParam("i") int i) throws Exception {
-      return proxy.oldException(i);
+   @Path("nocatch/old/old/{i}")
+   public String noCatchOldOld(@PathParam("i") int i) throws Exception {
+      return oldBehaviorProxy.oldException(i);
+   }
+
+   /**
+    * Uses a proxy to call oldException() to get an HTTP response derived from a WebApplicationException.
+    * The proxy will throw a WebApplicationExceptionWrapper because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is false.
+    *
+    * @param i determines element of oldExceptions to be thrown by oldException()
+    * @throws Exception
+    */
+   @GET
+   @Path("nocatch/new/old/{i}")
+   public String noCatchNewOld(@PathParam("i") int i) throws Exception {
+      return newBehaviorProxy.oldException(i);
    }
 
    /**
     * Uses a proxy to call newException() to get an HTTP response derived from a WebApplicationExceptionWrapper.
-    * Based on that response, the proxy will throw either a WebApplicationException or WebApplicationExceptionWrapper,
-    * depending on the value of ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR.
+    * The proxy will throw a WebApplicationException because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is true.
     *
     * @param i determines element of newExceptions to be thrown by newException()
     * @throws Exception
     */
    @GET
-   @Path("nocatch/new/{i}")
-   public String noCatchNew(@PathParam("i") int i) throws Exception {
-      return proxy.newException(i);
+   @Path("nocatch/old/new/{i}")
+   public String noCatchOldNew(@PathParam("i") int i) throws Exception {
+      return oldBehaviorProxy.newException(i);
+   }
+
+   /**
+    * Uses a proxy to call newException() to get an HTTP response derived from a WebApplicationExceptionWrapper.
+    * The proxy will throw a WebApplicationExceptionWrapper because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is false.
+    *
+    * @param i determines element of newExceptions to be thrown by newException()
+    * @throws Exception
+    */
+   @GET
+   @Path("nocatch/new/new/{i}")
+   public String noCatchNewNew(@PathParam("i") int i) throws Exception {
+      return newBehaviorProxy.newException(i);
    }
 
    /**
@@ -109,7 +130,7 @@ public class ClientWebApplicationExceptionMicroProfileProxyResource {
    @Path("catch/old/old/{i}")
    public String catchOldOld(@PathParam("i") int i) throws Exception {
       try {
-         proxy.oldException(i);
+         newBehaviorProxy.oldException(i);
          throw new Exception("expected exception");
       } catch (ResteasyWebApplicationException e) {
          throw new Exception("didn't expect ResteasyWebApplicationException");
@@ -138,7 +159,7 @@ public class ClientWebApplicationExceptionMicroProfileProxyResource {
    @Path("catch/old/new/{i}")
    public String catchOldNew(@PathParam("i") int i) throws Exception {
       try {
-         return proxy.newException(i);
+         return newBehaviorProxy.newException(i);
       } catch (ResteasyWebApplicationException e) {
          throw new Exception("didn't expect ResteasyWebApplicationException");
       } catch (WebApplicationException e) {
@@ -169,7 +190,7 @@ public class ClientWebApplicationExceptionMicroProfileProxyResource {
    @Path("catch/new/old/{i}")
    public String catchNewOld(@PathParam("i") int i) throws Exception {
       try {
-         return proxy.oldException(i);
+         return newBehaviorProxy.oldException(i);
       } catch (ResteasyWebApplicationException e) {
          throw new Exception("didn't expect ResteasyWebApplicationException");
       } catch (WebApplicationException e) {
@@ -205,7 +226,7 @@ public class ClientWebApplicationExceptionMicroProfileProxyResource {
    @Path("catch/new/new/{i}")
    public String catchNewNew(@PathParam("i") int i) throws Exception {
       try {
-         return proxy.newException(i);
+         return newBehaviorProxy.newException(i);
       } catch (ResteasyWebApplicationException e) {
          throw new Exception("didn't expect ResteasyWebApplicationException");
       } catch (WebApplicationException e) {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/resource/ClientWebApplicationExceptionProxyResourceInterface.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/resource/ClientWebApplicationExceptionProxyResourceInterface.java
@@ -7,14 +7,6 @@ import javax.ws.rs.PathParam;
 public interface ClientWebApplicationExceptionProxyResourceInterface {
 
    /**
-    * Sets the System property ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR
-    * @param value value property is set to
-    */
-   @GET
-   @Path("behavior/{value}")
-   void setBehavior(@PathParam("value") String value);
-
-   /**
     * Throws an instance of WebApplicationException from oldExceptions table. The Response returned by
     * WebApplicationException.getResponse() will be used by the container to create an HTTP response.
     *
@@ -39,27 +31,51 @@ public interface ClientWebApplicationExceptionProxyResourceInterface {
 
    /**
     * Uses a Client or proxy to call oldException() to get an HTTP response derived from a WebApplicationException.
-    * Based on that response, the Client or proxy will throw either a WebApplicationException or ResteasyWebApplicationException,
-    * depending on the value of ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR.
+    * The Client or proxy will throw a WebApplicationException because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is true.
     *
     * @param i determines element of oldExceptions to be thrown by oldException()
     * @throws Exception
     */
    @GET
-   @Path("nocatch/old/{i}")
-   String noCatchOld(@PathParam("i") int i) throws Exception;
+   @Path("nocatch/old/old/{i}")
+   String noCatchOldOld(@PathParam("i") int i) throws Exception;
+
+   /**
+    * Uses a Client or proxy to call oldException() to get an HTTP response derived from a WebApplicationException.
+    * The Client or proxy will throw a ResteasyWebApplicationException or WebApplicationExceptionWrapper because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is false.
+    *
+    * @param i determines element of oldExceptions to be thrown by oldException()
+    * @throws Exception
+    */
+   @GET
+   @Path("nocatch/new/old/{i}")
+   String noCatchNewOld(@PathParam("i") int i) throws Exception;
 
    /**
     * Uses a Client or proxy to call newException() to get an HTTP response derived from a ResteasyWebApplicationException.
-    * Based on that response, the Client or proxy will throw either a WebApplicationException or ResteasyWebApplicationException,
-    * depending on the value of ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR.
+    * The Client or proxy will throw a WebApplicationException because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is true.
     *
     * @param i determines element of newExceptions to be thrown by newException()
     * @throws Exception
     */
    @GET
-   @Path("nocatch/new/{i}")
-   String noCatchNew(@PathParam("i") int i) throws Exception;
+   @Path("nocatch/old/new/{i}")
+   String noCatchOldNew(@PathParam("i") int i) throws Exception;
+
+   /**
+    * Uses a Client or proxy to call newException() to get an HTTP response derived from a ResteasyWebApplicationException.
+    * The Client or proxy will throw a ResteasyWebApplicationException or WebApplicationExceptionWrapper because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is false.
+    *
+    * @param i determines element of newExceptions to be thrown by newException()
+    * @throws Exception
+    */
+   @GET
+   @Path("nocatch/new/new/{i}")
+   String noCatchNewNew(@PathParam("i") int i) throws Exception;
 
    /**
     * It is assumed that ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingResource.java
@@ -3,14 +3,11 @@ package org.jboss.resteasy.test.exception.resource;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-
-import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 
 import java.net.URI;
 
@@ -19,17 +16,6 @@ import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 
 @Path("")
 public class ClosedResponseHandlingResource {
-
-   /**
-    * Sets the System property ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR
-    * @param value value property is set to
-    */
-   @GET
-   @Path("behavior/{value}")
-   public void setBehavior(@PathParam("value") String value) {
-      System.setProperty(ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR, value);
-   }
-
    @Path("/testNotAcceptable/406")
    @GET
    public Response errorNotAcceptable() {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/config/ResteasyConfigFilterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/config/ResteasyConfigFilterTest.java
@@ -7,6 +7,7 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.MicroProfileDependent;
 import org.jboss.resteasy.test.microprofile.config.resource.MicroProfileConfigFilter;
 import org.jboss.resteasy.test.microprofile.config.resource.ResteasyConfigResource;
 import org.jboss.resteasy.utils.PermissionUtil;
@@ -16,6 +17,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -27,6 +29,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(MicroProfileDependent.class)
 public class ResteasyConfigFilterTest extends ResteasyConfigTestParent
 {
    @Deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/config/ResteasyConfigServletContextListenerTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/config/ResteasyConfigServletContextListenerTest.java
@@ -7,6 +7,7 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.MicroProfileDependent;
 import org.jboss.resteasy.test.microprofile.config.resource.MicroProfileConfigFilter;
 import org.jboss.resteasy.test.microprofile.config.resource.ResteasyConfigResource;
 import org.jboss.resteasy.utils.PermissionUtil;
@@ -16,6 +17,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -27,6 +29,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(MicroProfileDependent.class)
 public class ResteasyConfigServletContextListenerTest extends ResteasyConfigTestParent
 {
    @Deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/config/ResteasyConfigServletTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/config/ResteasyConfigServletTest.java
@@ -7,6 +7,7 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.MicroProfileDependent;
 import org.jboss.resteasy.test.microprofile.config.resource.ResteasyConfigResource;
 import org.jboss.resteasy.utils.PermissionUtil;
 import org.jboss.resteasy.utils.TestUtil;
@@ -15,6 +16,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -26,6 +28,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(MicroProfileDependent.class)
 public class ResteasyConfigServletTest extends ResteasyConfigTestParent
 {
    @Deployment

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HeaderPropagator.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HeaderPropagator.java
@@ -7,12 +7,16 @@ import javax.ws.rs.core.MultivaluedMap;
 
 import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.junit.Assert;
 
 public class HeaderPropagator implements ClientHeadersFactory {
    @Override
    public MultivaluedMap<String, String> update(MultivaluedMap<String, String> containerRequestHeaders, MultivaluedMap<String, String> clientRequestHeaders) {
-       Assert.assertNull(ResteasyProviderFactory.getContextData(HttpHeaders.class));
+       if (ResteasyProviderFactory.getContextData(HttpHeaders.class) != null) {
+           throw new RuntimeException("ResteasyProviderFactory.getContextData(HttpHeaders.class) is not null");
+       }
+       if (ResteasyProviderFactory.getContextData(HttpHeaders.class) != null) {
+           throw new RuntimeException("ResteasyProviderFactory.getContextData(HttpHeaders.class) is not null");
+       }
        List<String> prop = containerRequestHeaders.get("X-Propagated");
        if(prop != null)
           clientRequestHeaders.addAll("X-Propagated", prop);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HelloResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HelloResource.java
@@ -12,7 +12,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.junit.Assert;
 
 import io.reactivex.Single;
 
@@ -59,8 +58,12 @@ public class HelloResource {
     @Path("async-client-target")
     public CompletionStage<String> asyncClientTarget(@HeaderParam("X-Propagated") String propagatedHeader,
                                                 @HeaderParam("X-Not-Propagated") String nonPropagatedHeader) {
-       Assert.assertNull(nonPropagatedHeader);
-       Assert.assertEquals("got-a-value", propagatedHeader);
+        if (nonPropagatedHeader != null) {
+            throw new RuntimeException("nonPropagatedHeader is not null");
+        }
+        if (!propagatedHeader.equals("got-a-value")) {
+            throw new RuntimeException("propagatedHeader is not \"got-a-value\"");
+        }
        return CompletableFuture.completedFuture("OK");
     }
 
@@ -68,8 +71,12 @@ public class HelloResource {
     @Path("async-client")
     public CompletionStage<String> asyncClient(@HeaderParam("X-Propagated") String propagatedHeader,
                                                @HeaderParam("X-Not-Propagated") String nonPropagatedHeader){
-       Assert.assertEquals("got-a-value", propagatedHeader);
-       Assert.assertEquals("got-a-value", nonPropagatedHeader);
+        if (!propagatedHeader.equals("got-a-value")) {
+            throw new RuntimeException("propagatedHeader is not \"got-a-value\"");
+        }
+        if (!nonPropagatedHeader.equals("got-a-value")) {
+            throw new RuntimeException("nonPropagatedHeader is not \"got-a-value\"");
+        }
        return rest.asyncClientTarget();
     }
 
@@ -77,8 +84,12 @@ public class HelloResource {
     @Path("client-target")
     public String clientTarget(@HeaderParam("X-Propagated") String propagatedHeader,
                                @HeaderParam("X-Not-Propagated") String nonPropagatedHeader) {
-       Assert.assertNull(nonPropagatedHeader);
-       Assert.assertEquals("got-a-value", propagatedHeader);
+        if (nonPropagatedHeader != null) {
+            throw new RuntimeException("nonPropagatedHeader is not null");
+        }
+        if (!propagatedHeader.equals("got-a-value")) {
+            throw new RuntimeException("propagatedHeader is not \"got-a-value\"");
+        }
        return "OK";
     }
 
@@ -86,8 +97,12 @@ public class HelloResource {
     @Path("client")
     public String client(@HeaderParam("X-Propagated") String propagatedHeader,
                          @HeaderParam("X-Not-Propagated") String nonPropagatedHeader){
-       Assert.assertEquals("got-a-value", propagatedHeader);
-       Assert.assertEquals("got-a-value", nonPropagatedHeader);
+        if (!propagatedHeader.equals("got-a-value")) {
+            throw new RuntimeException("propagatedHeader is not \"got-a-value\"");
+        }
+        if (!nonPropagatedHeader.equals("got-a-value")) {
+            throw new RuntimeException("nonPropagatedHeader is not \"got-a-value\"");
+        }
        return rest.clientTarget();
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProviderPriorityTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProviderPriorityTest.java
@@ -7,6 +7,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.resteasy.category.MicroProfileDependent;
 import org.jboss.resteasy.utils.PortProviderUtil;
 import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
@@ -14,6 +15,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Priority;
@@ -31,6 +33,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(MicroProfileDependent.class)
 public class RestClientProviderPriorityTest
 {
     @ArquillianResource
@@ -42,6 +45,7 @@ public class RestClientProviderPriorityTest
         WebArchive war = TestUtil.prepareArchive(RestClientProviderPriorityTest.class.getSimpleName());
         war.addClass(HelloResource.class);
         war.addClass(HelloClient.class);
+        war.addClass(MicroProfileDependent.class);
         war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
         war.addAsManifestResource(new StringAsset("Dependencies: org.eclipse.microprofile.restclient,org.jboss.resteasy.resteasy-rxjava2 services\n"), "MANIFEST.MF");
         return TestUtil.finishContainerPrepare(war, null);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProxyTest.java
@@ -49,7 +49,7 @@ public class RestClientProxyTest
    @ArquillianResource
    URL url;
 
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> deploy()
    {
       WebArchive war = TestUtil.prepareArchive(RestClientProxyTest.class.getSimpleName());

--- a/testsuite/integration-tests/src/test/resources/org/jboss/resteasy/test/client/exception/webapplicationexception_web.xml
+++ b/testsuite/integration-tests/src/test/resources/org/jboss/resteasy/test/client/exception/webapplicationexception_web.xml
@@ -1,0 +1,9 @@
+<!DOCTYPE web-app PUBLIC
+        "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+        "http://java.sun.com/dtd/web-app_2_3.dtd" >
+<web-app>
+    <context-param>
+        <param-name>resteasy.original.webapplicationexception.behavior</param-name>
+        <param-value>true</param-value>
+    </context-param>
+</web-app>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -147,7 +147,7 @@
               </property>
             </activation>
             <properties>
-                <server.version>21.0.1.Final</server.version>
+                <server.version>23.0.2.Final</server.version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
I prepared this PR for 3.15 branch. Let me know whether I should port this for master branch or squash commits into one commit.

* RESTEasy jira: https://issues.redhat.com/browse/RESTEASY-2837
* Another related jira: https://issues.redhat.com/browse/JBEAP-21087

----
Summary of this PR from jira:
* Parametrize resteasy-client-microprofile version in TS for servers without MP bits
* Skip ResteasyConfigServletContextListenerTest, ResteasyConfigFilterTest, RestClientProviderPriorityTest and ResteasyConfigServletTest tests on runs without MP bits. These tests requires MP on server side.
* Add `(testable = false)` to deployment methods to AsynchronousCdiTest, InjectionTest, MDBInjectionTest and TimerInterceptorTest tests, so Arquillian doesn't add arquillian classes to deployment. Arquillian added info about testcase, but testcase is not present in deployment, so new version of weld failed (but old weld was tolerating it).
* Fix ClientWebApplicationExceptionTest, ClientWebApplicationExceptionResteasyProxyTest and ClientWebApplicationExceptionMicroProfileProxyTest for servers without MP Config.
* Use WF22 server for testing by default
