### PR TITLE
[RESTEASY-3033]:Fix Deadlock while sending sse events when first event is not yet send

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/HttpServletResponseWrapper.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/HttpServletResponseWrapper.java
@@ -144,7 +144,7 @@ public class HttpServletResponseWrapper implements HttpResponse
       private boolean asyncRegistered;
       private Queue<AsyncOperation> asyncQueue;
       private AsyncOperation lastAsyncOperation;
-      private boolean asyncListenerCalled;
+      private volatile boolean asyncListenerCalled;
 
       @Override
       public void write(int i) throws IOException
@@ -252,14 +252,14 @@ public class HttpServletResponseWrapper implements HttpResponse
       }
 
       @Override
-      public synchronized void onWritePossible() throws IOException
+      public void onWritePossible() throws IOException
       {
          asyncListenerCalled = true;
          flushQueue(response.getOutputStream());
       }
 
       @Override
-      public synchronized void onError(Throwable t)
+      public void onError(Throwable t)
       {
          asyncListenerCalled = true;
          if(lastAsyncOperation != null) {


### PR DESCRIPTION
* Remove the lock from  `DeferredOutputStream#onWritePossible()` and `DeferredOutputStream#onError()`. The queue is `ConcurrentLinkedQueue` and the` addToQueue()` is `synchronized`, so the queue order can be guaranteed.

* The `DeferredOutputStream`'s  `onWritePossible()` looks it adds to itself and it's executed once. When it is executed, it should not block adding queue operation and it doesn't hurt anything. 