### PR TITLE
[Resteasy 3096]: Resteasy new WebApplicationExceptions behavior

### DIFF
--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyBadRequestException.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyBadRequestException.java
@@ -14,14 +14,21 @@ public class ResteasyBadRequestException extends BadRequestException implements 
 
    private static final long serialVersionUID = -6250430572164780061L;
    private final BadRequestException wrapped;
+   private final Response sanitizedResponse;
 
     ResteasyBadRequestException(final BadRequestException wrapped) {
-        super(wrapped.getMessage(), sanitize(wrapped.getResponse()), wrapped.getCause());
+        super(wrapped.getMessage(), wrapped.getResponse(), wrapped.getCause());
         this.wrapped = wrapped;
+        this.sanitizedResponse = sanitize(wrapped.getResponse());
     }
 
     @Override
     public BadRequestException unwrap() {
         return wrapped;
+    }
+
+    @Override
+    public Response getSanitizedResponse() {
+        return sanitizedResponse;
     }
 }

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyClientErrorException.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyClientErrorException.java
@@ -1,6 +1,5 @@
 package org.jboss.resteasy.client.exception;
 
-
 import static org.jboss.resteasy.client.exception.WebApplicationExceptionWrapper.sanitize;
 
 import jakarta.ws.rs.ClientErrorException;
@@ -15,14 +14,21 @@ public class ResteasyClientErrorException extends ClientErrorException implement
 
    private static final long serialVersionUID = 6839671465938091898L;
    private final ClientErrorException wrapped;
+   private final Response sanitizedResponse;
 
     ResteasyClientErrorException(final ClientErrorException wrapped) {
-        super(wrapped.getMessage(), sanitize(wrapped.getResponse()), wrapped.getCause());
+        super(wrapped.getMessage(), wrapped.getResponse(), wrapped.getCause());
         this.wrapped = wrapped;
+        this.sanitizedResponse = sanitize(wrapped.getResponse());
     }
 
     @Override
     public ClientErrorException unwrap() {
         return wrapped;
+    }
+
+    @Override
+    public Response getSanitizedResponse() {
+        return sanitizedResponse;
     }
 }

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyForbiddenException.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyForbiddenException.java
@@ -14,14 +14,21 @@ public class ResteasyForbiddenException extends ForbiddenException implements We
 
    private static final long serialVersionUID = -581285336820307590L;
    private final ForbiddenException wrapped;
+   private final Response sanitizedResponse;
 
     ResteasyForbiddenException(final ForbiddenException wrapped) {
-        super(wrapped.getMessage(), sanitize(wrapped.getResponse()), wrapped.getCause());
+        super(wrapped.getMessage(), wrapped.getResponse(), wrapped.getCause());
         this.wrapped = wrapped;
+        this.sanitizedResponse = sanitize(wrapped.getResponse());
     }
 
     @Override
     public ForbiddenException unwrap() {
         return wrapped;
+    }
+
+    @Override
+    public Response getSanitizedResponse() {
+        return sanitizedResponse;
     }
 }

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyInternalServerErrorException.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyInternalServerErrorException.java
@@ -14,14 +14,21 @@ public class ResteasyInternalServerErrorException extends InternalServerErrorExc
 
    private static final long serialVersionUID = 5293921582428847923L;
    private final InternalServerErrorException wrapped;
+   private final Response sanitizedResponse;
 
     ResteasyInternalServerErrorException(final InternalServerErrorException wrapped) {
-        super(wrapped.getMessage(), sanitize(wrapped.getResponse()), wrapped.getCause());
+        super(wrapped.getMessage(), wrapped.getResponse(), wrapped.getCause());
         this.wrapped = wrapped;
+        this.sanitizedResponse = sanitize(wrapped.getResponse());
     }
 
     @Override
     public InternalServerErrorException unwrap() {
         return wrapped;
+    }
+
+    @Override
+    public Response getSanitizedResponse() {
+        return sanitizedResponse;
     }
 }

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyNotAcceptableException.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyNotAcceptableException.java
@@ -14,14 +14,21 @@ public class ResteasyNotAcceptableException extends NotAcceptableException imple
 
    private static final long serialVersionUID = 5369100091818187044L;
    private final NotAcceptableException wrapped;
+   private final Response sanitizedResponse;
 
     ResteasyNotAcceptableException(final NotAcceptableException wrapped) {
-        super(wrapped.getMessage(), sanitize(wrapped.getResponse()), wrapped.getCause());
+        super(wrapped.getMessage(), wrapped.getResponse(), wrapped.getCause());
         this.wrapped = wrapped;
+        this.sanitizedResponse = sanitize(wrapped.getResponse());
     }
 
     @Override
     public NotAcceptableException unwrap() {
         return wrapped;
+    }
+
+    @Override
+    public Response getSanitizedResponse() {
+        return sanitizedResponse;
     }
 }

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyNotAllowedException.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyNotAllowedException.java
@@ -14,14 +14,21 @@ public class ResteasyNotAllowedException extends NotAllowedException implements 
 
    private static final long serialVersionUID = -6319306078354018353L;
    private final NotAllowedException wrapped;
