### PR TITLE
Fixing the ResteasyViolationException#toString concurrency

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/api/validation/ResteasyViolationException.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/api/validation/ResteasyViolationException.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -207,14 +208,16 @@ public class ResteasyViolationException extends ConstraintViolationException
    {
       convertViolations();
       StringBuffer sb = new StringBuffer();
-      for (Iterator<List<ResteasyConstraintViolation>> it = violationLists.iterator(); it.hasNext(); )
-      {
-         List<ResteasyConstraintViolation> violations = it.next();
-         for (Iterator<ResteasyConstraintViolation> it2 = violations.iterator(); it2.hasNext(); )
-         {
-            sb.append(it2.next().toString()).append('\r');
+
+      CopyOnWriteArrayList<List<ResteasyConstraintViolation>> imutableViolations =
+              new CopyOnWriteArrayList<>(violationLists);
+
+      for (List<ResteasyConstraintViolation> violations : imutableViolations) {
+         for (ResteasyConstraintViolation violation: violations ) {
+            sb.append(violation.toString()).append('\r');
          }
       }
+
       return sb.toString();
    }
 
@@ -231,11 +234,13 @@ public class ResteasyViolationException extends ConstraintViolationException
       parameterViolations = container.getParameterViolations();
       returnValueViolations = container.getReturnValueViolations();
 
+
       violationLists.add(fieldViolations);
       violationLists.add(propertyViolations);
       violationLists.add(classViolations);
       violationLists.add(parameterViolations);
       violationLists.add(returnValueViolations);
+
    }
 
    protected void convertFromString(String stringRep)
@@ -298,6 +303,7 @@ public class ResteasyViolationException extends ConstraintViolationException
       violationLists.add(classViolations);
       violationLists.add(parameterViolations);
       violationLists.add(returnValueViolations);
+
    }
 
    protected int getField(int start, String line)
@@ -397,6 +403,7 @@ public class ResteasyViolationException extends ConstraintViolationException
       violationLists.add(classViolations);
       violationLists.add(parameterViolations);
       violationLists.add(returnValueViolations);
+
    }
 
    protected ResteasyConstraintViolation convertViolation(ConstraintViolation<?> violation)

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/api/validation/ResteasyViolationException.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/api/validation/ResteasyViolationException.java
@@ -39,17 +39,17 @@ public class ResteasyViolationException extends ConstraintViolationException
    private static final long serialVersionUID = 2623733139912277260L;
    public static final String SUPPRESS_VIOLATION_PATH = "resteasy.validation.suppress.path";
 
-   private List<CloneableMediaType> accept;
-   private Exception exception;
+   private volatile List<CloneableMediaType> accept;
+   private volatile Exception exception;
 
-   private List<ResteasyConstraintViolation> fieldViolations;
-   private List<ResteasyConstraintViolation> propertyViolations;
-   private List<ResteasyConstraintViolation> classViolations;
-   private List<ResteasyConstraintViolation> parameterViolations;
-   private List<ResteasyConstraintViolation> returnValueViolations;
+   private volatile List<ResteasyConstraintViolation> fieldViolations;
+   private volatile List<ResteasyConstraintViolation> propertyViolations;
+   private volatile List<ResteasyConstraintViolation> classViolations;
+   private volatile List<ResteasyConstraintViolation> parameterViolations;
+   private volatile List<ResteasyConstraintViolation> returnValueViolations;
 
-   private List<ResteasyConstraintViolation> allViolations;
-   private List<List<ResteasyConstraintViolation>> violationLists;
+   private volatile List<ResteasyConstraintViolation> allViolations;
+   private volatile List<List<ResteasyConstraintViolation>> violationLists;
 
    private transient ConstraintTypeUtil11 util = new ConstraintTypeUtil11();
    private boolean suppressPath;
@@ -209,10 +209,7 @@ public class ResteasyViolationException extends ConstraintViolationException
       convertViolations();
       StringBuffer sb = new StringBuffer();
 
