### PR TITLE
[RESTEASY-3057] Set Xerces as a module dependency for the org.jboss.r…

### DIFF
--- a/jboss-modules/src/main/resources/modules/org/jboss/resteasy/resteasy-jaxb-provider/main/module.xml
+++ b/jboss-modules/src/main/resources/modules/org/jboss/resteasy/resteasy-jaxb-provider/main/module.xml
@@ -26,13 +26,17 @@
 
     <dependencies>
         <module name="com.sun.xml.bind"/>
-        <module name="javax.xml.bind.api"/>
+        <module name="java.xml"/>
         <module name="javax.enterprise.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.ws.rs.api"/>
+        <module name="javax.xml.bind.api"/>
+        <!-- Some features are used in the SecureUnmarshaller that only work with Xerces. However, it's optional
+             because if these features are not used then it doesn't need to use Xerces.
+        -->
+        <module name="org.apache.xerces" optional="true" services="import"/>
+        <module name="org.jboss.logging"/>
         <module name="org.jboss.resteasy.resteasy-core"/>
         <module name="org.jboss.resteasy.resteasy-core-spi"/>
-        <module name="org.jboss.logging"/>
-        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/SecureUnmarshaller.java
+++ b/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/SecureUnmarshaller.java
@@ -93,8 +93,17 @@ public class SecureUnmarshaller implements Unmarshaller {
          SAXParserFactory f = factories[index];
          if (f == null)
          {
-            f = SAXParserFactory.newInstance();
-            configureParserFactory(f, disableExternalEntities, enableSecureProcessingFeature, disableDTDs);
+            // Get the current context class loader
+            final ClassLoader current = SecurityActions.getContextClassLoader();
+            try {
+               // Set the current context class loader to the class loader for this type
+               SecurityActions.setContextClassLoader();
+               f = SAXParserFactory.newInstance();
+               configureParserFactory(f, disableExternalEntities, enableSecureProcessingFeature, disableDTDs);
+            } finally {
+               // Reset the current context class loader
+               SecurityActions.setContextClassLoader(current);
+            }
             factories[index] = f;
          }
          SAXParser sp = f.newSAXParser();

--- a/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/SecurityActions.java
+++ b/providers/jaxb/src/main/java/org/jboss/resteasy/plugins/providers/jaxb/SecurityActions.java
@@ -1,0 +1,77 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.plugins.providers.jaxb;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * <strong>Not for external usage.</strong>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class SecurityActions {
+
+    private SecurityActions() {
+    }
+
+    /**
+     * Returns the current context class loader.
+     *
+     * @return the current context class loader
+     */
+    static ClassLoader getContextClassLoader() {
+        if (System.getSecurityManager() == null) {
+            return Thread.currentThread().getContextClassLoader();
+        }
+        return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> Thread.currentThread()
+                .getContextClassLoader());
+    }
+
+    /**
+     * Sets the context class loader to the class loader provided.
+     *
+     * @param cl the class loader to set
+     */
+    static void setContextClassLoader(final ClassLoader cl) {
+        if (System.getSecurityManager() == null) {
+            Thread.currentThread().setContextClassLoader(cl);
+        } else {
+            AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+                Thread.currentThread().setContextClassLoader(cl);
+                return null;
+            });
+        }
+    }
+
+    /**
+     * Sets the class loader to the class loader from this type.
+     */
+    static void setContextClassLoader() {
+        if (System.getSecurityManager() == null) {
+            Thread.currentThread().setContextClassLoader(SecurityActions.class.getClassLoader());
+        } else {
+            AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+                Thread.currentThread().setContextClassLoader(SecurityActions.class.getClassLoader());
+                return null;
+            });
+        }
+    }
+}


### PR DESCRIPTION
…esteasy.resteasy-jaxb-provider module. This also requires setting the TCCL when loading the JAXP to ensure the correct implementation is used.

https://issues.redhat.com/browse/RESTEASY-3057
Signed-off-by: James R. Perkins <jperkins@redhat.com>