### PR TITLE
[RESTEASY-2995] Configurable buffer size for AsyncOutputStream writer.

### DIFF
--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/AsyncOutputStream.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/AsyncOutputStream.java
@@ -1,5 +1,7 @@
 package org.jboss.resteasy.spi;
 
+import org.jboss.resteasy.spi.config.ConfigurationFactory;
+
 import java.io.OutputStream;
 import java.util.concurrent.CompletionStage;
 
@@ -7,6 +9,13 @@ import java.util.concurrent.CompletionStage;
  * OutputStream which supports async IO operations. Use these operations if you need to support async IO.
  */
 public abstract class AsyncOutputStream extends OutputStream {
+
+    public static int ASYNC_MESSAGE_WRITE_BUFFER_SIZE = ConfigurationFactory.getInstance()
+            .getConfiguration()
+            .getOptionalValue(
+                    "resteasy.async.output.stream.write.buffer.size",
+                    Integer.class
+            ).orElse(2048);
 
     /**
      * Flushes this async output stream.

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/AsyncOutputStream.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/AsyncOutputStream.java
@@ -10,7 +10,7 @@ import java.util.concurrent.CompletionStage;
  */
 public abstract class AsyncOutputStream extends OutputStream {
 
-    public static int ASYNC_MESSAGE_WRITE_BUFFER_SIZE = ConfigurationFactory.getInstance()
+    public static final int ASYNC_MESSAGE_WRITE_BUFFER_SIZE = ConfigurationFactory.getInstance()
             .getConfiguration()
             .getOptionalValue(
                     "resteasy.async.output.stream.write.buffer.size",

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/ProviderHelper.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/ProviderHelper.java
@@ -7,6 +7,8 @@ import javax.ws.rs.core.Variant.VariantListBuilder;
 import org.jboss.resteasy.spi.AsyncOutputStream;
 
 import com.ibm.asyncutil.iteration.AsyncTrampoline;
+import org.jboss.resteasy.spi.config.Configuration;
+import org.jboss.resteasy.spi.config.ConfigurationFactory;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -160,7 +162,12 @@ public final class ProviderHelper
     */
    public static CompletionStage<Void> writeTo(final InputStream in, final AsyncOutputStream out)
    {
-      final byte[] buf = new byte[2048];
+      final Configuration config = ConfigurationFactory.getInstance().getConfiguration();
+      final int bufferSize = config.getOptionalValue(
+              "resteasy.async.output.stream.writer.buffer.size",
+              Integer.class
+      ).orElse(2048);
+      final byte[] buf = new byte[bufferSize];
       return AsyncTrampoline.asyncWhile(
             read -> read != -1,
             read -> out.asyncWrite(buf, 0, read).thenApply(v -> asyncRead(in, buf)),

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/ProviderHelper.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/ProviderHelper.java
@@ -7,8 +7,6 @@ import javax.ws.rs.core.Variant.VariantListBuilder;
 import org.jboss.resteasy.spi.AsyncOutputStream;
 
 import com.ibm.asyncutil.iteration.AsyncTrampoline;
-import org.jboss.resteasy.spi.config.Configuration;
-import org.jboss.resteasy.spi.config.ConfigurationFactory;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -162,12 +160,7 @@ public final class ProviderHelper
     */
    public static CompletionStage<Void> writeTo(final InputStream in, final AsyncOutputStream out)
    {
-      final Configuration config = ConfigurationFactory.getInstance().getConfiguration();
-      final int bufferSize = config.getOptionalValue(
-              "resteasy.async.output.stream.writer.buffer.size",
-              Integer.class
-      ).orElse(2048);
-      final byte[] buf = new byte[bufferSize];
+      final byte[] buf = new byte[AsyncOutputStream.ASYNC_MESSAGE_WRITE_BUFFER_SIZE];
       return AsyncTrampoline.asyncWhile(
             read -> read != -1,
             read -> out.asyncWrite(buf, 0, read).thenApply(v -> asyncRead(in, buf)),


### PR DESCRIPTION
As this buffer is used to write data to OutputStream, in some cases like the resteasy-netty4 server adapter, the bytes chunks are written to the response and flushed on every chunk. If we go with the default for writing a data of size 10000 bytes it has to write and flush the data ~5 times. While this can have a slight impact on the performance it has a better memory utilisation with using a less buffer size. However for the applications that this memory usage is not a bigger concern as opposed to performance, we are facilitating with an option to override this buffer size. 