+   private final Response sanitizedResponse;
 
     ResteasyNotAllowedException(final NotAllowedException wrapped) {
-        super(wrapped.getMessage(), sanitize(wrapped.getResponse()), wrapped.getCause());
+        super(wrapped.getMessage(), wrapped.getResponse(), wrapped.getCause());
         this.wrapped = wrapped;
+        this.sanitizedResponse = sanitize(wrapped.getResponse());
     }
 
     @Override
     public NotAllowedException unwrap() {
         return wrapped;
+    }
+
+    @Override
+    public Response getSanitizedResponse() {
+        return sanitizedResponse;
     }
 }

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyNotAuthorizedException.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyNotAuthorizedException.java
@@ -4,6 +4,7 @@ import static org.jboss.resteasy.client.exception.WebApplicationExceptionWrapper
 
 import java.util.Collections;
 import java.util.List;
+
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.core.Response;
 
@@ -16,10 +17,12 @@ public class ResteasyNotAuthorizedException extends NotAuthorizedException imple
 
    private static final long serialVersionUID = 7034604450379314101L;
    private final NotAuthorizedException wrapped;
+   private final Response sanitizedResponse;
 
     ResteasyNotAuthorizedException(final NotAuthorizedException wrapped) {
-        super(wrapped.getMessage(), sanitize(wrapped.getResponse()), wrapped.getCause());
+        super(wrapped.getMessage(), wrapped.getResponse(), wrapped.getCause());
         this.wrapped = wrapped;
+        this.sanitizedResponse = sanitize(wrapped.getResponse());
     }
 
     @Override
@@ -30,5 +33,10 @@ public class ResteasyNotAuthorizedException extends NotAuthorizedException imple
     @Override
     public NotAuthorizedException unwrap() {
         return wrapped;
+    }
+
+    @Override
+    public Response getSanitizedResponse() {
+        return sanitizedResponse;
     }
 }

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyNotFoundException.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyNotFoundException.java
@@ -14,14 +14,21 @@ public class ResteasyNotFoundException extends NotFoundException implements WebA
 
    private static final long serialVersionUID = 8915809730318765630L;
    private final NotFoundException wrapped;
+   private final Response sanitizedResponse;
 
     ResteasyNotFoundException(final NotFoundException wrapped) {
-        super(wrapped.getMessage(), sanitize(wrapped.getResponse()), wrapped.getCause());
+        super(wrapped.getMessage(), wrapped.getResponse(), wrapped.getCause());
         this.wrapped = wrapped;
+        this.sanitizedResponse = sanitize(wrapped.getResponse());
     }
 
     @Override
     public NotFoundException unwrap() {
         return wrapped;
+    }
+
+    @Override
+    public Response getSanitizedResponse() {
+        return sanitizedResponse;
     }
 }

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyNotSupportedException.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyNotSupportedException.java
@@ -14,14 +14,21 @@ public class ResteasyNotSupportedException extends NotSupportedException impleme
 
    private static final long serialVersionUID = 6195843283913647466L;
    private final NotSupportedException wrapped;
+   private final Response sanitizedResponse;
 
     ResteasyNotSupportedException(final NotSupportedException wrapped) {
-        super(wrapped.getMessage(), sanitize(wrapped.getResponse()), wrapped.getCause());
+        super(wrapped.getMessage(), wrapped.getResponse(), wrapped.getCause());
         this.wrapped = wrapped;
+        this.sanitizedResponse = sanitize(wrapped.getResponse());
     }
 
     @Override
     public NotSupportedException unwrap() {
         return wrapped;
+    }
+
+    @Override
+    public Response getSanitizedResponse() {
+        return sanitizedResponse;
     }
 }

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyRedirectionException.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyRedirectionException.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.client.exception;
 import static org.jboss.resteasy.client.exception.WebApplicationExceptionWrapper.sanitize;
 
 import java.net.URI;
+
 import jakarta.ws.rs.RedirectionException;
 import jakarta.ws.rs.core.Response;
 
@@ -15,10 +16,12 @@ public class ResteasyRedirectionException extends RedirectionException implement
 
    private static final long serialVersionUID = 8815768802777099877L;
    private final RedirectionException wrapped;
+   private final Response sanitizedResponse;
 
     ResteasyRedirectionException(final RedirectionException wrapped) {
-        super(wrapped.getMessage(), sanitize(wrapped.getResponse()));
+        super(wrapped.getMessage(), wrapped.getResponse());
         this.wrapped = wrapped;
+        this.sanitizedResponse = sanitize(wrapped.getResponse());
     }
 
     @Override
@@ -29,5 +32,10 @@ public class ResteasyRedirectionException extends RedirectionException implement
     @Override
     public RedirectionException unwrap() {
         return wrapped;
+    }
+
+    @Override
+    public Response getSanitizedResponse() {
+        return sanitizedResponse;
     }
 }

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyServerErrorException.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyServerErrorException.java
@@ -14,14 +14,21 @@ public class ResteasyServerErrorException extends ServerErrorException implement
 
    private static final long serialVersionUID = 8591476266091129117L;
    private final ServerErrorException wrapped;
