### PR TITLE
[RESTEASY-1721] Eliminate ContextParameterInjector's dependence on se…

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ContextParameterInjector.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ContextParameterInjector.java
@@ -9,16 +9,15 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.spi.ValueInjector;
 import org.jboss.resteasy.spi.util.Types;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.WriteListener;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.ext.Providers;
 import javax.ws.rs.sse.Sse;
 import javax.ws.rs.sse.SseEventSink;
 
-import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -38,12 +37,35 @@ import java.util.concurrent.CompletionStage;
 @SuppressWarnings("unchecked")
 public class ContextParameterInjector implements ValueInjector
 {
+   private static Constructor<?> constructor;
+
    private Class<?> rawType;
    private Class<?> proxy;
    private ResteasyProviderFactory factory;
    private Type genericType;
    private Annotation[] annotations;
    private volatile boolean outputStreamWasWritten = false;
+
+   static
+   {
+      constructor = AccessController.doPrivileged(new PrivilegedAction<Constructor<?>>()
+      {
+         @Override
+         public Constructor<?> run()
+         {
+            try
+            {
+               Class.forName("javax.servlet.http.HttpServletResponse", false, Thread.currentThread().getContextClassLoader());
+               Class<?> clazz = Class.forName("org.jboss.resteasy.core.ContextServletOutputStream");
+               return clazz.getDeclaredConstructor(ContextParameterInjector.class, OutputStream.class);
+            }
+            catch (Exception e)
+            {
+               return null;
+            }
+         }
+      });
+   }
 
    public ContextParameterInjector(final Class<?> proxy, final Class<?> rawType, final Type genericType, final Annotation[] annotations, final ResteasyProviderFactory factory)
    {
@@ -135,8 +157,8 @@ public class ContextParameterInjector implements ValueInjector
             {
                if ("getOutputStream".equals(method.getName()))
                {
-                  ServletOutputStream sos = (ServletOutputStream) method.invoke(delegate, objects);
-                  return new ContextOutputStream(sos);
+                  OutputStream sos = (OutputStream) method.invoke(delegate, objects);
+                  return wrapServletOutputStream(sos);
                }
             }
             return method.invoke(delegate, objects);
@@ -213,11 +235,6 @@ public class ContextParameterInjector implements ValueInjector
       }
    }
 
-   boolean outputStreamWasWrittenTo()
-   {
-      return outputStreamWasWritten;
-   }
-
    protected Class<?>[] computeInterfaces(Object delegate, Class<?> cls)
    {
       Set<Class<?>> set = new HashSet<>();
@@ -241,149 +258,29 @@ public class ContextParameterInjector implements ValueInjector
       return set.toArray(new Class<?>[]{});
    }
 
-   private final class ContextOutputStream extends ServletOutputStream
+   OutputStream wrapServletOutputStream(OutputStream os)
    {
-      private ServletOutputStream delegate;
+      if (constructor != null)
+      {
+         try
+         {
+            return (OutputStream) constructor.newInstance(this, os);
+         }
+         catch (Exception e)
+         {
+            return os;
+         }
+      }
+      return os;
+   }
 
-      ContextOutputStream(final ServletOutputStream delegate)
-      {
-         this.delegate = delegate;
-      }
+   boolean isOutputStreamWasWritten()
+   {
+      return outputStreamWasWritten;
+   }
 
