### PR TITLE
Revert "[RESTEASY-2826] resteasy-vertx: Response Headers with String …

### DIFF
--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpResponse.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpResponse.java
@@ -146,7 +146,7 @@ public class VertxHttpResponse implements HttpResponse
                response.headers().add(key, delegate.toString(value));
             } else
             {
-               response.headers().add(key, value.toString());
+               response.headers().set(key, value.toString());
             }
          }
       }


### PR DESCRIPTION
…value of same type are overwritten"

This reverts commit cc9f0558eb6020a461d9d79350b81594c9164d22.

I'm verifying if reverting this commit solves the CI failures we keep on having in Windows runs.