### PR TITLE
Initial migration to Jakarta REST 3.1

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,81 +25,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: 8
-          distribution: 'temurin'
-          cache: 'maven'
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: 'maven'
-      - name: Build with Maven Java ${{ matrix.java }} on WildFly ${{ matrix.wildfly-version }} - Linux
-        if: runner.os == 'Linux'
-        run: |
-          echo "::group::Build Logs"
-          mvn clean install -U -B -fae -Dserver.version=${{ matrix.wildfly-version }} -Dgithub.actions -Djava8.home="$JAVA_HOME_8_X64"
-          echo "::endgroup::"
-      - name: Build with Maven Java ${{ matrix.java }} on WildFly ${{ matrix.wildfly-version }} - Windows
-        if: runner.os == 'Windows'
+      - name: Build with Maven Java ${{ matrix.java }} on WildFly ${{ matrix.wildfly-version }} - ${{ matrix.os }}
         run:  |
           echo "::group::Build Logs"
-          mvn clean install -U -B -fae '-Dserver.version=${{ matrix.wildfly-version }}' '-Dgithub.actions' '"-Djava8.home=%JAVA_HOME_8_X64%"'
-          echo "::endgroup::"
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: surefire-reports-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.wildfly-version }}
-          path: '**/surefire-reports/*.txt'
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: server-logs-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.wildfly-version }}
-          path: '**/server.log'
-
-  test-with-java8:
-
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest ]
-        wildfly-version: ['25.0.1.Final']
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: 8
-          distribution: 'temurin'
-          cache: 'maven'
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
-        with:
-          java-version: 11
-          distribution: 'temurin'
-          cache: 'maven'
-      - name: Build with Java 11
-        run: |
-          echo "::group::Build Logs"
-          mvn clean install -U -B -DskipTests
-          echo "::endgroup::"
-      - name: Test with Java 8 on WildFly ${{ matrix.wildfly-version }} - Linux
-        if: runner.os == 'Linux'
-        run:  |
-          echo "::group::Test Logs"
-          mvn clean install -U -B -fae -rf ':resteasy-testsuite' -Dserver.version=${{ matrix.wildfly-version }} -Dgithub.actions -Dtest.java8.home="$JAVA_HOME_8_X64"
-          echo "::endgroup::"
-      - name: Test with Java 8 on WildFly ${{ matrix.wildfly-version }} - Windows
-        if: runner.os == 'Windows'
-        run: |
-          echo "::group::Build Logs"
-          mvn clean install -U -B -fae -rf ':resteasy-testsuite' '-Dserver.version=${{ matrix.wildfly-version }}' '-Dgithub.actions' '"-Dtest.java8.home=%JAVA_HOME_8_X64%"'
+          mvn clean install -U -B -fae '-Dserver.version=${{ matrix.wildfly-version }}' '-Dgithub.actions'
           echo "::endgroup::"
       - uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/wildfly-build.yml
+++ b/.github/workflows/wildfly-build.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           repository: wildfly/wildfly
           fetch-depth: 0
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
           distribution: 'temurin'
           cache: 'maven'
       - name: Build WildFly

--- a/arquillian/RESTEASY-1056-jetty-bv11/pom.xml
+++ b/arquillian/RESTEASY-1056-jetty-bv11/pom.xml
@@ -25,8 +25,8 @@
           <artifactId>jboss-logging</artifactId>
       </dependency>
       <dependency>
-          <groupId>org.jboss.spec.javax.ws.rs</groupId>
-          <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+          <groupId>jakarta.ws.rs</groupId>
+          <artifactId>jakarta.ws.rs-api</artifactId>
       </dependency>
 
     <!-- Test dependencies -->

--- a/arquillian/RESTEASY-1056-jetty-bv11/pom.xml
+++ b/arquillian/RESTEASY-1056-jetty-bv11/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-misc-arquillian-tests</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>RESTEASY-1056-jetty-bv11</artifactId>

