### PR TITLE
[RESTEASY-2886] RESTEasy Java 16 Fixes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest ]
         java: ['1.8', '11']
-        wildfly-version: ['20.0.1.Final', '21.0.1.Final']
+        wildfly-version: ['22.0.1.Final', '23.0.2.Final']
 
     steps:
       - uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,20 @@
             </build>
       </profile>
       <profile>
+          <id>modular.jvm</id>
+          <activation>
+              <jdk>[9,)</jdk>
+          </activation>
+          <properties>
+              <modular.jdk.args>
+                  --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+                  --add-modules=java.se
+                  --add-opens=java.base/java.util=ALL-UNNAMED
+                  --add-opens=java.base/java.security=ALL-UNNAMED
+              </modular.jdk.args>
+          </properties>
+      </profile>
+      <profile>
           <id>github-actions</id>
           <activation>
               <property>

--- a/resteasy-core/pom.xml
+++ b/resteasy-core/pom.xml
@@ -116,13 +116,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.5</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
             <scope>test</scope>
         </dependency>
 

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -18,7 +18,7 @@
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.11.4</version.com.fasterxml.jackson>
         <version.com.google.guava>30.1-jre</version.com.google.guava>
-        <version.com.google.inject.guice>4.2.2</version.com.google.inject.guice>
+        <version.com.google.inject.guice>5.0.1</version.com.google.inject.guice>
         <version.com.io7m.xom>1.2.10</version.com.io7m.xom>
         <version.jakarta.mail>1.6.5</version.jakarta.mail>
         <version.org.glassfish.jaxb.jaxb>2.3.3-b02</version.org.glassfish.jaxb.jaxb>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -29,7 +29,7 @@
         <version.io.netty.netty>3.10.6.Final</version.io.netty.netty>
         <version.io.netty.netty4>4.1.60.Final</version.io.netty.netty4>
         <version.io.vertx>4.0.3</version.io.vertx>
-        <version.io.undertow>2.0.23.Final</version.io.undertow>
+        <version.io.undertow>2.2.7.Final</version.io.undertow>
         <version.jakarta.activation>1.2.1</version.jakarta.activation>
         <version.jakarta.enterprise.cdi-api>2.0.2</version.jakarta.enterprise.cdi-api>
         <version.jakarta.inject.jakarta.inject-api>1.0</version.jakarta.inject.jakarta.inject-api>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -71,10 +71,11 @@
         <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.3_spec>2.0.0.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.3_spec>
         <version.org.jboss.shrinkwrap.resolver>2.2.7</version.org.jboss.shrinkwrap.resolver>
         <version.org.slf4j>1.7.29</version.org.slf4j>
+        <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.core.wildfly-cli>7.0.0.Final</version.org.wildfly.core.wildfly-cli>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
-        <version.weld.api>3.1.SP3</version.weld.api>
-        <version.weld>3.1.5.Final</version.weld>
+        <version.weld.api>3.1.SP4</version.weld.api>
+        <version.weld>3.1.7.SP1</version.weld>
         <version.json.patch>1.13</version.json.patch>
 
         <!-- MicroProfile versions -->
@@ -369,6 +370,17 @@
                 <groupId>io.undertow</groupId>
                 <artifactId>undertow-core</artifactId>
                 <version>${version.io.undertow}</version>
+            </dependency>
+            <!-- Used by Under and some of it's dependencies, defining it here unifies the version -->
+            <dependency>
+                <groupId>org.wildfly.common</groupId>
+                <artifactId>wildfly-common</artifactId>
+                <version>${version.org.wildfly.common}</version>
+                <!-- Using provided and optional here because RESTEasy itself does not use this dependency. It's defined
+                     here to stop dependency convergences.
+                 -->
+                <scope>provided</scope>
+                <optional>true</optional>
             </dependency>
             <dependency>
                 <groupId>jakarta.enterprise</groupId>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -101,7 +101,7 @@
         <version.org.hibernate.validator>6.0.18.Final</version.org.hibernate.validator>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.6.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.rest-assured>3.3.0</version.rest-assured>
