### PR TITLE
[RESTEASY-3033] Block on the output stream for SseEventOutputImpl to …

### DIFF
--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
@@ -850,4 +850,7 @@ public interface Messages
 
    @Message(id = BASE + 2044, value = "Property %s not found")
    NoSuchElementException propertyNotFound(String name);
+
+   @Message(id = BASE + 2051, value = "Required context value not found.")
+   IllegalArgumentException requiredContextParameterNotFound();
 }

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyContext.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyContext.java
@@ -44,6 +44,25 @@ public final class ResteasyContext
       return (T) contextDataMap.get(type);
    }
 
+   /**
+    * Gets the current context for the type. If not found in the current context a {@linkplain IllegalArgumentException}
+    * is thrown.
+    *
+    * @param type the type to lookup in the context map
+    * @param <T>  the type of the lookup
+    *
+    * @return the context data
+    *
+    * @throws IllegalArgumentException if the type is not found in the current context
+    */
+   public static <T> T getRequiredContextData(final Class<T> type) {
+      final T result = getContextData(type);
+      if (result == null) {
+         throw Messages.MESSAGES.requiredContextParameterNotFound();
+      }
+      return result;
+   }
+
    public static <T> T popContextData(Class<T> type)
    {
       return (T) getContextDataMap().remove(type);

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/sse/SseEventOutputImpl.java
@@ -2,14 +2,19 @@ package org.jboss.resteasy.plugins.providers.sse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.annotation.Annotation;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.core.GenericType;
@@ -18,17 +23,16 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.sse.OutboundSseEvent;
 import javax.ws.rs.sse.SseEventSink;
-
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.SseElementType;
 import org.jboss.resteasy.annotations.Stream;
 import org.jboss.resteasy.core.ResourceMethodInvoker;
 import org.jboss.resteasy.core.ResteasyContext;
+import org.jboss.resteasy.core.ResteasyContext.CloseableContext;
 import org.jboss.resteasy.core.ServerResponseWriter;
+import org.jboss.resteasy.core.SynchronousDispatcher;
 import org.jboss.resteasy.plugins.server.Cleanable;
 import org.jboss.resteasy.plugins.server.Cleanables;
-import org.jboss.resteasy.core.SynchronousDispatcher;
-import org.jboss.resteasy.core.ResteasyContext.CloseableContext;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
 import org.jboss.resteasy.specimpl.BuiltResponse;
@@ -43,6 +47,13 @@ import org.jboss.resteasy.spi.util.FindAnnotation;
 public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements SseEventSink
 {
    private static final Logger LOG = Logger.getLogger(SseEventOutputImpl.class);
+
+   // States
+   private static final int READY = 0;
+   private static final int PROCESSING = 1;
+   private static final int PASSTHROUGH = 2;
+   private static final int CLOSED = 3;
+
    private final MessageBodyWriter<OutboundSseEvent> writer;
 
    private final ResteasyAsynchronousContext asyncContext;
@@ -51,15 +62,15 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
 
    private final HttpRequest request;
 
-   private volatile boolean closed;
-
    private final Map<Class<?>, Object> contextDataMap;
 
    private volatile boolean responseFlushed = false;
 
-   private final Object lock = new Object();
+   private final Object lock;
 
    private final ResteasyProviderFactory providerFactory;
+   private final AtomicInteger state;
+   private final Deque<FutureEvent> events;
 
    @Deprecated
    public SseEventOutputImpl(final MessageBodyWriter<OutboundSseEvent> writer)
@@ -72,7 +83,7 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
       this.writer = writer;
       contextDataMap = ResteasyContext.getContextDataMap();
       this.providerFactory = providerFactory;
-      request = ResteasyContext.getContextData(org.jboss.resteasy.spi.HttpRequest.class);
+      request = ResteasyContext.getRequiredContextData(org.jboss.resteasy.spi.HttpRequest.class);
       asyncContext = request.getAsyncContext();
 
       if (!asyncContext.isSuspended())
@@ -87,54 +98,28 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
          }
       }
 
