### PR TITLE
[RESTEASY-2970] SsePublisherClientTest fails with bootable-jar

### DIFF
--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -302,6 +302,7 @@
                                 <container.qualifier.managed.encoding>${container.qualifier.managed.encoding}</container.qualifier.managed.encoding>
                                 <container.offset.managed.encoding>${container.offset.managed.encoding}</container.offset.managed.encoding>
                                 <container.management.port.managed.encoding>${container.management.port.managed.encoding}</container.management.port.managed.encoding>
+                                <resteasy.microprofile.sseclient.buffersize>5</resteasy.microprofile.sseclient.buffersize>
                             </systemPropertyVariables>
                         </configuration>
                         <executions>


### PR DESCRIPTION
Adding the missing property to the bootable-jar surefire configuration.

https://issues.redhat.com/browse/RESTEASY-2970

This goes into the `3.15` branch only.