### PR TITLE
[RESTEASY-3041] Upgrade the wildfly-maven-plugin to 2.1.0.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <version.org.jacoco.plugin>0.7.9</version.org.jacoco.plugin>
         <version.org.jboss.galleon>4.2.8.Final</version.org.jboss.galleon>
         <version.org.wildfly.galleon-plugins>5.2.2.Final</version.org.wildfly.galleon-plugins>
-        <version.org.wildfly.plugins.wildfly-maven-plugin>2.1.0.Beta1</version.org.wildfly.plugins.wildfly-maven-plugin>
+        <version.org.wildfly.plugins.wildfly-maven-plugin>2.1.0.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
     </properties>
 
     <url>https://jboss.org/resteasy</url>


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-3041
Signed-off-by: James R. Perkins <jperkins@redhat.com>