### PR TITLE
[RESTEASY-3046]  DeferredOutputStream shouldn't clear lastOperation if not complete

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/HttpServletResponseWrapper.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/HttpServletResponseWrapper.java
@@ -234,6 +234,11 @@ public class HttpServletResponseWrapper implements HttpResponse
       {
          if(lastAsyncOperation != null) {
             lastAsyncOperation.future.complete(null);
+            // Check if operation is complete before clearing, as completion of the operation might trigger more writes
+            // that could reassign lastAsyncOperation, which could still be pending, if so then wait for next onWritePossible or onError
+            if(!lastAsyncOperation.future.isDone()) {
+               return;
+            }
             lastAsyncOperation = null;
          }
 


### PR DESCRIPTION
DeferredOutputStream should check if the lastAsyncOperation if done post completion before clearing it.

More details given [here](https://issues.redhat.com/browse/RESTEASY-3046)

A [reproducer](https://github.com/anthochristen/resteasy-tomcat)  