-      CopyOnWriteArrayList<List<ResteasyConstraintViolation>> imutableViolations =
-              new CopyOnWriteArrayList<>(violationLists);
-
-      for (List<ResteasyConstraintViolation> violations : imutableViolations) {
+      for (List<ResteasyConstraintViolation> violations : violationLists) {
          for (ResteasyConstraintViolation violation: violations ) {
             sb.append(violation.toString()).append('\r');
          }
@@ -227,13 +224,13 @@ public class ResteasyViolationException extends ConstraintViolationException
       {
          return;
       }
-      violationLists = new ArrayList<List<ResteasyConstraintViolation>>();
+      List<List<ResteasyConstraintViolation>> violationLists = new ArrayList<List<ResteasyConstraintViolation>>();
       fieldViolations = container.getFieldViolations();
       propertyViolations = container.getPropertyViolations();
       classViolations = container.getClassViolations();
       parameterViolations = container.getParameterViolations();
       returnValueViolations = container.getReturnValueViolations();
-
+      this.violationLists = new CopyOnWriteArrayList<>(violationLists);
 
       violationLists.add(fieldViolations);
       violationLists.add(propertyViolations);
@@ -297,7 +294,7 @@ public class ResteasyViolationException extends ConstraintViolationException
          throw new RuntimeException(Messages.MESSAGES.unableToParseException());
       }
 
-      violationLists = new ArrayList<List<ResteasyConstraintViolation>>();
+      violationLists = new CopyOnWriteArrayList<>();
       violationLists.add(fieldViolations);
       violationLists.add(propertyViolations);
       violationLists.add(classViolations);
@@ -358,11 +355,11 @@ public class ResteasyViolationException extends ConstraintViolationException
          return;
       }
 
-      fieldViolations       = new ArrayList<ResteasyConstraintViolation>();
-      propertyViolations    = new ArrayList<ResteasyConstraintViolation>();
-      classViolations       = new ArrayList<ResteasyConstraintViolation>();
-      parameterViolations   = new ArrayList<ResteasyConstraintViolation>();
-      returnValueViolations = new ArrayList<ResteasyConstraintViolation>();
+      fieldViolations       = new CopyOnWriteArrayList<>();
+      propertyViolations    = new CopyOnWriteArrayList<>();
+      classViolations       = new CopyOnWriteArrayList<>();
+      parameterViolations   = new CopyOnWriteArrayList<>();
+      returnValueViolations = new CopyOnWriteArrayList<>();
 
       if (getConstraintViolations() != null)
       {
@@ -397,7 +394,7 @@ public class ResteasyViolationException extends ConstraintViolationException
          }
       }
 
-      violationLists = new ArrayList<List<ResteasyConstraintViolation>>();
+      violationLists = new CopyOnWriteArrayList<>();
       violationLists.add(fieldViolations);
       violationLists.add(propertyViolations);
       violationLists.add(classViolations);

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/api/validation/ViolationReport.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/api/validation/ViolationReport.java
@@ -32,11 +32,11 @@ public class ViolationReport
       {
          this.exception = e.toString();
       }
-      this.fieldViolations = (ArrayList<ResteasyConstraintViolation>) exception.getFieldViolations();
-      this.propertyViolations = (ArrayList<ResteasyConstraintViolation>) exception.getPropertyViolations();
-      this.classViolations = (ArrayList<ResteasyConstraintViolation>) exception.getClassViolations();
-      this.parameterViolations = (ArrayList<ResteasyConstraintViolation>) exception.getParameterViolations();
-      this.returnValueViolations = (ArrayList<ResteasyConstraintViolation>) exception.getReturnValueViolations();
+      this.fieldViolations = new ArrayList<>(exception.getFieldViolations());
+      this.propertyViolations =  new ArrayList<>(exception.getPropertyViolations());
+      this.classViolations =  new ArrayList<>(exception.getClassViolations());
+      this.parameterViolations =  new ArrayList<>(exception.getParameterViolations());
+      this.returnValueViolations =  new ArrayList<>(exception.getReturnValueViolations());
    }
 
    public ViolationReport(final String s)


### PR DESCRIPTION
Signed-off-by: Rhuan Rocha <rhuan080@gmail.com>

This issue was identified in a scenario that the exception' object is delegated to a task that works in other threads. As it uses the iterator on ResteasyViolationException#toString and it calls the convertViolations method (that modifies the violationLists) it can generate an issue if called concurrently. I have seen it on 3.9.3.SP1-redhat-00001. It is why I'm sending a PR to this branch. However, the main branch has the same problem. I'll send a PR to the main soon.