-      response = ResteasyContext.getContextData(HttpResponse.class);
+      response = ResteasyContext.getRequiredContextData(HttpResponse.class);
+      try {
+         // This is an odd use-case for a lock. However, the AsyncOutputStream locks on itself which could lead to
+         // deadlocks if we use our own lock. Using the output stream as the lock avoids issues like this.
+         lock = response.getAsyncOutputStream();
+      } catch (IOException e) {
+         throw new UncheckedIOException(e);
+      }
+      state = new AtomicInteger(READY);
+      events = new ConcurrentLinkedDeque<>();
    }
 
    @Override
    public void close()
    {
-      close(true);
+      close(true, null);
    }
 
+   @Deprecated
    protected void close(boolean flushBeforeClose)
    {
-      // avoid even attempting to get a lock if someone else has closed it or is closing it
-      if(closed)
-         return;
-      synchronized (lock)
-      {
-         closed = true;
-         if(flushBeforeClose && responseFlushed) {
-            try(CloseableContext c = ResteasyContext.addCloseableContextDataLevel(contextDataMap)){
-               // make sure we flush to await for any queued data being sent
-               AsyncOutputStream aos = response.getAsyncOutputStream();
-               aos.asyncFlush().toCompletableFuture().get();
-            }catch(IOException | InterruptedException | ExecutionException x) {
-               // ignore it and let's just close
-            }
-         }
-         if (asyncContext.isSuspended())
-         {
-            ResteasyAsynchronousResponse asyncResponse = asyncContext.getAsyncResponse();
-            if (asyncResponse != null)
-            {
-               try {
-                  asyncResponse.complete();
-               } catch(RuntimeException x) {
-                  Throwable cause = x;
-                  while(cause.getCause() != null && cause.getCause() != cause)
-                     cause = cause.getCause();
-                  if(cause instanceof IOException) {
-                     // ignore it, we're closed now
-                  }else {
-                     LOG.debug(cause.getMessage());
-                     return;
-                  }
-               }
-            }
-         }
-         clearContextData();
-      }
+      close(flushBeforeClose, null);
    }
 
    public void clearContextData()
