### PR TITLE
[RESTEASY-2933] Upgrade Hibernate Validator to 6.0.22.Final

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -98,7 +98,7 @@
 
         <version.io.reactivex.rxjava2-rxjava>2.2.19</version.io.reactivex.rxjava2-rxjava>
         <version.org.reactivestreams>1.0.3</version.org.reactivestreams>
-        <version.org.hibernate.validator>6.0.18.Final</version.org.hibernate.validator>
+        <version.org.hibernate.validator>6.0.22.Final</version.org.hibernate.validator>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.6.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.rest-assured>3.3.0</version.rest-assured>
         <version.org.springframework>5.3.7</version.org.springframework>


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-2933