--- a/arquillian/RESTEASY-1630-jetty-resteasy-servlet-initializer/pom.xml
+++ b/arquillian/RESTEASY-1630-jetty-resteasy-servlet-initializer/pom.xml
@@ -28,8 +28,8 @@
       <artifactId>jboss-logging</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
 
     <!-- Test dependencies -->

--- a/arquillian/RESTEASY-1630-jetty-resteasy-servlet-initializer/pom.xml
+++ b/arquillian/RESTEASY-1630-jetty-resteasy-servlet-initializer/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-misc-arquillian-tests</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>RESTEASY-1630-jetty-resteasy-servlet-initializer</artifactId>

--- a/arquillian/RESTEASY-736-jetty/pom.xml
+++ b/arquillian/RESTEASY-736-jetty/pom.xml
@@ -17,8 +17,8 @@
           <artifactId>jboss-logging</artifactId>
       </dependency>
       <dependency>
-          <groupId>org.jboss.spec.javax.ws.rs</groupId>
-          <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+          <groupId>jakarta.ws.rs</groupId>
+          <artifactId>jakarta.ws.rs-api</artifactId>
       </dependency>
 
       <!-- Test dependencies -->

--- a/arquillian/RESTEASY-736-jetty/pom.xml
+++ b/arquillian/RESTEASY-736-jetty/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-misc-arquillian-tests</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>RESTEASY-736-jetty</artifactId>

--- a/arquillian/pom.xml
+++ b/arquillian/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>RESTEasy Misc Arquillian-based tests</name>

--- a/arquillian/pom.xml
+++ b/arquillian/pom.xml
@@ -24,8 +24,6 @@
         <version.arquillian.jetty>1.0.0.CR3</version.arquillian.jetty>
         <!-- Test properties -->
         <additionalJvmArgs/>
-        <!-- The Jakarta version of Jetty only supports Java 11 -->
-        <skip.java8.tests>true</skip.java8.tests>
     </properties>
 
     <dependencyManagement>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-dist</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -40,8 +40,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/distribution/src-distribution/pom.xml
+++ b/distribution/src-distribution/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-dist</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-src-dist</artifactId>

--- a/docbook/pom.xml
+++ b/docbook/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-reference-guide-${translation}</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <packaging>jdocbook</packaging>
     <name>RESTEasy Reference Guide (${translation})</name>
     <description/>

--- a/docbook/reference/en/en-US/master.xml
+++ b/docbook/reference/en/en-US/master.xml
@@ -70,7 +70,7 @@
    <bookinfo>
       <title>RESTEasy</title>
       <subtitle>Jakarta RESTFul Web Services</subtitle>
-      <releaseinfo>6.0.1-SNAPSHOT</releaseinfo>
+      <releaseinfo>6.1.0-SNAPSHOT</releaseinfo>
    </bookinfo>
 
    <toc/>

--- a/docbook/reference/en/en-US/modules/Installation_Configuration.xml
+++ b/docbook/reference/en/en-US/modules/Installation_Configuration.xml
@@ -256,7 +256,7 @@
                 <programlisting><![CDATA[$ galleon.sh install wildfly:current]]></programlisting>
 
                 To install the RESTEasy upgrade on top of that you simply need to use the tool again with the Maven GAV:
-                <programlisting><![CDATA[$ galleon.sh install org.jboss.resteasy:galleon-feature-pack:6.0.1-SNAPSHOT]]></programlisting>
+                <programlisting><![CDATA[$ galleon.sh install org.jboss.resteasy:galleon-feature-pack:6.1.0-SNAPSHOT]]></programlisting>
             </para>
             <para>
                 If you are using Maven to provision WildFly you can simply add the feature pack to your plugin configuration.
@@ -273,7 +273,7 @@
             <feature-pack>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>galleon-feature-pack</artifactId>
-                <version>6.0.1-SNAPSHOT</version>
+                <version>6.1.0-SNAPSHOT</version>
             </feature-pack>
         </feature-packs>
     </configuration>
