### PR TITLE
[RESTEASY-295] Use the org.jboss:jboss-parent parent POM for the BOM …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
 
         <!-- Plugins versions -->
         <version.org.jacoco.plugin>0.7.9</version.org.jacoco.plugin>
-        <version.compiler.plugin>3.8.0-jboss-2</version.compiler.plugin>
         <version.org.wildfly.plugins.wildfly-maven-plugin>2.1.0.Beta1</version.org.wildfly.plugins.wildfly-maven-plugin>
     </properties>
 
@@ -113,7 +112,6 @@
                 <module>resteasy-client-vertx</module>
                 <module>resteasy-client-reactor-netty</module>
                 <module>providers</module>
-                <module>resteasy-bom</module>
                 <module>resteasy-cache</module>
                 <module>resteasy-guice</module>
                 <module>security</module>
@@ -134,6 +132,8 @@
                 <module>arquillian</module>
                 <module>profiling-tests</module>
                 <module>testsuite</module>
+                <!-- Build this last -->
+                <module>resteasy-bom</module>
             </modules>
             <dependencyManagement>
                 <dependencies>

--- a/resteasy-bom/pom.xml
+++ b/resteasy-bom/pom.xml
@@ -1,18 +1,23 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
+    <!-- Use the jboss-parent as the parent. The org.jboss.resteasy:resteasy-jaxrs-all imports the
+         org.jboss.resteasy:resteasy-dependencies BOM which we do not want included in this BOM.
+    -->
     <parent>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
-   </parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>38</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>org.jboss.resteasy</groupId>
+    <artifactId>resteasy-bom</artifactId>
+    <version>4.7.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
 
     <name>RESTEasy Maven Import (BOM)</name>
     <description/>
-    <artifactId>resteasy-bom</artifactId>
-    <packaging>pom</packaging>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
…meant for users to consume.

https://issues.redhat.com/browse/RESTEASY-2955