### PR TITLE
Remove non-existing resteasy-reactive-context constraint

### DIFF
--- a/resteasy-bom/pom.xml
+++ b/resteasy-bom/pom.xml
@@ -188,11 +188,6 @@
             </dependency>
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-reactive-context</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
                  <artifactId>resteasy-rxjava2</artifactId>
                  <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Remove non-existing resteasy-reactive-context version constraint from the resteasy-bom.