### PR TITLE
[RESTEASY-2915] Disable some MicroProfile tests with prepared MicroPr…

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/config/MicroProfileConfigFilterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/config/MicroProfileConfigFilterTest.java
@@ -6,6 +6,7 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.MicroProfileDependent;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.test.microprofile.config.resource.MicroProfileConfigFilter;
 import org.jboss.resteasy.test.microprofile.config.resource.MicroProfileConfigResource;
@@ -19,6 +20,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.PropertyPermission;
@@ -31,6 +33,7 @@ import java.util.PropertyPermission;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(MicroProfileDependent.class)
 public class MicroProfileConfigFilterTest {
 
    static ResteasyClient client;
@@ -39,6 +42,7 @@ public class MicroProfileConfigFilterTest {
    public static Archive<?> deploy() {
       WebArchive war = TestUtil.prepareArchive(MicroProfileConfigFilterTest.class.getSimpleName())
             .addClass(MicroProfileConfigFilter.class)
+            .addClass(MicroProfileDependent.class)
             .setWebXML(MicroProfileConfigFilterTest.class.getPackage(), "web_filter.xml")
             .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
       war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/config/MicroProfileConfigServletTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/config/MicroProfileConfigServletTest.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.test.microprofile.config;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.MicroProfileDependent;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.test.microprofile.config.resource.MicroProfileConfigFilter;
 import org.jboss.resteasy.test.microprofile.config.resource.MicroProfileConfigResource;
@@ -16,6 +17,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.ClientBuilder;
@@ -30,6 +32,7 @@ import java.util.PropertyPermission;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(MicroProfileDependent.class)
 public class MicroProfileConfigServletTest {
 
    static ResteasyClient client;
@@ -38,6 +41,7 @@ public class MicroProfileConfigServletTest {
    public static Archive<?> deploy() {
       WebArchive war = TestUtil.prepareArchive(MicroProfileConfigServletTest.class.getSimpleName())
             .addClass(MicroProfileConfigFilter.class)
+            .addClass(MicroProfileDependent.class)
             .setWebXML(MicroProfileConfigServletTest.class.getPackage(), "web_servlet.xml")
             .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
       war.addAsManifestResource(PermissionUtil.createPermissionsXmlAsset(

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/MPClientCollectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/MPClientCollectionTest.java
@@ -4,6 +4,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.MicroProfileDependent;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.test.microprofile.restclient.resource.MPCollectionActivator;
 import org.jboss.resteasy.test.microprofile.restclient.resource.MPCollectionResource;
@@ -18,6 +19,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.ClientBuilder;
@@ -34,6 +36,7 @@ import java.util.List;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(MicroProfileDependent.class)
 public class MPClientCollectionTest {
     protected static final Logger LOG = Logger.getLogger(MPCollectionTest.class.getName());
     private static final String WAR_SERVICE = "war_service";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProxyRedeployTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProxyRedeployTest.java
@@ -7,6 +7,7 @@ import javax.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.MicroProfileDependent;
 import org.jboss.resteasy.test.microprofile.restclient.resource.RestClientProxyRedeployRemoteService;
 import org.jboss.resteasy.test.microprofile.restclient.resource.RestClientProxyRedeployResource;
 import org.jboss.resteasy.utils.PortProviderUtil;
@@ -17,15 +18,18 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(MicroProfileDependent.class)
 public class RestClientProxyRedeployTest
 {
    @Deployment(name="deployment1", order = 1)
    public static Archive<?> deploy1() {
       WebArchive war = TestUtil.prepareArchive(RestClientProxyRedeployTest.class.getSimpleName() + "1");
+      war.addClass(MicroProfileDependent.class);
       war.addClass(RestClientProxyRedeployRemoteService.class);
       war.addAsManifestResource(new StringAsset("Dependencies: org.eclipse.microprofile.restclient"), "MANIFEST.MF");
       war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
@@ -35,6 +39,7 @@ public class RestClientProxyRedeployTest
    @Deployment(name="deployment2", order = 2)
    public static Archive<?> deploy2() {
       WebArchive war = TestUtil.prepareArchive(RestClientProxyRedeployTest.class.getSimpleName() + "2");
+      war.addClass(MicroProfileDependent.class);
       war.addClass(RestClientProxyRedeployRemoteService.class);
       war.addAsManifestResource(new StringAsset("Dependencies: org.eclipse.microprofile.restclient"), "MANIFEST.MF");
       war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProxyTest.java
@@ -26,6 +26,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.resteasy.category.MicroProfileDependent;
 import org.jboss.resteasy.microprofile.client.BuilderResolver;
 import org.jboss.resteasy.utils.PortProviderUtil;
 import org.jboss.resteasy.utils.TestUtil;
@@ -42,6 +43,7 @@ import io.reactivex.Single;
 
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(MicroProfileDependent.class)
 public class RestClientProxyTest
 {
 


### PR DESCRIPTION
…ofileDependent category

Mark some another MicroProfile tests with `MicroProfileDependent`
category so they can be easily excluded from the test execution via an
appropriated profile (`microprofile.off`).

https://issues.redhat.com/browse/RESTEASY-2915

This goes into the `3.15` branch only.