@@ -360,17 +360,17 @@ public class MyApplication extends Application
 <dependency>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-core</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
 </dependency>
 <dependency>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-client</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
 </dependency>
 <dependency>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxb-provider</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
 </dependency>
 ]]></programlisting>
         <para>
@@ -403,7 +403,7 @@ public class MyApplication extends Application
 <dependency>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-servlet-initializer</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
 </dependency>
 ]]></programlisting>
         </section>
@@ -1398,12 +1398,12 @@ public abstract class Application
 <dependency>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-core</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
 </dependency>
 <dependency>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-client</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
 </dependency>
 ]]></programlisting>
 

--- a/docbook/reference/en/en-US/modules/Json-p.xml
+++ b/docbook/reference/en/en-US/modules/Json-p.xml
@@ -10,7 +10,7 @@
 <dependency>
    <groupId>org.jboss.resteasy</groupId>
    <artifactId>resteasy-json-p-provider</artifactId>
-   <version>6.0.1-SNAPSHOT</version>
+   <version>6.1.0-SNAPSHOT</version>
 </dependency>
 ]]></programlisting>
     <para>

--- a/docbook/reference/en/en-US/modules/Links.xml
+++ b/docbook/reference/en/en-US/modules/Links.xml
@@ -52,7 +52,7 @@
 					<tr>
 						<td>org.jboss.resteasy</td>
 						<td>resteasy-links</td>
-						<td>6.0.1-SNAPSHOT</td>
+						<td>6.1.0-SNAPSHOT</td>
 					</tr>
 				</tbody>
 			</table>

--- a/docbook/reference/en/en-US/modules/RESTEasy_Embedded_Container.xml
+++ b/docbook/reference/en/en-US/modules/RESTEasy_Embedded_Container.xml
@@ -138,7 +138,7 @@ public class UndertowTest
   <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jdk-http</artifactId>
-      <version>6.0.1-SNAPSHOT</version>
+      <version>6.1.0-SNAPSHOT</version>
   </dependency>
 ]]></programlisting>
 
@@ -167,7 +167,7 @@ public class UndertowTest
   <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-netty4</artifactId>
-      <version>6.0.1-SNAPSHOT</version>
+      <version>6.1.0-SNAPSHOT</version>
   </dependency>
 ]]></programlisting>
 
@@ -200,7 +200,7 @@ public class UndertowTest
   <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-reactor-netty</artifactId>
-      <version>6.0.1-SNAPSHOT</version>
+      <version>6.1.0-SNAPSHOT</version>
   </dependency>
 ]]></programlisting>
 
@@ -227,7 +227,7 @@ public class UndertowTest
   <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-vertx</artifactId>
-      <version>6.0.1-SNAPSHOT</version>
+      <version>6.1.0-SNAPSHOT</version>
   </dependency>
     ]]></programlisting>
 

--- a/docbook/reference/en/en-US/modules/signature.xml
+++ b/docbook/reference/en/en-US/modules/signature.xml
@@ -172,7 +172,7 @@
     <para><programlisting>        &lt;dependency&gt;
             &lt;groupId&gt;org.jboss.resteasy&lt;/groupId&gt;
             &lt;artifactId&gt;resteasy-crypto&lt;/artifactId&gt;
-            &lt;version&gt;6.0.1-SNAPSHOT&lt;/version&gt;
+            &lt;version&gt;6.1.0-SNAPSHOT&lt;/version&gt;
         &lt;/dependency&gt;
 
 </programlisting></para>

--- a/docbook/reference/en/en-US/modules/smime.xml
+++ b/docbook/reference/en/en-US/modules/smime.xml
@@ -21,7 +21,7 @@
     <para><programlisting>        &lt;dependency&gt;
             &lt;groupId&gt;org.jboss.resteasy&lt;/groupId&gt;
             &lt;artifactId&gt;resteasy-crypto&lt;/artifactId&gt;
