### PR TITLE
[RESTEASY-3151] Upgrade WildFly to 27.0.0.Alpha1 for CI runs.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest ]
         java: ['11', '17']
-        wildfly-version: ['26.1.0.Final']
+        wildfly-version: ['27.0.0.Alpha1']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-3151
Signed-off-by: James R. Perkins <jperkins@redhat.com>