+   private final Response sanitizedResponse;
 
     ResteasyServerErrorException(final ServerErrorException wrapped) {
-        super(wrapped.getMessage(), sanitize(wrapped.getResponse()), wrapped.getCause());
+        super(wrapped.getMessage(), wrapped.getResponse(), wrapped.getCause());
         this.wrapped = wrapped;
+        this.sanitizedResponse = sanitize(wrapped.getResponse());
     }
 
     @Override
     public ServerErrorException unwrap() {
         return wrapped;
+    }
+
+    @Override
+    public Response getSanitizedResponse() {
+        return sanitizedResponse;
     }
 }

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyServiceUnavailableException.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyServiceUnavailableException.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.client.exception;
 import static org.jboss.resteasy.client.exception.WebApplicationExceptionWrapper.sanitize;
 
 import java.util.Date;
+
 import jakarta.ws.rs.ServiceUnavailableException;
 import jakarta.ws.rs.core.Response;
 
@@ -15,10 +16,12 @@ public class ResteasyServiceUnavailableException extends ServiceUnavailableExcep
 
    private static final long serialVersionUID = -4477873328299557209L;
    private final ServiceUnavailableException wrapped;
+   private final Response sanitizedResponse;
 
     ResteasyServiceUnavailableException(final ServiceUnavailableException wrapped) {
-        super(wrapped.getMessage(), sanitize(wrapped.getResponse()), wrapped.getCause());
+        super(wrapped.getMessage(), wrapped.getResponse(), wrapped.getCause());
         this.wrapped = wrapped;
+        this.sanitizedResponse = sanitize(wrapped.getResponse());
     }
 
     @Override
@@ -34,5 +37,10 @@ public class ResteasyServiceUnavailableException extends ServiceUnavailableExcep
     @Override
     public ServiceUnavailableException unwrap() {
         return wrapped;
+    }
+
+    @Override
+    public Response getSanitizedResponse() {
+        return sanitizedResponse;
     }
 }

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyWebApplicationException.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/ResteasyWebApplicationException.java
@@ -14,6 +14,7 @@ public class ResteasyWebApplicationException extends WebApplicationException imp
 
    private static final long serialVersionUID = -8805699073882024461L;
    private final WebApplicationException wrapped;
+   private final Response sanitizedResponse;
 
     /**
      * Creates a new exception based on the wrapped exception. The response will be
@@ -22,12 +23,18 @@ public class ResteasyWebApplicationException extends WebApplicationException imp
      * @param wrapped the exception to wrap
      */
     public ResteasyWebApplicationException(final WebApplicationException wrapped) {
-        super(wrapped.getMessage(), wrapped.getCause(), sanitize(wrapped.getResponse()));
+        super(wrapped.getMessage(), wrapped.getCause(), wrapped.getResponse());
         this.wrapped = wrapped;
+        this.sanitizedResponse = sanitize(wrapped.getResponse());
     }
 
     @Override
     public WebApplicationException unwrap() {
         return wrapped;
+    }
+
+    @Override
+    public Response getSanitizedResponse() {
+        return sanitizedResponse;
     }
 }

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/WebApplicationExceptionWrapper.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/exception/WebApplicationExceptionWrapper.java
@@ -38,19 +38,19 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.resteasy.spi.config.Configuration;
 import org.jboss.resteasy.spi.config.ConfigurationFactory;
 import org.jboss.resteasy.spi.ResteasyDeployment;
+import org.jboss.resteasy.spi.SanitizedResponseHolder;
 
 /**
  * An interface which allows a {@link WebApplicationException} to be unwrapped.
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public interface WebApplicationExceptionWrapper<T extends WebApplicationException> {
+public interface WebApplicationExceptionWrapper<T extends WebApplicationException> extends SanitizedResponseHolder {
 
     /**
      * If the {@code resteasy.original.webapplicationexception.behavior} is set to {@code true} or the request is
      * determined to not be a server side request, then the {@link WebApplicationException} passed in will be returned.
-     * If the property is not set to {@code true} and this is a server side request then the exception is wrapped and
-     * the response is {@linkplain #sanitize(Response) sanitized}.
+     * If the property is not set to {@code true} and this is a server side request then the exception is wrapped.
      *
      * @param e the exception to possibly wrapped
      *
@@ -123,7 +123,7 @@ public interface WebApplicationExceptionWrapper<T extends WebApplicationExceptio
     }
 
     /**
-     * Sanitizes the response by creating a new response with only the status code, allowed methods, entity and the
+     * Sanitizes the response by creating a new response with only the status code, allowed methods and the
      * media type. All other information is removed.
      *
      * @param response the response to sanitize.

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/SanitizedResponseHolder.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/SanitizedResponseHolder.java
@@ -1,0 +1,18 @@
+package org.jboss.resteasy.spi;
+
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Holder for sanitized response.
+ *
+ * @author Nicolas NESMON
+ */
+public interface SanitizedResponseHolder {
+
+   /**
+    * Returns the sanitized response.
+    *
+    * @return the sanitized response;
+    */
+    Response getSanitizedResponse();
+}

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ExceptionHandler.java
@@ -9,6 +9,7 @@ import org.jboss.resteasy.spi.HttpResponseCodes;
 import org.jboss.resteasy.spi.NoLogWebApplicationException;
 import org.jboss.resteasy.spi.ReaderException;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.SanitizedResponseHolder;
 import org.jboss.resteasy.spi.UnhandledException;
 import org.jboss.resteasy.spi.WriterException;
 import org.jboss.resteasy.tracing.RESTEasyTracingLogger;
