### PR TITLE
[RESTEASY-3073] Account for comments when parsing service loader files

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/RegisterBuiltin.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/RegisterBuiltin.java
@@ -168,6 +168,10 @@ public class RegisterBuiltin
             String line;
             while ((line = reader.readLine()) != null)
             {
+               int commentIdx = line.indexOf('#');
+               if (commentIdx >= 0) {
+                  line = line.substring(0, commentIdx);
+               }
                line = line.trim();
                if (line.equals("")) continue;
                origins.put(line, url);


### PR DESCRIPTION
RESTEasy includes its own parser of service loader files (in the
`RegisterBuiltin` class). That parser doesn't account for comments,
even though those are legal (see [1]). That makes for some interesting
error messages when using e.g. RESTEasy's support for MicroProfile
Context Propagation, because that file does use comments [2].

[1] https://docs.oracle.com/javase/9/docs/api/java/util/ServiceLoader.html
[2] https://github.com/resteasy/resteasy-microprofile/blob/main/context-propagation/src/main/resources/META-INF/services/jakarta.ws.rs.ext.Providers