### PR TITLE
Require a minimum of Java 9 for compiling

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,13 +15,13 @@ jobs:
   build:
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest ]
-        java: ['1.8', '11']
-        wildfly-version: ['22.0.1.Final', '23.0.2.Final']
+        java: ['11', '16']
+        wildfly-version: ['23.0.2.Final']
 
     steps:
       - uses: actions/checkout@v2
@@ -31,12 +31,84 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: 'adopt'
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
-      - name: Build with Maven Java ${{ matrix.java }} on WildFly ${{ matrix.wildfly-version }}
-        run: mvn clean install -U -B -fae '-Dserver.version=${{ matrix.wildfly-version }}' '-Dgithub.actions'
+          distribution: 'adopt'
+      - name: Build with Maven Java ${{ matrix.java }} on WildFly ${{ matrix.wildfly-version }} - Linux
+        if: runner.os == 'Linux'
+        run: |
+          echo "::group::Build Logs"
+          mvn clean install -U -B -fae -Dserver.version=${{ matrix.wildfly-version }} -Dgithub.actions -Djava8.home="$JAVA_HOME_8_X64"
+          echo "::endgroup::"
+      - name: Build with Maven Java ${{ matrix.java }} on WildFly ${{ matrix.wildfly-version }} - Windows
+        if: runner.os == 'Windows'
+        run:  |
+          echo "::group::Build Logs"
+          mvn clean install -U -B -fae '-Dserver.version=${{ matrix.wildfly-version }}' '-Dgithub.actions' '"-Djava8.home=%JAVA_HOME_8_X64%"'
+          echo "::endgroup::"
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: surefire-reports-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.wildfly-version }}
+          path: '**/surefire-reports/*.txt'
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: server-logs-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.wildfly-version }}
+          path: '**/server.log'
+
+  test-with-java8:
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest ]
+        wildfly-version: ['23.0.2.Final']
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: 'adopt'
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'adopt'
+      - name: Build with Java 11
+        run: |
+          echo "::group::Build Logs"
+          mvn clean install -U -B -DskipTests
+          echo "::endgroup::"
+      - name: Test with Java 8 on WildFly ${{ matrix.wildfly-version }} - Linux
+        if: runner.os == 'Linux'
+        run:  |
+          echo "::group::Test Logs"
+          mvn clean install -U -B -fae -rf ':resteasy-testsuite' -Dserver.version=${{ matrix.wildfly-version }} -Dgithub.actions -Dtest.java8.home="$JAVA_HOME_8_X64"
+          echo "::endgroup::"
+      - name: Test with Java 8 on WildFly ${{ matrix.wildfly-version }} - Windows
+        if: runner.os == 'Windows'
+        run: |
+          echo "::group::Build Logs"
+          mvn clean install -U -B -fae -rf ':resteasy-testsuite' '-Dserver.version=${{ matrix.wildfly-version }}' '-Dgithub.actions' '"-Dtest.java8.home=%JAVA_HOME_8_X64%"'
+          echo "::endgroup::"
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
@@ -50,11 +122,7 @@ jobs:
 
   build-java-docs:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        java: ['1.8', '11']
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v1
@@ -63,10 +131,10 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-javadoc
-      - name: Set up JDK ${{ matrix.java }}
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.java }}
-      - name: Build Java Docs with Java ${{ matrix.java }}
+          java-version: 11
+      - name: Build Java Docs with Java 11
         run: mvn clean install -U -B -DskipTests '-Dmaven.javadoc.skip=false' javadoc:javadoc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ script:
 
 language: java
 jdk:
-  - openjdk8
+  - openjdk11
 env:
-  - SERVER_VERSION=21.0.1.Final ELYTRON=true
+  - SERVER_VERSION=23.0.2.Final ELYTRON=true
 jobs:
 addons:
   hosts:

