### PR TITLE
Fixing the ResteasyViolationException#toString concurrency

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/api/validation/ResteasyViolationException.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/api/validation/ResteasyViolationException.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -38,17 +39,17 @@ public class ResteasyViolationException extends ConstraintViolationException
    private static final long serialVersionUID = 2623733139912277260L;
    public static final String SUPPRESS_VIOLATION_PATH = "resteasy.validation.suppress.path";
 
-   private List<CloneableMediaType> accept;
-   private Exception exception;
+   private volatile List<CloneableMediaType> accept;
+   private volatile Exception exception;
 
-   private List<ResteasyConstraintViolation> fieldViolations;
-   private List<ResteasyConstraintViolation> propertyViolations;
-   private List<ResteasyConstraintViolation> classViolations;
-   private List<ResteasyConstraintViolation> parameterViolations;
-   private List<ResteasyConstraintViolation> returnValueViolations;
+   private volatile List<ResteasyConstraintViolation> fieldViolations;
+   private volatile List<ResteasyConstraintViolation> propertyViolations;
+   private volatile List<ResteasyConstraintViolation> classViolations;
+   private volatile List<ResteasyConstraintViolation> parameterViolations;
+   private volatile List<ResteasyConstraintViolation> returnValueViolations;
 
-   private List<ResteasyConstraintViolation> allViolations;
-   private List<List<ResteasyConstraintViolation>> violationLists;
+   private volatile List<ResteasyConstraintViolation> allViolations;
+   private volatile List<List<ResteasyConstraintViolation>> violationLists;
 
    private transient ConstraintTypeUtil11 util = new ConstraintTypeUtil11();
    private boolean suppressPath;
@@ -152,7 +153,7 @@ public class ResteasyViolationException extends ConstraintViolationException
       convertViolations();
       if (allViolations == null)
       {
-         allViolations = new ArrayList<ResteasyConstraintViolation>();
+         allViolations = new CopyOnWriteArrayList<>();
          allViolations.addAll(fieldViolations);
          allViolations.addAll(propertyViolations);
          allViolations.addAll(classViolations);
@@ -207,14 +208,13 @@ public class ResteasyViolationException extends ConstraintViolationException
    {
       convertViolations();
       StringBuffer sb = new StringBuffer();
-      for (Iterator<List<ResteasyConstraintViolation>> it = violationLists.iterator(); it.hasNext(); )
-      {
-         List<ResteasyConstraintViolation> violations = it.next();
-         for (Iterator<ResteasyConstraintViolation> it2 = violations.iterator(); it2.hasNext(); )
-         {
-            sb.append(it2.next().toString()).append('\r');
+
+      for (List<ResteasyConstraintViolation> violations : violationLists) {
+         for (ResteasyConstraintViolation violation: violations ) {
+            sb.append(violation.toString()).append('\r');
          }
       }
+
       return sb.toString();
    }
 
@@ -224,12 +224,13 @@ public class ResteasyViolationException extends ConstraintViolationException
       {
          return;
       }
-      violationLists = new ArrayList<List<ResteasyConstraintViolation>>();
+      List<List<ResteasyConstraintViolation>> violationLists = new ArrayList<List<ResteasyConstraintViolation>>();
       fieldViolations = container.getFieldViolations();
       propertyViolations = container.getPropertyViolations();
       classViolations = container.getClassViolations();
       parameterViolations = container.getParameterViolations();
       returnValueViolations = container.getReturnValueViolations();
+      this.violationLists = new CopyOnWriteArrayList<>(violationLists);
 
       violationLists.add(fieldViolations);
       violationLists.add(propertyViolations);
@@ -292,7 +293,7 @@ public class ResteasyViolationException extends ConstraintViolationException
          throw new RuntimeException(Messages.MESSAGES.unableToParseException());
       }
 
-      violationLists = new ArrayList<List<ResteasyConstraintViolation>>();
+      violationLists = new CopyOnWriteArrayList<>();
       violationLists.add(fieldViolations);
       violationLists.add(propertyViolations);
       violationLists.add(classViolations);
@@ -352,11 +353,11 @@ public class ResteasyViolationException extends ConstraintViolationException
          return;
       }
 
-      fieldViolations       = new ArrayList<ResteasyConstraintViolation>();
-      propertyViolations    = new ArrayList<ResteasyConstraintViolation>();
-      classViolations       = new ArrayList<ResteasyConstraintViolation>();
-      parameterViolations   = new ArrayList<ResteasyConstraintViolation>();
-      returnValueViolations = new ArrayList<ResteasyConstraintViolation>();
+      fieldViolations       = new CopyOnWriteArrayList<>();
+      propertyViolations    = new CopyOnWriteArrayList<>();
+      classViolations       = new CopyOnWriteArrayList<>();
+      parameterViolations   = new CopyOnWriteArrayList<>();
+      returnValueViolations = new CopyOnWriteArrayList<>();
 
       if (getConstraintViolations() != null)
       {
@@ -391,7 +392,7 @@ public class ResteasyViolationException extends ConstraintViolationException
          }
       }
 
