### PR TITLE
[RESTEASY-2892] Make sure the ResteasyConfiguration also checks the S…

### DIFF
--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/config/DefaultConfiguration.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/config/DefaultConfiguration.java
@@ -32,9 +32,13 @@ import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
 import org.jboss.resteasy.spi.ResteasyConfiguration;
 
 /**
- * A default configuration which first attempts to use the Eclipse MicroProfile Config API. If not present on the class
- * path the {@linkplain ResteasyConfiguration configuration} is used to resolve the value, followed by system properties
- * and then environment variables if not found in the previous search.
+ * A default configuration which first attempts to use the Eclipse MicroProfile Config API. If the MicroProfile Config
+ * API is not available value is searched in the following order:
+ * <ol>
+ *     <li>System properties</li>
+ *     <li>Environment variables</li>
+ *     <li>{@link ResteasyConfiguration}</li>
+ * </ol>
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/FilterBootstrap.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/FilterBootstrap.java
@@ -34,7 +34,11 @@ public class FilterBootstrap extends ListenerBootstrap
    @Override
    public String getInitParameter(String name)
    {
-      return config.getInitParameter(name);
+      String value = config.getInitParameter(name);
+      if (value == null) {
+         value = super.getInitParameter(name);
+      }
+      return value;
    }
 
    @Override

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/ServletBootstrap.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/ServletBootstrap.java
@@ -14,7 +14,7 @@ import java.util.Set;
  */
 public class ServletBootstrap extends ListenerBootstrap
 {
-   private ServletConfig config;
+   private final ServletConfig config;
 
    public ServletBootstrap(final ServletConfig config)
    {
@@ -34,7 +34,11 @@ public class ServletBootstrap extends ListenerBootstrap
    @Override
    public String getInitParameter(String name)
    {
-      return config.getInitParameter(name);
+      String value = config.getInitParameter(name);
+      if (value == null) {
+         value = super.getInitParameter(name);
+      }
+      return value;
    }
 
    @Override


### PR DESCRIPTION
…ervletContext for both the ServletBootstrap and FilterBootstrap.

https://issues.redhat.com/browse/RESTEASY-2892
Upstream: #2799

Please double check the checking order for the property value. Current for the `ServletBootstrap` it's:

1. System properties
2. Environment variables
3. `ServletConfig.getInitParameter()`
4. `ServletContext.getInitParameter()`

For the `FilterBootstrap it's:
1. System properties
2. Environment variables
3. `FilterConfig.getInitParameter()`
4. `ServletContext.getInitParameter()`