--- a/arquillian/RESTEASY-1056-jetty-bv11/src/test/resources/arquillian.xml
+++ b/arquillian/RESTEASY-1056-jetty-bv11/src/test/resources/arquillian.xml
@@ -14,8 +14,8 @@
     <container qualifier="jetty" default="true">
        <configuration>
            <property name="bindHttpPort">0</property>
-           <property name="javaVmArguments">${additionalJvmArgs} ${modular.jdk.args}</property>
-           <!--property name="javaVmArguments">${additionalJvmArgs} ${modular.jdk.args} -Xdebug -Xrunjdwp:transport=dt_socket,address=8585,server=y, suspend=y</property-->
+           <property name="javaVmArguments">${additionalJvmArgs}</property>
+           <!--property name="javaVmArguments">${additionalJvmArgs} -Xdebug -Xrunjdwp:transport=dt_socket,address=8585,server=y, suspend=y</property-->
        </configuration>
     </container>
 </arquillian>

--- a/arquillian/RESTEASY-1630-jetty-resteasy-servlet-initializer/src/test/resources/arquillian.xml
+++ b/arquillian/RESTEASY-1630-jetty-resteasy-servlet-initializer/src/test/resources/arquillian.xml
@@ -14,9 +14,9 @@
     <container qualifier="jetty" default="true">
        <configuration>
            <property name="bindHttpPort">0</property>
-           <property name="javaVmArguments">${additionalJvmArgs} ${modular.jdk.args}</property>
+           <property name="javaVmArguments">${additionalJvmArgs}</property>
          <!--
-           <property name="javaVmArguments">${additionalJvmArgs} ${modular.jdk.args} -Xdebug -Xrunjdwp:transport=dt_socket,address=8585,server=y, suspend=n</property>
+           <property name="javaVmArguments">${additionalJvmArgs} -Xdebug -Xrunjdwp:transport=dt_socket,address=8585,server=y, suspend=n</property>
          -->
        </configuration>
     </container>

--- a/arquillian/RESTEASY-736-jetty/pom.xml
+++ b/arquillian/RESTEASY-736-jetty/pom.xml
@@ -20,13 +20,6 @@
           <skip>true</skip>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
        

--- a/arquillian/pom.xml
+++ b/arquillian/pom.xml
@@ -53,13 +53,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -29,17 +29,19 @@
         <jboss.home/>
         <!-- print logs to file by default -->
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-        <!-- Modularized JDK support (various workarounds) - activated via profile -->
-        <modular.jdk.args/>
         <!-- maven-enforcer-plugin -->
         <maven.min.version>3.2.5</maven.min.version>
-        <jdk.min.version>${maven.compiler.source}</jdk.min.version>
+
+        <!-- Require at least Java 9 to compile, but compile down to Java 8 -->
+        <jdk.min.version>9</jdk.min.version>
+        <javadoc.additional.params>--release=8</javadoc.additional.params>
         <!-- maven-surefire-plugin -->
-        <surefire.system.args>-Xms512m -Xmx512m ${modular.jdk.args}</surefire.system.args>
+        <surefire.system.args>-Xms512m -Xmx512m</surefire.system.args>
+        <skip.java8.tests>false</skip.java8.tests>
         <!-- Plugins versions -->
         <version.org.jacoco.plugin>0.7.9</version.org.jacoco.plugin>
-        <version.javadoc.plugin>3.0.1</version.javadoc.plugin>
         <version.compiler.plugin>3.8.0-jboss-2</version.compiler.plugin>
+        <version.org.wildfly.plugins.wildfly-maven-plugin>2.1.0.Beta1</version.org.wildfly.plugins.wildfly-maven-plugin>
     </properties>
 
     <url>https://jboss.org/resteasy</url>
@@ -171,18 +173,39 @@
             </build>
       </profile>
       <profile>
-          <id>modular.jvm</id>
+          <id>java8.tests</id>
           <activation>
-              <jdk>[9,)</jdk>
+              <property>
+                  <name>java8.home</name>
+              </property>
           </activation>
