### PR TITLE
updated archive jaxb-runtime to version 3.0.0-M4

### DIFF
--- a/docbook/reference/en/en-US/modules/Jaxb.xml
+++ b/docbook/reference/en/en-US/modules/Jaxb.xml
@@ -119,8 +119,8 @@ public @interface Pretty {}
 import org.jboss.resteasy.core.interception.DecoratorProcessor;
 import org.jboss.resteasy.annotations.DecorateTypes;
 
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.PropertyException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.PropertyException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.Produces;
 import java.lang.annotation.Annotation;

--- a/docbook/reference/en/en-US/modules/Multipart.xml
+++ b/docbook/reference/en/en-US/modules/Multipart.xml
@@ -205,10 +205,10 @@ public interface InputPart {
 <![CDATA[
 package org.jboss.resteasy.test.providers.multipart.resource;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
 
 @XmlRootElement(name = "soup")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -398,10 +398,10 @@ public class Soup {
             <![CDATA[
     package org.jboss.resteasy.test.providers.multipart.resource;
 
-    import javax.xml.bind.annotation.XmlAccessType;
-    import javax.xml.bind.annotation.XmlAccessorType;
-    import javax.xml.bind.annotation.XmlElement;
-    import javax.xml.bind.annotation.XmlRootElement;
+    import jakarta.xml.bind.annotation.XmlAccessType;
+    import jakarta.xml.bind.annotation.XmlAccessorType;
+    import jakarta.xml.bind.annotation.XmlElement;
+    import jakarta.xml.bind.annotation.XmlRootElement;
 
     @XmlRootElement(name = "customer")
     @XmlAccessorType(XmlAccessType.FIELD)
@@ -660,10 +660,10 @@ public MultipartRelatedOutput postRelated(MultipartRelatedInput input)
 package org.jboss.resteasy.test.providers.multipart.resource;
 
 import javax.ws.rs.core.MediaType;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlMimeType;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlMimeType;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -832,10 +832,10 @@ public interface MultipartFormDataInput extends MultipartInput {
          <![CDATA[
 package org.jboss.resteasy.test.providers.multipart.resource;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "name")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/JAXBContextWrapper.java
+++ b/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/JAXBContextWrapper.java
@@ -51,14 +51,14 @@ public class JAXBContextWrapper extends JAXBContext
 
          if (System.getSecurityManager() == null)
          {
-            namespace[0] =  JAXBContextWrapper.class.getClassLoader().loadClass("com.sun.xml.bind.marshaller.NamespacePrefixMapper");
+            namespace[0] =  JAXBContextWrapper.class.getClassLoader().loadClass("org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper");
             mapper[0] =  JAXBContextWrapper.class.getClassLoader().loadClass("org.jboss.resteasy.plugins.providers.jaxb.XmlNamespacePrefixMapper");
          }
          else
          {
             AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
                @Override public Void run() throws Exception {
-                  namespace[0] =  JAXBContextWrapper.class.getClassLoader().loadClass("com.sun.xml.bind.marshaller.NamespacePrefixMapper");
+                  namespace[0] =  JAXBContextWrapper.class.getClassLoader().loadClass("org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper");
                   mapper[0] =  JAXBContextWrapper.class.getClassLoader().loadClass("org.jboss.resteasy.plugins.providers.jaxb.XmlNamespacePrefixMapper");
 
                   return null;

--- a/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/XmlNamespacePrefixMapper.java
+++ b/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/XmlNamespacePrefixMapper.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.plugins.providers.jaxb;
 
-import com.sun.xml.bind.marshaller.NamespacePrefixMapper;
+import org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper;
 
 import jakarta.xml.bind.annotation.XmlNs;
 import java.util.HashMap;

--- a/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/i18n/Messages.java
+++ b/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/i18n/Messages.java
@@ -43,7 +43,7 @@ public interface Messages
    @Message(id = BASE + 35, value = "Map wrapping failed, expect namespace of {0} got {1}", format=Format.MESSAGE_FORMAT)
    String mapWrappingFailedNamespace(String map, String namespace);
 
-   @Message(id = BASE + 40, value = "com.sun.xml.bind.marshaller.NamespacePrefixMapper is not in your classpath.  You need to use the JAXB RI for the prefix mapping feature")
+   @Message(id = BASE + 40, value = "org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper is not in your classpath.  You need to use the JAXB RI for the prefix mapping feature")
    String namespacePrefixMapperNotInClassPath();
 
    @Message(id = BASE + 45, value = "SecureUnmarshaller: unexpected use of unmarshal(%s)")

--- a/providers/resteasy-atom/src/main/java/org/jboss/resteasy/plugins/providers/atom/AtomEntryProvider.java
+++ b/providers/resteasy-atom/src/main/java/org/jboss/resteasy/plugins/providers/atom/AtomEntryProvider.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.plugins.providers.atom;
 
-import com.sun.xml.bind.marshaller.NamespacePrefixMapper;
+import org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper;
 
 import org.jboss.resteasy.core.messagebody.AsyncBufferedMessageBodyWriter;
 import org.jboss.resteasy.plugins.providers.jaxb.JAXBContextFinder;

--- a/providers/resteasy-atom/src/main/java/org/jboss/resteasy/plugins/providers/atom/AtomFeedProvider.java
+++ b/providers/resteasy-atom/src/main/java/org/jboss/resteasy/plugins/providers/atom/AtomFeedProvider.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.plugins.providers.atom;
 
-import com.sun.xml.bind.marshaller.NamespacePrefixMapper;
+import org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper;
 
 import org.jboss.resteasy.core.messagebody.AsyncBufferedMessageBodyWriter;
 import org.jboss.resteasy.plugins.providers.jaxb.JAXBContextFinder;

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -24,7 +24,7 @@
         <version.com.google.inject.guice>4.2.2</version.com.google.inject.guice>
         <version.com.io7m.xom>1.2.10</version.com.io7m.xom>
         <version.jakarta.mail>2.0.1</version.jakarta.mail>
-        <version.org.glassfish.jaxb.jaxb>2.3.3-b02</version.org.glassfish.jaxb.jaxb>
+        <version.org.glassfish.jaxb.jaxb>3.0.0-M4</version.org.glassfish.jaxb.jaxb>
         <version.com.sun.xml.fastinfoset>1.2.17</version.com.sun.xml.fastinfoset>
         <version.commons-io.commons-io>2.5</version.commons-io.commons-io>
         <version.commons-codec.commons-codec>1.14</version.commons-codec.commons-codec>

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/AtomProviderModelTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/AtomProviderModelTest.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.test.providers;
 
-import com.sun.xml.bind.marshaller.NamespacePrefixMapper;
+import org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jboss.resteasy.plugins.providers.atom.Content;


### PR DESCRIPTION
This updates org.glassfish.jaxb:jaxb-runtime to version
3.0.0-M4.  This resolves the unit test failure in  
server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/JaxrsAsyncTest.java

This archive version has the package name change to service
./META-INF/services/jakarta.xml.bind.JAXBContext and containes the new service impl file,
org.glassfish.jaxb.runtime.v2.ContextFactory.  The old service name was
./META-INF/services/javax.xml.bind.JAXBContext and its impl class name was
com/sun/xml/bind/v2/ContextFactory.class.

Also the old class name for com.sun.xml.bind.marshaller.NamespacePrefixMapper
has been changed to org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper.
There are several files I had to update with this reference.

Please review the PR and if you think it looks good please merge it.