-        <version.org.springframework>5.2.0.RELEASE</version.org.springframework>
+        <version.org.springframework>5.3.7</version.org.springframework>
         <version.io.projectreactor>2020.0.5</version.io.projectreactor>
 
         <version.asyncutil>0.1.0</version.asyncutil>
@@ -940,6 +940,11 @@
                 <artifactId>mockito-core</artifactId>
                 <version>${version.org.mockito}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${version.org.springframework}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -72,7 +72,7 @@
         <version.org.jboss.shrinkwrap.resolver>2.2.7</version.org.jboss.shrinkwrap.resolver>
         <version.org.slf4j>1.7.29</version.org.slf4j>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
-        <version.org.wildfly.core.wildfly-cli>7.0.0.Final</version.org.wildfly.core.wildfly-cli>
+        <version.org.wildfly.core.wildfly-cli>15.0.1.Final</version.org.wildfly.core.wildfly-cli>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.weld.api>3.1.SP4</version.weld.api>
         <version.weld>3.1.7.SP1</version.weld>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -70,6 +70,7 @@
         <version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>2.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>
         <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.3_spec>2.0.0.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.3_spec>
         <version.org.jboss.shrinkwrap.resolver>2.2.7</version.org.jboss.shrinkwrap.resolver>
+        <version.org.mockito>3.10.0</version.org.mockito>
         <version.org.slf4j>1.7.29</version.org.slf4j>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.core.wildfly-cli>15.0.1.Final</version.org.wildfly.core.wildfly-cli>
@@ -933,6 +934,12 @@
                 <groupId>org.jboss.marshalling</groupId>
                 <artifactId>jboss-marshalling-river</artifactId>
                 <version>${version.org.jboss.marshalling.jboss-marshalling}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.org.mockito}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/TestUtilSpring.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/TestUtilSpring.java
