### PR TITLE
Revert "[RESTEASY-3101] Upgrade Jakarta JSON Processing to 2.1 and move to ne…"

### DIFF
--- a/providers/json-binding/pom.xml
+++ b/providers/json-binding/pom.xml
@@ -32,8 +32,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.parsson</groupId>
-            <artifactId>parsson</artifactId>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.json.bind</groupId>

--- a/providers/json-p-ee7/pom.xml
+++ b/providers/json-p-ee7/pom.xml
@@ -34,8 +34,8 @@
             <artifactId>jakarta.json-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.parsson</groupId>
-            <artifactId>parsson</artifactId>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -34,7 +34,7 @@
         <version.jakarta.activation>2.0.0</version.jakarta.activation>
         <version.jakarta.enterprise.cdi-api>3.0.0</version.jakarta.enterprise.cdi-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.0</version.jakarta.inject.jakarta.inject-api>
-        <version.jakarta.json-api>2.1.0</version.jakarta.json-api>
+        <version.jakarta.json-api>2.0.0</version.jakarta.json-api>
         <version.jakarta.json.bind-api>2.0.0</version.jakarta.json.bind-api>
         <version.jakarta.validation-api>3.0.0</version.jakarta.validation-api>
         <version.junit>4.13.1</version.junit>
@@ -47,10 +47,10 @@
         <version.org.bouncycastle>1.70</version.org.bouncycastle>
         <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
         <version.org.eclipse.jetty>11.0.7</version.org.eclipse.jetty>
-        <version.org.eclipse.parsson>1.1.0</version.org.eclipse.parsson>
         <version.org.eclipse.yasson>2.0.1</version.org.eclipse.yasson>
         <version.com.github.tomakehurst.wiremock>2.20.0</version.com.github.tomakehurst.wiremock>
         <version.org.glassfish.jakarta.el>4.0.0</version.org.glassfish.jakarta.el>
+        <version.org.glassfish.jakarta.json>2.0.0</version.org.glassfish.jakarta.json>
         <version.jakarta.persistence.persistence-api>3.0.0</version.jakarta.persistence.persistence-api>
         <version.org.jacoco>0.8.7</version.org.jacoco>
         <version.org.jboss.logging.jboss-logging>3.4.2.Final</version.org.jboss.logging.jboss-logging>
@@ -434,11 +434,6 @@
                 <artifactId>jakarta.json-api</artifactId>
                 <version>${version.jakarta.json-api}</version>
             </dependency>
-            <dependency> <!-- json-p ri -->
-                <groupId>org.eclipse.parsson</groupId>
-                <artifactId>parsson</artifactId>
-                <version>${version.org.eclipse.parsson}</version>
-            </dependency>
             <dependency>
                 <groupId>jakarta.json.bind</groupId>
                 <artifactId>jakarta.json.bind-api</artifactId>
@@ -462,6 +457,11 @@
                         <artifactId>jakarta.json</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>jakarta.json</artifactId>
+                <version>${version.org.glassfish.jakarta.json}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.servlet</groupId>

--- a/server-adapters/resteasy-vertx/pom.xml
+++ b/server-adapters/resteasy-vertx/pom.xml
@@ -97,8 +97,8 @@
         </dependency>
         <!-- Jakarta JSON Processing implementation -->
         <dependency>
-            <groupId>org.eclipse.parsson</groupId>
-            <artifactId>parsson</artifactId>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Reverts resteasy/resteasy#3062

This breaks the TCK, so we need to revert it for now. We likely need the JSON Binding upgrade too. At this point we're waiting for an Eclipse Yasson release.