### PR TITLE
[4.5] [RESTEASY-2913] Remove JacksonDataTypeTest#testDatatypeNotSupportedDu…

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/JacksonDatatypeTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/JacksonDatatypeTest.java
@@ -109,16 +109,6 @@ public class JacksonDatatypeTest {
    }
 
    /**
-    * @tpTestDetails Check duration type without datatype supported
-    * @tpSince RESTEasy 3.1.0.CR3
-    */
-   @Test
-   public void testDatatypeNotSupportedDuration() throws Exception {
-      String strResponse = requestHelper("duration", DEFAULT_DEPLOYMENT);
-      Assert.assertThat("Wrong conversion of Duration", strResponse, not(containsString("PT5.000000006S")));
-   }
-
-   /**
     * @tpTestDetails Check null optional type without datatype supported
     * @tpSince RESTEasy 3.1.0.CR3
     */


### PR DESCRIPTION
…ration

This test doesn't make sense anymore since it tested scenario that
wasn't valid and is fixed in recent versions of RestEasy.

https://issues.redhat.com/browse/RESTEASY-2913