### PR TITLE
FormParam splitting

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/FormUrlEncodedProvider.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/FormUrlEncodedProvider.java
@@ -100,7 +100,7 @@ public class FormUrlEncodedProvider implements MessageBodyReader<MultivaluedMap>
       {
          if (param.indexOf('=') >= 0)
          {
-            String[] nv = param.split("=");
+            String[] nv = param.split("=", 2);
             String val = nv.length > 1 ? nv[1] : "";
             formData.add(nv[0], val);
          }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/FormParamInjectionTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/FormParamInjectionTest.java
@@ -1,0 +1,51 @@
+package org.jboss.resteasy.test.resource;
+
+import javax.ws.rs.core.MediaType;
+import org.jboss.resteasy.core.ResourceMethodRegistry;
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.jboss.resteasy.mock.MockHttpResponse;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.jboss.resteasy.test.resource.resource.FormParamResource;
+
+/**
+ * @tpSubChapter Resource tests
+ * @tpChapter Unit tests
+ * @tpTestCaseDetails Tests to make sure that FormParam are handled correctly
+ */
+public class FormParamInjectionTest {
+
+    ResourceMethodRegistry registry = new ResourceMethodRegistry(ResteasyProviderFactory.getInstance());
+    MockHttpResponse resp = new MockHttpResponse();
+
+    @Before
+    public void setup() {
+        registry.addPerRequestResource(FormParamResource.class);
+    }
+
+    @Test
+    public void testNoSplitAtSuccessiveEqualSign() throws Exception {
+        MockHttpRequest req = createMockHttpRequest("/form/split", "valueA=v1%3Dv2=v3");
+        Assert.assertEquals("v1=v2=v3", registry.getResourceInvoker(req).invoke(req, resp)
+                .getEntity());
+    }
+
+    /**
+     * Builds an instance of {@code MockHttpRequest} properly configured to make sure that all
+     * the {@code FormParam} are properly injected in all test cases otherwise we end up with
+     * a {@code NullPointerException}.
+     * @param uri the uri of the endpoint to test.
+     * @param form the encoded form that shall be sent in the form body.
+     * @return an instance of {@code MockHttpRequest} properly configured.
+     * @throws Exception in case the provided uri is not properly formed.
+     */
+    private static MockHttpRequest createMockHttpRequest(String uri, String form) throws Exception {
+        MockHttpRequest req = MockHttpRequest.post(uri);
+        req.contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE.withCharset("UTF-8"));
+        req.content(form.getBytes("UTF-8"));
+        return req;
+    }
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/FormParamResource.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/FormParamResource.java
@@ -1,0 +1,19 @@
+package org.jboss.resteasy.test.resource.resource;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+
+
+@Path("/form")
+public class FormParamResource {
+
+    @Path("/split")
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public String string(@FormParam("valueA") String value) {
+        return value;
+    }
+}


### PR DESCRIPTION
The implementation of the FormUrlEncodedProvider currently does not handle FormParams with plaintext equal signs correctly. 
When the value of a param contains unecoded equal signs which is correct according to the whatwg spec (https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set), the FormUrlEncodedProvider cuts of everything after the first equal sign.

In the parse algorithm definition in https://url.spec.whatwg.org/#urlencoded-parsing it is stated, that only the first equal sign in a key value pair is used to split the pair.
> If bytes contains a 0x3D (=), then let name be the bytes from the start of bytes up to but excluding its first 0x3D (=), and let value be the bytes, if any, after the first 0x3D (=) up to the end of bytes.

This behaviour occurred to me in an angular application which uses the angular HttpClient together with Quarkus using Resteasy. The HttParams object which is used there for form encoding does not encode equal signs and so the value is not properly received in a JAX-RS method using FormParam vaues. I also verified the correct behaviour after the patch in a Quarkus sample project. I can provide that if it is necessary.

