### PR TITLE
[RESTEASY-2766] Upgrade Resteasy to support vert.x 4 (#2622)

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -31,7 +31,7 @@
         <version.hamcrest>1.3</version.hamcrest>
         <version.io.netty.netty>3.10.6.Final</version.io.netty.netty>
         <version.io.netty.netty4>4.1.51.Final</version.io.netty.netty4>
-        <version.io.vertx>3.7.1</version.io.vertx>
+        <version.io.vertx>4.0.0</version.io.vertx>
         <version.io.undertow>2.0.23.Final</version.io.undertow>
         <version.jakarta.activation>1.2.1</version.jakarta.activation>
         <version.jakarta.enterprise.cdi-api>2.0.2</version.jakarta.enterprise.cdi-api>

--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/ChunkOutputStream.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/ChunkOutputStream.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import io.vertx.core.Promise;
 import org.jboss.resteasy.plugins.server.vertx.i18n.Messages;
 import org.jboss.resteasy.spi.AsyncOutputStream;
 
@@ -96,21 +97,21 @@ public class ChunkOutputStream extends AsyncOutputStream
          buffer.appendBytes(b, dataToWriteOffset, spaceLeftInCurrentChunk);
          dataToWriteOffset = dataToWriteOffset + spaceLeftInCurrentChunk;
          dataLengthLeftToWrite = dataLengthLeftToWrite - spaceLeftInCurrentChunk;
-         Future<Void> future;
+         Promise<Void> promise;
          if(handler != null) {
-            future = Future.future();
-            futures.add(future);
+            promise = Promise.promise();
+            futures.add(promise.future());
          } else {
-            future = null;
+            promise = null;
          }
-         flush(future);
+         flush(promise);
       }
       if (dataLengthLeftToWrite > 0)
       {
          buffer.appendBytes(b, dataToWriteOffset, dataLengthLeftToWrite);
       }
       if(handler != null) {
-         CompositeFuture.all(futures).setHandler(handler);
+         CompositeFuture.all(futures).onComplete(handler);
       }
    }
 

--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpRequest.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpRequest.java
@@ -67,7 +67,7 @@ public class VertxHttpRequest extends BaseHttpRequest
       this.request = request;
       this.dispatcher = dispatcher;
       this.httpHeaders = VertxUtil.extractHttpHeaders(request);
-      this.httpMethod = request.rawMethod();
+      this.httpMethod = request.method().name();
       this.executionContext = new VertxExecutionContext(this, response, dispatcher);
    }
 

--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxJaxrsServer.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxJaxrsServer.java
@@ -2,8 +2,8 @@ package org.jboss.resteasy.plugins.server.vertx;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpServer;
@@ -255,7 +255,7 @@ public class VertxJaxrsServer implements EmbeddedJaxrsServer<VertxJaxrsServer>
       protected HttpServer server;
 
       @Override
-      public void start(Future<Void> startFuture) throws Exception
+      public void start(Promise<Void> startPromise) throws Exception
       {
          Helper helper = deploymentMap.get(config().getString("helper"));
          server = vertx.createHttpServer(helper.serverOptions);
@@ -263,10 +263,10 @@ public class VertxJaxrsServer implements EmbeddedJaxrsServer<VertxJaxrsServer>
          server.listen(ar -> {
             if (ar.succeeded())
             {
-               startFuture.complete();
+               startPromise.complete();
             } else
             {
-               startFuture.fail(ar.cause());
+               startPromise.fail(ar.cause());
             }
          });
       }


### PR DESCRIPTION
* [RESTEASY-2766] Vert.x 4 support added

* Vert.x 4.0.0.CR2 -> 4.0.0

Testing if the Vert.X 4 upgrade is the related to the windows ci failures we have on master