### PR TITLE
** Test upgrading jboss-parent which upgrades surefire to 2.22.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>35</version>
+        <version>38</version>
         <relativePath/>
     </parent>
 

--- a/resteasy-bom/pom.xml
+++ b/resteasy-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>35</version>
+        <version>38</version>
         <relativePath/>
    </parent>
 

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>35</version>
+        <version>38</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/testsuite/arquillian-utils/pom.xml
+++ b/testsuite/arquillian-utils/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>35</version>
+        <version>38</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
I keep seeing intermittent  failures with:
```
Error:    org.apache.maven.surefire:surefire-junit47:jar:2.22.0
Error:  
Error:  from the specified remote repositories:
Error:    jboss-public-repository (https://repository.jboss.org/nexus/content/groups/public/, releases=true, snapshots=false),
Error:    central (https://repo.maven.apache.org/maven2, releases=true, snapshots=false)
Error:  Path to dependency: 
Error:      1) dummy:dummy:jar:1.0
```

This comes from the [`maven-surfire-plugin`](https://github.com/apache/maven-surefire/blob/12a10d2cb84525299485db394ffb318c640df5ba/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/SurefireDependencyResolver.java#L128). This was removed in 3.0.0 so this is to test that 3.0.0 works for RESTEasy and hopefully makes this issue go away.