### PR TITLE
Add a debug profile for WildFly container tests. This allows tests ru…

### DIFF
--- a/testsuite/integration-tests-spring-web/deployment/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests-spring-web/deployment/src/test/resources/arquillian.xml
@@ -12,7 +12,7 @@
             <!--<property name="javaVmArguments">-Xmx512m -XX:MaxPermSize=128m
                 -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y
             </property>-->
-            <property name="javaVmArguments">-server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node}
+            <property name="javaVmArguments">${debugJvmArgs} -server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node}
                 -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent}
             </property>
             <property name="managementAddress">${node}</property>

--- a/testsuite/integration-tests-spring/deployment/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests-spring/deployment/src/test/resources/arquillian.xml
@@ -12,7 +12,7 @@
             <!--<property name="javaVmArguments">-Xmx512m -XX:MaxPermSize=128m
                 -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y
             </property>-->
-            <property name="javaVmArguments">-server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node}
+            <property name="javaVmArguments">${debugJvmArgs} -server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node}
                 -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent}
             </property>
             <property name="managementAddress">${node}</property>

--- a/testsuite/integration-tests-spring/inmodule/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests-spring/inmodule/src/test/resources/arquillian.xml
@@ -12,7 +12,7 @@
             <!--<property name="javaVmArguments">-Xmx512m -XX:MaxPermSize=128m
                 -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y
             </property>-->
-            <property name="javaVmArguments">-server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent}</property>
+            <property name="javaVmArguments">${debugJvmArgs} -server -Xms96m -Xmx1024m -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent}</property>
             <property name="managementAddress">${node}</property>
         </configuration>
     </container>

--- a/testsuite/integration-tests/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests/src/test/resources/arquillian.xml
@@ -10,7 +10,7 @@
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
-                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.managed} -Djboss.server.base.dir=${container.base.dir.managed}
+                <property name="javaVmArguments">${debugJvmArgs} -server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.managed} -Djboss.server.base.dir=${container.base.dir.managed}
                 </property>
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.managed}</property>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -21,6 +21,7 @@
         <jacoco.agent/>
         <additionalJvmArgs/>
         <ipv6ArquillianSettings/>
+        <debugJvmArgs/>
         <jboss.server.config.file.name>standalone-full.xml</jboss.server.config.file.name>
     </properties>
 
@@ -460,6 +461,34 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>debug-java-11</id>
+            <activation>
+                <jdk>11</jdk>
+                <property>
+                    <name>debug</name>
+                </property>
+            </activation>
+            <properties>
+                <debug.port>8787</debug.port>
+                <debugJvmArgs>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:${debug.port}</debugJvmArgs>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>debug-java-8</id>
+            <activation>
+                <jdk>1.8</jdk>
+                <property>
+                    <name>debug</name>
+                </property>
+            </activation>
+            <properties>
+                <debug.port>8787</debug.port>
+                <debugJvmArgs>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debug.port}</debugJvmArgs>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
…n in WildFly or RESTEasy components to be debugged.

No JIRA for this one. It simply adds a profile to enable debugging.