### PR TITLE
[RESTEASY-3068] Upgrade Jetty to 11.0.7.

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -46,7 +46,7 @@
         <version.org.apache.maven>3.3.9</version.org.apache.maven> <!-- Used to download aether-provider -->
         <version.org.bouncycastle>1.69</version.org.bouncycastle>
         <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
-        <version.org.eclipse.jetty>11.0.1</version.org.eclipse.jetty>
+        <version.org.eclipse.jetty>11.0.7</version.org.eclipse.jetty>
         <version.org.eclipse.yasson>2.0.1</version.org.eclipse.yasson>
         <version.com.github.tomakehurst.wiremock>2.20.0</version.com.github.tomakehurst.wiremock>
         <version.org.glassfish.jakarta.el>4.0.0</version.org.glassfish.jakarta.el>


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-3068
Signed-off-by: James R. Perkins <jperkins@redhat.com>