### PR TITLE
Backport #2691 to main branch

### DIFF
--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -123,6 +123,44 @@
             <jboss.home>${project.build.directory}/test-server/wildfly-${server.version}</jboss.home>
           </properties>
         </profile>
+        <!--
+            By default, ${version.resteasy.testsuite} version for RESTEasy restclient is used.
+            But use.mp.from.project.profile allows to use ${project.version} version for RESTEasy restclient.
+                This is useful for test runs where we test resteasy version without RESTEasy restclient available.
+                In this case, tests with RESTEasy restclient are used for compatibility testing only.
+        -->
+        <profile>
+            <id>not.use.mp.from.project.profile</id>
+            <activation>
+                <property>
+                    <name>!ts.use.mp.from.project</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-client-microprofile</artifactId>
+                    <version>${version.resteasy.testsuite}</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>use.mp.from.project.profile</id>
+            <activation>
+                <property>
+                    <name>ts.use.mp.from.project</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-client-microprofile</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <dependencies>
@@ -181,13 +219,6 @@
         <dependency>
             <groupId>io.smallrye.config</groupId>
             <artifactId>smallrye-config</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client-microprofile</artifactId>
-            <version>${version.resteasy.testsuite}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/AsynchronousCdiTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/AsynchronousCdiTest.java
@@ -45,7 +45,7 @@ public class AsynchronousCdiTest {
       return PortProviderUtil.generateURL(path, AsynchronousCdiTest.class.getSimpleName());
    }
 
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> createTestArchive() {
       WebArchive war = TestUtil.prepareArchive(AsynchronousCdiTest.class.getSimpleName());
       war.addClasses(UtilityProducer.class)

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionTest.java
@@ -110,7 +110,7 @@ public class InjectionTest extends AbstractInjectionTestBase {
    private static int invocationCounter;
 
    @SuppressWarnings(value = "unchecked")
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> createTestArchive() throws Exception {
       initQueue();
       WebArchive war = TestUtil.prepareArchive(InjectionTest.class.getSimpleName());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/MDBInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/MDBInjectionTest.java
@@ -66,7 +66,7 @@ public class MDBInjectionTest extends AbstractInjectionTestBase {
    static Client client;
 
    @SuppressWarnings(value = "unchecked")
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> createTestArchive() throws Exception {
       initQueue();
       WebArchive war = TestUtil.prepareArchive(MDBInjectionTest.class.getSimpleName());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/TimerInterceptorTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/interceptors/TimerInterceptorTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertEquals;
 public class TimerInterceptorTest {
    protected static final Logger log = LogManager.getLogger(TimerInterceptorTest.class.getName());
 
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> createTestArchive() {
       WebArchive war = TestUtil.prepareArchive(TimerInterceptorTest.class.getSimpleName())
             .addClasses(UtilityProducer.class, PortProviderUtil.class)

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/ClientWebApplicationExceptionResteasyProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/ClientWebApplicationExceptionResteasyProxyTest.java
@@ -33,16 +33,36 @@ import org.junit.runner.RunWith;
 @RunAsClient
 public class ClientWebApplicationExceptionResteasyProxyTest {
 
-   private static ClientWebApplicationExceptionProxyResourceInterface proxy;
+   public static final String oldBehaviorDeploymentName = "OldBehaviorClientWebApplicationExceptionResteasyProxyTest";
+   public static final String newBehaviorDeploymentName = "NewBehaviorClientWebApplicationExceptionResteasyProxyTest";
+
+   private static ClientWebApplicationExceptionProxyResourceInterface oldBehaviorProxy;
+   private static ClientWebApplicationExceptionProxyResourceInterface newBehaviorProxy;
 
    static {
       ResteasyClient client = (ResteasyClient) ResteasyClientBuilder.newClient();
-      proxy = client.target(generateURL("/app/test/")).proxy(ClientWebApplicationExceptionProxyResourceInterface.class);
+      oldBehaviorProxy = client.target(PortProviderUtil.generateURL("/app/test/", oldBehaviorDeploymentName))
+              .proxy(ClientWebApplicationExceptionProxyResourceInterface.class);
+      newBehaviorProxy = client.target(PortProviderUtil.generateURL("/app/test/", newBehaviorDeploymentName))
+              .proxy(ClientWebApplicationExceptionProxyResourceInterface.class);
    }
 
-   @Deployment
-   public static Archive<?> deploy() {
-      WebArchive war = TestUtil.prepareArchive(ClientWebApplicationExceptionTest.class.getSimpleName());
+   @Deployment(name = oldBehaviorDeploymentName)
+   public static Archive<?> deployOldBehaviour() {
+      WebArchive war = TestUtil.prepareArchive(oldBehaviorDeploymentName);
+      war.addClass(ClientWebApplicationExceptionTest.class);
+      war.addClass(ClientWebApplicationExceptionResteasyProxyApplication.class);
+      war.addClass(ClientWebApplicationExceptionResteasyProxyResource.class);
+      war.addClass(PortProviderUtil.class);
+      war.addClass(TestUtil.class);
+      war.setWebXML(ClientWebApplicationExceptionResteasyProxyTest.class.getPackage(), "webapplicationexception_web.xml");
+      war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+      return TestUtil.finishContainerPrepare(war, null, ClientWebApplicationExceptionProxyResourceInterface.class);
+   }
+
+   @Deployment(name = newBehaviorDeploymentName)
+   public static Archive<?> deployNewBehavior() {
+      WebArchive war = TestUtil.prepareArchive(newBehaviorDeploymentName);
       war.addClass(ClientWebApplicationExceptionTest.class);
       war.addClass(ClientWebApplicationExceptionResteasyProxyApplication.class);
       war.addClass(ClientWebApplicationExceptionResteasyProxyResource.class);
@@ -50,10 +70,6 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
       war.addClass(TestUtil.class);
       war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
       return TestUtil.finishContainerPrepare(war, null, ClientWebApplicationExceptionProxyResourceInterface.class);
-   }
-
-   public static String generateURL(String path) {
-      return PortProviderUtil.generateURL(path, ClientWebApplicationExceptionTest.class.getSimpleName());
    }
 
    ////////////////////////////////////////////////////////////////////////////////////////////
@@ -69,7 +85,7 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
       for (int i = 0; i < ClientWebApplicationExceptionTest.oldExceptions.length; i++) {
          try {
             System.setProperty("node", "localhost");
-            proxy.oldException(i);
+            newBehaviorProxy.oldException(i);
             Assert.fail("expected exception");
          } catch (ResteasyWebApplicationException rwae) {
             Assert.fail("Didn't expect ResteasyWebApplicationException");
@@ -97,7 +113,7 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
    public void testNewExceptionsDirectly() throws Exception {
       for (int i = 0; i < ClientWebApplicationExceptionTest.newExceptions.length; i++) {
          try {
-            proxy.newException(i);
+            newBehaviorProxy.newException(i);
             Assert.fail("expected exception");
          } catch (ResteasyWebApplicationException rwae) {
             Assert.fail("Didn't expect ResteasyWebApplicationException");
@@ -132,28 +148,23 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testNoCatchOldBehaviorOldExceptions() throws Exception {
-      proxy.setBehavior("true");
-      try {
-         for (int i = 0; i < ClientWebApplicationExceptionTest.oldExceptions.length; i++) {
-            try {
-               proxy.noCatchOld(i);
-               Assert.fail("expected exception");
-            } catch (ResteasyWebApplicationException rwae) {
-               Assert.fail("Didn't expect ResteasyWebApplicationException");
-            } catch (WebApplicationException e) {
-               Response response = e.getResponse();
-               WebApplicationException wae = ClientWebApplicationExceptionTest.oldExceptions[i];
-               Assert.assertEquals(wae.getResponse().getStatus(), response.getStatus());
-               Assert.assertEquals(wae.getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
-               Assert.assertEquals(wae.getResponse().getEntity(), response.readEntity(String.class));
-               Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptionMap.get(response.getStatus()), e.getClass());
-            } catch (Exception e) {
-               Assert.fail("expected WebApplicationException");
-            }
+   public void testNoCatchOldBehaviorOldExceptions() {
+      for (int i = 0; i < ClientWebApplicationExceptionTest.oldExceptions.length; i++) {
+         try {
+            oldBehaviorProxy.noCatchOldOld(i);
+            Assert.fail("expected exception");
+         } catch (ResteasyWebApplicationException rwae) {
+            Assert.fail("Didn't expect ResteasyWebApplicationException");
+         } catch (WebApplicationException e) {
+            Response response = e.getResponse();
+            WebApplicationException wae = ClientWebApplicationExceptionTest.oldExceptions[i];
+            Assert.assertEquals(wae.getResponse().getStatus(), response.getStatus());
+            Assert.assertEquals(wae.getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
+            Assert.assertEquals(wae.getResponse().getEntity(), response.readEntity(String.class));
+            Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptionMap.get(response.getStatus()), e.getClass());
+         } catch (Exception e) {
+            Assert.fail("expected WebApplicationException");
          }
-      } finally {
-         proxy.setBehavior("false");
       }
    }
 
@@ -176,29 +187,24 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testNoCatchOldBehaviorNewExceptions() throws Exception {
-      proxy.setBehavior("true");
-      try {
-         for (int i = 0; i < ClientWebApplicationExceptionTest.newExceptions.length; i++) {
-            try {
-               proxy.noCatchNew(i);
-               Assert.fail("expected exception");
-            } catch (ResteasyWebApplicationException rwae) {
-               Assert.fail("Didn't expect ResteasyWebApplicationException");
-            } catch (WebApplicationException e) {
-               Response response = e.getResponse();
-               Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptions[i].getResponse().getStatus(), response.getStatus());
-               Assert.assertNull(response.getHeaderString("foo"));
-               Assert.assertTrue(response.readEntity(String.class).isEmpty());
-               // We compare the old exception here because this is coming from a client resulting in the exception thrown
-               // at the client not wrapped.
-               Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptionMap.get(response.getStatus()), e.getClass());
-            } catch (Exception e) {
-               Assert.fail("expected WebApplicationException");
-            }
+   public void testNoCatchOldBehaviorNewExceptions() {
+      for (int i = 0; i < ClientWebApplicationExceptionTest.newExceptions.length; i++) {
+         try {
+            oldBehaviorProxy.noCatchOldNew(i);
+            Assert.fail("expected exception");
+         } catch (ResteasyWebApplicationException rwae) {
+            Assert.fail("Didn't expect ResteasyWebApplicationException");
+         } catch (WebApplicationException e) {
+            Response response = e.getResponse();
+            Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptions[i].getResponse().getStatus(), response.getStatus());
+            Assert.assertNull(response.getHeaderString("foo"));
+            Assert.assertTrue(response.readEntity(String.class).isEmpty());
+            // We compare the old exception here because this is coming from a client resulting in the exception thrown
+            // at the client not wrapped.
+            Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptionMap.get(response.getStatus()), e.getClass());
+         } catch (Exception e) {
+            Assert.fail("expected WebApplicationException");
          }
-      } finally {
-         proxy.setBehavior("false");
       }
    }
 
@@ -217,10 +223,10 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testNoCatchNewBehaviorOldExceptions() throws Exception {
+   public void testNoCatchNewBehaviorOldExceptions() {
       for (int i = 0; i < ClientWebApplicationExceptionTest.oldExceptions.length; i++) {
          try {
-            proxy.noCatchOld(i);
+            newBehaviorProxy.noCatchNewOld(i);
             Assert.fail("expected exception");
          } catch (ResteasyWebApplicationException rwae) {
             Assert.fail("Didn't expect ResteasyWebApplicationException");
@@ -250,10 +256,10 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testNoCatchNewBehaviorNewExceptions() throws Exception {
+   public void testNoCatchNewBehaviorNewExceptions() {
       for (int i = 0; i < ClientWebApplicationExceptionTest.newExceptions.length; i++) {
          try {
-            proxy.noCatchNew(i);
+            newBehaviorProxy.noCatchNewNew(i);
             Assert.fail("expected exception");
          } catch (ResteasyWebApplicationException rwae) {
             Assert.fail("Didn't expect ResteasyWebApplicationException");
@@ -291,27 +297,22 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testCatchOldBehaviorOldExceptions() throws Exception {
-      proxy.setBehavior("true");
-      try {
-         for (int i = 0; i < ClientWebApplicationExceptionTest.oldExceptions.length; i++) {
-            try {
-               proxy.catchOldOld(i);
-               Assert.fail("expected exception");
-            } catch (ResteasyWebApplicationException rwae) {
-               Assert.fail("Didn't expect ResteasyWebApplicationException");
-            } catch (WebApplicationException e) {
-               Response response = e.getResponse();
-               Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getStatus(), response.getStatus());
-               Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
-               Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getEntity(), response.readEntity(String.class));
-               Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptionMap.get(response.getStatus()), e.getClass());
-            } catch (Exception e) {
-               Assert.fail("expected WebApplicationException");
-            }
+   public void testCatchOldBehaviorOldExceptions() {
+      for (int i = 0; i < ClientWebApplicationExceptionTest.oldExceptions.length; i++) {
+         try {
+            oldBehaviorProxy.catchOldOld(i);
+            Assert.fail("expected exception");
+         } catch (ResteasyWebApplicationException rwae) {
+            Assert.fail("Didn't expect ResteasyWebApplicationException");
+         } catch (WebApplicationException e) {
+            Response response = e.getResponse();
+            Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getStatus(), response.getStatus());
+            Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
+            Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getEntity(), response.readEntity(String.class));
+            Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptionMap.get(response.getStatus()), e.getClass());
+         } catch (Exception e) {
+            Assert.fail("expected WebApplicationException");
          }
-      } finally {
-         proxy.setBehavior("false");
       }
    }
 
@@ -334,28 +335,23 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testCatchOldBehaviorNewExceptions() throws Exception {
-      proxy.setBehavior("true");
-      try {
-         for (int i = 0; i < ClientWebApplicationExceptionTest.newExceptions.length; i++) {
-            try {
-               proxy.catchOldNew(i);
-               Assert.fail("expected exception");
-            } catch (ResteasyWebApplicationException e) {
-               Assert.fail("didn't expect ResteasyWebApplicationException");
-            } catch (WebApplicationException e) {
-               Response response = e.getResponse();
-               Assert.assertNotNull(response);
-               Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptions[i].getResponse().getStatus(), response.getStatus());
-               Assert.assertNull(response.getHeaderString("foo"));
-               Assert.assertTrue(response.readEntity(String.class).length() == 0);
-               Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptionMap.get(response.getStatus()), e.getClass());
-            } catch (Exception e) {
-               Assert.fail("expected WebApplicationException");
-            }
+   public void testCatchOldBehaviorNewExceptions() {
+      for (int i = 0; i < ClientWebApplicationExceptionTest.newExceptions.length; i++) {
+         try {
+            oldBehaviorProxy.catchOldNew(i);
+            Assert.fail("expected exception");
+         } catch (ResteasyWebApplicationException e) {
+            Assert.fail("didn't expect ResteasyWebApplicationException");
+         } catch (WebApplicationException e) {
+            Response response = e.getResponse();
+            Assert.assertNotNull(response);
+            Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptions[i].getResponse().getStatus(), response.getStatus());
+            Assert.assertNull(response.getHeaderString("foo"));
+            Assert.assertTrue(response.readEntity(String.class).length() == 0);
+            Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptionMap.get(response.getStatus()), e.getClass());
+         } catch (Exception e) {
+            Assert.fail("expected WebApplicationException");
          }
-      } finally {
-         proxy.setBehavior("false");
       }
    }
 
@@ -374,10 +370,10 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testCatchNewBehaviorOldExceptions() throws Exception {
+   public void testCatchNewBehaviorOldExceptions() {
       for (int i = 0; i < ClientWebApplicationExceptionTest.oldExceptions.length; i++) {
          try {
-            proxy.catchNewOld(i);
+            newBehaviorProxy.catchNewOld(i);
             Assert.fail("expected exception");
          } catch (ResteasyWebApplicationException e) {
             Assert.fail("didn't expect ResteasyWebApplicationException");
@@ -409,10 +405,10 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testCatchNewBehaviorNewExceptions() throws Exception {
+   public void testCatchNewBehaviorNewExceptions() {
       for (int i = 0; i < ClientWebApplicationExceptionTest.newExceptions.length; i++) {
          try {
-            proxy.catchNewNew(i);
+            newBehaviorProxy.catchNewNew(i);
             Assert.fail("expected exception");
          } catch (ResteasyWebApplicationException e) {
             Assert.fail("didn't expect ResteasyWebApplicationException");

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/ClientWebApplicationExceptionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/ClientWebApplicationExceptionTest.java
@@ -148,14 +148,18 @@ public class ClientWebApplicationExceptionTest {
    }
 
    private static Client client;
-   private static WebTarget behaviorTarget;
-   private static WebTarget target;
+
+   private static WebTarget oldBehaviorTarget;
+   private static WebTarget newBehaviorTarget;
+
+   public static final String oldBehaviorDeploymentName = "OldBehaviorClientWebApplicationExceptionTest";
+   public static final String newBehaviorDeploymentName = "NewBehaviorClientWebApplicationExceptionTest";
 
    @BeforeClass
    public static void beforeClass() throws Exception {
       client = ClientBuilder.newClient();
-      behaviorTarget = client.target(generateURL("/app/test/behavior/"));
-      target = client.target(generateURL("/app/test/"));
+      oldBehaviorTarget = client.target(PortProviderUtil.generateURL("/app/test/", oldBehaviorDeploymentName));
+      newBehaviorTarget = client.target(PortProviderUtil.generateURL("/app/test/", newBehaviorDeploymentName));
    }
 
    @AfterClass
@@ -163,9 +167,9 @@ public class ClientWebApplicationExceptionTest {
       client.close();
    }
 
-   @Deployment
-   public static Archive<?> deploy() {
-      WebArchive war = TestUtil.prepareArchive(ClientWebApplicationExceptionTest.class.getSimpleName());
+   @Deployment(name = newBehaviorDeploymentName)
+   public static Archive<?> deployNewBehavior() {
+      WebArchive war = TestUtil.prepareArchive(newBehaviorDeploymentName);
       war.addClass(ClientWebApplicationExceptionTest.class);
       war.addClass(ClientWebApplicationExceptionApplication.class);
       war.addClass(ClientWebApplicationExceptionResource.class);
@@ -174,8 +178,16 @@ public class ClientWebApplicationExceptionTest {
       return TestUtil.finishContainerPrepare(war, null, ClientWebApplicationExceptionResource.class);
    }
 
-   public static String generateURL(String path) {
-      return PortProviderUtil.generateURL(path, ClientWebApplicationExceptionTest.class.getSimpleName());
+   @Deployment(name = oldBehaviorDeploymentName)
+   public static Archive<?> deployOldBehaviour() {
+      WebArchive war = TestUtil.prepareArchive(oldBehaviorDeploymentName);
+      war.addClass(ClientWebApplicationExceptionTest.class);
+      war.addClass(ClientWebApplicationExceptionApplication.class);
+      war.addClass(ClientWebApplicationExceptionResource.class);
+      war.addClass(PortProviderUtil.class);
+      war.addClass(TestUtil.class);
+      war.setWebXML(ClientWebApplicationExceptionResteasyProxyTest.class.getPackage(), "webapplicationexception_web.xml");
+      return TestUtil.finishContainerPrepare(war, null, ClientWebApplicationExceptionResource.class);
    }
 
    ////////////////////////////////////////////////////////////////////////////////////////////
@@ -191,7 +203,7 @@ public class ClientWebApplicationExceptionTest {
    public void testOldExceptionsDirectly() {
       for (int i = 0; i < oldExceptions.length; i++) {
          try {
-            target.path("exception/old/" + i).request().get(String.class);
+            newBehaviorTarget.path("exception/old/" + i).request().get(String.class);
             Assert.fail("expected exception");
          } catch (ResteasyWebApplicationException rwae) {
             Assert.fail("Didn't expect ResteasyWebApplicationException");
@@ -205,7 +217,6 @@ public class ClientWebApplicationExceptionTest {
          } catch (Exception e) {
             Assert.fail("expected WebApplicationException");
          }
-
       }
    }
 
@@ -216,10 +227,10 @@ public class ClientWebApplicationExceptionTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testNewExceptionsDirectly() throws Exception {
+   public void testNewExceptionsDirectly() {
       for (int i = 0; i < newExceptions.length; i++) {
          try {
-            target.path("exception/new/" + i).request().get(String.class);
+            newBehaviorTarget.path("exception/new/" + i).request().get(String.class);
             Assert.fail("expected exception");
          } catch (ResteasyWebApplicationException rwae) {
             Assert.fail("Didn't expect ResteasyWebApplicationException");
@@ -254,30 +265,23 @@ public class ClientWebApplicationExceptionTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testNoCatchOldBehaviorOldExceptions() throws Exception {
-      Response behaviorResponse = behaviorTarget.path("true").request().get();
-      Assert.assertEquals(204, behaviorResponse.getStatus());
-      try {
-         for (int i = 0; i < oldExceptions.length; i++) {
-            try {
-               target.path("nocatch/old/" + i).request().get(String.class);
-               Assert.fail("expected exception");
-            } catch (ResteasyWebApplicationException rwae) {
-               Assert.fail("Didn't expect ResteasyWebApplicationException");
-            } catch (WebApplicationException e) {
-               Response response = e.getResponse();
-               WebApplicationException wae = oldExceptions[i];
-               Assert.assertEquals(wae.getResponse().getStatus(), response.getStatus());
-               Assert.assertEquals(wae.getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
-               Assert.assertEquals(wae.getResponse().getEntity(), response.readEntity(String.class));
-               Assert.assertEquals(oldExceptionMap.get(response.getStatus()), e.getClass());
-            } catch (Exception e) {
-               Assert.fail("expected WebApplicationException");
-            }
+   public void testNoCatchOldBehaviorOldExceptions() {
+      for (int i = 0; i < oldExceptions.length; i++) {
+         try {
+            oldBehaviorTarget.path("nocatch/old/old/" + i).request().get(String.class);
+            Assert.fail("expected exception");
+         } catch (ResteasyWebApplicationException rwae) {
+            Assert.fail("Didn't expect ResteasyWebApplicationException");
+         } catch (WebApplicationException e) {
+            Response response = e.getResponse();
+            WebApplicationException wae = oldExceptions[i];
+            Assert.assertEquals(wae.getResponse().getStatus(), response.getStatus());
+            Assert.assertEquals(wae.getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
+            Assert.assertEquals(wae.getResponse().getEntity(), response.readEntity(String.class));
+            Assert.assertEquals(oldExceptionMap.get(response.getStatus()), e.getClass());
+         } catch (Exception e) {
+            Assert.fail("expected WebApplicationException");
          }
-      } finally {
-         behaviorResponse = behaviorTarget.path("false").request().get();
-         Assert.assertEquals(204, behaviorResponse.getStatus());
       }
    }
 
@@ -299,31 +303,24 @@ public class ClientWebApplicationExceptionTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testNoCatchOldBehaviorNewExceptions() throws Exception {
-      Response behaviorResponse = behaviorTarget.path("true").request().get();
-      Assert.assertEquals(204, behaviorResponse.getStatus());
-      try {
-         for (int i = 0; i < newExceptions.length; i++) {
-            try {
-               target.path("nocatch/new/" + i).request().get(String.class);
-               Assert.fail("expected exception");
-            } catch (ResteasyWebApplicationException rwae) {
-               Assert.fail("Didn't expect ResteasyWebApplicationException");
-            } catch (WebApplicationException e) {
-               Response response = e.getResponse();
-               Assert.assertEquals(newExceptions[i].getResponse().getStatus(), response.getStatus());
-               Assert.assertNull(response.getHeaderString("foo"));
-               Assert.assertTrue(response.readEntity(String.class).isEmpty());
-               // We compare the old exception here because this is coming from a client resulting in the exception thrown
-               // at the client not wrapped.
-               Assert.assertEquals(oldExceptionMap.get(response.getStatus()), e.getClass());
-            } catch (Exception e) {
-               Assert.fail("expected WebApplicationException");
-            }
+   public void testNoCatchOldBehaviorNewExceptions() {
+      for (int i = 0; i < newExceptions.length; i++) {
+         try {
+            oldBehaviorTarget.path("nocatch/old/new/" + i).request().get(String.class);
+            Assert.fail("expected exception");
+         } catch (ResteasyWebApplicationException rwae) {
+            Assert.fail("Didn't expect ResteasyWebApplicationException");
+         } catch (WebApplicationException e) {
+            Response response = e.getResponse();
+            Assert.assertEquals(newExceptions[i].getResponse().getStatus(), response.getStatus());
+            Assert.assertNull(response.getHeaderString("foo"));
+            Assert.assertTrue(response.readEntity(String.class).isEmpty());
+            // We compare the old exception here because this is coming from a client resulting in the exception thrown
+            // at the client not wrapped.
+            Assert.assertEquals(oldExceptionMap.get(response.getStatus()), e.getClass());
+         } catch (Exception e) {
+            Assert.fail("expected WebApplicationException");
          }
-      } finally {
-         behaviorResponse = behaviorTarget.path("false").request().get();
-         Assert.assertEquals(204, behaviorResponse.getStatus());
       }
    }
 
@@ -342,10 +339,10 @@ public class ClientWebApplicationExceptionTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testNoCatchNewBehaviorOldExceptions() throws Exception {
+   public void testNoCatchNewBehaviorOldExceptions() {
       for (int i = 0; i < oldExceptions.length; i++) {
          try {
-            target.path("nocatch/old/" + i).request().get(String.class);
+            newBehaviorTarget.path("nocatch/new/old/" + i).request().get(String.class);
             Assert.fail("expected exception");
          } catch (ResteasyWebApplicationException rwae) {
             Assert.fail("Didn't expect ResteasyWebApplicationException");
@@ -375,10 +372,10 @@ public class ClientWebApplicationExceptionTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testNoCatchNewBehaviorNewExceptions() throws Exception {
+   public void testNoCatchNewBehaviorNewExceptions() {
       for (int i = 0; i < newExceptions.length; i++) {
          try {
-            target.path("nocatch/new/" + i).request().get(String.class);
+            newBehaviorTarget.path("nocatch/new/new/" + i).request().get(String.class);
             Assert.fail("expected exception");
          } catch (ResteasyWebApplicationException rwae) {
             Assert.fail("Didn't expect ResteasyWebApplicationException");
@@ -416,29 +413,22 @@ public class ClientWebApplicationExceptionTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testCatchOldBehaviorOldExceptions() throws Exception {
-      Response behaviorResponse = behaviorTarget.path("true").request().get();
-      Assert.assertEquals(204, behaviorResponse.getStatus());
-      try {
-         for (int i = 0; i < oldExceptions.length; i++) {
-            try {
-               target.path("catch/old/old/" + i).request().get(String.class);
-               Assert.fail("expected exception");
-            } catch (ResteasyWebApplicationException rwae) {
-               Assert.fail("Didn't expect ResteasyWebApplicationException");
-            } catch (WebApplicationException e) {
-               Response response = e.getResponse();
-               Assert.assertEquals(oldExceptions[i].getResponse().getStatus(), response.getStatus());
-               Assert.assertEquals(oldExceptions[i].getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
-               Assert.assertEquals(oldExceptions[i].getResponse().getEntity(), response.readEntity(String.class));
-               Assert.assertEquals(oldExceptionMap.get(response.getStatus()), e.getClass());
-            } catch (Exception e) {
-               Assert.fail("expected WebApplicationException");
-            }
+   public void testCatchOldBehaviorOldExceptions() {
+      for (int i = 0; i < oldExceptions.length; i++) {
+         try {
+            oldBehaviorTarget.path("catch/old/old/" + i).request().get(String.class);
+            Assert.fail("expected exception");
+         } catch (ResteasyWebApplicationException rwae) {
+            Assert.fail("Didn't expect ResteasyWebApplicationException");
+         } catch (WebApplicationException e) {
+            Response response = e.getResponse();
+            Assert.assertEquals(oldExceptions[i].getResponse().getStatus(), response.getStatus());
+            Assert.assertEquals(oldExceptions[i].getResponse().getHeaderString("foo"), response.getHeaderString("foo"));
+            Assert.assertEquals(oldExceptions[i].getResponse().getEntity(), response.readEntity(String.class));
+            Assert.assertEquals(oldExceptionMap.get(response.getStatus()), e.getClass());
+         } catch (Exception e) {
+            Assert.fail("expected WebApplicationException");
          }
-      } finally {
-         behaviorResponse = behaviorTarget.path("false").request().get();
-         Assert.assertEquals(204, behaviorResponse.getStatus());
       }
    }
 
@@ -461,30 +451,23 @@ public class ClientWebApplicationExceptionTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testCatchOldBehaviorNewExceptions() throws Exception {
-      Response behaviorResponse = behaviorTarget.path("true").request().get();
-      Assert.assertEquals(204, behaviorResponse.getStatus());
-      try {
-         for (int i = 0; i < newExceptions.length; i++) {
-            try {
-               target.path("catch/old/new/" + i).request().get(String.class);
-               Assert.fail("expected exception");
-            } catch (ResteasyWebApplicationException e) {
-               Assert.fail("didn't expect ResteasyWebApplicationException");
-            } catch (WebApplicationException e) {
-               Response response = e.getResponse();
-               Assert.assertNotNull(response);
-               Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptions[i].getResponse().getStatus(), response.getStatus());
-               Assert.assertNull(response.getHeaderString("foo"));
-               Assert.assertTrue(response.readEntity(String.class).length() == 0);
-               Assert.assertEquals(oldExceptionMap.get(response.getStatus()), e.getClass());
-            } catch (Exception e) {
-               Assert.fail("expected WebApplicationException");
-            }
+   public void testCatchOldBehaviorNewExceptions() {
+      for (int i = 0; i < newExceptions.length; i++) {
+         try {
+            oldBehaviorTarget.path("catch/old/new/" + i).request().get(String.class);
+            Assert.fail("expected exception");
+         } catch (ResteasyWebApplicationException e) {
+            Assert.fail("didn't expect ResteasyWebApplicationException");
+         } catch (WebApplicationException e) {
+            Response response = e.getResponse();
+            Assert.assertNotNull(response);
+            Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptions[i].getResponse().getStatus(), response.getStatus());
+            Assert.assertNull(response.getHeaderString("foo"));
+            Assert.assertTrue(response.readEntity(String.class).length() == 0);
+            Assert.assertEquals(oldExceptionMap.get(response.getStatus()), e.getClass());
+         } catch (Exception e) {
+            Assert.fail("expected WebApplicationException");
          }
-      } finally {
-         behaviorResponse = behaviorTarget.path("false").request().get();
-         Assert.assertEquals(204, behaviorResponse.getStatus());
       }
    }
 
@@ -503,10 +486,10 @@ public class ClientWebApplicationExceptionTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testCatchNewBehaviorOldExceptions() throws Exception {
+   public void testCatchNewBehaviorOldExceptions() {
       for (int i = 0; i < oldExceptions.length; i++) {
          try {
-            target.path("catch/new/old/" + i).request().get(String.class);
+            newBehaviorTarget.path("catch/new/old/" + i).request().get(String.class);
             Assert.fail("expected exception");
          } catch (ResteasyWebApplicationException e) {
             Assert.fail("didn't expect ResteasyWebApplicationException");
@@ -538,10 +521,10 @@ public class ClientWebApplicationExceptionTest {
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
-   public void testCatchNewBehaviorNewExceptions() throws Exception {
+   public void testCatchNewBehaviorNewExceptions() {
       for (int i = 0; i < newExceptions.length; i++) {
          try {
-            target.path("catch/new/new/" + i).request().get(String.class);
+            newBehaviorTarget.path("catch/new/new/" + i).request().get(String.class);
             Assert.fail("expected exception");
          } catch (ResteasyWebApplicationException e) {
             Assert.fail("didn't expect ResteasyWebApplicationException");

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/resource/ClientWebApplicationExceptionMicroProfileProxyResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/resource/ClientWebApplicationExceptionMicroProfileProxyResource.java
@@ -10,7 +10,6 @@ import org.jboss.resteasy.client.exception.ResteasyWebApplicationException;
 import org.jboss.resteasy.client.exception.WebApplicationExceptionWrapper;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.test.client.exception.ClientWebApplicationExceptionMicroProfileProxyTest;
 import org.jboss.resteasy.test.client.exception.ClientWebApplicationExceptionTest;
 import org.jboss.resteasy.utils.PortProviderUtil;
@@ -19,25 +18,19 @@ import org.junit.Assert;
 @Path("test")
 public class ClientWebApplicationExceptionMicroProfileProxyResource {
 
-   private static ClientWebApplicationExceptionProxyResourceInterface proxy;
+   private static ClientWebApplicationExceptionProxyResourceInterface oldBehaviorProxy;
+   private static ClientWebApplicationExceptionProxyResourceInterface newBehaviorProxy;
 
    static {
       ResteasyClient client = (ResteasyClient) ResteasyClientBuilder.newClient();
-      proxy = client.target(generateURL("/app/test/")).proxy(ClientWebApplicationExceptionProxyResourceInterface.class);
+      oldBehaviorProxy = client.target(PortProviderUtil.generateURL("/app/test/", ClientWebApplicationExceptionMicroProfileProxyTest.oldBehaviorDeploymentName))
+              .proxy(ClientWebApplicationExceptionProxyResourceInterface.class);
+      newBehaviorProxy = client.target(PortProviderUtil.generateURL("/app/test/", ClientWebApplicationExceptionMicroProfileProxyTest.newBehaviorDeploymentName))
+              .proxy(ClientWebApplicationExceptionProxyResourceInterface.class);
    }
 
    private static String generateURL(String path) {
       return PortProviderUtil.generateURL(path, ClientWebApplicationExceptionMicroProfileProxyTest.class.getSimpleName());
-   }
-
-   /**
-    * Sets the System property ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR
-    * @param value value property is set to
-    */
-   @GET
-   @Path("behavior/{value}")
-   public void setBehavior(@PathParam("value") String value) {
-      System.setProperty(ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR, value);
    }
 
    /**
@@ -68,30 +61,58 @@ public class ClientWebApplicationExceptionMicroProfileProxyResource {
 
    /**
     * Uses a proxy to call oldException() to get an HTTP response derived from a WebApplicationException.
-    * Based on that response, the proxy will throw either a WebApplicationException or WebApplicationExceptionWrapper,
-    * depending on the value of ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR.
+    * The proxy will throw a WebApplicationException because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is true.
     *
     * @param i determines element of oldExceptions to be thrown by oldException()
     * @throws Exception
     */
    @GET
-   @Path("nocatch/old/{i}")
-   public String noCatchOld(@PathParam("i") int i) throws Exception {
-      return proxy.oldException(i);
+   @Path("nocatch/old/old/{i}")
+   public String noCatchOldOld(@PathParam("i") int i) throws Exception {
+      return oldBehaviorProxy.oldException(i);
+   }
+
+   /**
+    * Uses a proxy to call oldException() to get an HTTP response derived from a WebApplicationException.
+    * The proxy will throw a WebApplicationExceptionWrapper because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is false.
+    *
+    * @param i determines element of oldExceptions to be thrown by oldException()
+    * @throws Exception
+    */
+   @GET
+   @Path("nocatch/new/old/{i}")
+   public String noCatchNewOld(@PathParam("i") int i) throws Exception {
+      return newBehaviorProxy.oldException(i);
    }
 
    /**
     * Uses a proxy to call newException() to get an HTTP response derived from a WebApplicationExceptionWrapper.
-    * Based on that response, the proxy will throw either a WebApplicationException or WebApplicationExceptionWrapper,
-    * depending on the value of ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR.
+    * The proxy will throw a WebApplicationException because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is true.
     *
     * @param i determines element of newExceptions to be thrown by newException()
     * @throws Exception
     */
    @GET
-   @Path("nocatch/new/{i}")
-   public String noCatchNew(@PathParam("i") int i) throws Exception {
-      return proxy.newException(i);
+   @Path("nocatch/old/new/{i}")
+   public String noCatchOldNew(@PathParam("i") int i) throws Exception {
+      return oldBehaviorProxy.newException(i);
+   }
+
+   /**
+    * Uses a proxy to call newException() to get an HTTP response derived from a WebApplicationExceptionWrapper.
+    * The proxy will throw a WebApplicationExceptionWrapper because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is false.
+    *
+    * @param i determines element of newExceptions to be thrown by newException()
+    * @throws Exception
+    */
+   @GET
+   @Path("nocatch/new/new/{i}")
+   public String noCatchNewNew(@PathParam("i") int i) throws Exception {
+      return newBehaviorProxy.newException(i);
    }
 
    /**
@@ -109,7 +130,7 @@ public class ClientWebApplicationExceptionMicroProfileProxyResource {
    @Path("catch/old/old/{i}")
    public String catchOldOld(@PathParam("i") int i) throws Exception {
       try {
-         proxy.oldException(i);
+         newBehaviorProxy.oldException(i);
          throw new Exception("expected exception");
       } catch (ResteasyWebApplicationException e) {
          throw new Exception("didn't expect ResteasyWebApplicationException");
@@ -138,7 +159,7 @@ public class ClientWebApplicationExceptionMicroProfileProxyResource {
    @Path("catch/old/new/{i}")
    public String catchOldNew(@PathParam("i") int i) throws Exception {
       try {
-         return proxy.newException(i);
+         return newBehaviorProxy.newException(i);
       } catch (ResteasyWebApplicationException e) {
          throw new Exception("didn't expect ResteasyWebApplicationException");
       } catch (WebApplicationException e) {
@@ -169,7 +190,7 @@ public class ClientWebApplicationExceptionMicroProfileProxyResource {
    @Path("catch/new/old/{i}")
    public String catchNewOld(@PathParam("i") int i) throws Exception {
       try {
-         return proxy.oldException(i);
+         return newBehaviorProxy.oldException(i);
       } catch (ResteasyWebApplicationException e) {
          throw new Exception("didn't expect ResteasyWebApplicationException");
       } catch (WebApplicationException e) {
@@ -205,7 +226,7 @@ public class ClientWebApplicationExceptionMicroProfileProxyResource {
    @Path("catch/new/new/{i}")
    public String catchNewNew(@PathParam("i") int i) throws Exception {
       try {
-         return proxy.newException(i);
+         return newBehaviorProxy.newException(i);
       } catch (ResteasyWebApplicationException e) {
          throw new Exception("didn't expect ResteasyWebApplicationException");
       } catch (WebApplicationException e) {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/resource/ClientWebApplicationExceptionProxyResourceInterface.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/resource/ClientWebApplicationExceptionProxyResourceInterface.java
@@ -7,14 +7,6 @@ import javax.ws.rs.PathParam;
 public interface ClientWebApplicationExceptionProxyResourceInterface {
 
    /**
-    * Sets the System property ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR
-    * @param value value property is set to
-    */
-   @GET
-   @Path("behavior/{value}")
-   void setBehavior(@PathParam("value") String value);
-
-   /**
     * Throws an instance of WebApplicationException from oldExceptions table. The Response returned by
     * WebApplicationException.getResponse() will be used by the container to create an HTTP response.
     *
@@ -39,27 +31,51 @@ public interface ClientWebApplicationExceptionProxyResourceInterface {
 
    /**
     * Uses a Client or proxy to call oldException() to get an HTTP response derived from a WebApplicationException.
-    * Based on that response, the Client or proxy will throw either a WebApplicationException or ResteasyWebApplicationException,
-    * depending on the value of ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR.
+    * The Client or proxy will throw a WebApplicationException because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is true.
     *
     * @param i determines element of oldExceptions to be thrown by oldException()
     * @throws Exception
     */
    @GET
-   @Path("nocatch/old/{i}")
-   String noCatchOld(@PathParam("i") int i) throws Exception;
+   @Path("nocatch/old/old/{i}")
+   String noCatchOldOld(@PathParam("i") int i) throws Exception;
+
+   /**
+    * Uses a Client or proxy to call oldException() to get an HTTP response derived from a WebApplicationException.
+    * The Client or proxy will throw a ResteasyWebApplicationException or WebApplicationExceptionWrapper because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is false.
+    *
+    * @param i determines element of oldExceptions to be thrown by oldException()
+    * @throws Exception
+    */
+   @GET
+   @Path("nocatch/new/old/{i}")
+   String noCatchNewOld(@PathParam("i") int i) throws Exception;
 
    /**
     * Uses a Client or proxy to call newException() to get an HTTP response derived from a ResteasyWebApplicationException.
-    * Based on that response, the Client or proxy will throw either a WebApplicationException or ResteasyWebApplicationException,
-    * depending on the value of ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR.
+    * The Client or proxy will throw a WebApplicationException because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is true.
     *
     * @param i determines element of newExceptions to be thrown by newException()
     * @throws Exception
     */
    @GET
-   @Path("nocatch/new/{i}")
-   String noCatchNew(@PathParam("i") int i) throws Exception;
+   @Path("nocatch/old/new/{i}")
+   String noCatchOldNew(@PathParam("i") int i) throws Exception;
+
+   /**
+    * Uses a Client or proxy to call newException() to get an HTTP response derived from a ResteasyWebApplicationException.
+    * The Client or proxy will throw a ResteasyWebApplicationException or WebApplicationExceptionWrapper because
+    * ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is false.
+    *
+    * @param i determines element of newExceptions to be thrown by newException()
+    * @throws Exception
+    */
+   @GET
+   @Path("nocatch/new/new/{i}")
+   String noCatchNewNew(@PathParam("i") int i) throws Exception;
 
    /**
     * It is assumed that ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/resource/ClosedResponseHandlingResource.java
@@ -3,7 +3,6 @@ package org.jboss.resteasy.test.exception.resource;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Context;
@@ -12,24 +11,11 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 
-import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
-
 import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
 import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 
 @Path("")
 public class ClosedResponseHandlingResource {
-
-   /**
-    * Sets the System property ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR
-    * @param value value property is set to
-    */
-   @GET
-   @Path("behavior/{value}")
-   public void setBehavior(@PathParam("value") String value) {
-      System.setProperty(ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR, value);
-   }
-
    @Path("/testNotAcceptable/406")
    @GET
    public Response errorNotAcceptable() {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HeaderPropagator.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HeaderPropagator.java
@@ -7,12 +7,13 @@ import javax.ws.rs.core.MultivaluedMap;
 
 import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
 import org.jboss.resteasy.core.ResteasyContext;
-import org.junit.Assert;
 
 public class HeaderPropagator implements ClientHeadersFactory {
    @Override
    public MultivaluedMap<String, String> update(MultivaluedMap<String, String> containerRequestHeaders, MultivaluedMap<String, String> clientRequestHeaders) {
-       Assert.assertNull(ResteasyContext.getContextData(HttpHeaders.class));
+       if (ResteasyContext.getContextData(HttpHeaders.class) != null) {
+           throw new RuntimeException("ResteasyProviderFactory.getContextData(HttpHeaders.class) is not null");
+       }
        List<String> prop = containerRequestHeaders.get("X-Propagated");
        if(prop != null)
           clientRequestHeaders.addAll("X-Propagated", prop);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HelloResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/HelloResource.java
@@ -12,7 +12,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.junit.Assert;
 
 import io.reactivex.Single;
 
@@ -59,8 +58,12 @@ public class HelloResource {
     @Path("async-client-target")
     public CompletionStage<String> asyncClientTarget(@HeaderParam("X-Propagated") String propagatedHeader,
                                                 @HeaderParam("X-Not-Propagated") String nonPropagatedHeader) {
-       Assert.assertNull(nonPropagatedHeader);
-       Assert.assertEquals("got-a-value", propagatedHeader);
+        if (nonPropagatedHeader != null) {
+            throw new RuntimeException("nonPropagatedHeader is not null");
+        }
+        if (!propagatedHeader.equals("got-a-value")) {
+            throw new RuntimeException("propagatedHeader is not \"got-a-value\"");
+        }
        return CompletableFuture.completedFuture("OK");
     }
 
@@ -68,8 +71,12 @@ public class HelloResource {
     @Path("async-client")
     public CompletionStage<String> asyncClient(@HeaderParam("X-Propagated") String propagatedHeader,
                                                @HeaderParam("X-Not-Propagated") String nonPropagatedHeader){
-       Assert.assertEquals("got-a-value", propagatedHeader);
-       Assert.assertEquals("got-a-value", nonPropagatedHeader);
+        if (!propagatedHeader.equals("got-a-value")) {
+            throw new RuntimeException("propagatedHeader is not \"got-a-value\"");
+        }
+        if (!nonPropagatedHeader.equals("got-a-value")) {
+            throw new RuntimeException("nonPropagatedHeader is not \"got-a-value\"");
+        }
        return rest.asyncClientTarget();
     }
 
@@ -77,8 +84,12 @@ public class HelloResource {
     @Path("client-target")
     public String clientTarget(@HeaderParam("X-Propagated") String propagatedHeader,
                                @HeaderParam("X-Not-Propagated") String nonPropagatedHeader) {
-       Assert.assertNull(nonPropagatedHeader);
-       Assert.assertEquals("got-a-value", propagatedHeader);
+        if (nonPropagatedHeader != null) {
+            throw new RuntimeException("nonPropagatedHeader is not null");
+        }
+        if (!propagatedHeader.equals("got-a-value")) {
+            throw new RuntimeException("propagatedHeader is not \"got-a-value\"");
+        }
        return "OK";
     }
 
@@ -86,8 +97,12 @@ public class HelloResource {
     @Path("client")
     public String client(@HeaderParam("X-Propagated") String propagatedHeader,
                          @HeaderParam("X-Not-Propagated") String nonPropagatedHeader){
-       Assert.assertEquals("got-a-value", propagatedHeader);
-       Assert.assertEquals("got-a-value", nonPropagatedHeader);
+        if (!propagatedHeader.equals("got-a-value")) {
+            throw new RuntimeException("propagatedHeader is not \"got-a-value\"");
+        }
+        if (!nonPropagatedHeader.equals("got-a-value")) {
+            throw new RuntimeException("nonPropagatedHeader is not \"got-a-value\"");
+        }
        return rest.clientTarget();
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/microprofile/restclient/RestClientProxyTest.java
@@ -49,7 +49,7 @@ public class RestClientProxyTest
    @ArquillianResource
    URL url;
 
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> deploy()
    {
       WebArchive war = TestUtil.prepareArchive(RestClientProxyTest.class.getSimpleName());

--- a/testsuite/integration-tests/src/test/resources/org/jboss/resteasy/test/client/exception/webapplicationexception_web.xml
+++ b/testsuite/integration-tests/src/test/resources/org/jboss/resteasy/test/client/exception/webapplicationexception_web.xml
@@ -1,0 +1,9 @@
+<!DOCTYPE web-app PUBLIC
+        "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+        "http://java.sun.com/dtd/web-app_2_3.dtd" >
+<web-app>
+    <context-param>
+        <param-name>resteasy.original.webapplicationexception.behavior</param-name>
+        <param-value>true</param-value>
+    </context-param>
+</web-app>


### PR DESCRIPTION
Backport #2691 to main branch


* [Jira with details - RESTEASY-2837](https://issues.redhat.com/browse/RESTEASY-2837)
* [3.15 MR](https://github.com/resteasy/Resteasy/pull/2691)
* The following commits can't be ported to main branch
  * [this commit adds MicroProfileDependent annotation to a few classes, but main branch doesn't contains MicroProfileDependent annotation at all](https://github.com/resteasy/Resteasy/pull/2691/commits/4ee71640d422015ef236f34278a54c7843c56bf0)
  * [This commit increase WF version for testing to WF23, but WF23 is already used in main branch](https://github.com/resteasy/Resteasy/pull/2691/commits/89a8dd9f8b261cc6a7d8e601771d176cab25987f)