### PR TITLE
[RESTEASY-2901] Clean up possibly-garbage Response before calling ExceptionHandler

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SynchronousDispatcher.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/SynchronousDispatcher.java
@@ -15,6 +15,7 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ResourceContext;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -190,6 +191,14 @@ public class SynchronousDispatcher implements Dispatcher
          onComplete.accept(null);
          return;
       }
+      // FIXME: losing X-Request-ID because ThreadLocal that keeps it in the application will not be there anymore when
+      // the ExceptionHandler below is called...
+      MultivaluedMap<String, Object> originalResponseHeaders = response.getOutputHeaders();
+      // cleans possibly partially written response
+      response.reset();
+      // FIXME: ... but maybe constructing the headers anew is actually the ExceptionHandler's job, since this is
+      // duplicating the Content-Type in the Map (no impact in the received Response in the browser though).
+      response.getOutputHeaders().putAll(originalResponseHeaders);
       Response handledResponse = new ExceptionHandler(providerFactory, unwrappedExceptions).handleException(request, e);
       if (handledResponse == null) throw new UnhandledException(e);
       if (!bufferExceptionEntity)

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/common/DispatcherResponseUtils.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/common/DispatcherResponseUtils.java
@@ -1,0 +1,48 @@
+package org.jboss.resteasy.test.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class DispatcherResponseUtils {
+    
+    @Path("/unsafe")
+    public static class MockUnsafeResource {
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response get() {
+            return Response.ok().entity(new UnsafeDto()).build();
+        }
+    }
+    
+    public static class UnsafeDto {
+        private String typeCode;
+        
+        public String getTypeDescription() {
+            // Causes NPE during jackson's serialization
+            if (this.typeCode.equals("not empty")) {
+                return "NOT EMPTY";
+            } else {
+                return this.typeCode;
+            }
+        }
+    }
+    
+    public static class JsonSerializationExceptionMapper implements ExceptionMapper<Exception> {
+        @Override
+        public Response toResponse(Exception e) {
+            Map<String, String> errorDetails = new HashMap<>();
+            errorDetails.put("ARQ-502", "JSON Serialization Error");
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(errorDetails)
+                    .type(MediaType.APPLICATION_JSON).build();
+        }
+    }
+    
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/core/DispatcherResponseJackson2Test.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/core/DispatcherResponseJackson2Test.java
@@ -4,15 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 
 import org.jboss.resteasy.core.Dispatcher;
 import org.jboss.resteasy.core.SynchronousDispatcher;
@@ -20,12 +11,13 @@ import org.jboss.resteasy.mock.MockHttpRequest;
 import org.jboss.resteasy.mock.MockHttpResponse;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.test.common.DispatcherResponseUtils;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 
-public class DispatcherResponseTest {
+public class DispatcherResponseJackson2Test {
     
     private Dispatcher dispatcher;
     
@@ -35,7 +27,7 @@ public class DispatcherResponseTest {
         
         ResteasyProviderFactory.getInstance()
                 .getExceptionMappers()
-                .put(JsonMappingException.class, new JsonMappingExceptionMapper());
+                .put(JsonMappingException.class, new DispatcherResponseUtils.JsonSerializationExceptionMapper());
         
         dispatcher = new SynchronousDispatcher(ResteasyProviderFactory.getInstance());
     }
@@ -43,9 +35,9 @@ public class DispatcherResponseTest {
     @Test
     public void testResponseAfterSerializationFailureDoesNotContainsGarbage()
             throws UnsupportedEncodingException, URISyntaxException {
-        dispatcher.getRegistry().addSingletonResource(new MockResource());
+        dispatcher.getRegistry().addSingletonResource(new DispatcherResponseUtils.MockUnsafeResource());
         
-        MockHttpRequest request = MockHttpRequest.get("/mockresource");
+        MockHttpRequest request = MockHttpRequest.get("/unsafe");
         MockUncommitedResponse response = new MockUncommitedResponse();
         
         dispatcher.invoke(request, response);
@@ -60,44 +52,12 @@ public class DispatcherResponseTest {
          * In the scenario seen when reporting RESTEASY-2901 the response was not commited when checked by
          * {@link SynchronousDispatcher#writeException(org.jboss.resteasy.spi.HttpRequest, org.jboss.resteasy.spi.HttpResponse, Throwable, java.util.function.Consumer)}
          * 
-         * TODO: Maybe this check returning false in that scenario is the root cause of the issue?
+         * TODO: Maybe this check returning false in such a scenario is the root cause of the issue? JSONB doesn't need
+         * this, so maybe it just doesn't mess with resteasy's OutputStream as jackson does.
          */
         @Override
         public boolean isCommitted() {
             return false;
-        }
-    }
-    
-    @Path("/mockresource")
-    public static class MockResource {
-        @GET
-        @Produces(MediaType.APPLICATION_JSON)
-        public Response get() {
-            return Response.ok().entity(new UnsafeDto()).build();
-        }
-    }
-    
-    public static class UnsafeDto {
-        private String typeCode;
-        
-        public String getTypeDescription() {
-            // Causes NPE during jackson's serialization
-            if (this.typeCode.equals("not empty")) {
-                return "NOT EMPTY";
-            } else {
-                return this.typeCode;
-            }
-        }
-    }
-    
-    public static class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingException> {
-        @Override
-        public Response toResponse(JsonMappingException exception) {
-            Map<String, String> errorDetails = new HashMap<>();
-            errorDetails.put("ARQ-502", "JSON Serialization Error");
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity(errorDetails)
-                    .type(MediaType.APPLICATION_JSON).build();
         }
     }
     

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/core/DispatcherResponseJsonBTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/core/DispatcherResponseJsonBTest.java
@@ -1,0 +1,47 @@
+package org.jboss.resteasy.test.core;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+
+import javax.ws.rs.ProcessingException;
+
+import org.jboss.resteasy.core.Dispatcher;
+import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.jboss.resteasy.mock.MockHttpResponse;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.test.common.DispatcherResponseUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DispatcherResponseJsonBTest {
+    
+    private Dispatcher dispatcher;
+    
+    @Before
+    public void before() {
+        ResteasyProviderFactory.getInstance()
+                .getExceptionMappers()
+                .put(ProcessingException.class, new DispatcherResponseUtils.JsonSerializationExceptionMapper());
+        
+        dispatcher = new SynchronousDispatcher(ResteasyProviderFactory.getInstance());
+    }
+    
+    @Test
+    public void testResponseAfterSerializationFailureDoesNotContainsGarbage()
+            throws UnsupportedEncodingException, URISyntaxException {
+        dispatcher.getRegistry().addSingletonResource(new DispatcherResponseUtils.MockUnsafeResource());
+        
+        MockHttpRequest request = MockHttpRequest.get("/unsafe");
+        MockHttpResponse response = new MockHttpResponse();
+        
+        dispatcher.invoke(request, response);
+        
+        assertEquals(500, response.getStatus());
+        // Below already doesn't fail even before RESTEASY-2901 is fixed
+        assertEquals("{\"ARQ-502\":\"JSON Serialization Error\"}", response.getContentAsString());
+    }
+    
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/core/DispatcherResponseTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/core/DispatcherResponseTest.java
@@ -1,0 +1,104 @@
+package org.jboss.resteasy.test.core;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.jboss.resteasy.core.Dispatcher;
+import org.jboss.resteasy.core.SynchronousDispatcher;
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.jboss.resteasy.mock.MockHttpResponse;
+import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+
+public class DispatcherResponseTest {
+    
+    private Dispatcher dispatcher;
+    
+    @Before
+    public void before() {
+        System.setProperty(ResteasyContextParameters.RESTEASY_PREFER_JACKSON_OVER_JSONB, "true");
+        
+        ResteasyProviderFactory.getInstance()
+                .getExceptionMappers()
+                .put(JsonMappingException.class, new JsonMappingExceptionMapper());
+        
+        dispatcher = new SynchronousDispatcher(ResteasyProviderFactory.getInstance());
+    }
+    
+    @Test
+    public void testResponseAfterSerializationFailureDoesNotContainsGarbage()
+            throws UnsupportedEncodingException, URISyntaxException {
+        dispatcher.getRegistry().addSingletonResource(new MockResource());
+        
+        MockHttpRequest request = MockHttpRequest.get("/mockresource");
+        MockUncommitedResponse response = new MockUncommitedResponse();
+        
+        dispatcher.invoke(request, response);
+        
+        assertEquals(500, response.getStatus());
+        // Below does not fail if RESTEASY-2901 is fixed
+        assertEquals("{\"ARQ-502\":\"JSON Serialization Error\"}", response.getContentAsString());
+    }
+    
+    public static class MockUncommitedResponse extends MockHttpResponse {
+        /**
+         * In the scenario seen when reporting RESTEASY-2901 the response was not commited when checked by
+         * {@link SynchronousDispatcher#writeException(org.jboss.resteasy.spi.HttpRequest, org.jboss.resteasy.spi.HttpResponse, Throwable, java.util.function.Consumer)}
+         * 
+         * TODO: Maybe this check returning false in that scenario is the root cause of the issue?
+         */
+        @Override
+        public boolean isCommitted() {
+            return false;
+        }
+    }
+    
+    @Path("/mockresource")
+    public static class MockResource {
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response get() {
+            return Response.ok().entity(new UnsafeDto()).build();
+        }
+    }
+    
+    public static class UnsafeDto {
+        private String typeCode;
+        
+        public String getTypeDescription() {
+            // Causes NPE during jackson's serialization
+            if (this.typeCode.equals("not empty")) {
+                return "NOT EMPTY";
+            } else {
+                return this.typeCode;
+            }
+        }
+    }
+    
+    public static class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingException> {
+        @Override
+        public Response toResponse(JsonMappingException exception) {
+            Map<String, String> errorDetails = new HashMap<>();
+            errorDetails.put("ARQ-502", "JSON Serialization Error");
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(errorDetails)
+                    .type(MediaType.APPLICATION_JSON).build();
+        }
+    }
+    
+}


### PR DESCRIPTION
**EDIT:** (Although this was originally discovered running 3.13.2.Final through WildFly 21.0.0.Final; it was reproduced on `main` branch as well - see #2804)

Hello all,

First attempt at contributing to fix https://issues.redhat.com/browse/RESTEASY-2901

I'll wait for a feedback from someone more knowledgable of the code in question, but I'm starting to think a more adequate/elegant fix could be made around the [definition of the `entityStream` used](https://github.com/resteasy/Resteasy/blob/3.13.2.Final/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/ResteasyJackson2Provider.java#L220) by ResteasyJackson2Provider, since the problem doesn't seem to happen with JSONB.

Cheers!