@@ -12,21 +12,8 @@ import java.util.List;
  */
 public class TestUtilSpring {
 
-   private static String defaultSpringVersion = "5.2.0.RELEASE";
+   private static final String defaultSpringVersion = "5.3.7";
    //protected static Logger logger;
-
-
-   /**
-    * Read system proprty
-    *
-    * @param name         of the property
-    * @param defaultValue which will be used if system property name is not defined
-    * @return property value
-    */
-   private static String readSystemProperty(String name, String defaultValue) {
-      String value = System.getProperty(name);
-      return (value == null) ? defaultValue : value;
-   }
 
    /**
     * Get spring version
@@ -34,7 +21,7 @@ public class TestUtilSpring {
     * @return Spring version.
     */
    private static String getSpringVersion() {
-      return readSystemProperty("version.org.springframework", defaultSpringVersion);
+      return System.getProperty("version.org.springframework", defaultSpringVersion);
    }
 
    /**

--- a/testsuite/integration-tests-spring-web/pom.xml
+++ b/testsuite/integration-tests-spring-web/pom.xml
@@ -16,7 +16,7 @@
     <name>RESTEasy Main testsuite: Spring Web integration tests</name>
 
     <properties>
-        <version.org.springframework>5.0.14.RELEASE</version.org.springframework>
+        <version.org.springframework>5.3.7</version.org.springframework>
         <version.org.aspectj>1.7.3</version.org.aspectj>
         <version.aopalliance>1.0</version.aopalliance>
     </properties>
@@ -109,4 +109,18 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <version.org.springframework>${version.org.springframework}</version.org.springframework>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/testsuite/integration-tests-spring/deployment/pom.xml
+++ b/testsuite/integration-tests-spring/deployment/pom.xml
@@ -93,7 +93,6 @@
                 </property>
             </activation>
             <properties>
-                <security.provider>elytron</security.provider>
                 <jboss.server.config.file.name>standalone-full-elytron.xml</jboss.server.config.file.name>
             </properties>
             <build>

--- a/testsuite/integration-tests-spring/deployment/pom.xml
+++ b/testsuite/integration-tests-spring/deployment/pom.xml
@@ -166,6 +166,17 @@
                 </excludes>
             </testResource>
         </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <version.org.springframework>${version.org.springframework}</version.org.springframework>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/testsuite/integration-tests-spring/inmodule/pom.xml
+++ b/testsuite/integration-tests-spring/inmodule/pom.xml
@@ -99,7 +99,6 @@
                 </property>
             </activation>
             <properties>
-                <security.provider>elytron</security.provider>
                 <jboss.server.config.file.name>standalone-full-elytron.xml</jboss.server.config.file.name>
             </properties>
             <build>

--- a/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/SpringMvcHttpResponseCodesTest.java
+++ b/testsuite/integration-tests-spring/inmodule/src/test/java/org/jboss/resteasy/test/spring/inmodule/SpringMvcHttpResponseCodesTest.java
@@ -33,10 +33,6 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.io.File;
-import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * @tpSubChapter Spring
@@ -53,7 +49,7 @@ public class SpringMvcHttpResponseCodesTest {
    private static Client nonAutorizedClient;
 
    @Deployment
-   private static Archive<?> deploy() {
+   public static Archive<?> deploy() {
       WebArchive war = TestUtil.prepareArchive(SpringMvcHttpResponseCodesTest.class.getSimpleName());
       war.addAsWebInfResource(SpringMvcHttpResponseCodesTest.class.getPackage(), "springMvcHttpResponseCodes/web-secure.xml", "web.xml");
       war.addAsWebInfResource(SpringMvcHttpResponseCodesTest.class.getPackage(), "springMvcHttpResponseCodes/jboss-web.xml", "jboss-web.xml");
@@ -190,12 +186,9 @@ public class SpringMvcHttpResponseCodesTest {
    }
 
    static class SecurityDomainSetup extends AbstractUsersRolesSecurityDomainSetup {
-
-      @Override
-      public void setConfigurationPath() throws URISyntaxException {
-         Path filepath= Paths.get(SpringMvcHttpResponseCodesTest.class.getResource("users.properties").toURI());
-         Path parent = filepath.getParent();
-         createPropertiesFiles(new File(parent.toUri()));
+      SecurityDomainSetup() {
+         super(SpringMvcHttpResponseCodesTest.class.getResource("users.properties"),
+                 SpringMvcHttpResponseCodesTest.class.getResource("roles.properties"));
       }
    }
 }

--- a/testsuite/integration-tests-spring/pom.xml
+++ b/testsuite/integration-tests-spring/pom.xml
@@ -16,7 +16,7 @@
     <name>RESTEasy Main testsuite: Spring integration tests</name>
 
     <properties>
-        <version.org.springframework>5.0.14.RELEASE</version.org.springframework>
+        <version.org.springframework>5.3.7</version.org.springframework>
         <version.org.aspectj>1.7.3</version.org.aspectj>
         <version.aopalliance>1.0</version.aopalliance>
     </properties>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -192,7 +192,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.hamcrest</groupId>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -131,7 +131,6 @@
                 </property>
             </activation>
             <properties>
-                <security.provider>elytron</security.provider>
                 <jboss.server.config.file.name>standalone-full-elytron.xml</jboss.server.config.file.name>
             </properties>
             <build>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/EJBTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/EJBTest.java
@@ -19,11 +19,13 @@ import org.jboss.resteasy.test.cdi.util.UtilityProducer;
 import org.jboss.resteasy.spi.HttpResponseCodes;
 import org.jboss.resteasy.utils.PermissionUtil;
 import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -72,7 +74,7 @@ public class EJBTest {
       // test needs to use special annotations in Application class, TestApplication class could not be used
       war.addClass(EJBApplication.class);
       war.addClass(PortProviderUtil.class);
-      war.addClasses(EJBBook.class, Constants.class, Counter.class, UtilityProducer.class, Utilities.class)
+      war.addClasses(EJBBook.class, Constants.class, Counter.class, UtilityProducer.class, Utilities.class, TestUtil.class)
          .addClasses(EJBBookReader.class, EJBBookReaderImpl.class)
          .addClasses(EJBBookWriterImpl.class)
          .addClasses(EJBResourceParent.class, EJBLocalResource.class, EJBRemoteResource.class, EJBBookResource.class)
@@ -144,6 +146,7 @@ public class EJBTest {
     */
    @Test
    public void testVerifyScopesRemoteEJB() throws Exception {
+      Assume.assumeFalse("Requires WFLY-14668 to be resolved for Java 16+", TestUtil.isModularJvm());
       log.info("starting testVerifyScopesRemoteEJB()");
 
       // Get proxy to JAX-RS resource as EJB.
@@ -188,6 +191,7 @@ public class EJBTest {
     */
    @Test
    public void testVerifyInjectionRemoteEJB() throws Exception {
+      Assume.assumeFalse("Requires WFLY-14668 to be resolved for Java 16+", TestUtil.isModularJvm());
       log.info("starting testVerifyInjectionRemoteEJB()");
 
       // Get proxy to JAX-RS resource as EJB.
@@ -301,6 +305,7 @@ public class EJBTest {
     */
    @Test
    public void testAsRemoteEJB() throws Exception {
+         Assume.assumeFalse("Requires WFLY-14668 to be resolved for Java 16+", TestUtil.isModularJvm());
       log.info("entering testAsRemoteEJB()");
 
       // Get proxy to JAX-RS resource as EJB.

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
@@ -1,9 +1,6 @@
 package org.jboss.resteasy.test.security;
 
 import java.io.File;
-import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Hashtable;
 
 import javax.ws.rs.NotAuthorizedException;
@@ -349,12 +346,9 @@ public class BasicAuthTest {
 
     static class SecurityDomainSetup extends AbstractUsersRolesSecurityDomainSetup {
 
-      @Override
-      public void setConfigurationPath() throws URISyntaxException {
-         Path filepath= Paths.get(BasicAuthTest.class.getResource("users.properties").toURI());
-         Path parent = filepath.getParent();
-         createPropertiesFiles(new File(parent.toUri()));
-      }
+        SecurityDomainSetup() {
+            super(BasicAuthTest.class.getResource("users.properties"), BasicAuthTest.class.getResource("roles.properties"));
+        }
 
    }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/CustomForbiddenMessageTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/CustomForbiddenMessageTest.java
@@ -31,10 +31,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.core.Response;
-import java.io.File;
-import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Hashtable;
 
 /**
@@ -103,11 +99,9 @@ public class CustomForbiddenMessageTest {
 
    static class SecurityDomainSetup extends AbstractUsersRolesSecurityDomainSetup {
 
-      @Override
-      public void setConfigurationPath() throws URISyntaxException {
-         Path filepath= Paths.get(CustomForbiddenMessageTest.class.getResource("users.properties").toURI());
-         Path parent = filepath.getParent();
-         createPropertiesFiles(new File(parent.toUri()));
+      SecurityDomainSetup() {
+         super(CustomForbiddenMessageTest.class.getResource("users.properties"),
+                 CustomForbiddenMessageTest.class.getResource("roles.properties"));
       }
    }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SecurityContextTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SecurityContextTest.java
@@ -23,11 +23,7 @@ import org.wildfly.extras.creaper.core.CommandFailedException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
-import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * @tpSubChapter Security
@@ -138,11 +134,9 @@ public class SecurityContextTest {
 
    static class SecurityDomainSetup extends AbstractUsersRolesSecurityDomainSetup {
 
-      @Override
-      public void setConfigurationPath() throws URISyntaxException {
-         Path filepath= Paths.get(SecurityContextTest.class.getResource("users.properties").toURI());
-         Path parent = filepath.getParent();
-         createPropertiesFiles(new File(parent.toUri()));
+      SecurityDomainSetup() {
+         super(SecurityContextTest.class.getResource("users.properties"),
+                 SecurityContextTest.class.getResource("roles.properties"));
       }
    }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/TwoSecurityDomainsTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/TwoSecurityDomainsTest.java
@@ -30,11 +30,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.core.Response;
-import java.io.File;
-import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.Map;
 
 /**
  * @tpSubChapter Security
@@ -44,7 +42,7 @@ import java.util.Hashtable;
  * in the Elytron subsystem.
  * @tpSince RESTEasy 3.0.21
  */
-@ServerSetup({TwoSecurityDomainsTest.SecurityDomainSetup1.class, TwoSecurityDomainsTest.SecurityDomainSetup2.class})
+@ServerSetup(TwoSecurityDomainsTest.SecurityDomainSetup.class)
 @RunWith(Arquillian.class)
 @RunAsClient
 @Category({ExpectedFailingOnWildFly18.class}) //WFLY-12655
@@ -114,26 +112,18 @@ public class TwoSecurityDomainsTest {
       Assert.assertEquals(WRONG_RESPONSE, "hello", response.readEntity(String.class));
    }
 
-   static class SecurityDomainSetup1 extends AbstractUsersRolesSecurityDomainSetup {
+   static class SecurityDomainSetup extends AbstractUsersRolesSecurityDomainSetup {
 
-      @Override
-      public void setConfigurationPath() throws URISyntaxException {
-         Path filepath= Paths.get(TwoSecurityDomainsTest.class.getResource("users.properties").toURI());
-         Path parent = filepath.getParent();
-         createPropertiesFiles(new File(parent.toUri()));
-         setSecurityDomainName(SECURITY_DOMAIN_DEPLOYMENT_1);
-         setSubsystem("picketBox");
+      SecurityDomainSetup() {
+         super(TwoSecurityDomainsTest.class.getResource("users.properties"),
+                 TwoSecurityDomainsTest.class.getResource("roles.properties"));
       }
-   }
 
-   static class SecurityDomainSetup2 extends AbstractUsersRolesSecurityDomainSetup {
-
-      @Override
-      public void setConfigurationPath() throws URISyntaxException {
-         Path filepath= Paths.get(TwoSecurityDomainsTest.class.getResource("users.properties").toURI());
-         Path parent = filepath.getParent();
-         createPropertiesFiles(new File(parent.toUri()));
-         setSecurityDomainName(SECURITY_DOMAIN_DEPLOYMENT_2);
+      public Map<String, String> getSecurityDomainConfig() {
+         final Map<String, String> config = new HashMap<>();
+         config.put(SECURITY_DOMAIN_DEPLOYMENT_1, "realm1");
+         config.put(SECURITY_DOMAIN_DEPLOYMENT_2, "realm2");
+         return config;
       }
    }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/EJBParameterViolationsOnlyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ejb/EJBParameterViolationsOnlyTest.java
@@ -27,6 +27,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -92,6 +93,7 @@ public class EJBParameterViolationsOnlyTest {
     */
    @Test
    public void testStateless() throws Exception {
+      Assume.assumeFalse("Requires WFLY-14668 to be resolved for Java 16+", TestUtil.isModularJvm());
       doValidationTest(client.target(generateURL("/app/stateless")));
    }
 
@@ -110,6 +112,7 @@ public class EJBParameterViolationsOnlyTest {
     */
    @Test
    public void testSingleton() throws Exception {
+      Assume.assumeFalse("Requires WFLY-14668 to be resolved for Java 16+", TestUtil.isModularJvm());
       doValidationTest(client.target(generateURL("/app/singleton")));
    }
 

--- a/testsuite/microprofile-tck/pom.xml
+++ b/testsuite/microprofile-tck/pom.xml
@@ -16,8 +16,9 @@
 
   <properties>
     <skip.mp.tck>false</skip.mp.tck>
-    <jetty9.version>9.2.28.v20190418</jetty9.version>
+    <jetty9.version>9.2.30.v20200428</jetty9.version>
     <jetty.version>${jetty9.version}</jetty.version>
+    <tck.timeout.offset>30</tck.timeout.offset>
   </properties>
 
   <dependencies>
@@ -210,7 +211,7 @@
         <configuration>
           <skip>${skip.mp.tck}</skip>
           <systemPropertyVariables>
-               <org.eclipse.microprofile.rest.client.tck.timeoutCushion>30</org.eclipse.microprofile.rest.client.tck.timeoutCushion>
+               <org.eclipse.microprofile.rest.client.tck.timeoutCushion>${tck.timeout.offset}</org.eclipse.microprofile.rest.client.tck.timeoutCushion>
           </systemPropertyVariables>
         </configuration>
         <executions>
@@ -245,6 +246,22 @@
       </activation>
       <properties>
         <skip.mp.tck>true</skip.mp.tck>
+      </properties>
+    </profile>
+    <profile>
+      <id>skip-mp-tck.modular.jvm</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <modular.jdk.args>
+          --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+          --add-modules=java.se
+          --add-opens=java.base/java.util=ALL-UNNAMED
+          --add-opens=java.base/java.security=ALL-UNNAMED
+          --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+        </modular.jdk.args>
+        <tck.timeout.offset>90</tck.timeout.offset>
       </properties>
     </profile>
   </profiles>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -248,20 +248,6 @@
             </properties>
         </profile>
 
-        <!-- https://issues.jboss.org/browse/MODULES-372 - JDK 11 - module not found java.se -->
-        <profile>
-            <id>modular-jdk</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <properties>
-                <modular.jdk.args>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED
-                    --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
-                    --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED
-                    --add-modules=java.se</modular.jdk.args>
-            </properties>
-        </profile>
-
         <profile>
             <id>ipv6</id>
             <activation>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -22,7 +22,6 @@
         <additionalJvmArgs/>
         <ipv6ArquillianSettings/>
         <jboss.server.config.file.name>standalone-full.xml</jboss.server.config.file.name>
-        <security.provider>picketbox</security.provider>
     </properties>
 
     <dependencyManagement>
@@ -106,7 +105,6 @@
                         <project.version>${project.version}</project.version>
                         <version.resteasy.testsuite>${version.resteasy.testsuite}</version.resteasy.testsuite>
                         <jboss.server.config.file.name>${jboss.server.config.file.name}</jboss.server.config.file.name>
-                        <security.provider>${security.provider}</security.provider>
                     </systemPropertyVariables>
                     <excludedGroups>org.jboss.resteasy.category.ExpectedFailing${additional.surefire.excluded.groups}</excludedGroups>
                 </configuration>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -186,7 +186,7 @@
               </property>
             </activation>
             <properties>
-                <server.version>21.0.1.Final</server.version>
+                <server.version>23.0.2.Final</server.version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
There are several changes here mostly component upgrades and changes to the VM arguments required for Java 16. 

There is also a change to drop legacy security (PicketLink/PicketBox) configuration in WildFly in favor of Elytron. The legacy security will not work with Java 16+.

JIRA's:
- https://issues.redhat.com/browse/RESTEASY-2886
- https://issues.redhat.com/browse/RESTEASY-2895
- https://issues.redhat.com/browse/RESTEASY-2896
- https://issues.redhat.com/browse/RESTEASY-2897
- https://issues.redhat.com/browse/RESTEASY-2898
- https://issues.redhat.com/browse/RESTEASY-2899
- https://issues.redhat.com/browse/RESTEASY-2900
- https://issues.redhat.com/browse/RESTEASY-2902
- https://issues.redhat.com/browse/RESTEASY-2903
- https://issues.redhat.com/browse/RESTEASY-2904