### PR TITLE
Fixing the ResteasyViolationException#toString concurrency

### DIFF
--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/api/validation/ViolationReport.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/api/validation/ViolationReport.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.api.validation;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -22,10 +23,10 @@ public class ViolationReport
 {
    private String exception;
 
-   private ArrayList<ResteasyConstraintViolation> propertyViolations = new ArrayList<ResteasyConstraintViolation>();
-   private ArrayList<ResteasyConstraintViolation> classViolations = new ArrayList<ResteasyConstraintViolation>();
-   private ArrayList<ResteasyConstraintViolation> parameterViolations = new ArrayList<ResteasyConstraintViolation>();
-   private ArrayList<ResteasyConstraintViolation> returnValueViolations = new ArrayList<ResteasyConstraintViolation>();
+   private List<ResteasyConstraintViolation> propertyViolations = new ArrayList<>();
+   private List<ResteasyConstraintViolation> classViolations = new ArrayList<>();
+   private List<ResteasyConstraintViolation> parameterViolations = new ArrayList<>();
+   private List<ResteasyConstraintViolation> returnValueViolations = new ArrayList<>();
 
    public ViolationReport(final ResteasyViolationException exception)
    {
@@ -34,10 +35,10 @@ public class ViolationReport
       {
          this.exception = e.toString();
       }
-      this.propertyViolations = (ArrayList<ResteasyConstraintViolation>) exception.getPropertyViolations();
-      this.classViolations = (ArrayList<ResteasyConstraintViolation>) exception.getClassViolations();
-      this.parameterViolations = (ArrayList<ResteasyConstraintViolation>) exception.getParameterViolations();
-      this.returnValueViolations = (ArrayList<ResteasyConstraintViolation>) exception.getReturnValueViolations();
+      this.propertyViolations =  exception.getPropertyViolations();
+      this.classViolations =  exception.getClassViolations();
+      this.parameterViolations =  exception.getParameterViolations();
+      this.returnValueViolations =  exception.getReturnValueViolations();
    }
 
    public ViolationReport(final String s)
@@ -69,22 +70,22 @@ public class ViolationReport
       return exception;
    }
 
-   public ArrayList<ResteasyConstraintViolation> getPropertyViolations()
+   public List<ResteasyConstraintViolation> getPropertyViolations()
    {
       return propertyViolations;
    }
 
-   public ArrayList<ResteasyConstraintViolation> getClassViolations()
+   public List<ResteasyConstraintViolation> getClassViolations()
    {
       return classViolations;
    }
 
-   public ArrayList<ResteasyConstraintViolation> getParameterViolations()
+   public List<ResteasyConstraintViolation> getParameterViolations()
    {
       return parameterViolations;
    }
 
-   public ArrayList<ResteasyConstraintViolation> getReturnValueViolations()
+   public List<ResteasyConstraintViolation> getReturnValueViolations()
    {
       return returnValueViolations;
    }

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/api/validation/ViolationReport.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/api/validation/ViolationReport.java
@@ -1,7 +1,6 @@
 package org.jboss.resteasy.api.validation;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -23,10 +22,10 @@ public class ViolationReport
 {
    private String exception;
 
-   private List<ResteasyConstraintViolation> propertyViolations = new ArrayList<>();
-   private List<ResteasyConstraintViolation> classViolations = new ArrayList<>();
-   private List<ResteasyConstraintViolation> parameterViolations = new ArrayList<>();
-   private List<ResteasyConstraintViolation> returnValueViolations = new ArrayList<>();
+   private ArrayList<ResteasyConstraintViolation> propertyViolations = new ArrayList<ResteasyConstraintViolation>();
+   private ArrayList<ResteasyConstraintViolation> classViolations = new ArrayList<ResteasyConstraintViolation>();
+   private ArrayList<ResteasyConstraintViolation> parameterViolations = new ArrayList<ResteasyConstraintViolation>();
+   private ArrayList<ResteasyConstraintViolation> returnValueViolations = new ArrayList<ResteasyConstraintViolation>();
 
    public ViolationReport(final ResteasyViolationException exception)
    {
@@ -35,10 +34,10 @@ public class ViolationReport
       {
          this.exception = e.toString();
       }
-      this.propertyViolations =  exception.getPropertyViolations();
-      this.classViolations =  exception.getClassViolations();
-      this.parameterViolations =  exception.getParameterViolations();
-      this.returnValueViolations =  exception.getReturnValueViolations();
+      this.propertyViolations =  new ArrayList<>(exception.getPropertyViolations());
+      this.classViolations =  new ArrayList<>(exception.getClassViolations());
+      this.parameterViolations =  new ArrayList<>(exception.getParameterViolations());
+      this.returnValueViolations =  new ArrayList<>(exception.getReturnValueViolations());
    }
 
    public ViolationReport(final String s)
@@ -70,22 +69,22 @@ public class ViolationReport
       return exception;
    }
 
-   public List<ResteasyConstraintViolation> getPropertyViolations()
+   public ArrayList<ResteasyConstraintViolation> getPropertyViolations()
    {
       return propertyViolations;
    }
 
-   public List<ResteasyConstraintViolation> getClassViolations()
+   public ArrayList<ResteasyConstraintViolation> getClassViolations()
    {
       return classViolations;
    }
 
-   public List<ResteasyConstraintViolation> getParameterViolations()
+   public ArrayList<ResteasyConstraintViolation> getParameterViolations()
    {
       return parameterViolations;
    }
 
-   public List<ResteasyConstraintViolation> getReturnValueViolations()
+   public ArrayList<ResteasyConstraintViolation> getReturnValueViolations()
    {
       return returnValueViolations;
    }


### PR DESCRIPTION
This issue was identified in a scenario that the exception' object is delegated to a task that works in other threads. As it uses the iterator on ResteasyViolationException#toString and it calls the convertViolations method (that modifies the violationLists) it can generate an issue if called concurrently.

JIRA: https://issues.redhat.com/browse/RESTEASY-2914
PR to 3.9: https://github.com/resteasy/Resteasy/pull/2806