### PR TITLE
Add back the ResteasyClientImpl constructor which allows a non-Contex…

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientImpl.java
@@ -37,6 +37,13 @@ public class ResteasyClientImpl implements ResteasyClient
 
 
    protected ResteasyClientImpl(final ClientHttpEngine httpEngine, final ExecutorService asyncInvocationExecutor, final boolean cleanupExecutor,
+                                final ScheduledExecutorService scheduledExecutorService, final ClientConfiguration configuration)
+   {
+      this(httpEngine, asyncInvocationExecutor, cleanupExecutor, ContextualExecutors.wrap(scheduledExecutorService), configuration);
+   }
+
+
+   protected ResteasyClientImpl(final ClientHttpEngine httpEngine, final ExecutorService asyncInvocationExecutor, final boolean cleanupExecutor,
                                 final ContextualScheduledExecutorService scheduledExecutorService, final ClientConfiguration configuration)
    {
       this.cleanupExecutor = cleanupExecutor;


### PR DESCRIPTION
…tualScheduledExecutorService to be passed.

Follows up on #2881