### PR TITLE
[RESTEASY-2994] Do no use module directories for the generated JavaDoc's

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,7 @@
                         <maxmemory>1024m</maxmemory>
                         <quiet>false</quiet>
                         <aggregate>true</aggregate>
+                        <additionalJOption>--no-module-directories</additionalJOption>
                         <excludePackageNames>
                             com.restfully.*:org.jboss.resteasy.examples.*:se.unlogic.*:org.jboss.resteasy.tests.*
                         </excludePackageNames>


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-2994