-      ////////////////////////////////////////////////////////////////
-      /// ServletOutputStream methods
-      ////////////////////////////////////////////////////////////////
-      @Override
-      public void print(String s) throws IOException
-      {
-         delegate.print(s);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void print(boolean b) throws IOException
-      {
-         delegate.print(b);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void print(char c) throws IOException
-      {
-         delegate.print(c);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void print(int i) throws IOException
-      {
-         delegate.print(i);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void print(long l) throws IOException
-      {
-         delegate.print(l);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void print(float f) throws IOException
-      {
-         delegate.print(f);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void print(double d) throws IOException
-      {
-         delegate.print(d);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void println() throws IOException
-      {
-         delegate.println();
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void println(String s) throws IOException
-      {
-         delegate.println(s);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void println(boolean b) throws IOException
-      {
-         delegate.println(b);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void println(char c) throws IOException
-      {
-         delegate.print(c);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void println(int i) throws IOException
-      {
-         delegate.println(i);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void println(long l) throws IOException
-      {
-         delegate.println(l);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void println(float f) throws IOException
-      {
-         delegate.println(f);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void println(double d) throws IOException
-      {
-         delegate.println(d);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public boolean isReady()
-      {
-         return delegate.isReady();
-      }
-      @Override
-      public void setWriteListener(WriteListener writeListener)
-      {
-         delegate.setWriteListener(writeListener);
-      }
-
-      ////////////////////////////////////////////////////////////////
-      /// OutputStream methods
-      ////////////////////////////////////////////////////////////////
-      @Override
-      public void write(byte[] b) throws IOException
-      {
-          delegate.write(b);
-          outputStreamWasWritten = true;
-      }
-      @Override
-      public void write(byte[] b, int off, int len) throws IOException
-      {
-         delegate.write(b, off, len);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void write(int b) throws IOException
-      {
-         delegate.write(b);
-         outputStreamWasWritten = true;
-      }
-      @Override
-      public void flush() throws IOException
-      {
-         delegate.flush();
-      }
-      @Override
-      public void close() throws IOException
-      {
-         delegate.close();
-      }
+   void setOutputStreamWasWritten(boolean outputStreamWasWritten)
+   {
+      this.outputStreamWasWritten = outputStreamWasWritten;
    }
 }

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ContextServletOutputStream.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ContextServletOutputStream.java
@@ -1,0 +1,165 @@
+package org.jboss.resteasy.core;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+
+class ContextServletOutputStream extends ServletOutputStream
+{
+   private final ContextParameterInjector injector;
+   private final ServletOutputStream delegate;
+
+   ContextServletOutputStream(final ContextParameterInjector injector, final OutputStream delegate)
+   {
+      this.injector = injector;
+      this.delegate = (ServletOutputStream) delegate;
+   }
+
+   ////////////////////////////////////////////////////////////////
+   /// ServletOutputStream methods
+   ////////////////////////////////////////////////////////////////
+   @Override
+   public void print(String s) throws IOException
+   {
+      delegate.print(s);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void print(boolean b) throws IOException
+   {
+      delegate.print(b);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void print(char c) throws IOException
+   {
+      delegate.print(c);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void print(int i) throws IOException
+   {
+      delegate.print(i);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void print(long l) throws IOException
+   {
+      delegate.print(l);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void print(float f) throws IOException
+   {
+      delegate.print(f);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void print(double d) throws IOException
+   {
+      delegate.print(d);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void println() throws IOException
+   {
+      delegate.println();
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void println(String s) throws IOException
+   {
+      delegate.println(s);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void println(boolean b) throws IOException
+   {
+      delegate.println(b);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void println(char c) throws IOException
+   {
+      delegate.print(c);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void println(int i) throws IOException
+   {
+      delegate.println(i);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void println(long l) throws IOException
+   {
+      delegate.println(l);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void println(float f) throws IOException
+   {
+      delegate.println(f);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void println(double d) throws IOException
+   {
+      delegate.println(d);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public boolean isReady()
+   {
+      return delegate.isReady();
+   }
+   @Override
+   public void setWriteListener(WriteListener writeListener)
+   {
+      delegate.setWriteListener(writeListener);
+   }
+
+   ////////////////////////////////////////////////////////////////
+   /// OutputStream methods
+   ////////////////////////////////////////////////////////////////
+   @Override
+   public void write(byte[] b) throws IOException
+   {
+       delegate.write(b);
+       injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void write(byte[] b, int off, int len) throws IOException
+   {
+      delegate.write(b, off, len);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void write(int b) throws IOException
+   {
+      delegate.write(b);
+      injector.setOutputStreamWasWritten(true);
+   }
+   @Override
+   public void flush() throws IOException
+   {
+      delegate.flush();
+   }
+   @Override
+   public void close() throws IOException
+   {
+      delegate.close();
+   }
+
+   public ServletOutputStream getDelegate()
+   {
+      return delegate;
+   }
+
+   public ContextParameterInjector getInjector()
+   {
+      return injector;
+   }
+}

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ResourceMethodInvoker.java
@@ -819,7 +819,7 @@ public class ResourceMethodInvoker implements ResourceInvoker, JaxrsInterceptorR
       {
          if (vi instanceof ContextParameterInjector)
          {
-            return ((ContextParameterInjector) vi).outputStreamWasWrittenTo();
+            return ((ContextParameterInjector) vi).isOutputStreamWasWritten();
          }
       }
       return false;


### PR DESCRIPTION
…rvlet classes

[RESTEASY-1721] Remove another reference to ServletOutputStream.

[RESTEASY-1721] Load ContextServletOutputStream by reflection.

[RESTEASY-1721] Make variables final in ContextServletOutputStream.

[RESTEASY-1721] Hide more details of the implementation.

[RESTEASY-1721] Checkstyle fix.

[RESTEASY-1723] Hide two more methods in ContextParameterInjector.