-            &lt;version&gt;6.0.1-SNAPSHOT&lt;/version&gt;
+            &lt;version&gt;6.1.0-SNAPSHOT&lt;/version&gt;
         &lt;/dependency&gt;
 
 </programlisting></para>

--- a/galleon-feature-pack/pom.xml
+++ b/galleon-feature-pack/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/galleon-feature-pack/pom.xml
+++ b/galleon-feature-pack/pom.xml
@@ -358,8 +358,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/galleon-feature-pack/src/main/resources/modules/system/layers/base/jakarta/ws/rs/api/main/module.xml
+++ b/galleon-feature-pack/src/main/resources/modules/system/layers/base/jakarta/ws/rs/api/main/module.xml
@@ -22,7 +22,7 @@
 <module xmlns="urn:jboss:module:1.9" name="jakarta.ws.rs.api">
 
     <resources>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_3.0_spec}"/>
+        <artifact name="${jakarta.ws.rs:jakarta.ws.rs-api}"/>
     </resources>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>38</version>
+        <version>39</version>
         <relativePath/>
     </parent>
 
@@ -34,12 +34,10 @@
         <!-- maven-enforcer-plugin -->
         <maven.min.version>3.2.5</maven.min.version>
 
-        <!-- Require at least Java 11 to compile, but compile down to Java 8 -->
+        <!-- Require at least Java 11 to compile -->
         <jdk.min.version>11</jdk.min.version>
-        <javadoc.additional.params>--release=8</javadoc.additional.params>
         <!-- maven-surefire-plugin -->
         <surefire.system.args>-Xms512m -Xmx512m</surefire.system.args>
-        <skip.java8.tests>false</skip.java8.tests>
 
         <maven.test.skip>false</maven.test.skip>
         <skipTests>${maven.test.skip}</skipTests>
@@ -50,6 +48,7 @@
         <galleon.offline>false</galleon.offline>
 
         <!-- Plugins versions -->
+        <version.javadoc.plugin>3.3.1</version.javadoc.plugin>
         <version.org.jacoco.plugin>0.7.9</version.org.jacoco.plugin>
         <version.org.jboss.galleon>4.2.8.Final</version.org.jboss.galleon>
         <version.org.wildfly.galleon-plugins>5.2.2.Final</version.org.wildfly.galleon-plugins>
@@ -206,41 +205,6 @@
             </dependencyManagement>
         </profile>
       <profile>
-          <id>java8.tests</id>
-          <activation>
-              <property>
-                  <name>java8.home</name>
-              </property>
-          </activation>
-          <build>
-              <plugins>
-                  <plugin>
-                      <groupId>org.apache.maven.plugins</groupId>
-                      <artifactId>maven-surefire-plugin</artifactId>
-                      <executions>
-                          <execution>
-                              <id>java8-test</id>
-                              <phase>test</phase>
-                              <goals>
-                                  <goal>test</goal>
-                              </goals>
-                              <configuration>
-                                  <skip>${skip.java8.tests}</skip>
-                                  <jvm>${java8.home}/bin/java</jvm>
-                                  <additionalClasspathElements>
-                                      <additionalClasspathElement>${java8.home}/lib/tools.jar</additionalClasspathElement>
-                                  </additionalClasspathElements>
-                                  <environmentVariables>
-                                      <JAVA_HOME>${java8.home}</JAVA_HOME>
-                                  </environmentVariables>
-                              </configuration>
-                          </execution>
-                      </executions>
-                  </plugin>
-              </plugins>
-          </build>
-      </profile>
-      <profile>
           <id>github-actions</id>
           <activation>
               <property>
@@ -289,6 +253,11 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <compilerArgs>
+                            <compilerArg>-Aorg.jboss.logging.tools.addGeneratedAnnotation=false</compilerArg>
+                        </compilerArgs>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>default-compile</id>
@@ -296,9 +265,6 @@
                             <goals>
                                 <goal>compile</goal>
                             </goals>
-                            <configuration>
-                                <release>8</release>
-                            </configuration>
                         </execution>
                     </executions>
                 </plugin>
