### PR TITLE
Make extractResult fail-fast when there's no content type

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ClientInvocation.java
@@ -160,7 +160,7 @@ public class ClientInvocation implements Invocation
          {
             if (response.getMediaType() == null)
             {
-               return null;
+               throw new ProcessingException("Response has no content type");
             }
             else
             {


### PR DESCRIPTION
This is a breaking change, it's probably a starting point. Probably a configuration is needed to opt-in for the feature.