-      violationLists = new ArrayList<List<ResteasyConstraintViolation>>();
+      violationLists = new CopyOnWriteArrayList<>();
       violationLists.add(fieldViolations);
       violationLists.add(propertyViolations);
       violationLists.add(classViolations);

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/api/validation/ViolationReport.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/api/validation/ViolationReport.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.api.validation;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -19,11 +20,11 @@ public class ViolationReport
 {
    private String exception;
 
-   private ArrayList<ResteasyConstraintViolation> fieldViolations = new ArrayList<ResteasyConstraintViolation>();
-   private ArrayList<ResteasyConstraintViolation> propertyViolations = new ArrayList<ResteasyConstraintViolation>();
-   private ArrayList<ResteasyConstraintViolation> classViolations = new ArrayList<ResteasyConstraintViolation>();
-   private ArrayList<ResteasyConstraintViolation> parameterViolations = new ArrayList<ResteasyConstraintViolation>();
-   private ArrayList<ResteasyConstraintViolation> returnValueViolations = new ArrayList<ResteasyConstraintViolation>();
+   private List<ResteasyConstraintViolation> fieldViolations = new ArrayList();
+   private List<ResteasyConstraintViolation> propertyViolations = new ArrayList();
+   private List<ResteasyConstraintViolation> classViolations = new ArrayList();
+   private List<ResteasyConstraintViolation> parameterViolations = new ArrayList();
+   private List<ResteasyConstraintViolation> returnValueViolations = new ArrayList();
 
    public ViolationReport(final ResteasyViolationException exception)
    {
@@ -32,11 +33,11 @@ public class ViolationReport
       {
          this.exception = e.toString();
       }
-      this.fieldViolations = (ArrayList<ResteasyConstraintViolation>) exception.getFieldViolations();
-      this.propertyViolations = (ArrayList<ResteasyConstraintViolation>) exception.getPropertyViolations();
-      this.classViolations = (ArrayList<ResteasyConstraintViolation>) exception.getClassViolations();
-      this.parameterViolations = (ArrayList<ResteasyConstraintViolation>) exception.getParameterViolations();
-      this.returnValueViolations = (ArrayList<ResteasyConstraintViolation>) exception.getReturnValueViolations();
+      this.fieldViolations =  exception.getFieldViolations();
+      this.propertyViolations = exception.getPropertyViolations();
+      this.classViolations = exception.getClassViolations();
+      this.parameterViolations = exception.getParameterViolations();
+      this.returnValueViolations = exception.getReturnValueViolations();
    }
 
    public ViolationReport(final String s)
@@ -53,27 +54,27 @@ public class ViolationReport
       return exception;
    }
 
-   public ArrayList<ResteasyConstraintViolation> getFieldViolations()
+   public List<ResteasyConstraintViolation> getFieldViolations()
    {
       return fieldViolations;
    }
 
-   public ArrayList<ResteasyConstraintViolation> getPropertyViolations()
+   public List<ResteasyConstraintViolation> getPropertyViolations()
    {
       return propertyViolations;
    }
 
