### PR TITLE
Remove the maven-help-plugin from the testsuite POM.

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -79,19 +79,6 @@
 
     <build>
         <plugins>
-            <!-- rls test
-            <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-help-plugin</artifactId>
-                    <version>3.2.0</version>
-            </plugin>
--->
-            <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-help-plugin</artifactId>
-                    <version>3.2.0</version>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
Signed-off-by: James R. Perkins <jperkins@redhat.com>