### PR TITLE
Use install for the JavaDoc CI build as verify seems to cause some is…

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -59,5 +59,5 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Build Java Docs with Java 11
-        run: mvn clean site verify -U -B -DskipTests
+        run: mvn clean site install -B -DskipTests
 


### PR DESCRIPTION
…sues.

Signed-off-by: James R. Perkins <jperkins@redhat.com>