-          <properties>
-              <modular.jdk.args>
-                  --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
-                  --add-modules=java.se
-                  --add-opens=java.base/java.util=ALL-UNNAMED
-                  --add-opens=java.base/java.security=ALL-UNNAMED
-              </modular.jdk.args>
-          </properties>
+          <build>
+              <plugins>
+                  <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-surefire-plugin</artifactId>
+                      <executions>
+                          <execution>
+                              <id>java8-test</id>
+                              <phase>test</phase>
+                              <goals>
+                                  <goal>test</goal>
+                              </goals>
+                              <configuration>
+                                  <skip>${skip.java8.tests}</skip>
+                                  <jvm>${java8.home}/bin/java</jvm>
+                                  <additionalClasspathElements>
+                                      <additionalClasspathElement>${java8.home}/lib/tools.jar</additionalClasspathElement>
+                                  </additionalClasspathElements>
+                                  <environmentVariables>
+                                      <JAVA_HOME>${java8.home}</JAVA_HOME>
+                                  </environmentVariables>
+                              </configuration>
+                          </execution>
+                      </executions>
+                  </plugin>
+              </plugins>
+          </build>
       </profile>
       <profile>
           <id>github-actions</id>
@@ -246,6 +269,22 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>default-compile</id>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                            <configuration>
+                                <release>8</release>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.surefire.plugin}</version>
                     <configuration>
@@ -257,9 +296,8 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>${version.javadoc.plugin}</version>
                     <configuration>
-                        <source>8</source>
+                        <doclint>none</doclint>
                         <minmemory>128m</minmemory>
                         <maxmemory>1024m</maxmemory>
                         <quiet>false</quiet>