@@ -321,7 +287,6 @@
                         <maxmemory>1024m</maxmemory>
                         <quiet>false</quiet>
                         <aggregate>true</aggregate>
-                        <additionalJOption>--no-module-directories</additionalJOption>
                         <excludePackageNames>
                             com.restfully.*:org.jboss.resteasy.examples.*:se.unlogic.*:org.jboss.resteasy.tests.*
                         </excludePackageNames>

--- a/profiling-tests/pom.xml
+++ b/profiling-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-profiling-tests</artifactId>

--- a/providers/fastinfoset/pom.xml
+++ b/providers/fastinfoset/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
 	    <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-fastinfoset-provider</artifactId>

--- a/providers/jackson2/pom.xml
+++ b/providers/jackson2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
 	    <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-jackson2-provider</artifactId>

--- a/providers/jaxb/pom.xml
+++ b/providers/jaxb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
 	    <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-jaxb-provider</artifactId>

--- a/providers/json-binding/pom.xml
+++ b/providers/json-binding/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-json-binding-provider</artifactId>

--- a/providers/json-p-ee7/pom.xml
+++ b/providers/json-p-ee7/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-json-p-provider</artifactId>

--- a/providers/multipart/pom.xml
+++ b/providers/multipart/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-multipart-provider</artifactId>

--- a/providers/pom.xml
+++ b/providers/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>RESTEasy Providers</name>

--- a/providers/resteasy-atom/pom.xml
+++ b/providers/resteasy-atom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-atom-provider</artifactId>

--- a/providers/resteasy-html/pom.xml
+++ b/providers/resteasy-html/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-html</artifactId>

--- a/providers/resteasy-validator-provider/pom.xml
+++ b/providers/resteasy-validator-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>resteasy-validator-provider</artifactId>

--- a/resteasy-bom/pom.xml
+++ b/resteasy-bom/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-bom</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>RESTEasy Maven Import (BOM)</name>

--- a/resteasy-cdi/pom.xml
+++ b/resteasy-cdi/pom.xml
@@ -13,8 +13,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/resteasy-cdi/pom.xml
+++ b/resteasy-cdi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>resteasy-cdi</artifactId>
     <name>RESTEasy CDI integration module</name>

--- a/resteasy-client-api/pom.xml
+++ b/resteasy-client-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resteasy-client-api/pom.xml
+++ b/resteasy-client-api/pom.xml
@@ -38,8 +38,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/resteasy-client-jetty/pom.xml
+++ b/resteasy-client-jetty/pom.xml
@@ -49,8 +49,8 @@
             <artifactId>jetty-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/resteasy-client-jetty/pom.xml
+++ b/resteasy-client-jetty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resteasy-client-jetty/pom.xml
+++ b/resteasy-client-jetty/pom.xml
@@ -12,12 +12,6 @@
     <artifactId>resteasy-client-jetty</artifactId>
     <name>RESTEasy Client - Jetty Engine</name>
 
-    <properties>
-        <!-- The Jakarta version of Jetty only supports Java 11 -->
-        <!-- TODO (jrp) because of this should we use Java 11 as the compile version? -->
-        <skip.java8.tests>true</skip.java8.tests>
-    </properties>
-
     <dependencies>
 
         <dependency>

--- a/resteasy-client-reactor-netty/pom.xml
+++ b/resteasy-client-reactor-netty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/resteasy-client-vertx/pom.xml
+++ b/resteasy-client-vertx/pom.xml
@@ -43,8 +43,8 @@
             <artifactId>vertx-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/resteasy-client-vertx/pom.xml
+++ b/resteasy-client-vertx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resteasy-client/pom.xml
+++ b/resteasy-client/pom.xml
@@ -70,8 +70,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/resteasy-client/pom.xml
+++ b/resteasy-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resteasy-core-spi/pom.xml
+++ b/resteasy-core-spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-core-spi</artifactId>

