### PR TITLE
[RESTEASY-2866] Make proxy interface check configurable

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyDeploymentImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyDeploymentImpl.java
@@ -86,7 +86,6 @@ public class ResteasyDeploymentImpl implements ResteasyDeployment
    protected String paramMapping;
    protected Map<String, Object> properties;
    protected boolean statisticsEnabled;
-   protected boolean contextProxyToImplementAllInterfaces;
 
    @SuppressWarnings("rawtypes")
    public ResteasyDeploymentImpl() {

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyDeploymentImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyDeploymentImpl.java
@@ -86,6 +86,7 @@ public class ResteasyDeploymentImpl implements ResteasyDeployment
    protected String paramMapping;
    protected Map<String, Object> properties;
    protected boolean statisticsEnabled;
+   protected boolean contextProxyToImplementAllInterfaces;
 
    @SuppressWarnings("rawtypes")
    public ResteasyDeploymentImpl() {

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/ConfigurationBootstrap.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/ConfigurationBootstrap.java
@@ -251,6 +251,19 @@ public abstract class ConfigurationBootstrap implements ResteasyConfiguration
       {
          deployment.setStatisticsEnabled(Boolean.valueOf(statisticsEnabled));
       }
+
+      String proxiesImplAllInterfaces = getParameter(ResteasyContextParameters.RESTEASY_PROXY_IMPLEMENT_ALL_INTERFACES);
+      if (proxiesImplAllInterfaces != null)
+      {
+         boolean b = parseBooleanParam(ResteasyContextParameters.RESTEASY_PROXY_IMPLEMENT_ALL_INTERFACES,
+               proxiesImplAllInterfaces);
+         deployment.setProperty(ResteasyContextParameters.RESTEASY_PROXY_IMPLEMENT_ALL_INTERFACES, b);
+      }
+      else
+      {
+         deployment.setProperty(ResteasyContextParameters.RESTEASY_PROXY_IMPLEMENT_ALL_INTERFACES, false);
+      }
+
       return deployment;
    }
 
@@ -262,7 +275,6 @@ public abstract class ConfigurationBootstrap implements ResteasyConfiguration
          return false;
       } else {
          throw new RuntimeException(Messages.MESSAGES.keyCouldNotBeParsed(key));
-
       }
    }
 

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/ResteasyContextParameters.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/ResteasyContextParameters.java
@@ -55,7 +55,7 @@ public interface ResteasyContextParameters {
    String RESTEASY_TRACING_TYPE_ON_DEMAND = "ON_DEMAND";
 
    /**
-    * Set level o tracing information.
+    * Set level of tracing information.
     * <p>
     * The property allows to set application default level o diagnostic information.
     * Tracing level can be changed for each request by specifying request HTTP header {@code X-RESTEasy-Tracing-Threshold}.
@@ -100,4 +100,8 @@ public interface ResteasyContextParameters {
     String RESTEASY_FAIL_FAST_ON_MULTIPLE_RESOURCES_MATCHING = "resteasy.fail.fast.on.multiple.resources.matching";
     String RESTEASY_MATCH_CACHE_ENABLED = "resteasy.match.cache.enabled";
     String RESTEASY_MATCH_CACHE_SIZE = "resteasy.match.cache.size";
+
+    // Added for non-quarkus servers - to enable generated proxies to implement all interfaces of delegate object.
+    String RESTEASY_PROXY_IMPLEMENT_ALL_INTERFACES = "resteasy.proxy.implement.all.interfaces"; // default is false
+
 }

--- a/resteasy-core/src/test/java/org/jboss/resteasy/core/ContextParameterInjectionTest.java
+++ b/resteasy-core/src/test/java/org/jboss/resteasy/core/ContextParameterInjectionTest.java
@@ -1,39 +1,84 @@
 package org.jboss.resteasy.core;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
+import javax.servlet.ServletContext;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 
+import org.jboss.resteasy.plugins.server.servlet.ConfigurationBootstrap;
+import org.jboss.resteasy.plugins.server.servlet.ListenerBootstrap;
+import org.jboss.resteasy.spi.ResteasyDeployment;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.junit.Test;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 public class ContextParameterInjectionTest {
+   private static final String RESTEASY_PROXY_IMPLEMENT_ALL_INTERFACES = "resteasy.proxy.implement.all.interfaces";
+   private static final Map<String, String> preTestProps = new HashMap<>();
+
+   @BeforeClass
+   public static void enableConfigForImplementingAllInterfaces() {
+      if (System.getProperties().containsKey(RESTEASY_PROXY_IMPLEMENT_ALL_INTERFACES)) {
+         String value = System.getProperty(RESTEASY_PROXY_IMPLEMENT_ALL_INTERFACES);
+         preTestProps.put(RESTEASY_PROXY_IMPLEMENT_ALL_INTERFACES, value);
+      }
+   }
 
    @AfterClass
    public static void cleanup() {
+      if (!preTestProps.containsKey(RESTEASY_PROXY_IMPLEMENT_ALL_INTERFACES)) {
+         System.clearProperty(RESTEASY_PROXY_IMPLEMENT_ALL_INTERFACES);
+      } else {
+         preTestProps.forEach(System::setProperty);
+      }
       ResteasyProviderFactory.setInstance(null);
    }
 
    @Test
+   public void testInjectedProxyImplementsOnlySpecificInterfaceByDefault() {
+      System.clearProperty(RESTEASY_PROXY_IMPLEMENT_ALL_INTERFACES);
+      Object proxy = createProxy();
+      assertTrue("Proxy does not implemented expected JAXRS interface", proxy instanceof ContainerRequestFilter);
+      assertFalse("Proxy implements non-JAXRS interfaces", proxy instanceof CoolInterface);
+   }
+
+   @Test
    public void testInjectedProxyImplementsAllInterfaces() {
-      final Class<ContainerRequestFilter> filterClass = ContainerRequestFilter.class;
-      final ContainerRequestFilter coolInstance = new CoolFilter();
-      ResteasyProviderFactory mockFactory = mock(ResteasyProviderFactory.class);
-      when(mockFactory.getContextData(filterClass, filterClass, null, false)).thenReturn(coolInstance);
-
-      ResteasyProviderFactory.setInstance(mockFactory);
-
-      ContextParameterInjector cpi = new ContextParameterInjector(null, filterClass, filterClass, null, mockFactory);
-      Object proxy = cpi.createProxy();
+      System.setProperty(RESTEASY_PROXY_IMPLEMENT_ALL_INTERFACES, "true");
+      Object proxy = createProxy();
+      assertTrue("Proxy does not implemented expected JAXRS interface", proxy instanceof ContainerRequestFilter);
       assertTrue("Proxy does not implement all expected interfaces", proxy instanceof CoolInterface);
       assertEquals("cool", ((CoolInterface)proxy).coolMethod());
+   }
+
+   private Object createProxy() {
+      ServletContext mockServletContext = mock(ServletContext.class);
+      when(mockServletContext.getAttribute(ResteasyDeployment.class.getName())).thenReturn(null);
+      ConfigurationBootstrap configBootstrap = new ListenerBootstrap(mockServletContext);
+      ResteasyContext.pushContext(ResteasyDeployment.class, configBootstrap.createDeployment());
+      try {
+         final Class<ContainerRequestFilter> filterClass = ContainerRequestFilter.class;
+         final ContainerRequestFilter coolInstance = new CoolFilter();
+         ResteasyProviderFactory mockFactory = mock(ResteasyProviderFactory.class);
+         when(mockFactory.getContextData(filterClass, filterClass, null, false)).thenReturn(coolInstance);
+
+         ResteasyProviderFactory.setInstance(mockFactory);
+
+         ContextParameterInjector cpi = new ContextParameterInjector(null, filterClass, filterClass, null, mockFactory);
+         return cpi.createProxy();
+      } finally {
+         ResteasyContext.removeContextDataLevel();
+      }
    }
 
    public interface CoolInterface {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/contextProxyInterfaces/ContextProxyInterfacesTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/contextProxyInterfaces/ContextProxyInterfacesTest.java
@@ -1,5 +1,8 @@
 package org.jboss.resteasy.test.contextProxyInterfaces;
 
+import java.util.Collections;
+import java.util.Map;
+
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.core.Response;
@@ -36,7 +39,8 @@ public class ContextProxyInterfacesTest {
    {
       WebArchive war = TestUtil.prepareArchive(ContextProxyInterfacesTest.class.getSimpleName());
       war.addClasses(TestUtil.class, PortProviderUtil.class);
-      return TestUtil.finishContainerPrepare(war, null, CastableConfigurationResource.class);
+      Map<String, String> contextParams = Collections.singletonMap("resteasy.proxy.implement.all.interfaces", "true");
+      return TestUtil.finishContainerPrepare(war, contextParams, CastableConfigurationResource.class);
    }
 
    private String generateURL(String path)


### PR DESCRIPTION
The default should be false (i.e. only use the JAX-RS context interface, not other interfaces implemented by the delegate). This check is necessary because the reflection done in checking for additional interfaces does not work with Quarkus (where it expects the reflection to be done already in a Jandex index or something similar).  