### PR TITLE
[RESTEASY-2996] Calling send for each chunk with flush and completing the future

### DIFF
--- a/server-adapters/resteasy-reactor-netty/pom.xml
+++ b/server-adapters/resteasy-reactor-netty/pom.xml
@@ -68,6 +68,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson2-provider</artifactId>
             <version>${project.version}</version>

--- a/server-adapters/resteasy-reactor-netty/src/main/java/org/jboss/resteasy/plugins/server/reactor/netty/ChunkOutputStream.java
+++ b/server-adapters/resteasy-reactor-netty/src/main/java/org/jboss/resteasy/plugins/server/reactor/netty/ChunkOutputStream.java
@@ -1,156 +1,138 @@
 package org.jboss.resteasy.plugins.server.reactor.netty;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.jboss.resteasy.plugins.server.reactor.netty.i18n.Messages;
 import org.jboss.resteasy.spi.AsyncOutputStream;
-import reactor.core.publisher.Flux;
+import org.jboss.resteasy.spi.WriterException;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
-import reactor.core.publisher.Sinks.EmitFailureHandler;
+import reactor.netty.NettyOutbound;
 import reactor.netty.http.server.HttpServerRequest;
 import reactor.netty.http.server.HttpServerResponse;
-import reactor.util.function.Tuple2;
-import reactor.util.function.Tuples;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Supplier;
+import java.util.function.Predicate;
 
 /**
  * This is the output stream leveraged by {@link
  * ReactorNettyHttpResponse#getOutputStream}.  It provides the heavy lifting
- * for actually transfering the bytes written by RestEasy to a {@link
- * Flux<byte[]>}, which is what reactor-netty works with.  Most of the heavy
+ * for actually transferring the bytes written by RestEasy to a {@link NettyOutbound},
+ * which is what reactor-netty works with.  Most of the heavy
  * lifting occurs in {@link #asyncWrite(byte[], int, int)}.
  */
 class ChunkOutputStream extends AsyncOutputStream {
 
-   private static final EmitFailureHandler EMIT_FAILURE_HANDLER = EmitFailureHandler.FAIL_FAST;
+    /**
+     * This is the {@link Mono} that we return from {@link ReactorNettyJaxrsServer.Handler#handle(HttpServerRequest,
+     * HttpServerResponse)}
+     */
+    private final Sinks.Empty<Void> completionSink;
 
-   private final ReactorNettyHttpResponse parentResponse;
+    /**
+     * Indicates that we've starting sending the response bytes.
+     */
+    private volatile boolean started;
 
-   /**
-    * This is the {@link Mono} that we return from
-    * {@link ReactorNettyJaxrsServer.Handler#handle(HttpServerRequest, HttpServerResponse)}
-    */
-   private final Sinks.Empty<Void> completionSink;
+    private final NettyOutbound nettyOutbound;
 
-   /**
-    * Indicates that we've starting sending the response bytes.
-    */
-   private volatile boolean started;
+    /**
+     * Used in {@link NettyOutbound#send(Publisher, Predicate)} to trigger flushing the bytes before the {@link
+     * CompletableFuture} returned from `NettyOutbound#then().toFuture()` completes.
+     */
+    private static final Predicate<ByteBuf> FLUSH_ON_EACH_WRITE = bb -> true;
 
-   /**
-    * This is ultimately think 'sink' that we write bytes to in
-    * {@link #asyncWrite(byte[], int, int)}.
-    */
-   private Sinks.Many<Tuple2<byte[], CompletableFuture<Void>>> byteSink;
+    private final ReactorNettyHttpResponse parentResponse;
 
-   /**
-    * This is used to establish {@link #byteSink} upon the first writing of bytes.
-    */
-   private final Supplier<Sinks.Many<Tuple2<byte[], CompletableFuture<Void>>>> byteSinkSupplier;
+    ChunkOutputStream(
+            final ReactorNettyHttpResponse parentResponse,
+            final HttpServerResponse reactorNettyResponse,
+            final Sinks.Empty<Void> completionSink
+    ) {
+        this.completionSink = Objects.requireNonNull(completionSink);
+        this.parentResponse = Objects.requireNonNull(parentResponse);
+        this.nettyOutbound = Objects.requireNonNull(reactorNettyResponse);
+    }
 
-   ChunkOutputStream(
-       final ReactorNettyHttpResponse parentResponse,
-       final HttpServerResponse reactorNettyResponse,
-       final Sinks.Empty<Void> completionSink
-   ) {
-       this.parentResponse = Objects.requireNonNull(parentResponse);
-       this.completionSink = Objects.requireNonNull(completionSink);
-       Objects.requireNonNull(reactorNettyResponse);
-       this.byteSinkSupplier = () -> {
-           final Sinks.Many<Tuple2<byte[], CompletableFuture<Void>>> outSink = Sinks.many().multicast().onBackpressureBuffer();
-           final Flux<byte[]> byteFlux = outSink.asFlux().map(tup -> {
-                   tup.getT2().complete(null);
-                   return tup.getT1();
-               });
+    @Override
+    public void write(int b) {
+        write(new byte[]{(byte) b}, 0, 1);
+    }
 
-           SinkSubscriber.subscribe(completionSink, Mono.from(reactorNettyResponse.sendByteArray(byteFlux)));
-
-           return outSink;
-       };
-   }
-
-   @Override
-   public void write(int b) {
-       write(new byte[] {(byte)b}, 0, 1);
-   }
-
-   @Override
-   public void close() throws IOException {
-       if (!started || byteSink == null) {
-           SinkSubscriber.subscribe(completionSink, Mono.empty());
-       } else {
-           byteSink.emitComplete(EMIT_FAILURE_HANDLER);
-       }
-   }
-
-   @Override
-   public void write(byte[] bs, int off, int len) {
-       try {
-           asyncWrite(bs, off, len).get();
-       } catch (final InterruptedException ie) {
-           Thread.currentThread().interrupt();
-           throw new RuntimeException(ie);
-       } catch (final ExecutionException ee) {
-           throw new RuntimeException(ee);
-       }
-   }
-
-   @Override
-   public void flush() {
-       try {
-           asyncFlush().get();
-       } catch (final InterruptedException ie) {
-           Thread.currentThread().interrupt();
-           throw new RuntimeException(ie);
-       } catch (final ExecutionException ee) {
-           throw new RuntimeException(ee);
-       }
-   }
-
-   @Override
-   public CompletableFuture<Void> asyncFlush() {
-
-       // [AG] Discuss with @crankydillo.  Here is my understanding:
-       //   - asyncFlush is used mainly for SSE.
-       //   - The idea seems to be to send the element immediately without
-       //     waiting for the rest of the elements.  Anyway, that's what SSE is.
-       //   - But, at the same time, it is trying to not overload.  So, kind of
-       //     doing backpressure.  Only if the previous flush is complete,
-       //     then request the next element from the app.
-       //   - The backpressure mechanism is already built into Reactor Netty.  But,
-       //     the question is how to communicate that.
-       //   - Please see https://projectreactor.io/docs/netty/release/reference/index.html#_sse.
-       //     It reads `The flushing strategy is "flush after every element" emitted
-       //     by the provided Publisher`.  So, we do not need to call flush individually.
-       //
-       //   In summary, we are not controlling flushing, instead Reactor Netty does.
-       //   Also, this#asyncWrite will manage the backpressure.  I assume Reactor Netty
-       //   will backpressure if it cannot flush, and that would mean an element won't be
-       //   requested so asyncWrite won't complete until the element is pulled.  Also,
-       //   asyncFlush is called right after an asyncWrite.  So, asyncFlush looks
-       //   useless.
-
-       return CompletableFuture.completedFuture(null);
-   }
-
-   @Override
-   public CompletableFuture<Void> asyncWrite(final byte[] bs, int offset, int length) {
-        final CompletableFuture<Void> cf = new CompletableFuture<>();
-        if (!started) {
-            byteSink = byteSinkSupplier.get();
-            parentResponse.committed();
-            started = true;
+    @Override
+    public void write(byte[] bs, int off, int len) {
+        try {
+            asyncWrite(bs, off, len).toCompletableFuture().get();
+        } catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReactorNettySendException(ie);
+        } catch (final ExecutionException ee) {
+            throw new ReactorNettySendException(ee);
         }
+    }
 
-        byte[] bytes = bs;
-        if (offset != 0 || length != bs.length) {
-            bytes = Arrays.copyOfRange(bs, offset, offset + length);
+    @Override
+    public void flush() {
+        try {
+            asyncFlush().get();
+        } catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new ReactorNettySendException(ie);
+        } catch (final ExecutionException ee) {
+            throw new ReactorNettySendException(ee);
         }
-        byteSink.emitNext(Tuples.of(bytes, cf), EMIT_FAILURE_HANDLER);
-        return cf;
-   }
+    }
+
+    @Override
+    public CompletableFuture<Void> asyncFlush() {
+        // Everything flows through asyncWrite and we are flushing on each call, so we
+        // will treat that as a no-op for now, assuming that callers of this would have
+        // chained this onto an asyncWrite.  I hope that doesn't mess up SSE..
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> asyncWrite(final byte[] bs, int offset, int length) {
+        try {
+            if (!started) {
+                parentResponse.committed();
+                started = true;
+            }
+            byte[] bytes = bs;
+            if (offset != 0 || length != bs.length) {
+                bytes = Arrays.copyOfRange(bs, offset, offset + length);
+            }
+
+            return nettyOutbound
+                    .send(Mono.just(Unpooled.wrappedBuffer(bytes)), FLUSH_ON_EACH_WRITE)
+                    .then()
+                    .doOnError(err -> completionSink.emitError(err, Sinks.EmitFailureHandler.FAIL_FAST))
+                    .doOnCancel(() -> completionSink.emitError(
+                            new WriterException(Messages.MESSAGES.responseWriteAborted()),
+                            Sinks.EmitFailureHandler.FAIL_FAST
+                    ))
+                    .doOnDiscard(
+                            ByteBuf.class,
+                            byteBuf -> completionSink.emitError(
+                                    new WriterException(Messages.MESSAGES.responseWriteAborted()),
+                                    Sinks.EmitFailureHandler.FAIL_FAST
+                    ))
+                    .toFuture();
+        } catch (final Exception e) {
+            completionSink.emitError(e, Sinks.EmitFailureHandler.FAIL_FAST);
+            final CompletableFuture<Void> cf = new CompletableFuture<>();
+            cf.completeExceptionally(e);
+            return cf;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        SinkSubscriber.subscribe(completionSink, Mono.empty());
+    }
 }

--- a/server-adapters/resteasy-reactor-netty/src/main/java/org/jboss/resteasy/plugins/server/reactor/netty/ReactorNettyHttpResponse.java
+++ b/server-adapters/resteasy-reactor-netty/src/main/java/org/jboss/resteasy/plugins/server/reactor/netty/ReactorNettyHttpResponse.java
@@ -36,9 +36,9 @@ public class ReactorNettyHttpResponse implements HttpResponse {
     private final Sinks.Empty<Void> completionSink;
 
     public ReactorNettyHttpResponse(
-        final HttpMethod method,
-        final HttpServerResponse resp,
-        final Sinks.Empty<Void> completionSink
+            final HttpMethod method,
+            final HttpServerResponse resp,
+            final Sinks.Empty<Void> completionSink
     ) {
         this.resp = resp;
         this.completionSink = completionSink;
@@ -238,8 +238,8 @@ public class ReactorNettyHttpResponse implements HttpResponse {
     @Override
     public void sendError(int status) {
         final Mono<Void> respMono = resp.status(status)
-            .header(HttpHeaderNames.CONTENT_LENGTH, HttpHeaderValues.ZERO)
-            .then();
+                .header(HttpHeaderNames.CONTENT_LENGTH, HttpHeaderValues.ZERO)
+                .then();
 
         committed = true;
         SinkSubscriber.subscribe(completionSink, respMono);
@@ -250,10 +250,10 @@ public class ReactorNettyHttpResponse implements HttpResponse {
     @Override
     public void sendError(int status, String message) {
         final Mono<Void> respMono = resp.status(status)
-            .header(HttpHeaderNames.CONTENT_LENGTH, Integer.toString(message.length()))
-            .header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN)
-            .sendString(Mono.just(message))
-            .then();
+                .header(HttpHeaderNames.CONTENT_LENGTH, Integer.toString(message.length()))
+                .header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN)
+                .sendString(Mono.just(message))
+                .then();
 
         SinkSubscriber.subscribe(completionSink, respMono);
         committed();

--- a/server-adapters/resteasy-reactor-netty/src/main/java/org/jboss/resteasy/plugins/server/reactor/netty/ReactorNettySendException.java
+++ b/server-adapters/resteasy-reactor-netty/src/main/java/org/jboss/resteasy/plugins/server/reactor/netty/ReactorNettySendException.java
@@ -1,0 +1,8 @@
+package org.jboss.resteasy.plugins.server.reactor.netty;
+
+public class ReactorNettySendException extends RuntimeException {
+
+    public ReactorNettySendException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/server-adapters/resteasy-reactor-netty/src/main/java/org/jboss/resteasy/plugins/server/reactor/netty/i18n/Messages.java
+++ b/server-adapters/resteasy-reactor-netty/src/main/java/org/jboss/resteasy/plugins/server/reactor/netty/i18n/Messages.java
@@ -21,4 +21,7 @@ public interface Messages
 
     @Message(id = BASE + 5, value = "Already suspended")
     String alreadySuspended();
+
+    @Message(id = BASE + 10, value = "Response write aborted abruptly")
+    String responseWriteAborted();
 }

--- a/server-adapters/resteasy-reactor-netty/src/test/java/org/jboss/resteasy/plugins/server/reactor/netty/ChunkOutputStreamTest.java
+++ b/server-adapters/resteasy-reactor-netty/src/test/java/org/jboss/resteasy/plugins/server/reactor/netty/ChunkOutputStreamTest.java
@@ -1,0 +1,376 @@
+package org.jboss.resteasy.plugins.server.reactor.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.cookie.Cookie;
+import org.jboss.resteasy.plugins.providers.ProviderHelper;
+import org.jboss.resteasy.spi.WriterException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.netty.Connection;
+import reactor.netty.NettyOutbound;
+import reactor.netty.channel.AbortedException;
+import reactor.netty.http.server.HttpServerResponse;
+import reactor.netty.http.server.WebsocketServerSpec;
+import reactor.netty.http.websocket.WebsocketInbound;
+import reactor.netty.http.websocket.WebsocketOutbound;
+import reactor.test.StepVerifier;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ChunkOutputStreamTest {
+
+    private static ByteArrayOutputStream baos;
+
+    @Test
+    public void testAsyncWrite_forSuccessfulWrite() throws IOException {
+        baos = new ByteArrayOutputStream();
+        try {
+            final Sinks.Empty<Void> completionSink = Sinks.empty();
+
+            final TestHttpServerResponse testHttpServerResponse = new BufferingHttpServerResponse();
+            final ReactorNettyHttpResponse httpServerResponse = new ReactorNettyHttpResponse(
+                    HttpMethod.POST,
+                    testHttpServerResponse,
+                    completionSink
+            );
+            final ChunkOutputStream chunkOutputStream = new ChunkOutputStream(
+                    httpServerResponse,
+                    testHttpServerResponse,
+                    completionSink
+            );
+
+            final String inputData = mkInputData();
+            final InputStream in = new ByteArrayInputStream(inputData.getBytes(StandardCharsets.UTF_8));
+            StepVerifier
+                    .create(Mono.fromCompletionStage(ProviderHelper.writeToAndCloseInput(in, chunkOutputStream)))
+                    .verifyComplete();
+            Assert.assertEquals(inputData, baos.toString());
+        } finally {
+            baos.close();
+        }
+    }
+
+    @Test
+    public void testAsyncWrite_withErrorOnSend() {
+        final Sinks.Empty<Void> completionSink = Sinks.empty();
+
+        final TestHttpServerResponse testHttpServerResponse = new ErrorHttpServerResponse();
+        final ReactorNettyHttpResponse httpServerResponse = new ReactorNettyHttpResponse(
+                HttpMethod.POST,
+                testHttpServerResponse,
+                completionSink
+        );
+        final ChunkOutputStream chunkOutputStream = new ChunkOutputStream(
+                httpServerResponse,
+                testHttpServerResponse,
+                completionSink
+        );
+
+        final byte[] errorBytes = "ERROR".getBytes(StandardCharsets.UTF_8);
+        final CompletableFuture<Void> asyncWriteFuture = chunkOutputStream.asyncWrite(
+                errorBytes,
+                0,
+                errorBytes.length
+        );
+
+        StepVerifier.create(Mono.fromCompletionStage(asyncWriteFuture).then(completionSink.asMono()))
+                .verifyError(AbortedException.class);
+    }
+
+    @Test
+    public void testAsyncWrite_forErrorOnDiscard() {
+        final Sinks.Empty<Void> completionSink = Sinks.empty();
+
+        final TestHttpServerResponse testHttpServerResponse = new DiscardingHttpServerResponse();
+        final ReactorNettyHttpResponse httpServerResponse = new ReactorNettyHttpResponse(
+                HttpMethod.POST,
+                testHttpServerResponse,
+                completionSink
+        );
+        final ChunkOutputStream chunkOutputStream = new ChunkOutputStream(
+                httpServerResponse,
+                testHttpServerResponse,
+                completionSink
+        );
+
+        final byte[] inputBytes = "DISCARD".getBytes(StandardCharsets.UTF_8);
+        final CompletableFuture<Void> asyncWriteFuture = chunkOutputStream.asyncWrite(
+                inputBytes,
+                0,
+                inputBytes.length
+        );
+
+        StepVerifier
+                .create(Mono
+                        .fromCompletionStage(asyncWriteFuture)
+                        .then(completionSink.asMono()
+                                .timeout(Duration.ofSeconds(2))
+                        )
+                )
+                .verifyError(WriterException.class);
+    }
+
+    @Test
+    public void testAsyncWrite_forErrorOnCancel() {
+        final Sinks.Empty<Void> completionSink = Sinks.empty();
+        final StringBuffer buffer = new StringBuffer();
+        completionSink.asMono().subscribe(v -> {}, err -> buffer.append(err.getClass().getName()));
+
+        final TestHttpServerResponse testHttpServerResponse = new SuccessHttpServerResponse();
+        final ReactorNettyHttpResponse httpServerResponse = new ReactorNettyHttpResponse(
+                HttpMethod.POST,
+                testHttpServerResponse,
+                completionSink
+        );
+        final ChunkOutputStream chunkOutputStream = new ChunkOutputStream(
+                httpServerResponse,
+                testHttpServerResponse,
+                completionSink
+        );
+
+        final byte[] inputBytes = "CANCEL".getBytes(StandardCharsets.UTF_8);
+        final CompletableFuture<Void> asyncWriteFuture = chunkOutputStream.asyncWrite(
+                inputBytes,
+                0,
+                inputBytes.length
+        );
+
+        StepVerifier.create(Mono.fromCompletionStage(asyncWriteFuture))
+                .thenCancel()
+                .verify();
+        Assert.assertEquals(WriterException.class.getName(), buffer.toString());
+    }
+
+    public String mkInputData() {
+        final Random random = new Random();
+        final Function<Integer, String> charFn = (index) -> random.nextInt() % 2 == 0 ? "a" : "b";
+        return IntStream.range(0, 50000)
+                .mapToObj(charFn::apply)
+                .collect(Collectors.joining());
+    }
+
+    abstract static class TestHttpServerResponse implements HttpServerResponse {
+
+        @Override
+        public ByteBufAllocator alloc() {
+            return null;
+        }
+
+        public abstract NettyOutbound send(Publisher<? extends ByteBuf> publisher, Predicate<ByteBuf> predicate);
+
+        @Override
+        public NettyOutbound sendObject(Publisher<?> publisher, Predicate<Object> predicate) {
+            return null;
+        }
+
+        @Override
+        public NettyOutbound sendObject(Object o) {
+            return null;
+        }
+
+        @Override
+        public <S> NettyOutbound sendUsing(Callable<? extends S> callable, BiFunction<? super Connection, ? super S, ?> biFunction, Consumer<? super S> consumer) {
+            return null;
+        }
+
+        @Override
+        public HttpServerResponse addCookie(Cookie cookie) {
+            return null;
+        }
+
+        @Override
+        public HttpServerResponse addHeader(CharSequence charSequence, CharSequence charSequence1) {
+            return null;
+        }
+
+        @Override
+        public HttpServerResponse chunkedTransfer(boolean b) {
+            return null;
+        }
+
+        @Override
+        public HttpServerResponse withConnection(Consumer<? super Connection> consumer) {
+            return null;
+        }
+
+        @Override
+        public HttpServerResponse compression(boolean b) {
+            return null;
+        }
+
+        @Override
+        public boolean hasSentHeaders() {
+            return false;
+        }
+
+        @Override
+        public HttpServerResponse header(CharSequence charSequence, CharSequence charSequence1) {
+            return null;
+        }
+
+        @Override
+        public HttpServerResponse headers(HttpHeaders httpHeaders) {
+            return null;
+        }
+
+        @Override
+        public HttpServerResponse keepAlive(boolean b) {
+            return null;
+        }
+
+        @Override
+        public HttpHeaders responseHeaders() {
+            return null;
+        }
+
+        @Override
+        public Mono<Void> send() {
+            return null;
+        }
+
+        @Override
+        public NettyOutbound sendHeaders() {
+            return null;
+        }
+
+        @Override
+        public Mono<Void> sendNotFound() {
+            return null;
+        }
+
+        @Override
+        public Mono<Void> sendRedirect(String s) {
+            return null;
+        }
+
+        @Override
+        public Mono<Void> sendWebsocket(BiFunction<? super WebsocketInbound, ? super WebsocketOutbound, ? extends Publisher<Void>> biFunction, WebsocketServerSpec websocketServerSpec) {
+            return null;
+        }
+
+        @Override
+        public HttpServerResponse sse() {
+            return null;
+        }
+
+        @Override
+        public HttpResponseStatus status() {
+            return null;
+        }
+
+        @Override
+        public HttpServerResponse status(HttpResponseStatus httpResponseStatus) {
+            return null;
+        }
+
+        @Override
+        public Map<CharSequence, List<Cookie>> allCookies() {
+            return null;
+        }
+
+        @Override
+        public Map<CharSequence, Set<Cookie>> cookies() {
+            return null;
+        }
+
+        @Override
+        public String fullPath() {
+            return null;
+        }
+
+        @Override
+        public String requestId() {
+            return null;
+        }
+
+        @Override
+        public boolean isKeepAlive() {
+            return false;
+        }
+
+        @Override
+        public boolean isWebsocket() {
+            return false;
+        }
+
+        @Override
+        public HttpMethod method() {
+            return null;
+        }
+
+        @Override
+        public String uri() {
+            return null;
+        }
+
+        @Override
+        public HttpVersion version() {
+            return null;
+        }
+    }
+
+    static class DiscardingHttpServerResponse extends TestHttpServerResponse {
+        @Override
+        public NettyOutbound send(Publisher<? extends ByteBuf> publisher, Predicate<ByteBuf> predicate) {
+            return then(Flux.from(publisher).skipLast(1).then());
+        }
+    }
+
+    static class ErrorHttpServerResponse extends TestHttpServerResponse {
+        @Override
+        public NettyOutbound send(Publisher<? extends ByteBuf> publisher, Predicate<ByteBuf> predicate) {
+            return then(Mono.error(AbortedException.beforeSend()));
+        }
+    }
+
+    static class SuccessHttpServerResponse extends TestHttpServerResponse {
+        @Override
+        public NettyOutbound send(Publisher<? extends ByteBuf> publisher, Predicate<ByteBuf> predicate) {
+            return then(Flux.from(publisher).then());
+        }
+    }
+
+    static class BufferingHttpServerResponse extends TestHttpServerResponse {
+
+        @Override
+        public NettyOutbound send(Publisher<? extends ByteBuf> publisher, Predicate<ByteBuf> predicate) {
+            return then(Flux.from(publisher).map(byteBuf -> {
+                try {
+                    byteBuf.readBytes(baos, byteBuf.readableBytes());
+                } catch (final IOException e) {
+                    Assert.fail("Error writing bytes to outputstream : " +  e.getMessage());
+                } finally {
+                    byteBuf.release();
+                }
+                return true;
+            }).then());
+        }
+    }
+
+}

--- a/server-adapters/resteasy-reactor-netty/src/test/java/org/jboss/resteasy/test/StreamingOutputTest.java
+++ b/server-adapters/resteasy-reactor-netty/src/test/java/org/jboss/resteasy/test/StreamingOutputTest.java
@@ -1,25 +1,36 @@
 package org.jboss.resteasy.test;
 
+import org.apache.commons.io.IOUtils;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.plugins.server.reactor.netty.ReactorNettyContainer;
+import org.jboss.resteasy.spi.AsyncStreamingOutput;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.jboss.resteasy.test.TestPortProvider.generateURL;
 
@@ -75,8 +86,26 @@ public class StreamingOutputTest
          };
       }
 
+      @POST
+      @Path("/largeContent")
+      @Produces(MediaType.TEXT_PLAIN)
+      public StreamingOutput largeContent(final InputStream in) {
+         return out -> IOUtils.copy(in, out);
+      }
 
-
+      @POST
+      @Path("/async/largeContent")
+      @Produces(MediaType.TEXT_PLAIN)
+      public AsyncStreamingOutput asyncLargeContent(final InputStream in) {
+         final BiConsumer<InputStream, OutputStream> writeFunction = (input, output) -> {
+            try {
+               IOUtils.copy(input, output);
+            } catch (final IOException e) {
+               throw new RuntimeException(e);
+            }
+         };
+         return out -> CompletableFuture.runAsync(() -> writeFunction.accept(in, out));
+      }
    }
 
    @BeforeClass
@@ -137,5 +166,32 @@ public class StreamingOutputTest
               "\n9\n" +
               "\n"));
       Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+   }
+
+   @Test
+   public void testStreamingOutputForLargeContent()
+   {
+      testStreamingLargeContent("/org/jboss/resteasy/test/largeContent");
+   }
+
+   @Test
+   public void testAsyncStreamingOutputForLargeContent()
+   {
+      testStreamingLargeContent("/org/jboss/resteasy/test/async/largeContent");
+   }
+
+   private void testStreamingLargeContent(final String path) {
+      final Random random = new Random();
+      final Function<Integer, String> charFn = (index) -> random.nextInt() % 2 == 0 ? "a" : "b";
+      final String inputData = IntStream.range(0, 50_000)
+              .mapToObj(charFn::apply)
+              .collect(Collectors.joining(","));
+      final Response response = client
+              .target(BASE_URI)
+              .path(path)
+              .request()
+              .post(Entity.text(inputData));
+      Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+      Assert.assertEquals(inputData, response.readEntity(String.class));
    }
 }


### PR DESCRIPTION
I cherry picked this change from the main branch as we need this change back ported to the last release version. 

Main [PR](https://github.com/resteasy/resteasy/pull/2882). 