### PR TITLE
[RESTEASY-2997] Remove the message from a client response which could…

### DIFF
--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
@@ -1,7 +1,6 @@
 package org.jboss.resteasy.core;
 
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
-import org.jboss.resteasy.specimpl.BuiltResponse;
 import org.jboss.resteasy.spi.ApplicationException;
 import org.jboss.resteasy.spi.Failure;
 import org.jboss.resteasy.spi.HttpRequest;
@@ -181,17 +180,6 @@ public class ExceptionHandler
 
       if (response != null)
       {
-         BuiltResponse bResponse = (BuiltResponse)response;
-         if (bResponse.getStatus() == HttpResponseCodes.SC_BAD_REQUEST
-            || bResponse.getStatus() == HttpResponseCodes.SC_NOT_FOUND)
-         {
-            if (message != null)
-            {
-               Response.ResponseBuilder builder = bResponse.fromResponse(response);
-               builder.type(MediaType.TEXT_HTML).entity(message);
-               return builder.build();
-            }
-         }
          return response;
 
       } else {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/ResourceInfoInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/ResourceInfoInjectionTest.java
@@ -64,7 +64,7 @@ public class ResourceInfoInjectionTest {
       Response response = target.request().get();
       String entity = response.readEntity(String.class);
       Assert.assertEquals("ResponseFilter was probably not applied to response", HttpResponseCodes.SC_NOT_FOUND * 2, response.getStatus());
-      Assert.assertTrue("Wrong body of response",  entity.startsWith("RESTEASY003210"));
+      Assert.assertTrue("Wrong body of response",  entity.isEmpty());
    }
 
    /**

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/FormParamTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/FormParamTest.java
@@ -146,7 +146,7 @@ public class FormParamTest {
             header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED).post(null);
       Assert.assertEquals(response.getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
       String entity = response.readEntity(String.class);
-      Assert.assertTrue(ERROR_CODE, entity.contains("RESTEASY003870"));
+      Assert.assertTrue(ERROR_CODE, entity.isEmpty());
       response.close();
    }
 


### PR DESCRIPTION
… indicate which Jakarta REST implementation is being used.

https://issues.redhat.com/browse/RESTEASY-2997