### PR TITLE
An attempt at completing `asyncWrite` CompletableFuture when..

### DIFF
--- a/server-adapters/resteasy-reactor-netty/src/main/java/org/jboss/resteasy/plugins/server/reactor/netty/ChunkOutputStream.java
+++ b/server-adapters/resteasy-reactor-netty/src/main/java/org/jboss/resteasy/plugins/server/reactor/netty/ChunkOutputStream.java
@@ -1,5 +1,9 @@
 package org.jboss.resteasy.plugins.server.reactor.netty;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.util.ByteProcessor;
 import org.jboss.resteasy.spi.AsyncOutputStream;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -11,6 +15,14 @@ import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.ScatteringByteChannel;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -60,15 +72,16 @@ class ChunkOutputStream extends AsyncOutputStream {
        this.parentResponse = Objects.requireNonNull(parentResponse);
        this.completionSink = Objects.requireNonNull(completionSink);
        Objects.requireNonNull(reactorNettyResponse);
+
        this.byteSinkSupplier = () -> {
-           final Sinks.Many<Tuple2<byte[], CompletableFuture<Void>>> outSink = Sinks.many().multicast().onBackpressureBuffer();
-           final Flux<byte[]> byteFlux = outSink.asFlux().map(tup -> {
-                   tup.getT2().complete(null);
-                   return tup.getT1();
-               });
+           final Sinks.Many<Tuple2<byte[], CompletableFuture<Void>>> outSink =
+               Sinks.many().unicast().onBackpressureBuffer();
 
-           SinkSubscriber.subscribe(completionSink, Mono.from(reactorNettyResponse.sendByteArray(byteFlux)));
+           final Flux<ByteBuf> byteFlux =
+               outSink.asFlux()
+                   .map(tup -> new WrappedByteBuf(Unpooled.wrappedBuffer(tup.getT1()), tup.getT2()));
 
+           SinkSubscriber.subscribe(completionSink, Mono.from(reactorNettyResponse.send(byteFlux)));
            return outSink;
        };
    }
@@ -153,4 +166,994 @@ class ChunkOutputStream extends AsyncOutputStream {
         byteSink.emitNext(Tuples.of(bytes, cf), EMIT_FAILURE_HANDLER);
         return cf;
    }
