### PR TITLE
[RESTEASY-3033] Block on the output stream for SseEventOutputImpl to …

### DIFF
--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
@@ -853,4 +853,7 @@ public interface Messages
 
    @Message(id = BASE + 2050, value = "The executor has been shutdown and is no longer available.")
    IllegalStateException executorShutdown();
+
+   @Message(id = BASE + 2051, value = "Required context value not found.")
+   IllegalArgumentException requiredContextParameterNotFound();
 }

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyContext.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyContext.java
@@ -46,6 +46,25 @@ public final class ResteasyContext
    }
 
    /**
+    * Gets the current context for the type. If not found in the current context a {@linkplain IllegalArgumentException}
+    * is thrown.
+    *
+    * @param type the type to lookup in the context map
+    * @param <T>  the type of the lookup
+    *
+    * @return the context data
+    *
+    * @throws IllegalArgumentException if the type is not found in the current context
+    */
+   public static <T> T getRequiredContextData(final Class<T> type) {
+      final T result = getContextData(type);
+      if (result == null) {
+         throw Messages.MESSAGES.requiredContextParameterNotFound();
+      }
+      return result;
+   }
+
+   /**
     * Gets the current context for the type. If the context does not exist the value is resolved from the {@code newValue}
     * supplier and pushed to the current context.
     *

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
@@ -2,14 +2,19 @@ package org.jboss.resteasy.plugins.providers.sse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.annotation.Annotation;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.core.GenericType;
@@ -18,17 +23,16 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.MessageBodyWriter;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.SseEventSink;
-
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.SseElementType;
 import org.jboss.resteasy.annotations.Stream;
 import org.jboss.resteasy.core.ResourceMethodInvoker;
 import org.jboss.resteasy.core.ResteasyContext;
+import org.jboss.resteasy.core.ResteasyContext.CloseableContext;
 import org.jboss.resteasy.core.ServerResponseWriter;
+import org.jboss.resteasy.core.SynchronousDispatcher;
 import org.jboss.resteasy.plugins.server.Cleanable;
 import org.jboss.resteasy.plugins.server.Cleanables;
-import org.jboss.resteasy.core.SynchronousDispatcher;
-import org.jboss.resteasy.core.ResteasyContext.CloseableContext;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
 import org.jboss.resteasy.specimpl.BuiltResponse;
@@ -43,6 +47,13 @@ import org.jboss.resteasy.spi.util.FindAnnotation;
 public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements SseEventSink
 {
    private static final Logger LOG = Logger.getLogger(SseEventOutputImpl.class);
+
+   // States
+   private static final int READY = 0;
+   private static final int PROCESSING = 1;
+   private static final int PASSTHROUGH = 2;
+   private static final int CLOSED = 3;
+
    private final MessageBodyWriter<OutboundSseEvent> writer;
 
    private final ResteasyAsynchronousContext asyncContext;
@@ -51,15 +62,15 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
 
    private final HttpRequest request;
 
-   private volatile boolean closed;
-
    private final Map<Class<?>, Object> contextDataMap;
 
    private volatile boolean responseFlushed = false;
 
-   private final Object lock = new Object();
+   private final Object lock;
 
    private final ResteasyProviderFactory providerFactory;
+   private final AtomicInteger state;
+   private final Deque<FutureEvent> events;
 
    @Deprecated
    public SseEventOutputImpl(final MessageBodyWriter<OutboundSseEvent> writer)
@@ -72,7 +83,7 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
       this.writer = writer;
       contextDataMap = ResteasyContext.getContextDataMap();
       this.providerFactory = providerFactory;
-      request = ResteasyContext.getContextData(org.jboss.resteasy.spi.HttpRequest.class);
+      request = ResteasyContext.getRequiredContextData(org.jboss.resteasy.spi.HttpRequest.class);
       asyncContext = request.getAsyncContext();
 
       if (!asyncContext.isSuspended())
@@ -87,54 +98,28 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
          }
       }
 
-      response = ResteasyContext.getContextData(HttpResponse.class);
+      response = ResteasyContext.getRequiredContextData(HttpResponse.class);
+      try {
+         // This is an odd use-case for a lock. However, the AsyncOutputStream locks on itself which could lead to
+         // deadlocks if we use our own lock. Using the output stream as the lock avoids issues like this.
+         lock = response.getAsyncOutputStream();
+      } catch (IOException e) {
+         throw new UncheckedIOException(e);
+      }
+      state = new AtomicInteger(READY);
+      events = new ConcurrentLinkedDeque<>();
    }
 
    @Override
    public void close()
    {
-      close(true);
+      close(true, null);
    }
 
+   @Deprecated
    protected void close(boolean flushBeforeClose)
    {
-      // avoid even attempting to get a lock if someone else has closed it or is closing it
-      if(closed)
-         return;
-      synchronized (lock)
-      {
-         closed = true;
-         if(flushBeforeClose && responseFlushed) {
-            try(CloseableContext c = ResteasyContext.addCloseableContextDataLevel(contextDataMap)){
-               // make sure we flush to await for any queued data being sent
-               AsyncOutputStream aos = response.getAsyncOutputStream();
-               aos.asyncFlush().toCompletableFuture().get();
-            }catch(IOException | InterruptedException | ExecutionException x) {
-               // ignore it and let's just close
-            }
-         }
-         if (asyncContext.isSuspended())
-         {
-            ResteasyAsynchronousResponse asyncResponse = asyncContext.getAsyncResponse();
-            if (asyncResponse != null)
-            {
-               try {
-                  asyncResponse.complete();
-               } catch(RuntimeException x) {
-                  Throwable cause = x;
-                  while(cause.getCause() != null && cause.getCause() != cause)
-                     cause = cause.getCause();
-                  if(cause instanceof IOException) {
-                     // ignore it, we're closed now
-                  }else {
-                     LOG.debug(cause.getMessage());
-                     return;
-                  }
-               }
-            }
-         }
-         clearContextData();
-      }
+      close(flushBeforeClose, null);
    }
 
    public void clearContextData()
@@ -165,62 +150,11 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
 
    private CompletionStage<Void> internalFlushResponseToClient(boolean throwIOException)
    {
-      // avoid even attempting to get a lock if someone else has flushed the response
-      if(responseFlushed)
-         return CompletableFuture.completedFuture(null);
       synchronized (lock)
       {
          if (!responseFlushed)
          {
-            BuiltResponse jaxrsResponse = null;
-            if (this.closed)
-            {
-               jaxrsResponse = (BuiltResponse) Response.noContent().build();
-            }
-            else //set back to client 200 OK to implies the SseEventOutput is ready
-            {
-               ResourceMethodInvoker method =(ResourceMethodInvoker) request.getAttribute(ResourceMethodInvoker.class.getName());
-               MediaType[] mediaTypes = method.getProduces();
-               if (mediaTypes != null &&  getSseEventType(mediaTypes) != null)
-               {
-                  // @Produces("text/event-stream")
-                  SseElementType sseElementType = FindAnnotation.findAnnotation(method.getMethodAnnotations(),SseElementType.class);
-                  if (sseElementType != null)
-                  {
-                     // Get element media type from @SseElementType.
-                     Map<String, String> parameterMap = new HashMap<String, String>();
-                     parameterMap.put(SseConstants.SSE_ELEMENT_MEDIA_TYPE, sseElementType.value());
-                     MediaType mediaType = new MediaType(MediaType.SERVER_SENT_EVENTS_TYPE.getType(), MediaType.SERVER_SENT_EVENTS_TYPE.getSubtype(), parameterMap);
-                     jaxrsResponse = (BuiltResponse) Response.ok().type(mediaType).build();
-                  }
-                  else
-                  {
-                     // No element media type declared.
-                     jaxrsResponse = (BuiltResponse) Response.ok().type(getSseEventType(mediaTypes)).build();
-//                   // use "element-type=text/plain"?
-                  }
-               }
-               else
-               {
-                  Stream stream = FindAnnotation.findAnnotation(method.getMethodAnnotations(),Stream.class);
-                  if (stream != null)
-                  {
-                     // Get element media type from @Produces.
-                     jaxrsResponse = (BuiltResponse) Response.ok("").build();
-                     MediaType elementType = ServerResponseWriter.getResponseMediaType(jaxrsResponse, request, response, providerFactory, method);
-                     Map<String, String> parameterMap = new HashMap<String, String>();
-                     parameterMap.put(SseConstants.SSE_ELEMENT_MEDIA_TYPE, elementType.toString());
-                     String[] streamType = getStreamType(method);
-                     MediaType mediaType = new MediaType(streamType[0], streamType[1], parameterMap);
-                     jaxrsResponse = (BuiltResponse) Response.ok().type(mediaType).build();
-                  }
-                  else
-                  {
-                     throw new RuntimeException(Messages.MESSAGES.expectedStreamOrSseMediaType());
-                  }
-               }
-            }
-
+            final BuiltResponse jaxrsResponse = createResponse();
             try
             {
                CompletableFuture<Void> ret = new CompletableFuture<>();
@@ -232,7 +166,7 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
                            aos = response.getAsyncOutputStream();
                         } catch (IOException x)
                         {
-                           close(false);
+                           close(false, x);
                            ret.completeExceptionally(x);
                            return;
                         }
@@ -248,7 +182,7 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
                            if(e instanceof CompletionException)
                               e = e.getCause();
                            if(e instanceof IOException)
-                              close(false);
+                              close(false, e);
                            if(throwIOException)
                               ret.completeExceptionally(e);
                            else
@@ -260,7 +194,7 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
             }
             catch (IOException e)
             {
-               close(false);
+               close(false, e);
                CompletableFuture<Void> ret = new CompletableFuture<>();
                if (throwIOException)
                {
@@ -278,30 +212,59 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
    @Override
    public boolean isClosed()
    {
-      return closed;
+      return state.get() == CLOSED;
    }
 
    @Override
    public CompletionStage<?> send(OutboundSseEvent event)
    {
+      final int state = this.state.get();
+      if (state == CLOSED) {
+         // FIXME: should be this
+         // CompletableFuture<?> ret = new CompletableFuture<>();
+         // ret.completeExceptionally(new IllegalStateException(Messages.MESSAGES.sseEventSinkIsClosed()));
+         // return ret;
+         // But the TCK expects a real exception
+         throw new IllegalStateException(Messages.MESSAGES.sseEventSinkIsClosed());
+      }
+      if (state == PASSTHROUGH) {
+         synchronized (lock) {
+            return internalWriteEvent(event);
+         }
+      } else if (state == PROCESSING) {
+         final FutureEvent futureEvent = new FutureEvent(event);
+         events.addLast(futureEvent);
+         return futureEvent.future
+                 .thenRun(this::drainQueue);
+      }
+      final FutureEvent futureEvent = new FutureEvent(event);
+      events.addLast(futureEvent);
+      return internalFlushResponseToClient(true)
+              .thenRun(this::drainQueue)
+              .exceptionally((e) -> {
+                 if (e instanceof CompletionException)
+                    e = e.getCause();
+                 if (e instanceof IOException)
+                    close(false, e);
+                 LogMessages.LOGGER.failedToWriteSseEvent(event.toString(), e);
+                 SynchronousDispatcher.rethrow(e);
+                 // never reached
+                 return null;
+              });
+   }
+
+   @Deprecated
+   protected CompletionStage<Void> writeEvent(OutboundSseEvent event)
+   {
       synchronized (lock)
       {
-         if (closed)
-         {
-            // FIXME: should be this
-//            CompletableFuture<?> ret = new CompletableFuture<>();
-//            ret.completeExceptionally(new IllegalStateException(Messages.MESSAGES.sseEventSinkIsClosed()));
-//            return ret;
-            // But the TCK expects a real exception
-            throw new IllegalStateException(Messages.MESSAGES.sseEventSinkIsClosed());
-         }
-         // eager composition to guarantee ordering
-         return internalFlushResponseToClient(true)
-                 .thenCompose(v ->  writeEvent(event));
+         return internalWriteEvent(event);
       }
    }
 
-   protected CompletionStage<Void> writeEvent(OutboundSseEvent event)
+
+
+   private CompletionStage<Void> internalWriteEvent(final OutboundSseEvent event)
    {
       synchronized (lock)
       {
@@ -312,7 +275,7 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
                //// Check media type?
                ByteArrayOutputStream bout = new ByteArrayOutputStream();
                MediaType mediaType = event.getMediaType();
-               boolean mediaTypeSet = event instanceof OutboundSseEventImpl ? ((OutboundSseEventImpl) event).isMediaTypeSet() : true;
+               boolean mediaTypeSet = !(event instanceof OutboundSseEventImpl) || ((OutboundSseEventImpl) event).isMediaTypeSet();
                if (mediaType == null || !mediaTypeSet)
                {
                   Object o = response.getOutputHeaders().getFirst("Content-Type");
@@ -355,23 +318,23 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
                // eager composition to guarantee ordering
                return aos.asyncWrite(bout.toByteArray())
                        .thenCompose(v ->  aos.asyncFlush())
-                     .exceptionally(e -> {
-                        if(e instanceof CompletionException)
-                           e = e.getCause();
-                        if(e instanceof IOException)
-                           close(false);
-                        LogMessages.LOGGER.failedToWriteSseEvent(event.toString(), e);
-                        SynchronousDispatcher.rethrow(e);
-                        // never reached
-                        return null;
-                     });
+                       .exceptionally(e -> {
+                          if(e instanceof CompletionException)
+                             e = e.getCause();
+                          if(e instanceof IOException)
+                             close(false, e);
+                          LogMessages.LOGGER.failedToWriteSseEvent(event.toString(), e);
+                          SynchronousDispatcher.rethrow(e);
+                          // never reached
+                          return null;
+                       });
             }
          }
          catch (IOException e)
          {
             //The connection could be broken or closed. whenever IO error happens, mark closed to true to
             //stop event writing
-            close(false);
+            close(false, e);
             LogMessages.LOGGER.failedToWriteSseEvent(event.toString(), e);
             CompletableFuture<Void> ret = new CompletableFuture<>();
             ret.completeExceptionally(e);
@@ -386,6 +349,58 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
          }
       }
       return CompletableFuture.completedFuture(null);
+   }
+
+   private BuiltResponse createResponse() {
+      BuiltResponse jaxrsResponse;
+      if (state.get() == CLOSED)
+      {
+         jaxrsResponse = (BuiltResponse) Response.noContent().build();
+      }
+      else //set back to client 200 OK to implies the SseEventOutput is ready
+      {
+         ResourceMethodInvoker method =(ResourceMethodInvoker) request.getAttribute(ResourceMethodInvoker.class.getName());
+         MediaType[] mediaTypes = method.getProduces();
+         if (mediaTypes != null &&  getSseEventType(mediaTypes) != null)
+         {
+            // @Produces("text/event-stream")
+            SseElementType sseElementType = FindAnnotation.findAnnotation(method.getMethodAnnotations(),SseElementType.class);
+            if (sseElementType != null)
+            {
+               // Get element media type from @SseElementType.
+               Map<String, String> parameterMap = new HashMap<>();
+               parameterMap.put(SseConstants.SSE_ELEMENT_MEDIA_TYPE, sseElementType.value());
+               MediaType mediaType = new MediaType(MediaType.SERVER_SENT_EVENTS_TYPE.getType(), MediaType.SERVER_SENT_EVENTS_TYPE.getSubtype(), parameterMap);
+               jaxrsResponse = (BuiltResponse) Response.ok().type(mediaType).build();
+            }
+            else
+            {
+               // No element media type declared.
+               jaxrsResponse = (BuiltResponse) Response.ok().type(getSseEventType(mediaTypes)).build();
+//                   // use "element-type=text/plain"?
+            }
+         }
+         else
+         {
+            Stream stream = FindAnnotation.findAnnotation(method.getMethodAnnotations(),Stream.class);
+            if (stream != null)
+            {
+               // Get element media type from @Produces.
+               jaxrsResponse = (BuiltResponse) Response.ok("").build();
+               MediaType elementType = ServerResponseWriter.getResponseMediaType(jaxrsResponse, request, response, providerFactory, method);
+               Map<String, String> parameterMap = new HashMap<>();
+               parameterMap.put(SseConstants.SSE_ELEMENT_MEDIA_TYPE, elementType.toString());
+               String[] streamType = getStreamType(method);
+               MediaType mediaType = new MediaType(streamType[0], streamType[1], parameterMap);
+               jaxrsResponse = (BuiltResponse) Response.ok().type(mediaType).build();
+            }
+            else
+            {
+               throw new RuntimeException(Messages.MESSAGES.expectedStreamOrSseMediaType());
+            }
+         }
+      }
+      return jaxrsResponse;
    }
 
    private String[] getStreamType(ResourceMethodInvoker method)
@@ -428,4 +443,93 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
       }
       return null;
   }
+
+   private void close(final boolean flushBeforeClose, final Throwable error) {
+      // avoid even attempting to get a lock if someone else has closed it or is closing it
+      if (state.getAndSet(CLOSED) != CLOSED) {
+         if (error != null) {
+            drainQueue(error);
+         } else {
+            synchronized (lock) {
+               events.clear();
+            }
+         }
+         if (flushBeforeClose && responseFlushed) {
+            try (CloseableContext c = ResteasyContext.addCloseableContextDataLevel(contextDataMap)) {
+               // make sure we flush to await for any queued data being sent
+               AsyncOutputStream aos = response.getAsyncOutputStream();
+               aos.asyncFlush().toCompletableFuture().get();
+            } catch (IOException | InterruptedException | ExecutionException x) {
+               // ignore it and let's just close
+            }
+         }
+         if (asyncContext.isSuspended()) {
+            ResteasyAsynchronousResponse asyncResponse = asyncContext.getAsyncResponse();
+            if (asyncResponse != null) {
+               try {
+                  asyncResponse.complete();
+               } catch (RuntimeException x) {
+                  Throwable cause = x;
+                  while (cause.getCause() != null && cause.getCause() != cause)
+                     cause = cause.getCause();
+                  if (cause instanceof IOException) {
+                     // ignore it, we're closed now
+                  } else {
+                     LOG.debug(cause.getMessage());
+                     return;
+                  }
+               }
+            }
+         }
+         clearContextData();
+      }
+   }
+
+   private void drainQueue() {
+      state.compareAndSet(READY, PROCESSING);
+      synchronized (lock) {
+         drainQueue(null);
+      }
+      // We block here to ensure that events don't pass through until we drain the queue one additional time.
+      synchronized (lock) {
+         // If we're not in a closed state, drain the queue one more time to ensure nothing was added during the
+         // previous lock.
+         if (state.compareAndSet(PROCESSING, PASSTHROUGH)) {
+            drainQueue(null);
+         }
+      }
+   }
+
+   private void drainQueue(final Throwable throwable) {
+      FutureEvent event;
+      final AtomicReference<Throwable> thrown = new AtomicReference<>(null);
+      while ((event = events.pollFirst()) != null) {
+         final Throwable t = throwable == null ? thrown.get() : throwable;
+         if (t != null) {
+            event.future.completeExceptionally(t);
+         } else {
+            final OutboundSseEvent e = event.event;
+            final CompletableFuture<Void> future = event.future;
+            internalWriteEvent(e)
+                    .thenRun(() -> future.complete(null))
+                    .exceptionally((error) -> {
+                       LOG.debugf("Failed to process event %s - %s", future, e);
+                       thrown.set(error);
+                       future.completeExceptionally(error);
+                       SynchronousDispatcher.rethrow(error);
+                       return null;
+                    });
+         }
+      }
+   }
+
+   private static class FutureEvent {
+      final CompletableFuture<Void> future;
+      final OutboundSseEvent event;
+
+      private FutureEvent(final OutboundSseEvent event) {
+         this.event = event;
+         future = new CompletableFuture<>();
+      }
+   }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcasterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcasterTest.java
@@ -1,10 +1,13 @@
 package org.jboss.resteasy.test.providers.sse;
 
 import org.jboss.resteasy.core.ResteasyContext;
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.jboss.resteasy.mock.MockHttpResponse;
 import org.jboss.resteasy.plugins.providers.sse.OutboundSseEventImpl;
 import org.jboss.resteasy.plugins.providers.sse.SseBroadcasterImpl;
 import org.jboss.resteasy.plugins.providers.sse.SseEventOutputImpl;
 import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.ResteasyAsynchronousContext;
 import org.junit.Assert;
 import org.junit.Before;
@@ -14,6 +17,8 @@ import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.SseEventSink;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -215,6 +220,10 @@ public class SseBroadcasterTest
 
    @Test
    public void testRemoveDisconnectedEventSink() throws Exception {
+      final Map<Class<?>, Object> testContext = new HashMap<>();
+      testContext.put(HttpRequest.class, new MockHttpRequest(){});
+      testContext.put(HttpResponse.class, new MockHttpResponse());
+      ResteasyContext.pushContextDataMap(testContext);
       SseBroadcasterImpl sseBroadcasterImpl = new SseBroadcasterImpl();
 
       final ConcurrentLinkedQueue<SseEventSink> outputQueue = getOutputQueue(sseBroadcasterImpl);
@@ -249,6 +258,8 @@ public class SseBroadcasterTest
          Assert.assertTrue(outputQueue.size() == 1);
          Assert.assertSame(outputQueue.peek(), sseEventSink1);
       }
+
+      ResteasyContext.removeContextDataLevel();
    }
 
    @SuppressWarnings("unchecked")

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseResource.java
@@ -6,9 +6,11 @@ import java.io.Reader;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.xml.namespace.QName;
 
 import jakarta.servlet.ServletContext;
 import jakarta.ws.rs.DELETE;
@@ -28,8 +30,6 @@ import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseBroadcaster;
 import jakarta.ws.rs.sse.SseEventSink;
 import jakarta.xml.bind.JAXBElement;
-import javax.xml.namespace.QName;
-
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.plugins.providers.sse.SseConstants;
 
@@ -54,13 +54,11 @@ public class SseResource
 
    private volatile SseBroadcaster sseBroadcaster;
 
-   private Object openLock = new Object();
+   private final Object openLock = new Object();
 
-   private volatile boolean sending = true;
+   private final List<OutboundSseEvent> eventsStore = new ArrayList<>();
 
-   private List<OutboundSseEvent> eventsStore = new ArrayList<OutboundSseEvent>();
-
-   private AtomicInteger noContentCount = new AtomicInteger();
+   private final AtomicInteger noContentCount = new AtomicInteger();
 
    private static final Logger logger = Logger.getLogger(SseResource.class);
 
@@ -256,7 +254,7 @@ public class SseResource
       {
          public void run()
          {
-            while (!eventSink.isClosed() && sending)
+            while (!eventSink.isClosed())
             {
                try
                {
@@ -285,14 +283,6 @@ public class SseResource
       {
          return !eventSink.isClosed();
       }
-
-   }
-
-   @GET
-   @Path("/stopevent")
-   public void stopEvent()
-   {
-      this.sending = false;
 
    }
 
@@ -367,7 +357,7 @@ public class SseResource
       {
          public void run()
          {
-            if (!eventSink.isClosed() && sending)
+            if (!eventSink.isClosed())
             {
                try
                {
@@ -402,7 +392,7 @@ public class SseResource
       {
          public void run()
          {
-            if (!eventSink.isClosed() && sending)
+            if (!eventSink.isClosed())
             {
                try
                {
@@ -423,6 +413,36 @@ public class SseResource
          }
       });
    }
+
+   @GET
+   @Path("/initialization-deadlock")
+   @Produces(MediaType.SERVER_SENT_EVENTS)
+   public void initializationDeadlock(@Context SseEventSink sink) {
+      if (sink == null) {
+         throw new IllegalStateException("No client connected.");
+      }
+      final ExecutorService service = (ExecutorService) servletContext
+              .getAttribute(ExecutorServletContextListener.TEST_EXECUTOR);
+      service.execute(() -> {
+         int i = 0;
+         final CompletableFuture<?> firstMsg = sink.send(createEvent(i++, "msg-"))
+                 .toCompletableFuture();
+         while (!firstMsg.isDone()) {
+            sink.send(createEvent(i++, "msg-"));
+         }
+         sink.send(createEvent(i, "last-msg-"))
+                 .thenAccept(v -> sink.close());
+      });
+   }
+
+   private OutboundSseEvent createEvent(final int id, final String prefix) {
+      return sse.newEventBuilder()
+              .id(Integer.toString(id))
+              .mediaType(MediaType.TEXT_PLAIN_TYPE)
+              .data(prefix + id)
+              .build();
+   }
+
    public static String toString(final Reader input) throws IOException {
 
        final char[] buffer = new char[2048];


### PR DESCRIPTION
…ensure there is no deadlock between the processing and writing to the output stream. Use queuing to ensure order of sink events.

https://issues.redhat.com/browse/RESTEASY-3033
Signed-off-by: James R. Perkins <jperkins@redhat.com>