--- a/resteasy-core-spi/pom.xml
+++ b/resteasy-core-spi/pom.xml
@@ -41,8 +41,8 @@
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/resteasy-core/pom.xml
+++ b/resteasy-core/pom.xml
@@ -41,8 +41,8 @@
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/resteasy-core/pom.xml
+++ b/resteasy-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-core</artifactId>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -65,6 +65,7 @@
         <version.jakarta.ejb.ejb-api>4.0.0</version.jakarta.ejb.ejb-api>
         <version.jakarta.interceptor.interceptor-api>2.0.0</version.jakarta.interceptor.interceptor-api>
         <version.jakarta.jms.jms-api>3.0.0</version.jakarta.jms.jms-api>
+        <version.jakarta.ws.rs>3.0.0</version.jakarta.ws.rs>
         <version.jakarta.xml.bind.bind-api>3.0.1</version.jakarta.xml.bind.bind-api>
         <version.jakarta.servlet.servlet-api>5.0.0</version.jakarta.servlet.servlet-api>
         <version.jakarta.transaction.transaction-api>2.0.0</version.jakarta.transaction.transaction-api>
@@ -218,9 +219,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.jboss.spec.javax.ws.rs</groupId>
-                <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
-                <version>${version.javax.ws.rs-api}</version>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${version.jakarta.ws.rs}</version>
             </dependency>
 
             <dependency>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -380,7 +380,7 @@
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.spec.javax.annotation</groupId>
-                        <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+                        <artifactId>jboss-annotations-api_1.3_spec</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-dependencies</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>RESTEasy dependencies BOM</name>
     <description>RESTEasy dependencies BOM</description>

--- a/resteasy-jsapi/pom.xml
+++ b/resteasy-jsapi/pom.xml
@@ -20,8 +20,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/resteasy-jsapi/pom.xml
+++ b/resteasy-jsapi/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-jsapi</artifactId>

--- a/resteasy-links/pom.xml
+++ b/resteasy-links/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-links</artifactId>

--- a/resteasy-links/pom.xml
+++ b/resteasy-links/pom.xml
@@ -20,8 +20,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.persistence</groupId>

--- a/resteasy-reactor/pom.xml
+++ b/resteasy-reactor/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>resteasy-reactor</artifactId>
   <name>RESTEasy Reactor integration</name>

--- a/resteasy-rxjava2/pom.xml
+++ b/resteasy-rxjava2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>resteasy-rxjava2</artifactId>
   <name>RESTEasy RxJava 2 integration</name>

--- a/resteasy-servlet-initializer/pom.xml
+++ b/resteasy-servlet-initializer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-servlet-initializer</artifactId>

--- a/resteasy-servlet-initializer/pom.xml
+++ b/resteasy-servlet-initializer/pom.xml
@@ -19,8 +19,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/resteasy-stats/pom.xml
+++ b/resteasy-stats/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-stats</artifactId>

--- a/resteasy-upgrade-guide/pom.xml
+++ b/resteasy-upgrade-guide/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-upgrade-guide-${translation}</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <packaging>jdocbook</packaging>
     <name>RESTEasy Upgrade Guide (${translation})</name>
     <description/>

--- a/resteasy-wadl-undertow-connector/pom.xml
+++ b/resteasy-wadl-undertow-connector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resteasy-wadl-undertow-connector/pom.xml
+++ b/resteasy-wadl-undertow-connector/pom.xml
@@ -41,8 +41,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/resteasy-wadl/pom.xml
+++ b/resteasy-wadl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resteasy-wadl/pom.xml
+++ b/resteasy-wadl/pom.xml
@@ -21,8 +21,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/security/jose-jwt/pom.xml
+++ b/security/jose-jwt/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>security-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>RESTEasy Security</name>

--- a/security/resteasy-crypto/pom.xml
+++ b/security/resteasy-crypto/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>security-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-adapters/pom.xml
+++ b/server-adapters/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
     <name>RESTEasy Http Adapter Plugins</name>
     <description/>

