### PR TITLE
RESTEASY-3118 Upgrade Spring to 5.3.18

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -103,7 +103,7 @@
         <version.org.hibernate.validator>6.2.0.Final</version.org.hibernate.validator>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.6.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.rest-assured>3.3.0</version.rest-assured>
-        <version.org.springframework>5.3.7</version.org.springframework>
+        <version.org.springframework>5.3.18</version.org.springframework>
         <version.io.projectreactor>2020.0.8</version.io.projectreactor>
 
         <version.asyncutil>0.1.0</version.asyncutil>

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/TestUtilSpring.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/TestUtilSpring.java
@@ -12,7 +12,8 @@ import java.util.List;
  */
 public class TestUtilSpring {
 
-   private static final String defaultSpringVersion = "5.3.7";
+
+   private static final String defaultSpringVersion = "5.3.18";
    //protected static Logger logger;
 
    /**


### PR DESCRIPTION
According to Spring blog: https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement

We need to update Spring version to address vulnerability.