### PR TITLE
[RESTEASY-3037] Ignore tests that require tracing if the org.jboss.re…

### DIFF
--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/category/TracingRequired.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/category/TracingRequired.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.category;
+
+/**
+ * A marker for a test category that indicates the tracing API is required.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public interface TracingRequired {
+}

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -118,6 +118,17 @@
             </plugins>
           </build>
         </profile>
+        <profile>
+            <id>skip.tracing.tests</id>
+            <activation>
+                <property>
+                    <name>skip.tracing.tests</name>
+                </property>
+            </activation>
+            <properties>
+                <additional.surefire.exclude.tracing.tests>,org.jboss.resteasy.category.TracingRequired</additional.surefire.exclude.tracing.tests>
+            </properties>
+        </profile>
     </profiles>
 
     <dependencies>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/ClosedResponseHandlingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/exception/ClosedResponseHandlingTest.java
@@ -10,6 +10,7 @@ import javax.ws.rs.NotSupportedException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.TracingRequired;
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.test.exception.resource.ClosedResponseHandlingEnableTracingRequestFilter;
@@ -22,6 +23,7 @@ import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.jboss.resteasy.utils.PortProviderUtil.generateURL;
@@ -36,6 +38,7 @@ import static org.jboss.resteasy.utils.PortProviderUtil.generateURL;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(TracingRequired.class)
 public class ClosedResponseHandlingTest {
 
    public static final String oldBehaviorDeploymentName = "OldBehaviorClosedResponseHandlingTest";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/tracing/TracingTestBase.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/tracing/TracingTestBase.java
@@ -9,6 +9,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.resteasy.category.TracingRequired;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.utils.PortProviderUtil;
 import org.jboss.resteasy.utils.TestUtil;
@@ -18,6 +19,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Client;
@@ -31,6 +33,7 @@ import static org.jboss.resteasy.test.ContainerConstants.TRACING_CONTAINER_QUALI
 
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(TracingRequired.class)
 public abstract class TracingTestBase {
    protected static final String WAR_BASIC_TRACING_FILE = "war_basic_tracing";
    protected static final String WAR_ON_DEMAND_TRACING_FILE = "war_on_demand_tracing";

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <version.resteasy.testsuite>${project.version}</version.resteasy.testsuite>
         <additional.surefire.excluded.groups/>
+        <additional.surefire.exclude.tracing.tests/>
         <!-- default value required for cmd-line -->
         <securityManagerArg>-DSECMGR="false"</securityManagerArg>
         <jacoco.agent/>
@@ -112,7 +113,7 @@
                         <version.resteasy.testsuite>${version.resteasy.testsuite}</version.resteasy.testsuite>
                         <jboss.server.config.file.name>${jboss.server.config.file.name}</jboss.server.config.file.name>
                     </systemPropertyVariables>
-                    <excludedGroups>org.jboss.resteasy.category.ExpectedFailing${additional.surefire.excluded.groups}</excludedGroups>
+                    <excludedGroups>org.jboss.resteasy.category.ExpectedFailing${additional.surefire.excluded.groups}${additional.surefire.exclude.tracing.tests}</excludedGroups>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
…steasy.resteasy-tracing-api module is not present.

https://issues.redhat.com/browse/RESTEASY-3037
Signed-off-by: James R. Perkins <jperkins@redhat.com>