### PR TITLE
[RESTEASY-2880] Config options for in-memory limit

### DIFF
--- a/providers/multipart/pom.xml
+++ b/providers/multipart/pom.xml
@@ -67,6 +67,11 @@
             <artifactId>microprofile-config-api</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/HeaderFlushedOutputStream.java
+++ b/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/HeaderFlushedOutputStream.java
@@ -11,8 +11,8 @@ import java.nio.charset.StandardCharsets;
  * @version $Revision: 1 $
  */
 public class HeaderFlushedOutputStream extends OutputStream {
-   private MultivaluedMap<String, Object> headers;
-   private OutputStream stream;
+   private final MultivaluedMap<String, Object> headers;
+   private final OutputStream stream;
    private boolean headersFlushed = false;
 
    public HeaderFlushedOutputStream(final MultivaluedMap<String, Object> headers,

--- a/providers/multipart/src/test/java/org/jboss/resteasy/plugins/providers/multipart/Mime4JWorkaroundTest.java
+++ b/providers/multipart/src/test/java/org/jboss/resteasy/plugins/providers/multipart/Mime4JWorkaroundTest.java
@@ -2,15 +2,47 @@ package org.jboss.resteasy.plugins.providers.multipart;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class Mime4JWorkaroundTest {
 
+   private static final Map<String, String> preTestProperties = new HashMap<>();
+
+   @BeforeClass
+   public static void saveCurrentStateOfMemThresholdProperty()
+   {
+      if (System.getProperties().containsKey(Mime4JWorkaround.MEM_THRESHOLD_PROPERTY))
+      {
+         String value = System.getProperty(Mime4JWorkaround.MEM_THRESHOLD_PROPERTY);
+         preTestProperties.put(Mime4JWorkaround.MEM_THRESHOLD_PROPERTY, value);
+      }
+   }
+
+   @AfterClass
+   public static void resetPropertiesToPreTestValues()
+   {
+      if (!preTestProperties.containsKey(Mime4JWorkaround.MEM_THRESHOLD_PROPERTY))
+      {
+         System.clearProperty(Mime4JWorkaround.MEM_THRESHOLD_PROPERTY);
+      }
+      else
+      {
+         preTestProperties.forEach(System::setProperty);
+      }
+   }
+
    @Before
-   public void unsetMemThresholdProperty() {
+   public void unsetMemThresholdProperty()
+   {
       System.clearProperty(Mime4JWorkaround.MEM_THRESHOLD_PROPERTY);
    }
+
    @Test
    public void testMemThresholdDefault()
    {

--- a/providers/multipart/src/test/java/org/jboss/resteasy/plugins/providers/multipart/Mime4JWorkaroundTest.java
+++ b/providers/multipart/src/test/java/org/jboss/resteasy/plugins/providers/multipart/Mime4JWorkaroundTest.java
@@ -1,0 +1,47 @@
+package org.jboss.resteasy.plugins.providers.multipart;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class Mime4JWorkaroundTest {
+
+   @Before
+   public void unsetMemThresholdProperty() {
+      System.clearProperty(Mime4JWorkaround.MEM_THRESHOLD_PROPERTY);
+   }
+   @Test
+   public void testMemThresholdDefault()
+   {
+      assertEquals(Mime4JWorkaround.DEFAULT_MEM_THRESHOLD, Mime4JWorkaround.getMemThreshold());
+   }
+
+   @Test
+   public void testMemThresholdConfigProperty()
+   {
+      System.setProperty(Mime4JWorkaround.MEM_THRESHOLD_PROPERTY, "2048");
+      assertEquals(2048, Mime4JWorkaround.getMemThreshold());
+   }
+
+   @Test
+   public void testInvalidMemThresholdConfigPropertyReturnsDefault_NegativeNumber()
+   {
+      System.setProperty(Mime4JWorkaround.MEM_THRESHOLD_PROPERTY, "-2048");
+      assertEquals(Mime4JWorkaround.DEFAULT_MEM_THRESHOLD, Mime4JWorkaround.getMemThreshold());
+   }
+
+   @Test
+   public void testInvalidMemThresholdConfigPropertyReturnsDefault_DecimalNumber()
+   {
+      System.setProperty(Mime4JWorkaround.MEM_THRESHOLD_PROPERTY, "2048.2");
+      assertEquals(Mime4JWorkaround.DEFAULT_MEM_THRESHOLD, Mime4JWorkaround.getMemThreshold());
+   }
+
+   @Test
+   public void testInvalidMemThresholdConfigPropertyReturnsDefault_NotANumber()
+   {
+      System.setProperty(Mime4JWorkaround.MEM_THRESHOLD_PROPERTY, "Infinity");
+      assertEquals(Mime4JWorkaround.DEFAULT_MEM_THRESHOLD, Mime4JWorkaround.getMemThreshold());
+   }
+}

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43Engine.java
@@ -52,6 +52,9 @@ import java.util.Map;
 public class ManualClosingApacheHttpClient43Engine implements ApacheHttpClientEngine
 {
 
+   static final String FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY =
+      "org.jboss.resteasy.client.jaxrs.engines.fileUploadInMemoryThreshold";
+
    /**
     * Used to build temp file prefix.
     */
@@ -121,39 +124,58 @@ public class ManualClosingApacheHttpClient43Engine implements ApacheHttpClientEn
 
    public ManualClosingApacheHttpClient43Engine()
    {
-      this.httpClient = createDefaultHttpClient();
-      this.allowClosingHttpClient = true;
+      this(null, null, true, null);
    }
 
    public ManualClosingApacheHttpClient43Engine(final HttpHost defaultProxy)
    {
-      this.defaultProxy = defaultProxy;
-      this.httpClient = createDefaultHttpClient();
-      this.allowClosingHttpClient = true;
+      this(null, null, true, defaultProxy);
    }
 
    public ManualClosingApacheHttpClient43Engine(final HttpClient httpClient)
    {
-      this.httpClient = httpClient;
-      this.allowClosingHttpClient = true;
+      this(httpClient, null, true, null);
    }
 
    public ManualClosingApacheHttpClient43Engine(final HttpClient httpClient, final boolean closeHttpClient)
    {
-      if (closeHttpClient && !(httpClient instanceof CloseableHttpClient))
+      this(httpClient, null, closeHttpClient, null);
+   }
+
+   public ManualClosingApacheHttpClient43Engine(final HttpClient httpClient,
+         final HttpContextProvider httpContextProvider)
+   {
+      this(httpClient, httpContextProvider, true, null);
+   }
+
+   private ManualClosingApacheHttpClient43Engine(final HttpClient httpClient,
+         final HttpContextProvider httpContextProvider, final boolean closeHttpClient, final HttpHost defaultProxy)
+   {
+      this.httpClient = httpClient != null ? httpClient : createDefaultHttpClient();
+      if (closeHttpClient && !(this.httpClient instanceof CloseableHttpClient))
       {
          throw new IllegalArgumentException(
                "httpClient must be a CloseableHttpClient instance in order for allowing engine to close it!");
       }
-      this.httpClient = httpClient;
-      this.allowClosingHttpClient = closeHttpClient;
-   }
-
-   public ManualClosingApacheHttpClient43Engine(final HttpClient httpClient, final HttpContextProvider httpContextProvider)
-   {
-      this.httpClient = httpClient;
       this.httpContextProvider = httpContextProvider;
-      this.allowClosingHttpClient = true;
+      this.allowClosingHttpClient = closeHttpClient;
+      this.defaultProxy = defaultProxy;
+
+      try
+      {
+         int threshold = Integer.parseInt(ConfigurationFactory.getInstance().getConfiguration()
+               .getOptionalValue(FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY, String.class)
+               .orElse("1"));
+         if (threshold > -1)
+         {
+            this.fileUploadInMemoryThresholdLimit = threshold;
+         }
+         LogMessages.LOGGER.debugf("Negative threshold, %s, specified. Using default value", threshold);
+      }
+      catch (Exception e)
+      {
+         LogMessages.LOGGER.debug("Exception caught parsing memory threshold. Using default value.", e);
+      }
    }
 
    /**

--- a/resteasy-client/src/test/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43EngineTest.java
+++ b/resteasy-client/src/test/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43EngineTest.java
@@ -1,14 +1,46 @@
 package org.jboss.resteasy.client.jaxrs.engines;
 
 import static org.junit.Assert.assertEquals;
+import static org.jboss.resteasy.client.jaxrs.engines.ManualClosingApacheHttpClient43Engine.FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ManualClosingApacheHttpClient43EngineTest {
 
+   private static final Map<String, String> preTestProperties = new HashMap<>();
+
+   @BeforeClass
+   public static void saveCurrentStateOfMemThresholdProperty()
+   {
+      if (System.getProperties().containsKey(FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY))
+      {
+         String value = System.getProperty(FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY);
+         preTestProperties.put(FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY, value);
+      }
+   }
+
+   @AfterClass
+   public static void resetPropertiesToPreTestValues()
+   {
+      if (!preTestProperties.containsKey(FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY))
+      {
+         System.clearProperty(FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY);
+      }
+      else
+      {
+         preTestProperties.forEach(System::setProperty);
+      }
+   }
+
    @Before
-   public void unsetMemThresholdProperty() {
+   public void unsetMemThresholdProperty()
+   {
       System.clearProperty(ManualClosingApacheHttpClient43Engine.FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY);
    }
    @Test

--- a/resteasy-client/src/test/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43EngineTest.java
+++ b/resteasy-client/src/test/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43EngineTest.java
@@ -1,0 +1,47 @@
+package org.jboss.resteasy.client.jaxrs.engines;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ManualClosingApacheHttpClient43EngineTest {
+
+   @Before
+   public void unsetMemThresholdProperty() {
+      System.clearProperty(ManualClosingApacheHttpClient43Engine.FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY);
+   }
+   @Test
+   public void testMemThresholdDefault()
+   {
+      assertEquals(1, new ManualClosingApacheHttpClient43Engine().getFileUploadInMemoryThresholdLimit());
+   }
+
+   @Test
+   public void testMemThresholdConfigProperty()
+   {
+      System.setProperty(ManualClosingApacheHttpClient43Engine.FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY, "8");
+      assertEquals(8, new ManualClosingApacheHttpClient43Engine().getFileUploadInMemoryThresholdLimit());
+   }
+
+   @Test
+   public void testInvalidMemThresholdConfigPropertyReturnsDefault_NegativeNumber()
+   {
+      System.setProperty(ManualClosingApacheHttpClient43Engine.FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY, "-8");
+      assertEquals(1, new ManualClosingApacheHttpClient43Engine().getFileUploadInMemoryThresholdLimit());
+   }
+
+   @Test
+   public void testInvalidMemThresholdConfigPropertyReturnsDefault_DecimalNumber()
+   {
+      System.setProperty(ManualClosingApacheHttpClient43Engine.FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY, "2048.2");
+      assertEquals(1, new ManualClosingApacheHttpClient43Engine().getFileUploadInMemoryThresholdLimit());
+   }
+
+   @Test
+   public void testInvalidMemThresholdConfigPropertyReturnsDefault_NotANumber()
+   {
+      System.setProperty(ManualClosingApacheHttpClient43Engine.FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY, "Infinity");
+      assertEquals(1, new ManualClosingApacheHttpClient43Engine().getFileUploadInMemoryThresholdLimit());
+   }
+}


### PR DESCRIPTION
This change addresses issue [RESTEASY-2880](https://issues.redhat.com/browse/RESTEASY-2880) by allowing users to configure the in-memory limit of the server (default 1024 bytes) and the client (default 1MB) by setting the following config properties, respectively:
org.jboss.resteasy.plugins.providers.multipart.memoryThreshold=<newThresholdInBytes>
org.jboss.resteasy.client.jaxrs.engines.fileUploadInMemoryThreshold=<newThresholdInMegaBytes>


