### PR TITLE
*** JIRA REQUIRED: This is an initial test for upgrading surefire to …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <version.org.jacoco.plugin>0.7.9</version.org.jacoco.plugin>
         <version.javadoc.plugin>3.0.1</version.javadoc.plugin>
         <version.compiler.plugin>3.8.0-jboss-2</version.compiler.plugin>
+        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
     </properties>
 
     <url>http://rest-easy.org</url>
@@ -200,9 +201,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${version.surefire.plugin}</version>
                     <configuration>
-                        <forkMode>once</forkMode>
                         <runOrder>alphabetical</runOrder>
                         <argLine>${surefire.system.args}</argLine>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>35</version>
+        <version>38</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
…get around issues with CI failing with the dummy:dummy:1.0 artifact not being able to be downloaded.

I keep seeing intermittent  failures with:
```
Error:    org.apache.maven.surefire:surefire-junit47:jar:2.22.0
Error:  
Error:  from the specified remote repositories:
Error:    jboss-public-repository (https://repository.jboss.org/nexus/content/groups/public/, releases=true, snapshots=false),
Error:    central (https://repo.maven.apache.org/maven2, releases=true, snapshots=false)
Error:  Path to dependency: 
Error:      1) dummy:dummy:jar:1.0
```

This comes from the [`maven-surfire-plugin`](https://github.com/apache/maven-surefire/blob/12a10d2cb84525299485db394ffb318c640df5ba/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/SurefireDependencyResolver.java#L128). This was removed in 3.0.0 so this is to test that 3.0.0 works for RESTEasy and hopefully makes this issue go away.