### PR TITLE
[3.15] [RESTEASY-2912] Incorrect naming of JsonpMPtest class.

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/JsonpMPTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/JsonpMPTest.java
@@ -32,8 +32,8 @@ import java.net.URI;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public class JsonpMPtest {
-    protected static final Logger LOG = Logger.getLogger(JsonpMPtest.class.getName());
+public class JsonpMPTest {
+    protected static final Logger LOG = Logger.getLogger(JsonpMPTest.class.getName());
     private static final String WAR_SERVICE = "jsonP_service";
 
     @Deployment(name=WAR_SERVICE)


### PR DESCRIPTION
Name of JsonpMPtest causes that it is not detected and executed by
surefire-plugin automatically [1].

[1] https://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html

https://issues.redhat.com/browse/RESTEASY-2912