--- a/server-adapters/resteasy-jdk-http/pom.xml
+++ b/server-adapters/resteasy-jdk-http/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-http-adapter-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-adapters/resteasy-netty4-cdi/pom.xml
+++ b/server-adapters/resteasy-netty4-cdi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-http-adapter-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-adapters/resteasy-netty4/pom.xml
+++ b/server-adapters/resteasy-netty4/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-http-adapter-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-adapters/resteasy-reactor-netty/pom.xml
+++ b/server-adapters/resteasy-reactor-netty/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-http-adapter-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-adapters/resteasy-undertow/pom.xml
+++ b/server-adapters/resteasy-undertow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-http-adapter-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-adapters/resteasy-vertx/pom.xml
+++ b/server-adapters/resteasy-vertx/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-http-adapter-pom</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/testsuite/arquillian-utils/pom.xml
+++ b/testsuite/arquillian-utils/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-testsuite</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>arquillian-utils</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <name>RESTEasy Main testsuite: Arquillian utils</name>
     <packaging>jar</packaging>
     <properties>

--- a/testsuite/integration-tests-embedded/pom.xml
+++ b/testsuite/integration-tests-embedded/pom.xml
@@ -6,7 +6,7 @@
    <parent>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-testsuite</artifactId>
-      <version>6.0.1-SNAPSHOT</version>
+      <version>6.1.0-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/testsuite/integration-tests-embedded/pom.xml
+++ b/testsuite/integration-tests-embedded/pom.xml
@@ -74,10 +74,10 @@
           <groupId>jakarta.annotation</groupId>
           <artifactId>jakarta.annotation-api</artifactId>
       </dependency>
-      <dependency>
-         <groupId>org.jboss.spec.javax.ws.rs</groupId>
-         <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
-      </dependency>
+       <dependency>
+           <groupId>jakarta.ws.rs</groupId>
+           <artifactId>jakarta.ws.rs-api</artifactId>
+       </dependency>
       <dependency>
          <groupId>org.jboss.logging</groupId>
          <artifactId>jboss-logging</artifactId>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-testsuite</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -24,9 +24,6 @@
         <ipv6ArquillianSettings/>
         <debugJvmArgs/>
         <jboss.server.config.file.name>standalone-full.xml</jboss.server.config.file.name>
-
-        <!-- Skip the default Java 8 testing. This will have to be done in CI or locally by setting the test.java.home -->
-        <skip.java8.tests>true</skip.java8.tests>
         <test.java.home>${java.home}</test.java.home>
     </properties>
 
@@ -218,34 +215,6 @@
             <properties>
                 <version.resteasy.testsuite>${version.resteasy.testsuite}</version.resteasy.testsuite>
             </properties>
-        </profile>
-
-        <profile>
-            <id>java8-integration-tests</id>
-            <activation>
-                <property>
-                    <name>test.java8.home</name>
-                </property>
-            </activation>
-            <properties>
-                <test.java.home>${test.java8.home}</test.java.home>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <additionalClasspathElements>
-                                <additionalClasspathElement>${test.java.home}/lib/tools.jar</additionalClasspathElement>
-                            </additionalClasspathElements>
-                            <environmentVariables>
-                                <JAVA_HOME>${test.java.home}</JAVA_HOME>
-                            </environmentVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
         <profile>
@@ -473,19 +442,6 @@
             <properties>
                 <debug.port>8787</debug.port>
                 <debugJvmArgs>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:${debug.port}</debugJvmArgs>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>debug-java-8</id>
-            <activation>
-                <property>
-                    <name>debug.java.8</name>
-                </property>
-            </activation>
-            <properties>
-                <debug.port>8787</debug.port>
-                <debugJvmArgs>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debug.port}</debugJvmArgs>
             </properties>
         </profile>
     </profiles>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>RESTEasy Main testsuite</name>

--- a/testsuite/unit-tests/pom.xml
+++ b/testsuite/unit-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-testsuite</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
The actual specification has not been released yet. However, the version will need to be bumped and the minimum Java version needs to be 11.