### PR TITLE
[RESTEASY-3167] Upgrade Jetty from 11.0.7 to 11.0.11

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -47,7 +47,7 @@
         <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
         <version.org.eclipse.angus.angus-activation>1.0.0</version.org.eclipse.angus.angus-activation>
         <version.org.eclipse.angus.angus-mail>1.0.0</version.org.eclipse.angus.angus-mail>
-        <version.org.eclipse.jetty>11.0.7</version.org.eclipse.jetty>
+        <version.org.eclipse.jetty>11.0.11</version.org.eclipse.jetty>
         <version.org.eclipse.parsson>1.1.0</version.org.eclipse.parsson>
         <version.org.eclipse.yasson>3.0.0</version.org.eclipse.yasson>
         <version.com.github.tomakehurst.wiremock>2.20.0</version.com.github.tomakehurst.wiremock>


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-3167
Signed-off-by: James R. Perkins <jperkins@redhat.com>