-   public ArrayList<ResteasyConstraintViolation> getClassViolations()
+   public List<ResteasyConstraintViolation> getClassViolations()
    {
       return classViolations;
    }
 
-   public ArrayList<ResteasyConstraintViolation> getParameterViolations()
+   public List<ResteasyConstraintViolation> getParameterViolations()
    {
       return parameterViolations;
    }
 
-   public ArrayList<ResteasyConstraintViolation> getReturnValueViolations()
+   public List<ResteasyConstraintViolation> getReturnValueViolations()
    {
       return returnValueViolations;
    }

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/api/validation/ViolationReport.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/api/validation/ViolationReport.java
@@ -1,7 +1,6 @@
 package org.jboss.resteasy.api.validation;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -20,11 +19,11 @@ public class ViolationReport
 {
    private String exception;
 
-   private List<ResteasyConstraintViolation> fieldViolations = new ArrayList();
-   private List<ResteasyConstraintViolation> propertyViolations = new ArrayList();
-   private List<ResteasyConstraintViolation> classViolations = new ArrayList();
-   private List<ResteasyConstraintViolation> parameterViolations = new ArrayList();
-   private List<ResteasyConstraintViolation> returnValueViolations = new ArrayList();
+   private ArrayList<ResteasyConstraintViolation> fieldViolations = new ArrayList<ResteasyConstraintViolation>();
+   private ArrayList<ResteasyConstraintViolation> propertyViolations = new ArrayList<ResteasyConstraintViolation>();
+   private ArrayList<ResteasyConstraintViolation> classViolations = new ArrayList<ResteasyConstraintViolation>();
+   private ArrayList<ResteasyConstraintViolation> parameterViolations = new ArrayList<ResteasyConstraintViolation>();
+   private ArrayList<ResteasyConstraintViolation> returnValueViolations = new ArrayList<ResteasyConstraintViolation>();
 
    public ViolationReport(final ResteasyViolationException exception)
    {
@@ -33,11 +32,11 @@ public class ViolationReport
       {
          this.exception = e.toString();
       }
-      this.fieldViolations =  exception.getFieldViolations();
-      this.propertyViolations = exception.getPropertyViolations();
-      this.classViolations = exception.getClassViolations();
-      this.parameterViolations = exception.getParameterViolations();
-      this.returnValueViolations = exception.getReturnValueViolations();
+      this.fieldViolations = new ArrayList<>(exception.getFieldViolations());
+      this.propertyViolations = new ArrayList<>(exception.getPropertyViolations());
+      this.classViolations = new ArrayList<>(exception.getClassViolations());
+      this.parameterViolations = new ArrayList<>(exception.getParameterViolations());
+      this.returnValueViolations = new ArrayList<>(exception.getReturnValueViolations());
    }
 
    public ViolationReport(final String s)
@@ -54,27 +53,27 @@ public class ViolationReport
       return exception;
    }
 
-   public List<ResteasyConstraintViolation> getFieldViolations()
+   public ArrayList<ResteasyConstraintViolation> getFieldViolations()
    {
       return fieldViolations;
    }
 
-   public List<ResteasyConstraintViolation> getPropertyViolations()
+   public ArrayList<ResteasyConstraintViolation> getPropertyViolations()
    {
       return propertyViolations;
    }
 
-   public List<ResteasyConstraintViolation> getClassViolations()
+   public ArrayList<ResteasyConstraintViolation> getClassViolations()
    {
       return classViolations;
    }
 
-   public List<ResteasyConstraintViolation> getParameterViolations()
+   public ArrayList<ResteasyConstraintViolation> getParameterViolations()
    {
       return parameterViolations;
    }
 
-   public List<ResteasyConstraintViolation> getReturnValueViolations()
+   public ArrayList<ResteasyConstraintViolation> getReturnValueViolations()
    {
       return returnValueViolations;
    }


### PR DESCRIPTION
Signed-off-by: Rhuan Rocha <rhuan080@gmail.com>

This issue was identified in a scenario that the exception' object is delegated to a task that works in other threads. As it uses the iterator on ResteasyViolationException#toString and it calls the convertViolations method (that modifies the violationLists) it can generate an issue if called concurrently. 