@@ -286,6 +324,12 @@
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${version.org.jacoco.plugin}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-maven-plugin</artifactId>
+                    <version>${version.org.wildfly.plugins.wildfly-maven-plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/profiling-tests/pom.xml
+++ b/profiling-tests/pom.xml
@@ -77,20 +77,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <skipIfEmpty>true</skipIfEmpty>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/microprofile/client/header/HeaderUtils.java
+++ b/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/microprofile/client/header/HeaderUtils.java
@@ -3,9 +3,6 @@ package org.jboss.resteasy.microprofile.client.header;
 import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
 
 import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,18 +22,7 @@ public class HeaderUtils {
      * @return method handle
      */
     public static MethodHandle createMethodHandle(final Method method, final Object clientProxy) {
-        try {
-            Constructor<MethodHandles.Lookup> constructor = MethodHandles.Lookup.class
-                    .getDeclaredConstructor(Class.class);
-            constructor.setAccessible(true);
-            MethodHandles.Lookup lookup = constructor.newInstance(method.getDeclaringClass());
-            return lookup
-                    .in(method.getDeclaringClass())
-                    .unreflectSpecial(method, method.getDeclaringClass())
-                    .bindTo(clientProxy);
-        } catch (IllegalAccessException | NoSuchMethodException | InstantiationException | InvocationTargetException e) {
-            throw new RestClientDefinitionException("Failed to generate method handle for " + method, e);
-        }
+        return JdkSpecific.createMethodHandle(method, clientProxy);
     }
 
     /**

--- a/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/microprofile/client/header/JdkSpecific.java
+++ b/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/microprofile/client/header/JdkSpecific.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.microprofile.client.header;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
+
+/**
+ * This is used for calls that are specific to different JVM versions.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class JdkSpecific {
+
+    static MethodHandle createMethodHandle(final Method method, final Object clientProxy) {
+        try {
+            Constructor<MethodHandles.Lookup> constructor = MethodHandles.Lookup.class
+                    .getDeclaredConstructor(Class.class);
+            constructor.setAccessible(true);
+            MethodHandles.Lookup lookup = constructor.newInstance(method.getDeclaringClass());
+            return lookup
+                    .in(method.getDeclaringClass())
+                    .unreflectSpecial(method, method.getDeclaringClass())
+                    .bindTo(clientProxy);
+        } catch (IllegalAccessException | NoSuchMethodException | InstantiationException | InvocationTargetException e) {
+            throw new RestClientDefinitionException("Failed to generate method handle for " + method, e);
+        }
+    }
+}

--- a/resteasy-client-microprofile/src/main/java9/src/org/jboss/resteasy/microprofile/client/header/JdkSpecific.java
+++ b/resteasy-client-microprofile/src/main/java9/src/org/jboss/resteasy/microprofile/client/header/JdkSpecific.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.microprofile.client.header;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+
+import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
+
+/**
+ * This is used for calls that are specific to different JVM versions.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class JdkSpecific {
+
+    static MethodHandle createMethodHandle(final Method method, final Object clientProxy) {
+        try {
+            final Class<?> proxyType = method.getDeclaringClass();
+            return MethodHandles.lookup()
+                    .findSpecial(proxyType, method.getName(), MethodType.methodType(method.getReturnType(), method.getParameterTypes()), proxyType)
+                    .bindTo(clientProxy);
+        } catch (IllegalAccessException | NoSuchMethodException e) {
+            throw new RestClientDefinitionException("Failed to generate method handle for " + method, e);
+        }
+    }
+}

--- a/testsuite/arquillian-utils/pom.xml
+++ b/testsuite/arquillian-utils/pom.xml
@@ -201,13 +201,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/testsuite/integration-tests-embedded/pom.xml
+++ b/testsuite/integration-tests-embedded/pom.xml
@@ -16,13 +16,6 @@
    <artifactId>integration-tests-embedded</artifactId>
    <name>RESTEasy Main testsuite: Embedded Server tests</name>
 
-
-   <properties>
-      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <maven.compiler.source>1.8</maven.compiler.source>
-      <maven.compiler.target>1.8</maven.compiler.target>
-   </properties>
-
    <dependencies>
       <dependency>
          <groupId>junit</groupId>
@@ -118,123 +111,70 @@
       </dependency>
    </dependencies>
 
-   <build>
-      <plugins>
-
-         <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <executions>
-               <execution>
-                  <id>default-test</id>
-                  <goals>
-                     <goal>test</goal>
-                  </goals>
-
-                  <configuration>
-                     <includes>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
                         <include>**/*Test.java</include>
-                     </includes>
-                     <excludes></excludes>
-                     <!-- since 2.5 -->
-                     <!--
-                     <systemPropertyVariables>
-                       <fileName>${fileName}</fileName>
-                     </systemPropertyVariables>
-                     -->
-                     <!-- deprecated -->
-                     <systemProperties>
-                        <property>
-                           <name>fileName</name>
-                           <value>org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer</value>
-                        </property>
-                     </systemProperties>
-                  </configuration>
-               </execution>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
 
-               <execution>
-                  <id>NettyJaxrsServer</id>
-                  <goals>
-                     <goal>test</goal>
-                  </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <fileName>org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer</fileName>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
 
-                  <configuration>
-                     <includes>
-                        <include>**/*Test.java</include>
-                     </includes>
-                     <excludes></excludes>
-                     <!-- since 2.5 -->
-                     <!--
-                     <systemPropertyVariables>
-                       <fileName>${fileName}</fileName>
-                     </systemPropertyVariables>
-                     -->
-                     <!-- deprecated -->
-                     <systemProperties>
-                        <property>
-                           <name>fileName</name>
-                           <value>org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer</value>
-                        </property>
-                     </systemProperties>
-                  </configuration>
-               </execution>
+                    <execution>
+                        <id>NettyJaxrsServer</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
 
-               <execution>
-                  <id>SunHttpJaxrsServer</id>
-                  <goals>
-                     <goal>test</goal>
-                  </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <fileName>org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer</fileName>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
 
-                  <configuration>
-                     <includes>
-                        <include>**/*Test.java</include>
-                     </includes>
-                     <excludes></excludes>
-                     <!-- since 2.5 -->
-                     <!--
-                     <systemPropertyVariables>
-                       <fileName>${fileName}</fileName>
-                     </systemPropertyVariables>
-                     -->
-                     <!-- deprecated -->
-                     <systemProperties>
-                        <property>
-                           <name>fileName</name>
-                           <value>org.jboss.resteasy.plugins.server.sun.http.SunHttpJaxrsServer</value>
-                        </property>
-                     </systemProperties>
-                  </configuration>
-               </execution>
+                    <execution>
+                        <id>SunHttpJaxrsServer</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
 
-               <execution>
-                  <id>VertxJaxrsServer</id>
-                  <goals>
-                     <goal>test</goal>
-                  </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <fileName>org.jboss.resteasy.plugins.server.sun.http.SunHttpJaxrsServer</fileName>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
 
-                  <configuration>
-                     <includes>
-                        <include>**/*Test.java</include>
-                     </includes>
-                     <excludes></excludes>
-                     <!-- since 2.5 -->
-                     <!--
-                     <systemPropertyVariables>
-                       <fileName>${fileName}</fileName>
-                     </systemPropertyVariables>
-                     -->
-                     <!-- deprecated -->
-                     <systemProperties>
-                        <property>
-                           <name>fileName</name>
-                           <value>org.jboss.resteasy.plugins.server.vertx.VertxJaxrsServer</value>
-                        </property>
-                     </systemProperties>
-                  </configuration>
-               </execution>
+                    <execution>
+                        <id>VertxJaxrsServer</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
 
-            </executions>
-         </plugin>
-      </plugins>
-   </build>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <fileName>org.jboss.resteasy.plugins.server.vertx.VertxJaxrsServer</fileName>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/testsuite/integration-tests-spring-web/deployment/pom.xml
+++ b/testsuite/integration-tests-spring-web/deployment/pom.xml
@@ -255,7 +255,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
                 <configuration>
                     <parameters>true</parameters>
                 </configuration>

--- a/testsuite/integration-tests-spring-web/deployment/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests-spring-web/deployment/src/test/resources/arquillian.xml
@@ -13,7 +13,7 @@
                 -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y
             </property>-->
             <property name="javaVmArguments">${debugJvmArgs} -server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node}
-                -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent}
+                -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent}
             </property>
             <property name="managementAddress">${node}</property>
         </configuration>

--- a/testsuite/integration-tests-spring/deployment/pom.xml
+++ b/testsuite/integration-tests-spring/deployment/pom.xml
@@ -118,27 +118,21 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <inherited>false</inherited>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>enable-elytron-full-cli</id>
                                 <phase>process-test-resources</phase>
                                 <goals>
-                                    <goal>exec</goal>
+                                    <goal>execute-commands</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>${java.home}/bin/java</executable>
-                                    <commandlineArgs>
-                                        ${modular.jdk.args} -jar ${jboss.home}/jboss-modules.jar
-                                        -mp ${jboss.home}/modules
-                                        org.jboss.as.cli
-                                        --file=${basedir}/../../config/enable-elytron-full.cli
-                                    </commandlineArgs>
-                                    <environmentVariables>
-                                        <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
-                                    </environmentVariables>
+                                    <jboss-home>${jboss.home}</jboss-home>
+                                    <offline>true</offline>
+                                    <scripts>
+                                        <script>${basedir}/../../config/enable-elytron-full.cli</script>
+                                    </scripts>
                                 </configuration>
                             </execution>
                         </executions>

--- a/testsuite/integration-tests-spring/deployment/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests-spring/deployment/src/test/resources/arquillian.xml
@@ -13,7 +13,7 @@
                 -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y
             </property>-->
             <property name="javaVmArguments">${debugJvmArgs} -server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node}
-                -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent}
+                -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent}
             </property>
             <property name="managementAddress">${node}</property>
         </configuration>

--- a/testsuite/integration-tests-spring/inmodule/pom.xml
+++ b/testsuite/integration-tests-spring/inmodule/pom.xml
@@ -124,27 +124,21 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <inherited>false</inherited>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>enable-elytron-full-cli</id>
                                 <phase>process-test-resources</phase>
                                 <goals>
-                                    <goal>exec</goal>
+                                    <goal>execute-commands</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>${java.home}/bin/java</executable>
-                                    <commandlineArgs>
-                                        ${modular.jdk.args} -jar ${jboss.home}/jboss-modules.jar
-                                        -mp ${jboss.home}/modules
-                                        org.jboss.as.cli
-                                        --file=${basedir}/../../config/enable-elytron-full.cli
-                                    </commandlineArgs>
-                                    <environmentVariables>
-                                        <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
-                                    </environmentVariables>
+                                    <jboss-home>${jboss.home}</jboss-home>
+                                    <offline>true</offline>
+                                    <scripts>
+                                        <script>${basedir}/../../config/enable-elytron-full.cli</script>
+                                    </scripts>
                                 </configuration>
                             </execution>
                         </executions>

--- a/testsuite/integration-tests-spring/inmodule/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests-spring/inmodule/src/test/resources/arquillian.xml
@@ -12,7 +12,7 @@
             <!--<property name="javaVmArguments">-Xmx512m -XX:MaxPermSize=128m
                 -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y
             </property>-->
-            <property name="javaVmArguments">${debugJvmArgs} -server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent}</property>
+            <property name="javaVmArguments">${debugJvmArgs} -server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent}</property>
             <property name="managementAddress">${node}</property>
         </configuration>
     </container>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -156,27 +156,21 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <inherited>false</inherited>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>enable-elytron-full-cli</id>
                                 <phase>process-test-resources</phase>
                                 <goals>
-                                    <goal>exec</goal>
+                                    <goal>execute-commands</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>${java.home}/bin/java</executable>
-                                    <commandlineArgs>
-                                        ${modular.jdk.args} -jar ${jboss.home}/jboss-modules.jar
-                                        -mp ${jboss.home}/modules
-                                        org.jboss.as.cli
-                                        --file=${basedir}/../config/enable-elytron-full.cli
-                                    </commandlineArgs>
-                                    <environmentVariables>
-                                        <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
-                                    </environmentVariables>
+                                    <jboss-home>${jboss.home}</jboss-home>
+                                    <offline>true</offline>
+                                    <scripts>
+                                        <script>${basedir}/../config/enable-elytron-full.cli</script>
+                                    </scripts>
                                 </configuration>
                             </execution>
                         </executions>

--- a/testsuite/integration-tests/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests/src/test/resources/arquillian.xml
@@ -10,7 +10,7 @@
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
-                <property name="javaVmArguments">${debugJvmArgs} -server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.managed} -Djboss.server.base.dir=${container.base.dir.managed}
+                <property name="javaVmArguments">${debugJvmArgs} -server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.managed} -Djboss.server.base.dir=${container.base.dir.managed}
                 </property>
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.managed}</property>
@@ -21,7 +21,7 @@
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
-                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.gzip} -Dresteasy.allowGzip=true -Djboss.server.base.dir=${container.base.dir.manual.gzip}
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.gzip} -Dresteasy.allowGzip=true -Djboss.server.base.dir=${container.base.dir.manual.gzip}
                 </property>
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.manual.gzip}</property>
@@ -32,7 +32,7 @@
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">standalone-tracing.xml</property>
-                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.tracing} -Djboss.server.base.dir=${container.base.dir.manual.tracing}</property>
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.tracing} -Djboss.server.base.dir=${container.base.dir.manual.tracing}</property>
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.manual.tracing}</property>
             </configuration>
@@ -42,7 +42,7 @@
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
-                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=localhost -Djboss.bind.address.management=localhost -Dnode=localhost -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.ssl} -Djboss.server.base.dir=${container.base.dir.manual.ssl}
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=localhost -Djboss.bind.address.management=localhost -Dnode=localhost -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.ssl} -Djboss.server.base.dir=${container.base.dir.manual.ssl}
                 </property>
                 <property name="managementAddress">localhost</property>
                 <property name="managementPort">${container.management.port.manual.ssl}</property>
@@ -53,7 +53,7 @@
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
-                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=localhost -Djboss.bind.address.management=localhost -Dnode=localhost -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.ssl.wrong} -Djboss.server.base.dir=${container.base.dir.manual.ssl.wrong}
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=localhost -Djboss.bind.address.management=localhost -Dnode=localhost -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.ssl.wrong} -Djboss.server.base.dir=${container.base.dir.manual.ssl.wrong}
                 </property>
                 <property name="managementAddress">localhost</property>
                 <property name="managementPort">${container.management.port.manual.ssl.wrong}</property>
@@ -64,7 +64,7 @@
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
-                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=localhost -Djboss.bind.address.management=localhost -Dnode=localhost -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.ssl.wildcard} -Djboss.server.base.dir=${container.base.dir.manual.ssl.wildcard}
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=localhost -Djboss.bind.address.management=localhost -Dnode=localhost -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.ssl.wildcard} -Djboss.server.base.dir=${container.base.dir.manual.ssl.wildcard}
                 </property>
                 <property name="managementAddress">localhost</property>
                 <property name="managementPort">${container.management.port.manual.ssl.wildcard}</property>
@@ -75,7 +75,7 @@
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
-                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=localhost -Djboss.bind.address.management=localhost -Dnode=localhost -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.ssl.sni} -Djboss.server.base.dir=${container.base.dir.manual.ssl.sni}
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=localhost -Djboss.bind.address.management=localhost -Dnode=localhost -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.manual.ssl.sni} -Djboss.server.base.dir=${container.base.dir.manual.ssl.sni}
                 </property>
                 <property name="managementAddress">localhost</property>
                 <property name="managementPort">${container.management.port.manual.ssl.sni}</property>
@@ -87,7 +87,7 @@
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
                 <!-- Forcing file.encoding=us-ascii in order to test RESTEASY-2171 -->
-                <property name="javaVmArguments">-Dorg.jboss.resteasy.port=15080 -Dfile.encoding=us-ascii -server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.managed.encoding} -Djboss.server.base.dir=${container.base.dir.managed.encoding}
+                <property name="javaVmArguments">-Dorg.jboss.resteasy.port=15080 -Dfile.encoding=us-ascii -server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.managed.encoding} -Djboss.server.base.dir=${container.base.dir.managed.encoding}
                 </property>
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.managed.encoding}</property>

--- a/testsuite/microprofile-tck/pom.xml
+++ b/testsuite/microprofile-tck/pom.xml
@@ -236,24 +236,5 @@
         <skip.mp.tck>true</skip.mp.tck>
       </properties>
     </profile>
-    <profile>
-      <id>jdk-9</id>
-      <activation>
-        <property>
-          <name>!test.java.home</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</argLine>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 </project>

--- a/testsuite/microprofile-tck/pom.xml
+++ b/testsuite/microprofile-tck/pom.xml
@@ -18,7 +18,7 @@
     <skip.mp.tck>false</skip.mp.tck>
     <jetty9.version>9.2.30.v20200428</jetty9.version>
     <jetty.version>${jetty9.version}</jetty.version>
-    <tck.timeout.offset>30</tck.timeout.offset>
+    <tck.timeout.offset>90</tck.timeout.offset>
   </properties>
 
   <dependencies>
@@ -213,24 +213,12 @@
           <systemPropertyVariables>
                <org.eclipse.microprofile.rest.client.tck.timeoutCushion>${tck.timeout.offset}</org.eclipse.microprofile.rest.client.tck.timeoutCushion>
           </systemPropertyVariables>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+          <dependenciesToScan>
+            <dependency>org.eclipse.microprofile.rest.client:microprofile-rest-client-tck</dependency>
+          </dependenciesToScan>
         </configuration>
-        <executions>
-          <execution>
-            <id>default-test</id>
-            <phase>test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <forkCount>1</forkCount>
-              <reuseForks>false</reuseForks>
-              <dependenciesToScan>
-                <dependency>org.eclipse.microprofile.rest.client:microprofile-rest-client-tck</dependency>
-              </dependenciesToScan>
-            </configuration>
-          </execution>
-        </executions>
-
       </plugin>
 
     </plugins>
@@ -249,20 +237,23 @@
       </properties>
     </profile>
     <profile>
-      <id>skip-mp-tck.modular.jvm</id>
+      <id>jdk-9</id>
       <activation>
-        <jdk>[9,)</jdk>
+        <property>
+          <name>!test.java.home</name>
+        </property>
       </activation>
-      <properties>
-        <modular.jdk.args>
-          --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
-          --add-modules=java.se
-          --add-opens=java.base/java.util=ALL-UNNAMED
-          --add-opens=java.base/java.security=ALL-UNNAMED
-          --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
-        </modular.jdk.args>
-        <tck.timeout.offset>90</tck.timeout.offset>
-      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -23,6 +23,10 @@
         <ipv6ArquillianSettings/>
         <debugJvmArgs/>
         <jboss.server.config.file.name>standalone-full.xml</jboss.server.config.file.name>
+
+        <!-- Skip the default Java 8 testing. This will have to be done in CI or locally by setting the test.java.home -->
+        <skip.java8.tests>true</skip.java8.tests>
+        <test.java.home>${java.home}</test.java.home>
     </properties>
 
     <dependencyManagement>
@@ -95,6 +99,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <jvm>${test.java.home}/bin/java</jvm>
                     <failIfNoTests>false</failIfNoTests>
                     <systemPropertyVariables>
                         <securityManagerArg>${securityManagerArg}</securityManagerArg>
@@ -233,6 +238,34 @@
             <properties>
                 <version.resteasy.testsuite>${version.resteasy.testsuite}</version.resteasy.testsuite>
             </properties>
+        </profile>
+
+        <profile>
+            <id>java8-integration-tests</id>
+            <activation>
+                <property>
+                    <name>test.java8.home</name>
+                </property>
+            </activation>
+            <properties>
+                <test.java.home>${test.java8.home}</test.java.home>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <additionalClasspathElements>
+                                <additionalClasspathElement>${test.java.home}/lib/tools.jar</additionalClasspathElement>
+                            </additionalClasspathElements>
+                            <environmentVariables>
+                                <JAVA_HOME>${test.java.home}</JAVA_HOME>
+                            </environmentVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
         <profile>
@@ -450,9 +483,8 @@
         </profile>
 
         <profile>
-            <id>debug-java-11</id>
+            <id>debug</id>
             <activation>
-                <jdk>11</jdk>
                 <property>
                     <name>debug</name>
                 </property>
@@ -466,9 +498,8 @@
         <profile>
             <id>debug-java-8</id>
             <activation>
-                <jdk>1.8</jdk>
                 <property>
-                    <name>debug</name>
+                    <name>debug.java.8</name>
                 </property>
             </activation>
             <properties>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -119,20 +119,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <skipIfEmpty>true</skipIfEmpty>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>${version.enforcer.plugin}</version>
                 <executions>


### PR DESCRIPTION
JIRA's this resolves:
- https://issues.redhat.com/browse/RESTEASY-2907
- https://issues.redhat.com/browse/RESTEASY-2905
- https://issues.redhat.com/browse/RESTEASY-2910

This reduces to only running on WildFly 23 for now. Once WildFly 24 is released we can add that. It also executes tests for Java 11, Java 16 and Java 8. Note the testsuite requires a separate run as any files generated during the initial Java 9+ run may cause issues when running under Java 8. By files I'm referring to things like generated JKS files.
