### PR TITLE
[RESTEASY-2826] resteasy-vertx: Response Headers with String value of…

### DIFF
--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpResponse.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpResponse.java
@@ -146,7 +146,7 @@ public class VertxHttpResponse implements HttpResponse
                response.headers().add(key, delegate.toString(value));
             } else
             {
-               response.headers().set(key, value.toString());
+               response.headers().add(key, value.toString());
             }
          }
       }


### PR DESCRIPTION
… same type are overwritten