### PR TITLE
[RESTEASY-3176] Upgrade WildFly to 27.0.0.Alpha4. Migrate away from W…

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest ]
         java: ['11', '17']
-        wildfly-version: ['27.0.0.Alpha3']
+        wildfly-version: ['27.0.0.Alpha4']
 
     steps:
       - uses: actions/checkout@v2

--- a/docbook/reference/en/en-US/modules/Installation_Configuration.xml
+++ b/docbook/reference/en/en-US/modules/Installation_Configuration.xml
@@ -271,6 +271,11 @@
         <offline>false</offline>
         <feature-packs>
             <feature-pack>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-ee-galleon-pack</artifactId>
+                <version>${version.org.wildfly}</version>
+            </feature-pack>
+            <feature-pack>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>galleon-feature-pack</artifactId>
                 <version>6.1.1.Final-SNAPSHOT</version>

--- a/galleon-feature-pack/pom.xml
+++ b/galleon-feature-pack/pom.xml
@@ -47,23 +47,8 @@
         <!-- Feature pack dependencies -->
         <dependency>
             <groupId>org.wildfly</groupId>
-            <artifactId>wildfly-preview-feature-pack</artifactId>
+            <artifactId>wildfly-ee-galleon-pack</artifactId>
             <type>zip</type>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.sun.xml.ws</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.jaxb</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.galleon-plugins</groupId>
-            <artifactId>transformer</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <!-- Other dependencies -->

--- a/galleon-feature-pack/wildfly-feature-pack-build.xml
+++ b/galleon-feature-pack/wildfly-feature-pack-build.xml
@@ -19,8 +19,8 @@
   -->
 <build xmlns="urn:wildfly:feature-pack-build:3.1" producer="org.jboss.resteasy:galleon-feature-pack">
     <dependencies>
-        <dependency group-id="org.wildfly" artifact-id="wildfly-preview-feature-pack" translate-to-fpl="true">
-            <name>org.wildfly:wildfly-preview-feature-pack</name>
+        <dependency group-id="org.wildfly" artifact-id="wildfly-ee-galleon-pack" translate-to-fpl="true">
+            <name>org.wildfly:wildfly-ee-galleon-pack</name>
             <packages inherit="true">
                 <!-- Exclude modules no longer provided by RESTEasy -->
                 <exclude name="org.jboss.resteasy.resteasy-spring"/>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <dep.arquillian-bom.version>1.7.0.Alpha10</dep.arquillian-bom.version>
         <version.org.jboss.arquillian.container.arquillian-weld-embedded>2.0.0.Final</version.org.jboss.arquillian.container.arquillian-weld-embedded>
         <version.org.jboss.resteasy.checkstyle>1.0.0.Final</version.org.jboss.resteasy.checkstyle>
-        <server.version>27.0.0.Alpha3</server.version>
+        <server.version>27.0.0.Alpha4</server.version>
         <version.org.wildfly>${server.version}</version.org.wildfly>
         <version.org.wildfly.arquillian.wildfly-arquillian>5.0.0.Alpha3</version.org.wildfly.arquillian.wildfly-arquillian>
 
@@ -54,8 +54,8 @@
         <!-- Plugins versions -->
         <version.javadoc.plugin>3.3.1</version.javadoc.plugin>
         <version.org.jacoco.plugin>0.7.9</version.org.jacoco.plugin>
-        <version.org.jboss.galleon>5.0.2.Final</version.org.jboss.galleon>
-        <version.org.wildfly.galleon-plugins>5.2.2.Final</version.org.wildfly.galleon-plugins>
+        <version.org.jboss.galleon>5.0.5.Final</version.org.jboss.galleon>
+        <version.org.wildfly.galleon-plugins>5.2.11.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.plugins.wildfly-maven-plugin>2.1.0.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
 
@@ -183,7 +183,7 @@
                     </dependency>
                     <dependency>
                         <groupId>org.wildfly</groupId>
-                        <artifactId>wildfly-preview-feature-pack</artifactId>
+                        <artifactId>wildfly-ee-galleon-pack</artifactId>
                         <version>${version.org.wildfly}</version>
                         <type>zip</type>
                     </dependency>
@@ -198,18 +198,6 @@
                         <artifactId>wildfly-config-gen</artifactId>
                         <version>${version.org.wildfly.galleon-plugins}</version>
                     </dependency>
-                    <dependency>
-                        <groupId>org.wildfly.galleon-plugins</groupId>
-                        <artifactId>transformer</artifactId>
-                        <version>${version.org.wildfly.galleon-plugins}</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>*</groupId>
-                                <artifactId>*</artifactId>
-                            </exclusion>
-                        </exclusions>
-                    </dependency>
-
                 </dependencies>
             </dependencyManagement>
         </profile>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -143,7 +143,7 @@
                     <feature-packs>
                         <feature-pack>
                             <groupId>org.wildfly</groupId>
-                            <artifactId>wildfly-preview-feature-pack</artifactId>
+                            <artifactId>wildfly-ee-galleon-pack</artifactId>
                             <version>${version.org.wildfly}</version>
                             <inherit-configs>false</inherit-configs>
                             <included-configs>


### PR DESCRIPTION
…ildFly Preview to the standard WildFly EE Galleon Pack.

https://issues.redhat.com/browse/RESTEASY-3176
Signed-off-by: James R. Perkins <jperkins@redhat.com>