@@ -165,62 +150,11 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
 
    private CompletionStage<Void> internalFlushResponseToClient(boolean throwIOException)
    {
-      // avoid even attempting to get a lock if someone else has flushed the response
-      if(responseFlushed)
-         return CompletableFuture.completedFuture(null);
       synchronized (lock)
       {
          if (!responseFlushed)
          {
-            BuiltResponse jaxrsResponse = null;
-            if (this.closed)
-            {
-               jaxrsResponse = (BuiltResponse) Response.noContent().build();
-            }
-            else //set back to client 200 OK to implies the SseEventOutput is ready
-            {
-               ResourceMethodInvoker method =(ResourceMethodInvoker) request.getAttribute(ResourceMethodInvoker.class.getName());
-               MediaType[] mediaTypes = method.getProduces();
-               if (mediaTypes != null &&  getSseEventType(mediaTypes) != null)
-               {
-                  // @Produces("text/event-stream")
-                  SseElementType sseElementType = FindAnnotation.findAnnotation(method.getMethodAnnotations(),SseElementType.class);
-                  if (sseElementType != null)
-                  {
-                     // Get element media type from @SseElementType.
-                     Map<String, String> parameterMap = new HashMap<String, String>();
-                     parameterMap.put(SseConstants.SSE_ELEMENT_MEDIA_TYPE, sseElementType.value());
-                     MediaType mediaType = new MediaType(MediaType.SERVER_SENT_EVENTS_TYPE.getType(), MediaType.SERVER_SENT_EVENTS_TYPE.getSubtype(), parameterMap);
-                     jaxrsResponse = (BuiltResponse) Response.ok().type(mediaType).build();
-                  }
-                  else
-                  {
-                     // No element media type declared.
-                     jaxrsResponse = (BuiltResponse) Response.ok().type(getSseEventType(mediaTypes)).build();
-//                   // use "element-type=text/plain"?
-                  }
-               }
-               else
-               {
-                  Stream stream = FindAnnotation.findAnnotation(method.getMethodAnnotations(),Stream.class);
-                  if (stream != null)
-                  {
-                     // Get element media type from @Produces.
-                     jaxrsResponse = (BuiltResponse) Response.ok("").build();
-                     MediaType elementType = ServerResponseWriter.getResponseMediaType(jaxrsResponse, request, response, providerFactory, method);
-                     Map<String, String> parameterMap = new HashMap<String, String>();
-                     parameterMap.put(SseConstants.SSE_ELEMENT_MEDIA_TYPE, elementType.toString());
-                     String[] streamType = getStreamType(method);
-                     MediaType mediaType = new MediaType(streamType[0], streamType[1], parameterMap);
-                     jaxrsResponse = (BuiltResponse) Response.ok().type(mediaType).build();
-                  }
-                  else
-                  {
-                     throw new RuntimeException(Messages.MESSAGES.expectedStreamOrSseMediaType());
-                  }
-               }
-            }
-
+            final BuiltResponse jaxrsResponse = createResponse();
             try
             {
                CompletableFuture<Void> ret = new CompletableFuture<>();
@@ -232,7 +166,7 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
                            aos = response.getAsyncOutputStream();
                         } catch (IOException x)
                         {
-                           close(false);
+                           close(false, x);
                            ret.completeExceptionally(x);
                            return;
                         }
@@ -248,7 +182,7 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
                            if(e instanceof CompletionException)
                               e = e.getCause();
                            if(e instanceof IOException)
-                              close(false);
+                              close(false, e);
                            if(throwIOException)
                               ret.completeExceptionally(e);
                            else
@@ -260,7 +194,7 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
             }
             catch (IOException e)
             {
-               close(false);
+               close(false, e);
                CompletableFuture<Void> ret = new CompletableFuture<>();
                if (throwIOException)
                {
@@ -278,30 +212,59 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
    @Override
    public boolean isClosed()
    {
-      return closed;
+      return state.get() == CLOSED;
    }
 
    @Override
    public CompletionStage<?> send(OutboundSseEvent event)
    {
+      final int state = this.state.get();
+      if (state == CLOSED) {
+         // FIXME: should be this
+         // CompletableFuture<?> ret = new CompletableFuture<>();
+         // ret.completeExceptionally(new IllegalStateException(Messages.MESSAGES.sseEventSinkIsClosed()));
+         // return ret;
+         // But the TCK expects a real exception
+         throw new IllegalStateException(Messages.MESSAGES.sseEventSinkIsClosed());
+      }
+      if (state == PASSTHROUGH) {
+         synchronized (lock) {
+            return internalWriteEvent(event);
+         }
+      } else if (state == PROCESSING) {
+         final FutureEvent futureEvent = new FutureEvent(event);
+         events.addLast(futureEvent);
+         return futureEvent.future
+                 .thenRun(this::drainQueue);
+      }
+      final FutureEvent futureEvent = new FutureEvent(event);
+      events.addLast(futureEvent);
+      return internalFlushResponseToClient(true)
+              .thenRun(this::drainQueue)
+              .exceptionally((e) -> {
+                 if (e instanceof CompletionException)
+                    e = e.getCause();
+                 if (e instanceof IOException)
+                    close(false, e);
+                 LogMessages.LOGGER.failedToWriteSseEvent(event.toString(), e);
+                 SynchronousDispatcher.rethrow(e);
+                 // never reached
+                 return null;
+              });
+   }
+
+   @Deprecated
+   protected CompletionStage<Void> writeEvent(OutboundSseEvent event)
+   {
       synchronized (lock)
       {
-         if (closed)
-         {
-            // FIXME: should be this
-//            CompletableFuture<?> ret = new CompletableFuture<>();
-//            ret.completeExceptionally(new IllegalStateException(Messages.MESSAGES.sseEventSinkIsClosed()));
-//            return ret;
-            // But the TCK expects a real exception
-            throw new IllegalStateException(Messages.MESSAGES.sseEventSinkIsClosed());
-         }
-         // eager composition to guarantee ordering
-         return internalFlushResponseToClient(true)
-                 .thenCompose(v ->  writeEvent(event));
+         return internalWriteEvent(event);
       }
    }
 
-   protected CompletionStage<Void> writeEvent(OutboundSseEvent event)
+
+
+   private CompletionStage<Void> internalWriteEvent(final OutboundSseEvent event)
    {
       synchronized (lock)
       {
@@ -312,7 +275,7 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
                //// Check media type?
                ByteArrayOutputStream bout = new ByteArrayOutputStream();
                MediaType mediaType = event.getMediaType();
-               boolean mediaTypeSet = event instanceof OutboundSseEventImpl ? ((OutboundSseEventImpl) event).isMediaTypeSet() : true;
+               boolean mediaTypeSet = !(event instanceof OutboundSseEventImpl) || ((OutboundSseEventImpl) event).isMediaTypeSet();
                if (mediaType == null || !mediaTypeSet)
                {
                   Object o = response.getOutputHeaders().getFirst("Content-Type");
@@ -355,23 +318,23 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
                // eager composition to guarantee ordering
                return aos.asyncWrite(bout.toByteArray())
                        .thenCompose(v ->  aos.asyncFlush())
-                     .exceptionally(e -> {
-                        if(e instanceof CompletionException)
-                           e = e.getCause();
-                        if(e instanceof IOException)
-                           close(false);
-                        LogMessages.LOGGER.failedToWriteSseEvent(event.toString(), e);
-                        SynchronousDispatcher.rethrow(e);
-                        // never reached
-                        return null;
-                     });
+                       .exceptionally(e -> {
+                          if(e instanceof CompletionException)
+                             e = e.getCause();
+                          if(e instanceof IOException)
+                             close(false, e);
+                          LogMessages.LOGGER.failedToWriteSseEvent(event.toString(), e);
+                          SynchronousDispatcher.rethrow(e);
+                          // never reached
+                          return null;
+                       });
             }
          }
          catch (IOException e)
          {
             //The connection could be broken or closed. whenever IO error happens, mark closed to true to
             //stop event writing
-            close(false);
+            close(false, e);
             LogMessages.LOGGER.failedToWriteSseEvent(event.toString(), e);
             CompletableFuture<Void> ret = new CompletableFuture<>();
             ret.completeExceptionally(e);
@@ -386,6 +349,58 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
          }
       }
       return CompletableFuture.completedFuture(null);
+   }
+
+   private BuiltResponse createResponse() {
+      BuiltResponse jaxrsResponse;
+      if (state.get() == CLOSED)
+      {
+         jaxrsResponse = (BuiltResponse) Response.noContent().build();
+      }
+      else //set back to client 200 OK to implies the SseEventOutput is ready
+      {
+         ResourceMethodInvoker method =(ResourceMethodInvoker) request.getAttribute(ResourceMethodInvoker.class.getName());
+         MediaType[] mediaTypes = method.getProduces();
+         if (mediaTypes != null &&  getSseEventType(mediaTypes) != null)
+         {
+            // @Produces("text/event-stream")
+            SseElementType sseElementType = FindAnnotation.findAnnotation(method.getMethodAnnotations(),SseElementType.class);
+            if (sseElementType != null)
+            {
+               // Get element media type from @SseElementType.
+               Map<String, String> parameterMap = new HashMap<>();
+               parameterMap.put(SseConstants.SSE_ELEMENT_MEDIA_TYPE, sseElementType.value());
+               MediaType mediaType = new MediaType(MediaType.SERVER_SENT_EVENTS_TYPE.getType(), MediaType.SERVER_SENT_EVENTS_TYPE.getSubtype(), parameterMap);
+               jaxrsResponse = (BuiltResponse) Response.ok().type(mediaType).build();
+            }
+            else
+            {
+               // No element media type declared.
+               jaxrsResponse = (BuiltResponse) Response.ok().type(getSseEventType(mediaTypes)).build();
+//                   // use "element-type=text/plain"?
+            }
+         }
+         else
+         {
+            Stream stream = FindAnnotation.findAnnotation(method.getMethodAnnotations(),Stream.class);
+            if (stream != null)
+            {
+               // Get element media type from @Produces.
+               jaxrsResponse = (BuiltResponse) Response.ok("").build();
+               MediaType elementType = ServerResponseWriter.getResponseMediaType(jaxrsResponse, request, response, providerFactory, method);
+               Map<String, String> parameterMap = new HashMap<>();
+               parameterMap.put(SseConstants.SSE_ELEMENT_MEDIA_TYPE, elementType.toString());
+               String[] streamType = getStreamType(method);
+               MediaType mediaType = new MediaType(streamType[0], streamType[1], parameterMap);
+               jaxrsResponse = (BuiltResponse) Response.ok().type(mediaType).build();
+            }
+            else
+            {
+               throw new RuntimeException(Messages.MESSAGES.expectedStreamOrSseMediaType());
+            }
+         }
+      }
+      return jaxrsResponse;
    }
 
    private String[] getStreamType(ResourceMethodInvoker method)
@@ -428,4 +443,93 @@ public class SseEventOutputImpl extends GenericType<OutboundSseEvent> implements
       }
       return null;
   }
+
+   private void close(final boolean flushBeforeClose, final Throwable error) {
+      // avoid even attempting to get a lock if someone else has closed it or is closing it
+      if (state.getAndSet(CLOSED) != CLOSED) {
+         if (error != null) {
+            drainQueue(error);
+         } else {
+            synchronized (lock) {
+               events.clear();
+            }
+         }
+         if (flushBeforeClose && responseFlushed) {
+            try (CloseableContext c = ResteasyContext.addCloseableContextDataLevel(contextDataMap)) {
+               // make sure we flush to await for any queued data being sent
+               AsyncOutputStream aos = response.getAsyncOutputStream();
+               aos.asyncFlush().toCompletableFuture().get();
+            } catch (IOException | InterruptedException | ExecutionException x) {
+               // ignore it and let's just close
+            }
+         }
+         if (asyncContext.isSuspended()) {
+            ResteasyAsynchronousResponse asyncResponse = asyncContext.getAsyncResponse();
+            if (asyncResponse != null) {
+               try {
+                  asyncResponse.complete();
+               } catch (RuntimeException x) {
+                  Throwable cause = x;
+                  while (cause.getCause() != null && cause.getCause() != cause)
+                     cause = cause.getCause();
+                  if (cause instanceof IOException) {
+                     // ignore it, we're closed now
+                  } else {
+                     LOG.debug(cause.getMessage());
+                     return;
+                  }
+               }
+            }
+         }
+         clearContextData();
+      }
+   }
+
+   private void drainQueue() {
+      state.compareAndSet(READY, PROCESSING);
+      synchronized (lock) {
+         drainQueue(null);
+      }
+      // We block here to ensure that events don't pass through until we drain the queue one additional time.
+      synchronized (lock) {
+         // If we're not in a closed state, drain the queue one more time to ensure nothing was added during the
+         // previous lock.
+         if (state.compareAndSet(PROCESSING, PASSTHROUGH)) {
+            drainQueue(null);
+         }
+      }
+   }
+
+   private void drainQueue(final Throwable throwable) {
+      FutureEvent event;
+      final AtomicReference<Throwable> thrown = new AtomicReference<>(null);
+      while ((event = events.pollFirst()) != null) {
+         final Throwable t = throwable == null ? thrown.get() : throwable;
+         if (t != null) {
+            event.future.completeExceptionally(t);
+         } else {
+            final OutboundSseEvent e = event.event;
+            final CompletableFuture<Void> future = event.future;
+            internalWriteEvent(e)
+                    .thenRun(() -> future.complete(null))
+                    .exceptionally((error) -> {
+                       LOG.debugf("Failed to process event %s - %s", future, e);
+                       thrown.set(error);
+                       future.completeExceptionally(error);
+                       SynchronousDispatcher.rethrow(error);
+                       return null;
+                    });
+         }
+      }
+   }
+
+   private static class FutureEvent {
+      final CompletableFuture<Void> future;
+      final OutboundSseEvent event;
+
+      private FutureEvent(final OutboundSseEvent event) {
+         this.event = event;
+         future = new CompletableFuture<>();
+      }
+   }
 }

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/HttpServletResponseWrapper.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/HttpServletResponseWrapper.java
@@ -2,11 +2,12 @@ package org.jboss.resteasy.plugins.server.servlet;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.servlet.ServletOutputStream;
 import javax.servlet.WriteListener;
