### PR TITLE
[RESTEASY-2865] setTimeout(..) in TimeoutHandler

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/Servlet3AsyncHttpRequest.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/Servlet3AsyncHttpRequest.java
@@ -255,6 +255,7 @@ public class Servlet3AsyncHttpRequest extends HttpServletInputMessage
             if (timeoutHandler != null)
             {
                timeoutHandler.handleTimeout(this);
+               return;
             }
             resume(new ServiceUnavailableException());
          }

--- a/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpRequest.java
+++ b/server-adapters/resteasy-netty4/src/main/java/org/jboss/resteasy/plugins/server/netty/NettyHttpRequest.java
@@ -443,6 +443,7 @@ public class NettyHttpRequest extends BaseHttpRequest
             if (timeoutHandler != null)
             {
                timeoutHandler.handleTimeout(this);
+               return;
             }
             if (done) return;
             resume(new ServiceUnavailableException());

--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpRequest.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxHttpRequest.java
@@ -393,6 +393,7 @@ public class VertxHttpRequest extends BaseHttpRequest
             if (timeoutHandler != null)
             {
                timeoutHandler.handleTimeout(this);
+               return;
             }
             if (done) return;
             resume(new ServiceUnavailableException());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncTimeoutTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/asynch/AsyncTimeoutTest.java
@@ -53,4 +53,25 @@ public class AsyncTimeoutTest {
         response.close();
     }
 
+    @Test
+    public void testAsyncTimeoutHandlerExtendsTimeOut() throws Exception {
+        WebTarget base = client.target(generateURL("/extendedTimeout"));
+        long startTime = System.nanoTime();
+        Response response = base.request().get();
+        long elapsedTime = System.nanoTime() - startTime;
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals("Extended timeout hello", response.readEntity(String.class));
+        Assert.assertTrue("Timeout fired too quickly", elapsedTime > 4000000000L);
+        response.close();
+    }
+
+    @Test
+    public void testResumeAfterSettingAsyncTimeoutHandler() throws Exception
+    {
+       WebTarget base = client.target(generateURL("/resumeAfterSettingTimeoutHandler"));
+       Response response = base.request().get();
+       Assert.assertEquals(200, response.getStatus());
+       Assert.assertEquals("From initial", response.readEntity(String.class));
+       response.close();
+    }
 }


### PR DESCRIPTION
This PR resolves JIRA [RESTEASY-2865](https://issues.redhat.com/browse/RESTEASY-2865) by ensuring that the `handleTimeout()` does not call `resume(new ServiceUnavailableException())` immediately after invoking the user's `TimeoutHandler`.  