@@ -29,6 +30,7 @@ import java.util.Set;
  */
 public class ExceptionHandler
 {
+
    protected ResteasyProviderFactoryImpl providerFactory;
    protected Set<String> unwrappedExceptions = new HashSet<String>();
    protected boolean mapperExecuted;
@@ -171,7 +173,8 @@ public class ExceptionHandler
          Response response = wae.getResponse();
          if (response != null) {
             try {
-               if (response.getEntity() != null) return response;
+               if (response.getEntity() != null)
+                  return wae instanceof SanitizedResponseHolder ? ((SanitizedResponseHolder) wae).getSanitizedResponse() : wae.getResponse();
             }
             catch(IllegalStateException ise) {
                // IllegalStateException from ClientResponse.getEntity() means the response is closed and got no entity
@@ -224,7 +227,7 @@ public class ExceptionHandler
       LogMessages.LOGGER.failedExecutingDebug(request.getHttpMethod(),
               request.getUri().getPath(), e);
 
-      Response response = e.getResponse();
+      Response response = e instanceof SanitizedResponseHolder ? ((SanitizedResponseHolder) e).getSanitizedResponse() : e.getResponse();
 
       if (response != null)
       {
@@ -291,7 +294,7 @@ public class ExceptionHandler
       {
          LogMessages.LOGGER.failedToExecute(wae);
       }
-      Response response = wae.getResponse();
+      Response response = wae instanceof SanitizedResponseHolder ? ((SanitizedResponseHolder) wae).getSanitizedResponse() : wae.getResponse();
       return response;
    }
 
@@ -325,7 +328,13 @@ public class ExceptionHandler
             WebApplicationException wae = (WebApplicationException) e;
             if (wae.getResponse() != null && wae.getResponse().getEntity() != null)
             {
-               jaxrsResponse = wae.getResponse();
+               if (wae instanceof SanitizedResponseHolder)
+               {
+                  jaxrsResponse = ((SanitizedResponseHolder) wae).getSanitizedResponse();
+               } else
+               {
+                  jaxrsResponse = wae.getResponse();
+               }
             } else
             {
                // look at exception's subClass tree for possible mappers
@@ -369,4 +378,5 @@ public class ExceptionHandler
       }
       return jaxrsResponse;
    }
+
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/ClientWebApplicationExceptionResteasyProxyTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/ClientWebApplicationExceptionResteasyProxyTest.java
@@ -106,7 +106,7 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
    /**
     * @tpTestDetails For each ResteasyWebApplicationException in newExceptions, calls the resource method newException() to throw
     *                that ResteasyWebApplicationException. Since it is running on the client side, the standard behavior of throwing a
-    *                WebApplicationException will occur. That WebApplicationException should match the result returned by newException().
+    *                WebApplicationException will occur. That WebApplicationException should be sanitized.
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
@@ -133,12 +133,12 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
     * @tpTestDetails 1. The value of ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is
     *                   set to "true" to compel the original Client behavior on the server side.
     *
-    *                2. For each WebApplicationException in oldExceptions, the resource method noCatchOld() is called.
+    *                2. For each WebApplicationException in oldExceptions, the resource method noCatchOldOld() is called.
     *
-    *                3. noCatchOld() calls oldException(), which throws the chosen member of oldExceptions. The resulting
+    *                3. noCatchOldOld() calls oldException(), which throws the chosen member of oldExceptions. The resulting
     *                   HTTP response contains the status, headers, and entity in that WebApplicationException.
     *
-    *                4. In noCatchOld(), the original behavior causes the HTTP response to be turned into a WebApplicationException,
+    *                4. In noCatchOldOld(), the original behavior causes the HTTP response to be turned into a WebApplicationException,
     *                   which is thrown by the Client. The resulting HTTP response contains the status, headers, and entity in that
     *                   WebApplicationException.
     *
@@ -173,12 +173,12 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
     *                   set to "true" to compel the original Client behavior on the server side.
     *
     *                2. For each ResteasyWebApplicationException in ClientWebApplicationExceptionTest.newExceptions,
-    *                   the resource method noCatchNew() is called.
+    *                   the resource method noCatchOldNew() is called.
     *
-    *                3. noCatchNew() calls newException(), which throws the matching member of newExceptions. The resulting
+    *                3. noCatchOldNew() calls newException(), which throws the matching member of newExceptions. The resulting
     *                   Response is sanitized.
     *
-    *                4. In noCatchNew(), the original behavior causes the HTTP response to be turned into a WebApplicationException,
+    *                4. In noCatchOldNew(), the original behavior causes the HTTP response to be turned into a WebApplicationException,
     *                   which is thrown by the Client. The resulting HTTP response is sanitized.
     *
     *                5. The client side Client constructs and throws a WebApplicationException which is checked for a sanitized
@@ -209,12 +209,12 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
    }
 
    /**
-    * @tpTestDetails 1. For each WebApplicationException in oldExceptions, the resource method noCatchOld() is called.
+    * @tpTestDetails 1. For each WebApplicationException in oldExceptions, the resource method noCatchNewOld() is called.
     *
-    *                2. noCatchOld() calls oldException(), which throws the matching member of oldExceptions. The resulting
+    *                2. noCatchNewOld() calls oldException(), which throws the matching member of oldExceptions. The resulting
     *                   HTTP response contains the status, headers, and entity in that WebApplicationException.
     *
-    *                3. In noCatchOld(), the new behavior causes the HTTP response to be turned into a ResteasyWebApplicationException,
+    *                3. In noCatchNewOld(), the new behavior causes the HTTP response to be turned into a ResteasyWebApplicationException,
     *                   which is thrown by the Client. ResteasyWebApplicationException.getResponse() returns a sanitized Response.
     *
     *                4. The client side Client constructs and throws a WebApplicationException which is checked for a sanitized
@@ -242,12 +242,12 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
    }
 
    /**
-    * @tpTestDetails 1. For each ResteasyWebApplicationException in newExceptions, the resource method noCatchNew() is called.
+    * @tpTestDetails 1. For each ResteasyWebApplicationException in newExceptions, the resource method noCatchNewNew() is called.
     *
-    *                2. noCatchNew() calls newException(), which throws the matching member of newExceptions.
-    *                   ResteasyWebApplicationException.getResponse() returns a sanitized Response.
+    *                2. noCatchNewNew() calls newException(), which throws the matching member of newExceptions.
+    *                   The resulting response is sanitized.
     *
-    *                3. In noCatchNew(), the new behavior causes the HTTP response to be turned into a ResteasyWebApplicationException,
+    *                3. In noCatchNewNew(), the new behavior causes the HTTP response to be turned into a ResteasyWebApplicationException,
     *                   which is thrown by the Client. The resulting  HTTP response has a sanitized Response.
     *
     *                4. The client side Client constructs and throws a WebApplicationException which is checked for a sanitized
@@ -323,7 +323,7 @@ public class ClientWebApplicationExceptionResteasyProxyTest {
     *                2. For each ResteasyWebApplicationException in newExceptions, the resource method catchOldNew() is called.
     *
     *                3. catchOldNew() calls newException(), which throws the chosen member of newExceptions.
-    *                   ResteasyWebApplicationException.getResponse() returns a sanitized Response.
+    *                   The resulting response is sanitized.
     *
     *                4. In catchOldNew(), the original behavior causes the HTTP response to be turned into a WebApplicationException,
     *                   which is thrown by the Client. That WebApplicationException is caught, verified to

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/ClientWebApplicationExceptionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/ClientWebApplicationExceptionTest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotAcceptableException;
 import jakarta.ws.rs.NotAllowedException;
@@ -83,7 +84,7 @@ public class ClientWebApplicationExceptionTest {
          new WebApplicationException(commonBuilder.status(401).build()),
          new WebApplicationException(commonBuilder.status(403).build()),
          new WebApplicationException(commonBuilder.status(404).build()),
-         new WebApplicationException(commonBuilder.status(405).build()),
+         new WebApplicationException(Response.fromResponse(commonBuilder.status(405).build()).allow(HttpMethod.GET).build()),
          new WebApplicationException(commonBuilder.status(406).build()),
          new WebApplicationException(commonBuilder.status(415).build()),
          new WebApplicationException(commonBuilder.status(500).build()),

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/ClientWebApplicationExceptionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/ClientWebApplicationExceptionTest.java
@@ -223,7 +223,7 @@ public class ClientWebApplicationExceptionTest {
    /**
     *  @tpTestDetails For each ResteasyWebApplicationException in newExceptions, calls the resource method newException() to throw
     *                 that ResteasyWebApplicationException. Since it is running on the client side, the standard behavior of throwing a
-    *                 WebApplicationException will occur. That WebApplicationException should match the result returned by newException()
+    *                 WebApplicationException will occur. That WebApplicationException should be sanitized.
     * @tpSince RESTEasy 4.6.0.Final
     */
    @Test
@@ -250,12 +250,12 @@ public class ClientWebApplicationExceptionTest {
     * @tpTestDetails  1. The value of ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is
     *                    set to "true" to compel the original Client behavior on the server side.
     *
-    *                 2. For each WebApplicationException in oldExceptions, the resource method noCatchOld() is called.
+    *                 2. For each WebApplicationException in oldExceptions, the resource method noCatchOldOld() is called.
     *
-    *                 3. noCatchOld() calls oldException(), which throws the chosen member of oldExceptions. The resulting
+    *                 3. noCatchOldOld() calls oldException(), which throws the chosen member of oldExceptions. The resulting
     *                    HTTP response contains the status, headers, and entity in that WebApplicationException.
     *
-    *                 4. In noCatchOld(), the original behavior causes the HTTP response to be turned into a WebApplicationException,
+    *                 4. In noCatchOldOld(), the original behavior causes the HTTP response to be turned into a WebApplicationException,
     *                    which is thrown by the Client. The resulting HTTP response contains the status, headers, and entity in that
     *                    WebApplicationException.
     *
@@ -289,12 +289,12 @@ public class ClientWebApplicationExceptionTest {
     * @tpTestDetails 1. The value of ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR is
     *                   set to "true" to compel the original Client behavior on the server side.
     *
-    *                2. For each ResteasyWebApplicationException in newExceptions, the resource method noCatchNew() is called.
+    *                2. For each ResteasyWebApplicationException in newExceptions, the resource method noCatchOldNew() is called.
     *
-    *                3. noCatchNew() calls newException(), which throws the matching member of newExceptions. The resulting
+    *                3. noCatchOldNew() calls newException(), which throws the matching member of newExceptions. The resulting
     *                   Response is sanitized.
     *
-    *                4. In noCatchNew(), the original behavior causes the HTTP response to be turned into a WebApplicationException,
+    *                4. In noCatchOldNew(), the original behavior causes the HTTP response to be turned into a WebApplicationException,
     *                   which is thrown by the Client. The resulting HTTP response is sanitized.
     *
     *                5. The client side Client constructs and throws a WebApplicationException which is checked for a sanitized
@@ -325,12 +325,12 @@ public class ClientWebApplicationExceptionTest {
    }
 
    /**
-    * @tpTestDetails 1. For each WebApplicationException in oldExceptions, the resource method noCatchOld() is called.
+    * @tpTestDetails 1. For each WebApplicationException in oldExceptions, the resource method noCatchNewOld() is called.
     *
-    *                2. noCatchOld() calls oldException(), which throws the matching member of oldExceptions. The resulting
+    *                2. noCatchNewOld() calls oldException(), which throws the matching member of oldExceptions. The resulting
     *                   HTTP response contains the status, headers, and entity in that WebApplicationException.
     *
-    *                3. In noCatchOld(), the new behavior causes the HTTP response to be turned into a WebApplicationExceptionWrapper,
+    *                3. In noCatchNewOld(), the new behavior causes the HTTP response to be turned into a WebApplicationExceptionWrapper,
     *                   which is thrown by the Client. WebApplicationExceptionWrapper.getResponse() returns a sanitized Response.
     *
     *                4. The client side Client constructs and throws a WebApplicationException which is checked for a sanitized
@@ -358,12 +358,12 @@ public class ClientWebApplicationExceptionTest {
    }
 
    /**
-    * @tpTestDetails 1. For each ResteasyWebApplicationException in newExceptions, the resource method noCatchNew() is called.
+    * @tpTestDetails 1. For each ResteasyWebApplicationException in newExceptions, the resource method noCatchNewNew() is called.
     *
-    *                2. noCatchNew() calls newException(), which throws the matching member of newExceptions.
-    *                   WebApplicationExceptionWrapper.getResponse() returns a sanitized Response.
+    *                2. noCatchNewNew() calls newException(), which throws the matching member of newExceptions.
+    *                   The resulting response is sanitized.
     *
-    *                3. In noCatchNew(), the new behavior causes the HTTP response to be turned into a WebApplicationExceptionWrapper,
+    *                3. In noCatchNewNew(), the new behavior causes the HTTP response to be turned into a WebApplicationExceptionWrapper,
     *                   which is thrown by the Client. The resulting  HTTP response has a sanitized Response.
     *
     *                4. The client side Client constructs and throws a WebApplicationException which is checked for a sanitized
@@ -439,7 +439,7 @@ public class ClientWebApplicationExceptionTest {
     *                2. For each ResteasyWebApplicationException in newExceptions, the resource method catchOldNew() is called.
     *
     *                3. catchOldNew() calls newException(), which throws the chosen member of newExceptions.
-    *                   WebApplicationExceptionWrapper.getResponse() returns a sanitized Response.
+    *                   The resulting response is sanitized.
     *
     *                4. In catchOldNew(), the original behavior causes the HTTP response to be turned into a WebApplicationException,
     *                   which is thrown by the Client. That WebApplicationException is caught, verified to

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/resource/ClientWebApplicationExceptionResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/resource/ClientWebApplicationExceptionResource.java
@@ -42,7 +42,8 @@ public class ClientWebApplicationExceptionResource {
 
    /**
     * Throws an instance of ResteasyWebApplicationException from newExceptions table.
-    * ResteasyWebApplicationException.getResponse() returns a sanitized response.
+    * ResteasyWebApplicationException.getResponse() will be used by the container to create a sanitized
+    * HTTP response.
     *
     * @param i determines element of newExceptions to be thrown
     * @throws Exception
@@ -174,10 +175,10 @@ public class ClientWebApplicationExceptionResource {
     * It is assumed that ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR holds
     * "false" when this method is invoked.
     *
-    * Uses a Client to call oldException().  Since the new behavior is configured, the proxy will throw a
-    * WebApplicationExceptionWrapper, which is caught and examined. getResponse() should return a sanitized
-    * Response, but the unwrapped Response should match the WebApplicationException
-    * thrown by oldException(). That WebApplicationExceptionWrapper is then rethrown.
+    * Uses a Client to call oldException().  Since the new behavior is configured, the client will throw a
+    * WebApplicationExceptionWrapper, which is caught and examined. getResponse() and the unwrapped Response
+    * should match the WebApplicationException thrown by oldException().
+    * That WebApplicationExceptionWrapper is then rethrown.
     *
     * @param i determines element of oldExceptions to be thrown by oldException()
     * @throws Exception
@@ -189,16 +190,13 @@ public class ClientWebApplicationExceptionResource {
          newBehaviorTarget.path("exception/old/" + i).request().get(String.class);
          throw new Exception("expected exception");
       } catch (WebApplicationException e) {
-         Response sanitizedResponse = e.getResponse();
-         Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getStatus(), sanitizedResponse.getStatus());
-         Assert.assertNull(sanitizedResponse.getHeaderString("foo"));
-         Assert.assertFalse(sanitizedResponse.hasEntity());
-         Response originalResponse = WebApplicationExceptionWrapper.unwrap(e).getResponse();
-         Assert.assertNotNull(originalResponse);
-         Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getStatus(), originalResponse.getStatus());
-         Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getHeaderString("foo"), originalResponse.getHeaderString("foo"));
-         Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getEntity(), originalResponse.readEntity(String.class));
-         Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptionMap.get(originalResponse.getStatus()), e.getClass());
+         Response notSanitizedResponse = e.getResponse();
+         Assert.assertNotNull(notSanitizedResponse);
+         Assert.assertEquals(WebApplicationExceptionWrapper.unwrap(e).getResponse(), notSanitizedResponse);
+         Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getStatus(), notSanitizedResponse.getStatus());
+         Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getHeaderString("foo"), notSanitizedResponse.getHeaderString("foo"));
+         Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getEntity(), notSanitizedResponse.readEntity(String.class));
+         Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptionMap.get(notSanitizedResponse.getStatus()), e.getClass());
          throw e;
       } catch (Exception e) {
          throw new Exception("expected WebApplicationException, not " + e.getClass());
@@ -209,10 +207,10 @@ public class ClientWebApplicationExceptionResource {
     * It is assumed that ResteasyContextParameters.RESTEASY_ORIGINAL_WEBAPPLICATIONEXCEPTION_BEHAVIOR holds
     * "false" when this method is invoked.
     *
-    * Uses a Client to call newException(). Since the new behavior is configured, the proxy will throw a
-    * WebApplicationExceptionWrapper, which is caught and examined. getResponse() should return a sanitized
-    * Response, but the unwrapped Response should match the WebApplicationException
-    * thrown by newException(). That WebApplicationExceptionWrapper is then rethrown.
+    * Uses a Client to call newException(). Since the new behavior is configured, the client will throw a
+    * WebApplicationExceptionWrapper, which is caught and examined. getResponse() and the unwrapped Response
+    * should a sanitized response.
+    * That WebApplicationExceptionWrapper is then rethrown.
     *
     * @param i determines element of newExceptions to be thrown by newException()
     * @throws Exception
@@ -225,15 +223,12 @@ public class ClientWebApplicationExceptionResource {
          throw new Exception("expected exception");
       } catch (WebApplicationException e) {
          Response sanitizedResponse = e.getResponse();
+         Assert.assertNotNull(sanitizedResponse);
+         Assert.assertEquals(WebApplicationExceptionWrapper.unwrap(e).getResponse(), sanitizedResponse);
          Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptions[i].getResponse().getStatus(), sanitizedResponse.getStatus());
          Assert.assertNull(sanitizedResponse.getHeaderString("foo"));
-         Assert.assertFalse(sanitizedResponse.hasEntity());
-         Response originalResponse = WebApplicationExceptionWrapper.unwrap(e).getResponse();
-         Assert.assertNotNull(originalResponse);
-         Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptions[i].getResponse().getStatus(), originalResponse.getStatus());
-         Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptions[i].getResponse().getHeaderString("foo"), originalResponse.getHeaderString("foo"));
-         Assert.assertTrue(originalResponse.readEntity(String.class).isEmpty());
-         Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptionMap.get(originalResponse.getStatus()), e.getClass());
+         Assert.assertTrue(sanitizedResponse.readEntity(String.class).isEmpty());
+         Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptionMap.get(sanitizedResponse.getStatus()), e.getClass());
          throw e;
       } catch (Exception e) {
          throw new Exception("expected WebApplicationException, not " + e.getClass());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/resource/ClientWebApplicationExceptionResteasyProxyResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/resource/ClientWebApplicationExceptionResteasyProxyResource.java
@@ -44,7 +44,9 @@ public class ClientWebApplicationExceptionResteasyProxyResource {
 
    /**
     * Throws an instance of ResteasyWebApplicationException from newExceptions table.
-    * ResteasyWebApplicationException.getResponse() returns a sanitized response.
+    * ResteasyWebApplicationException.getResponse() will be used by the container to create a sanitized
+    * HTTP response.
+    *
     * @param i determines element of newExceptions to be thrown
     * @throws Exception
     */
@@ -176,9 +178,9 @@ public class ClientWebApplicationExceptionResteasyProxyResource {
     * "false" when this method is invoked.
     *
     * Uses a Client to call oldException().  Since the new behavior is configured, the proxy will throw a
-    * WebApplicationExceptionWrapper, which is caught and examined. getResponse() should return a sanitized
-    * Response, but the unwrapped Response should match the WebApplicationException
-    * thrown by oldException(). That WebApplicationExceptionWrapper is then rethrown.
+    * WebApplicationExceptionWrapper, which is caught and examined. getResponse() and the unwrapped Response
+    * should match the WebApplicationException thrown by oldException().
+    * That WebApplicationExceptionWrapper is then rethrown.
     *
     * @param i determines element of oldExceptions to be thrown by oldException()
     * @throws Exception
@@ -189,16 +191,13 @@ public class ClientWebApplicationExceptionResteasyProxyResource {
       try {
          return newBehaviorProxy.oldException(i);
       } catch (WebApplicationException e) {
-         Response sanitizedResponse = e.getResponse();
-         Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getStatus(), sanitizedResponse.getStatus());
-         Assert.assertNull(sanitizedResponse.getHeaderString("foo"));
-         Assert.assertFalse(sanitizedResponse.hasEntity());
-         Response originalResponse = WebApplicationExceptionWrapper.unwrap(e).getResponse();
-         Assert.assertNotNull(originalResponse);
-         Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getStatus(), originalResponse.getStatus());
-         Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getHeaderString("foo"), originalResponse.getHeaderString("foo"));
-         Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getEntity(), originalResponse.readEntity(String.class));
-         Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptionMap.get(originalResponse.getStatus()), e.getClass());
+         Response notSanitizedResponse = e.getResponse();
+         Assert.assertNotNull(notSanitizedResponse);
+         Assert.assertEquals(WebApplicationExceptionWrapper.unwrap(e).getResponse(), notSanitizedResponse);
+         Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getStatus(), notSanitizedResponse.getStatus());
+         Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getHeaderString("foo"), notSanitizedResponse.getHeaderString("foo"));
+         Assert.assertEquals(ClientWebApplicationExceptionTest.oldExceptions[i].getResponse().getEntity(), notSanitizedResponse.readEntity(String.class));
+         Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptionMap.get(notSanitizedResponse.getStatus()), e.getClass());
          throw e;
       } catch (Exception e) {
          throw new Exception("expected ResteasyWebApplicationException, not " + e.getClass());
@@ -210,9 +209,9 @@ public class ClientWebApplicationExceptionResteasyProxyResource {
     * "false" when this method is invoked.
     *
     * Uses a Client to call newException(). Since the new behavior is configured, the proxy will throw a
-    * WebApplicationExceptionWrapper, which is caught and examined. getResponse() should return a sanitized
-    * Response, but the unwrapped Response should match the WebApplicationException
-    * thrown by newException(). That WebApplicationExceptionWrapper is then rethrown.
+    * WebApplicationExceptionWrapper, which is caught and examined. getResponse() and the unwrapped Response
+    * should a sanitized response.
+    * That WebApplicationExceptionWrapper is then rethrown.
     *
     * @param i determines element of newExceptions to be thrown by newException()
     * @throws Exception
@@ -224,15 +223,12 @@ public class ClientWebApplicationExceptionResteasyProxyResource {
          return newBehaviorProxy.newException(i);
       } catch (WebApplicationException e) {
          Response sanitizedResponse = e.getResponse();
+         Assert.assertNotNull(sanitizedResponse);
+         Assert.assertEquals(WebApplicationExceptionWrapper.unwrap(e).getResponse(), sanitizedResponse);
          Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptions[i].getResponse().getStatus(), sanitizedResponse.getStatus());
          Assert.assertNull(sanitizedResponse.getHeaderString("foo"));
-         Assert.assertFalse(sanitizedResponse.hasEntity());
-         Response originalResponse = WebApplicationExceptionWrapper.unwrap(e).getResponse();
-         Assert.assertNotNull(originalResponse);
-         Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptions[i].getResponse().getStatus(), originalResponse.getStatus());
-         Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptions[i].getResponse().getHeaderString("foo"), originalResponse.getHeaderString("foo"));
-         Assert.assertTrue(originalResponse.readEntity(String.class).isEmpty());
-         Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptionMap.get(originalResponse.getStatus()), e.getClass());
+         Assert.assertTrue(sanitizedResponse.readEntity(String.class).isEmpty());
+         Assert.assertEquals(ClientWebApplicationExceptionTest.newExceptionMap.get(sanitizedResponse.getStatus()), e.getClass());
          throw e;
       } catch (Exception e) {
          throw new Exception("expected WebApplicationException, not " + e.getClass());


### PR DESCRIPTION
Hi guys,

This PR is my proposal to fix inconsistency spotted by this [JIRA](https://issues.redhat.com/browse/RESTEASY-3096).

As I said in the JIRA description, the way `WebApplicationException` thrown by client in a server side context are handled, using subtypes of  `org.jboss.resteasy.client.exception.WebApplicationExceptionWrapper` to return a sanitized `jakarta.ws.rs.core.Response`  with no entity and only few important headers, looks fine to me and does not bother me.

But what bothers me more is, the insconsistency in the `WebApplicationException#getResponse()` method behavior:

- If  `WebApplicationException` is thrown by client in a server side context, then `WebApplicationException#getResponse()`  returns a sanitized reponse that does not match nor represents the remote side response.
- But if  `WebApplicationException` is thrown by client in a non server side context, then `WebApplicationException#getResponse()`  returns a reponse that match and represents the remote side response.

This inconsitency does not make sense to me and AFAIK is not written in the JAX-RS spec. More, in case of  `WebApplicationException` thrown by client in a server side context, to get the real response developper must write RESTeasy specific code and add a compile dependency to RESTeasy to invoke `WebApplicationExceptionWrapper.unwrap`. To my mind it's a bit restrictive. I mean as a developper I should not have to depend on any implementation to get a basic response.

So this proposal is about:
- making `WebApplicationException#getResponse()` consistent and always return the exact remote side response, regardless of  where the `WebApplicationException` is thrown (server side context or not).
- preserving current `WebApplicationException` thrown by client in a server side context handling.

Let me know what you think.

Thanks

Nicolas