@@ -30,8 +31,8 @@ public class HttpServletResponseWrapper implements HttpResponse
 {
    public abstract class AsyncOperation
    {
-      CompletableFuture<Void> future = new CompletableFuture<>();
-      OutputStream stream;
+      final CompletableFuture<Void> future = new CompletableFuture<>();
+      final OutputStream stream;
       public AsyncOperation(final OutputStream stream)
       {
          this.stream = stream;
@@ -47,9 +48,9 @@ public class HttpServletResponseWrapper implements HttpResponse
    public class WriteOperation extends AsyncOperation
    {
 
-      private byte[] bytes;
-      private int offset;
-      private int length;
+      private final byte[] bytes;
+      private final int offset;
+      private final int length;
 
       public WriteOperation(final OutputStream stream, final byte[] bytes, final int offset, final int length)
       {
@@ -115,14 +116,14 @@ public class HttpServletResponseWrapper implements HttpResponse
       }
    }
 
-   protected HttpServletResponse response;
+   protected final HttpServletResponse response;
    protected int status = 200;
    protected MultivaluedMap<String, Object> outputHeaders;
-   protected ResteasyProviderFactory factory;
-   protected OutputStream outputStream = new DeferredOutputStream();
+   protected final ResteasyProviderFactory factory;
+   private OutputStream outputStream;
    protected volatile boolean suppressExceptionDuringChunkedTransfer = true;
-   protected HttpServletRequest request;
-   protected Map<Class<?>, Object> contextDataMap;
+   protected final HttpServletRequest request;
+   protected final Map<Class<?>, Object> contextDataMap;
 
    // RESTEASY-1784
    @Override
@@ -138,36 +139,50 @@ public class HttpServletResponseWrapper implements HttpResponse
    /**
     * RESTEASY-684 wants to defer access to outputstream until a write happens
     *
+    * <p>
+    * Note that all locking is on {@code this} and should remain that way to avoid deadlocks on consumers of this
+    * stream.
+    * </p>
+    *
     */
    protected class DeferredOutputStream extends AsyncOutputStream implements WriteListener
    {
-      private boolean asyncRegistered;
-      private Queue<AsyncOperation> asyncQueue;
+      private final ServletOutputStream out;
+      // Guarded by this
+      private final Queue<AsyncOperation> asyncQueue;
+      private final AtomicBoolean asyncRegistered;
+      // Guarded by this
       private AsyncOperation lastAsyncOperation;
-      private boolean asyncListenerCalled;
+      private volatile boolean asyncListenerCalled;
+
+      DeferredOutputStream() throws IOException {
+         asyncQueue = new LinkedList<>();
+         out = response.getOutputStream();
+         asyncRegistered = new AtomicBoolean();
+      }
 
       @Override
       public void write(int i) throws IOException
       {
-         response.getOutputStream().write(i);
+         out.write(i);
       }
 
       @Override
       public void write(byte[] bytes) throws IOException
       {
-         response.getOutputStream().write(bytes);
+         out.write(bytes);
       }
 
       @Override
       public void write(byte[] bytes, int i, int i1) throws IOException
       {
-         response.getOutputStream().write(bytes, i, i1);
+         out.write(bytes, i, i1);
       }
 
       @Override
       public void flush() throws IOException
       {
-         response.getOutputStream().flush();
+         out.flush();
       }
 
       @Override
@@ -197,79 +212,64 @@ public class HttpServletResponseWrapper implements HttpResponse
          // fetch it from the context directly to avoid having to restore the context just in case we're invoked on a context-less thread
          HttpRequest resteasyRequest = (HttpRequest) contextDataMap.get(HttpRequest.class);
          if(request.isAsyncStarted() && !resteasyRequest.getAsyncContext().isOnInitialRequest()) {
+            boolean flush = false;
             synchronized(this) {
-               ServletOutputStream os;
-               try
-               {
-                  os = response.getOutputStream();
-               } catch (IOException e)
-               {
-                  // return a failed future, do not queue it
-                  op.future.completeExceptionally(e);
-                  return;
+               if (asyncRegistered.compareAndSet(false, true)) {
+                  out.setWriteListener(this);
                }
-               if(!asyncRegistered) {
-                  // start the queue
-                  asyncRegistered = true;
-                  // make sure we have something ready to be executed
-                  addToQueue(op);
-                  os.setWriteListener(this);
-                  // never call isReady before Undertow is ready and has already called our listener at least once
-               } else if(asyncListenerCalled && os.isReady()) {
+               if(asyncListenerCalled && out.isReady()) {
                   // it's possible that we startAsync and queue, then queue another event and the stream becomes ready before
                   // onWritePossible is called, which means we need to flush the queue here to guarantee ordering if that happens
-                  addToQueue(op);
-                  flushQueue(os);
+                  asyncQueue.add(op);
+                  flush = true;
                } else {
                   // just queue
-                  addToQueue(op);
+                  asyncQueue.add(op);
                }
+            }
+            // Invoked outside the lock to avoid deadlocks, the flushQueue itself locks on this
+            if (flush) {
+               flushQueue();
             }
          } else {
             op.work(null);
          }
       }
 
-      private void flushQueue(ServletOutputStream sos)
+      private void flushQueue()
       {
-         if(lastAsyncOperation != null) {
-            lastAsyncOperation.future.complete(null);
-            lastAsyncOperation = null;
-         }
+         synchronized (this) {
+            if (lastAsyncOperation != null) {
+               lastAsyncOperation.future.complete(null);
+               lastAsyncOperation = null;
+            }
 
-         while(!asyncQueue.isEmpty() && sos.isReady()) {
-            lastAsyncOperation = asyncQueue.poll();
-            lastAsyncOperation.work(sos);
+            while (out.isReady() && (lastAsyncOperation = asyncQueue.poll()) != null) {
+               lastAsyncOperation.work(out);
+            }
          }
-      }
-
-      private synchronized void addToQueue(AsyncOperation op)
-      {
-         if(asyncQueue == null) {
-            asyncQueue = new ConcurrentLinkedQueue<>();
-         }
-         asyncQueue.add(op);
       }
 
       @Override
-      public synchronized void onWritePossible() throws IOException
-      {
+      public void onWritePossible() {
          asyncListenerCalled = true;
-         flushQueue(response.getOutputStream());
+         flushQueue();
       }
 
       @Override
-      public synchronized void onError(Throwable t)
+      public void onError(Throwable t)
       {
-         asyncListenerCalled = true;
-         if(lastAsyncOperation != null) {
-            lastAsyncOperation.future.completeExceptionally(t);
-            lastAsyncOperation = null;
-         }
-         while(!asyncQueue.isEmpty()) {
-            AsyncOperation op = asyncQueue.poll();
-            if(!op.future.isDone())
-               op.future.completeExceptionally(t);
+         synchronized (this) {
+            asyncListenerCalled = true;
+            if (lastAsyncOperation != null) {
+               lastAsyncOperation.future.completeExceptionally(t);
+               lastAsyncOperation = null;
+            }
+            AsyncOperation op;
+            while ((op = asyncQueue.poll()) != null) {
+               if (!op.future.isDone())
+                  op.future.completeExceptionally(t);
+            }
          }
       }
    }
@@ -299,13 +299,16 @@ public class HttpServletResponseWrapper implements HttpResponse
       return outputHeaders;
    }
 
-   public OutputStream getOutputStream() throws IOException
+   public synchronized OutputStream getOutputStream() throws IOException
    {
+      if (outputStream == null) {
+         outputStream = new DeferredOutputStream();
+      }
       return outputStream;
    }
 
    @Override
-   public void setOutputStream(OutputStream os)
+   public synchronized void setOutputStream(OutputStream os)
    {
       this.outputStream = os;
    }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcasterTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseBroadcasterTest.java
@@ -1,10 +1,13 @@
 package org.jboss.resteasy.test.providers.sse;
 
 import org.jboss.resteasy.core.ResteasyContext;
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.jboss.resteasy.mock.MockHttpResponse;
 import org.jboss.resteasy.plugins.providers.sse.OutboundSseEventImpl;
 import org.jboss.resteasy.plugins.providers.sse.SseBroadcasterImpl;
 import org.jboss.resteasy.plugins.providers.sse.SseEventOutputImpl;
 import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.ResteasyAsynchronousContext;
 import org.junit.Assert;
 import org.junit.Before;
@@ -14,6 +17,8 @@ import javax.ws.rs.sse.OutboundSseEvent;
 import javax.ws.rs.sse.SseEventSink;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -215,6 +220,10 @@ public class SseBroadcasterTest
 
    @Test
    public void testRemoveDisconnectedEventSink() throws Exception {
+      final Map<Class<?>, Object> testContext = new HashMap<>();
+      testContext.put(HttpRequest.class, new MockHttpRequest(){});
+      testContext.put(HttpResponse.class, new MockHttpResponse());
+      ResteasyContext.pushContextDataMap(testContext);
       SseBroadcasterImpl sseBroadcasterImpl = new SseBroadcasterImpl();
 
       final ConcurrentLinkedQueue<SseEventSink> outputQueue = getOutputQueue(sseBroadcasterImpl);
@@ -249,6 +258,8 @@ public class SseBroadcasterTest
          Assert.assertTrue(outputQueue.size() == 1);
          Assert.assertSame(outputQueue.peek(), sseEventSink1);
       }
+
+      ResteasyContext.removeContextDataLevel();
    }
 
    @SuppressWarnings("unchecked")

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSinkTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/SseEventSinkTest.java
@@ -13,7 +13,6 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.sse.SseEventSource;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -25,7 +24,6 @@ import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,18 +51,8 @@ public class SseEventSinkTest
       return PortProviderUtil.generateURL(path, SseEventSinkTest.class.getSimpleName());
    }
 
-   @After
-   public void stopSendEvent() throws Exception
-   {
-      Client isOpenClient = ClientBuilder.newClient();
-      Invocation.Builder isOpenRequest = isOpenClient.target(generateURL("/server-sent-events/stopevent"))
-            .request();
-      isOpenRequest.get();
-
-   }
-
    @Test
-   public void testCloseByEvnetSource() throws Exception
+   public void testCloseByEventSource() throws Exception
    {
       final CountDownLatch latch = new CountDownLatch(5);
       final List<String> results = new ArrayList<String>();
@@ -108,5 +96,46 @@ public class SseEventSinkTest
             results.indexOf("messageAfterClose") == -1);
       Assert.assertFalse("EventSink close is expected ", isOpenRequest.get().readEntity(Boolean.class));
 
+   }
+
+   /**
+    * @tpTestDetails Test deadlock in sending of first sse events seen in 3.7.2
+    * @tpInfo RESTEASY-3033
+    * @tpSince RESTEasy 3.7.2
+    */
+   @Test
+   public void deadlockAtInitialization() throws Exception {
+      for (int i = 0; i < 100; i++) {
+         testDeadlockAtInitialization(i);
+      }
+   }
+
+   private void testDeadlockAtInitialization(final int run) throws Exception {
+      final CountDownLatch latch = new CountDownLatch(1);
+      final List<String> results = new ArrayList<>();
+      final Client client = ClientBuilder.newClient();
+      try {
+         final WebTarget target = client.target(generateURL("/server-sent-events/initialization-deadlock"));
+         try (SseEventSource eventSource = SseEventSource.target(target).build()) {
+            eventSource.register(event -> {
+               final String msg = event.readData(String.class);
+               results.add(msg);
+               if (msg.startsWith("last-msg")) {
+                  latch.countDown();
+               }
+            }, ex -> {
+               logger.error(ex.getMessage(), ex);
+               Assert.fail(ex.getMessage());
+            });
+            eventSource.open();
+            final boolean await = latch.await(15, TimeUnit.SECONDS);
+            Assert.assertTrue(String.format("Waiting for event to be delivered has timed out at run %d.", run), await);
+            for (int i = 0; i < results.size(); i++) {
+               Assert.assertTrue(String.format("Wrong message order in run %d: %s", run, results), results.get(i).endsWith("-" + i));
+            }
+         }
+      } finally {
+         client.close();
+      }
    }
 }


### PR DESCRIPTION
…ensure there is no deadlock between the processing and writing to the output stream. Use queuing to ensure order of sink events.

https://issues.redhat.com/browse/RESTEASY-3033
Signed-off-by: James R. Perkins <jperkins@redhat.com>

Upstream: #2962