+
+    /**
+     * The ultimate purpose of this wrapper is to complete the {@link CompletableFuture} returned
+     * from {@link #asyncWrite(byte[], int, int)}.  It achieves this with by using the assumption
+     * that reactor-netty will call one of the ByteBuf release methods (e.g. {@link ByteBuf#release()}.
+     */
+    private static class WrappedByteBuf extends ByteBuf {
+        private final CompletableFuture<Void> cf;
+        private final ByteBuf delegate;
+
+        public WrappedByteBuf(final ByteBuf delegate, final CompletableFuture<Void> cf) {
+            this.cf = cf;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public int capacity() {
+            return delegate.capacity();
+        }
+
+        @Override
+        public ByteBuf capacity(int newCapacity) {
+            return new WrappedByteBuf(delegate.capacity(newCapacity), cf);
+        }
+
+        @Override
+        public int maxCapacity() {
+            return delegate.maxCapacity();
+        }
+
+        @Override
+        public ByteBufAllocator alloc() {
+            // TODO technically this should be implemented..
+            return delegate.alloc();
+        }
+
+        @Override
+        @Deprecated
+        public ByteOrder order() {
+            return delegate.order();
+        }
+
+        @Override
+        @Deprecated
+        public ByteBuf order(ByteOrder endianness) {
+            return new WrappedByteBuf(delegate.order(endianness), cf);
+        }
+
+        @Override
+        public ByteBuf unwrap() {
+            return new WrappedByteBuf(delegate.unwrap(), cf);
+        }
+
+        @Override
+        public boolean isDirect() {
+            return delegate.isDirect();
+        }
+
+        @Override
+        public boolean isReadOnly() {
+            return delegate.isReadOnly();
+        }
+
+        @Override
+        public ByteBuf asReadOnly() {
+            return new WrappedByteBuf(delegate.asReadOnly(), cf);
+        }
+
+        @Override
+        public int readerIndex() {
+            return delegate.readerIndex();
+        }
+
+        @Override
+        public ByteBuf readerIndex(int readerIndex) {
+            return new WrappedByteBuf(delegate.readerIndex(readerIndex), cf);
+        }
+
+        @Override
+        public int writerIndex() {
+            return delegate.writerIndex();
+        }
+
+        @Override
+        public ByteBuf writerIndex(int writerIndex) {
+            return new WrappedByteBuf(delegate.writerIndex(writerIndex), cf);
+        }
+
+        @Override
+        public ByteBuf setIndex(int readerIndex, int writerIndex) {
+            return new WrappedByteBuf(delegate.setIndex(readerIndex, writerIndex), cf);
+        }
+
+        @Override
+        public int readableBytes() {
+            return delegate.readableBytes();
+        }
+
+        @Override
+        public int writableBytes() {
+            return delegate.writableBytes();
+        }
+
+        @Override
+        public int maxWritableBytes() {
+            return delegate.maxWritableBytes();
+        }
+
+        @Override
+        public int maxFastWritableBytes() {
+            return delegate.maxFastWritableBytes();
+        }
+
+        @Override
+        public boolean isReadable() {
+            return delegate.isReadable();
+        }
+
+        @Override
+        public boolean isReadable(int size) {
+            return delegate.isReadable(size);
+        }
+
+        @Override
+        public boolean isWritable() {
+            return delegate.isWritable();
+        }
+
+        @Override
+        public boolean isWritable(int size) {
+            return delegate.isWritable(size);
+        }
+
+        @Override
+        public ByteBuf clear() {
+            return new WrappedByteBuf(delegate.clear(), cf);
+        }
+
+        @Override
+        public ByteBuf markReaderIndex() {
+            return new WrappedByteBuf(delegate.markReaderIndex(), cf);
+        }
+
+        @Override
+        public ByteBuf resetReaderIndex() {
+            return new WrappedByteBuf(delegate.resetReaderIndex(), cf);
+        }
+
+        @Override
+        public ByteBuf markWriterIndex() {
+            return new WrappedByteBuf(delegate.markWriterIndex(), cf);
+        }
+
+        @Override
+        public ByteBuf resetWriterIndex() {
+            return new WrappedByteBuf(delegate.resetWriterIndex(), cf);
+        }
+
+        @Override
+        public ByteBuf discardReadBytes() {
+            return new WrappedByteBuf(delegate.discardReadBytes(), cf);
+        }
+
+        @Override
+        public ByteBuf discardSomeReadBytes() {
+            return new WrappedByteBuf(delegate.discardSomeReadBytes(), cf);
+        }
+
+        @Override
+        public ByteBuf ensureWritable(int minWritableBytes) {
+            return new WrappedByteBuf(delegate.ensureWritable(minWritableBytes), cf);
+        }
+
+        @Override
+        public int ensureWritable(int minWritableBytes, boolean force) {
+            return delegate.ensureWritable(minWritableBytes, force);
+        }
+
+        @Override
+        public boolean getBoolean(int index) {
+            return delegate.getBoolean(index);
+        }
+
+        @Override
+        public byte getByte(int index) {
+            return delegate.getByte(index);
+        }
+
+        @Override
+        public short getUnsignedByte(int index) {
+            return delegate.getUnsignedByte(index);
+        }
+
+        @Override
+        public short getShort(int index) {
+            return delegate.getShort(index);
+        }
+
+        @Override
+        public short getShortLE(int index) {
+            return delegate.getShortLE(index);
+        }
+
+        @Override
+        public int getUnsignedShort(int index) {
+            return delegate.getUnsignedShort(index);
+        }
+
+        @Override
+        public int getUnsignedShortLE(int index) {
+            return delegate.getUnsignedShortLE(index);
+        }
+
+        @Override
+        public int getMedium(int index) {
+            return delegate.getMedium(index);
+        }
+
+        @Override
+        public int getMediumLE(int index) {
+            return delegate.getMediumLE(index);
+        }
+
+        @Override
+        public int getUnsignedMedium(int index) {
+            return delegate.getUnsignedMedium(index);
+        }
+
+        @Override
+        public int getUnsignedMediumLE(int index) {
+            return delegate.getUnsignedMediumLE(index);
+        }
+
+        @Override
+        public int getInt(int index) {
+            return delegate.getInt(index);
+        }
+
+        @Override
+        public int getIntLE(int index) {
+            return delegate.getIntLE(index);
+        }
+
+        @Override
+        public long getUnsignedInt(int index) {
+            return delegate.getUnsignedInt(index);
+        }
+
+        @Override
+        public long getUnsignedIntLE(int index) {
+            return delegate.getUnsignedIntLE(index);
+        }
+
+        @Override
+        public long getLong(int index) {
+            return delegate.getLong(index);
+        }
+
+        @Override
+        public long getLongLE(int index) {
+            return delegate.getLongLE(index);
+        }
+
+        @Override
+        public char getChar(int index) {
+            return delegate.getChar(index);
+        }
+
+        @Override
+        public float getFloat(int index) {
+            return delegate.getFloat(index);
+        }
+
+        @Override
+        public float getFloatLE(int index) {
+            return delegate.getFloatLE(index);
+        }
+
+        @Override
+        public double getDouble(int index) {
+            return delegate.getDouble(index);
+        }
+
+        @Override
+        public double getDoubleLE(int index) {
+            return delegate.getDoubleLE(index);
+        }
+
+        @Override
+        public ByteBuf getBytes(int index, ByteBuf dst) {
+            return new WrappedByteBuf(delegate.getBytes(index, dst), cf);
+        }
+
+        @Override
+        public ByteBuf getBytes(int index, ByteBuf dst, int length) {
+            return new WrappedByteBuf(delegate.getBytes(index, dst, length), cf);
+        }
+
+        @Override
+        public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
+            return new WrappedByteBuf(delegate.getBytes(index, dst, dstIndex, length), cf);
+        }
+
+        @Override
+        public ByteBuf getBytes(int index, byte[] dst) {
+            return new WrappedByteBuf(delegate.getBytes(index, dst), cf);
+        }
+
+        @Override
+        public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
+            return new WrappedByteBuf(delegate.getBytes(index, dst, dstIndex, length), cf);
+        }
+
+        @Override
+        public ByteBuf getBytes(int index, ByteBuffer dst) {
+            return new WrappedByteBuf(delegate.getBytes(index, dst), cf);
+        }
+
+        @Override
+        public ByteBuf getBytes(int index, OutputStream out, int length) throws IOException {
+            return new WrappedByteBuf(delegate.getBytes(index, out, length), cf);
+        }
+
+        @Override
+        public int getBytes(int index, GatheringByteChannel out, int length) throws IOException {
+            return delegate.getBytes(index, out, length);
+        }
+
+        @Override
+        public int getBytes(int index, FileChannel out, long position, int length) throws IOException {
+            return delegate.getBytes(index, out, position, length);
+        }
+
+        @Override
+        public CharSequence getCharSequence(int index, int length, Charset charset) {
+            return delegate.getCharSequence(index, length, charset);
+        }
+
+        @Override
+        public ByteBuf setBoolean(int index, boolean value) {
+            return new WrappedByteBuf(delegate.setBoolean(index, value), cf);
+        }
+
+        @Override
+        public ByteBuf setByte(int index, int value) {
+            return new WrappedByteBuf(delegate.setByte(index, value), cf);
+        }
+
+        @Override
+        public ByteBuf setShort(int index, int value) {
+            return new WrappedByteBuf(delegate.setShort(index, value), cf);
+        }
+
+        @Override
+        public ByteBuf setShortLE(int index, int value) {
+            return new WrappedByteBuf(delegate.setShortLE(index, value), cf);
+        }
+
+        @Override
+        public ByteBuf setMedium(int index, int value) {
+            return new WrappedByteBuf(delegate.setMedium(index, value), cf);
+        }
+
+        @Override
+        public ByteBuf setMediumLE(int index, int value) {
+            return new WrappedByteBuf(delegate.setMediumLE(index, value), cf);
+        }
+
+        @Override
+        public ByteBuf setInt(int index, int value) {
+            return new WrappedByteBuf(delegate.setInt(index, value), cf);
+        }
+
+        @Override
+        public ByteBuf setIntLE(int index, int value) {
+            return new WrappedByteBuf(delegate.setIntLE(index, value), cf);
+        }
+
+        @Override
+        public ByteBuf setLong(int index, long value) {
+            return new WrappedByteBuf(delegate.setLong(index, value), cf);
+        }
+
+        @Override
+        public ByteBuf setLongLE(int index, long value) {
+            return new WrappedByteBuf(delegate.setLongLE(index, value), cf);
+        }
+
+        @Override
+        public ByteBuf setChar(int index, int value) {
+            return new WrappedByteBuf(delegate.setChar(index, value), cf);
+        }
+
+        @Override
+        public ByteBuf setFloat(int index, float value) {
+            return new WrappedByteBuf(delegate.setFloat(index, value), cf);
+        }
+
+        @Override
+        public ByteBuf setFloatLE(int index, float value) {
+            return new WrappedByteBuf(delegate.setFloatLE(index, value), cf);
+        }
+
+        @Override
+        public ByteBuf setDouble(int index, double value) {
+            return new WrappedByteBuf(delegate.setDouble(index, value), cf);
+        }
+
+        @Override
+        public ByteBuf setDoubleLE(int index, double value) {
+            return new WrappedByteBuf(delegate.setDoubleLE(index, value), cf);
+        }
+
+        @Override
+        public ByteBuf setBytes(int index, ByteBuf src) {
+            return new WrappedByteBuf(delegate.setBytes(index, src), cf);
+        }
+
+        @Override
+        public ByteBuf setBytes(int index, ByteBuf src, int length) {
+            return new WrappedByteBuf(delegate.setBytes(index, src, length), cf);
+        }
+
+        @Override
+        public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
+            return new WrappedByteBuf(delegate.setBytes(index, src, srcIndex, length), cf);
+        }
+
+        @Override
+        public ByteBuf setBytes(int index, byte[] src) {
+            return new WrappedByteBuf(delegate.setBytes(index, src), cf);
+        }
+
+        @Override
+        public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
+            return new WrappedByteBuf(delegate.setBytes(index, src, srcIndex, length), cf);
+        }
+
+        @Override
+        public ByteBuf setBytes(int index, ByteBuffer src) {
+            return new WrappedByteBuf(delegate.setBytes(index, src), cf);
+        }
+
+        @Override
+        public int setBytes(int index, InputStream in, int length) throws IOException {
+            return delegate.setBytes(index, in, length);
+        }
+
+        @Override
+        public int setBytes(int index, ScatteringByteChannel in, int length) throws IOException {
+            return delegate.setBytes(index, in, length);
+        }
+
+        @Override
+        public int setBytes(int index, FileChannel in, long position, int length) throws IOException {
+            return delegate.setBytes(index, in, position, length);
+        }
+
+        @Override
+        public ByteBuf setZero(int index, int length) {
+            return new WrappedByteBuf(delegate.setZero(index, length), cf);
+        }
+
+        @Override
+        public int setCharSequence(int index, CharSequence sequence, Charset charset) {
+            return delegate.setCharSequence(index, sequence, charset);
+        }
+
+        @Override
+        public boolean readBoolean() {
+            return delegate.readBoolean();
+        }
+
+        @Override
+        public byte readByte() {
+            return delegate.readByte();
+        }
+
+        @Override
+        public short readUnsignedByte() {
+            return delegate.readUnsignedByte();
+        }
+
+        @Override
+        public short readShort() {
+            return delegate.readShort();
+        }
+
+        @Override
+        public short readShortLE() {
+            return delegate.readShortLE();
+        }
+
+        @Override
+        public int readUnsignedShort() {
+            return delegate.readUnsignedShort();
+        }
+
+        @Override
+        public int readUnsignedShortLE() {
+            return delegate.readUnsignedShortLE();
+        }
+
+        @Override
+        public int readMedium() {
+            return delegate.readMedium();
+        }
+
+        @Override
+        public int readMediumLE() {
+            return delegate.readMediumLE();
+        }
+
+        @Override
+        public int readUnsignedMedium() {
+            return delegate.readUnsignedMedium();
+        }
+
+        @Override
+        public int readUnsignedMediumLE() {
+            return delegate.readUnsignedMediumLE();
+        }
+
+        @Override
+        public int readInt() {
+            return delegate.readInt();
+        }
+
+        @Override
+        public int readIntLE() {
+            return delegate.readIntLE();
+        }
+
+        @Override
+        public long readUnsignedInt() {
+            return delegate.readUnsignedInt();
+        }
+
+        @Override
+        public long readUnsignedIntLE() {
+            return delegate.readUnsignedIntLE();
+        }
+
+        @Override
+        public long readLong() {
+            return delegate.readLong();
+        }
+
+        @Override
+        public long readLongLE() {
+            return delegate.readLongLE();
+        }
+
+        @Override
+        public char readChar() {
+            return delegate.readChar();
+        }
+
+        @Override
+        public float readFloat() {
+            return delegate.readFloat();
+        }
+
+        @Override
+        public float readFloatLE() {
+            return delegate.readFloatLE();
+        }
+
+        @Override
+        public double readDouble() {
+            return delegate.readDouble();
+        }
+
+        @Override
+        public double readDoubleLE() {
+            return delegate.readDoubleLE();
+        }
+
+        @Override
+        public ByteBuf readBytes(int length) {
+            return new WrappedByteBuf(delegate.readBytes(length), cf);
+        }
+
+        @Override
+        public ByteBuf readSlice(int length) {
+            return new WrappedByteBuf(delegate.readSlice(length), cf);
+        }
+
+        @Override
+        public ByteBuf readRetainedSlice(int length) {
+            return new WrappedByteBuf(delegate.readRetainedSlice(length), cf);
+        }
+
+        @Override
+        public ByteBuf readBytes(ByteBuf dst) {
+            return new WrappedByteBuf(delegate.readBytes(dst), cf);
+        }
+
+        @Override
+        public ByteBuf readBytes(ByteBuf dst, int length) {
+            return new WrappedByteBuf(delegate.readBytes(dst, length), cf);
+        }
+
+        @Override
+        public ByteBuf readBytes(ByteBuf dst, int dstIndex, int length) {
+            return new WrappedByteBuf(delegate.readBytes(dst, dstIndex, length), cf);
+        }
+
+        @Override
+        public ByteBuf readBytes(byte[] dst) {
+            return new WrappedByteBuf(delegate.readBytes(dst), cf);
+        }
+
+        @Override
+        public ByteBuf readBytes(byte[] dst, int dstIndex, int length) {
+            return new WrappedByteBuf(delegate.readBytes(dst, dstIndex, length), cf);
+        }
+
+        @Override
+        public ByteBuf readBytes(ByteBuffer dst) {
+            return new WrappedByteBuf(delegate.readBytes(dst), cf);
+        }
+
+        @Override
+        public ByteBuf readBytes(OutputStream out, int length) throws IOException {
+            return new WrappedByteBuf(delegate.readBytes(out, length), cf);
+        }
+
+        @Override
+        public int readBytes(GatheringByteChannel out, int length) throws IOException {
+            return delegate.readBytes(out, length);
+        }
+
+        @Override
+        public CharSequence readCharSequence(int length, Charset charset) {
+            return delegate.readCharSequence(length, charset);
+        }
+
+        @Override
+        public int readBytes(FileChannel out, long position, int length) throws IOException {
+            return delegate.readBytes(out, position, length);
+        }
+
+        @Override
+        public ByteBuf skipBytes(int length) {
+            return new WrappedByteBuf(delegate.skipBytes(length), cf);
+        }
+
+        @Override
+        public ByteBuf writeBoolean(boolean value) {
+            return new WrappedByteBuf(delegate.writeBoolean(value), cf);
+        }
+
+        @Override
+        public ByteBuf writeByte(int value) {
+            return new WrappedByteBuf(delegate.writeByte(value), cf);
+        }
+
+        @Override
+        public ByteBuf writeShort(int value) {
+            return new WrappedByteBuf(delegate.writeShort(value), cf);
+        }
+
+        @Override
+        public ByteBuf writeShortLE(int value) {
+            return new WrappedByteBuf(delegate.writeShortLE(value), cf);
+        }
+
+        @Override
+        public ByteBuf writeMedium(int value) {
+            return new WrappedByteBuf(delegate.writeMedium(value), cf);
+        }
+
+        @Override
+        public ByteBuf writeMediumLE(int value) {
+            return new WrappedByteBuf(delegate.writeMediumLE(value), cf);
+        }
+
+        @Override
+        public ByteBuf writeInt(int value) {
+            return new WrappedByteBuf(delegate.writeInt(value), cf);
+        }
+
+        @Override
+        public ByteBuf writeIntLE(int value) {
+            return new WrappedByteBuf(delegate.writeIntLE(value), cf);
+        }
+
+        @Override
+        public ByteBuf writeLong(long value) {
+            return new WrappedByteBuf(delegate.writeLong(value), cf);
+        }
+
+        @Override
+        public ByteBuf writeLongLE(long value) {
+            return new WrappedByteBuf(delegate.writeLongLE(value), cf);
+        }
+
+        @Override
+        public ByteBuf writeChar(int value) {
+            return new WrappedByteBuf(delegate.writeChar(value), cf);
+        }
+
+        @Override
+        public ByteBuf writeFloat(float value) {
+            return new WrappedByteBuf(delegate.writeFloat(value), cf);
+        }
+
+        @Override
+        public ByteBuf writeFloatLE(float value) {
+            return new WrappedByteBuf(delegate.writeFloatLE(value), cf);
+        }
+
+        @Override
+        public ByteBuf writeDouble(double value) {
+            return new WrappedByteBuf(delegate.writeDouble(value), cf);
+        }
+
+        @Override
+        public ByteBuf writeDoubleLE(double value) {
+            return new WrappedByteBuf(delegate.writeDoubleLE(value), cf);
+        }
+
+        @Override
+        public ByteBuf writeBytes(ByteBuf src) {
+            return new WrappedByteBuf(delegate.writeBytes(src), cf);
+        }
+
+        @Override
+        public ByteBuf writeBytes(ByteBuf src, int length) {
+            return new WrappedByteBuf(delegate.writeBytes(src, length), cf);
+        }
+
+        @Override
+        public ByteBuf writeBytes(ByteBuf src, int srcIndex, int length) {
+            return new WrappedByteBuf(delegate.writeBytes(src, srcIndex, length), cf);
+        }
+
+        @Override
+        public ByteBuf writeBytes(byte[] src) {
+            return new WrappedByteBuf(delegate.writeBytes(src), cf);
+        }
+
+        @Override
+        public ByteBuf writeBytes(byte[] src, int srcIndex, int length) {
+            return new WrappedByteBuf(delegate.writeBytes(src, srcIndex, length), cf);
+        }
+
+        @Override
+        public ByteBuf writeBytes(ByteBuffer src) {
+            return new WrappedByteBuf(delegate.writeBytes(src), cf);
+        }
+
+        @Override
+        public int writeBytes(InputStream in, int length) throws IOException {
+            return delegate.writeBytes(in, length);
+        }
+
+        @Override
+        public int writeBytes(ScatteringByteChannel in, int length) throws IOException {
+            return delegate.writeBytes(in, length);
+        }
+
+        @Override
+        public int writeBytes(FileChannel in, long position, int length) throws IOException {
+            return delegate.writeBytes(in, position, length);
+        }
+
+        @Override
+        public ByteBuf writeZero(int length) {
+            return new WrappedByteBuf(delegate.writeZero(length), cf);
+        }
+
+        @Override
+        public int writeCharSequence(CharSequence sequence, Charset charset) {
+            return delegate.writeCharSequence(sequence, charset);
+        }
+
+        @Override
+        public int indexOf(int fromIndex, int toIndex, byte value) {
+            return delegate.indexOf(fromIndex, toIndex, value);
+        }
+
+        @Override
+        public int bytesBefore(byte value) {
+            return delegate.bytesBefore(value);
+        }
+
+        @Override
+        public int bytesBefore(int length, byte value) {
+            return delegate.bytesBefore(length, value);
+        }
+
+        @Override
+        public int bytesBefore(int index, int length, byte value) {
+            return delegate.bytesBefore(index, length, value);
+        }
+
+        @Override
+        public int forEachByte(ByteProcessor processor) {
+            return delegate.forEachByte(processor);
+        }
+
+        @Override
+        public int forEachByte(int index, int length, ByteProcessor processor) {
+            return delegate.forEachByte(index, length, processor);
+        }
+
+        @Override
+        public int forEachByteDesc(ByteProcessor processor) {
+            return delegate.forEachByteDesc(processor);
+        }
+
+        @Override
+        public int forEachByteDesc(int index, int length, ByteProcessor processor) {
+            return delegate.forEachByteDesc(index, length, processor);
+        }
+
+        @Override
+        public ByteBuf copy() {
+            return new WrappedByteBuf(delegate.copy(), cf);
+        }
+
+        @Override
+        public ByteBuf copy(int index, int length) {
+            return new WrappedByteBuf(delegate.copy(index, length), cf);
+        }
+
+        @Override
+        public ByteBuf slice() {
+            return new WrappedByteBuf(delegate.slice(), cf);
+        }
+
+        @Override
+        public ByteBuf retainedSlice() {
+            return new WrappedByteBuf(delegate.retainedSlice(), cf);
+        }
+
+        @Override
+        public ByteBuf slice(int index, int length) {
+            return new WrappedByteBuf(delegate.slice(index, length), cf);
+        }
+
+        @Override
+        public ByteBuf retainedSlice(int index, int length) {
+            return new WrappedByteBuf(delegate.retainedSlice(index, length), cf);
+        }
+
+        @Override
+        public ByteBuf duplicate() {
+            return new WrappedByteBuf(delegate.duplicate(), cf);
+        }
+
+        @Override
+        public ByteBuf retainedDuplicate() {
+            return new WrappedByteBuf(delegate.retainedDuplicate(), cf);
+        }
+
+        @Override
+        public int nioBufferCount() {
+            return delegate.nioBufferCount();
+        }
+
+        @Override
+        public ByteBuffer nioBuffer() {
+            return delegate.nioBuffer();
+        }
+
+        @Override
+        public ByteBuffer nioBuffer(int index, int length) {
+            return delegate.nioBuffer(index, length);
+        }
+
+        @Override
+        public ByteBuffer internalNioBuffer(int index, int length) {
+            return delegate.internalNioBuffer(index, length);
+        }
+
+        @Override
+        public ByteBuffer[] nioBuffers() {
+            return delegate.nioBuffers();
+        }
+
+        @Override
+        public ByteBuffer[] nioBuffers(int index, int length) {
+            return delegate.nioBuffers(index, length);
+        }
+
+        @Override
+        public boolean hasArray() {
+            return delegate.hasArray();
+        }
+
+        @Override
+        public byte[] array() {
+            return delegate.array();
+        }
+
+        @Override
+        public int arrayOffset() {
+            return delegate.arrayOffset();
+        }
+
+        @Override
+        public boolean hasMemoryAddress() {
+            return delegate.hasMemoryAddress();
+        }
+
+        @Override
+        public long memoryAddress() {
+            return delegate.memoryAddress();
+        }
+
+        @Override
+        public boolean isContiguous() {
+            return delegate.isContiguous();
+        }
+
+        @Override
+        public String toString(Charset charset) {
+            return delegate.toString(charset);
+        }
+
+        @Override
+        public String toString(int index, int length, Charset charset) {
+            return delegate.toString(index, length, charset);
+        }
+
+        @Override
+        public int hashCode() {
+            return delegate.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return delegate.equals(obj);
+        }
+
+        @Override
+        public int compareTo(ByteBuf buffer) {
+            return delegate.compareTo(buffer);
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+
+        @Override
+        public ByteBuf retain(int increment) {
+            return new WrappedByteBuf(delegate.retain(increment), cf);
+        }
+
+        @Override
+        public ByteBuf retain() {
+            return new WrappedByteBuf(delegate.retain(), cf);
+        }
+
+        @Override
+        public ByteBuf touch() {
+            return new WrappedByteBuf(delegate.touch(), cf);
+        }
+
+        @Override
+        public ByteBuf touch(Object hint) {
+            return new WrappedByteBuf(delegate.touch(hint), cf);
+        }
+
+        @Override
+        public int refCnt() {
+            return delegate.refCnt();
+        }
+
+        @Override
+        public boolean release() {
+            return completingRelease(delegate.release());
+        }
+
+        @Override
+        public boolean release(int i) {
+            return completingRelease(delegate.release(i));
+        }
+
+        private boolean completingRelease(final boolean released) {
+            if (released) {
+                cf.complete(null);
+            }
+            return released;
+        }
+    }
 }


### PR DESCRIPTION
reactor-netty is done with the `byte[]`.  Trying to avoid copying the bytes into a new array on each call to `asyncWrite`.

The code as written today _must_ be fixed as it can result in jumbled up bytes being sent over the wire.