### PR TITLE
[RESTEASY-3179] Remove wiremock which is no longer used.

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -52,7 +52,6 @@
         <version.org.eclipse.jetty>11.0.11</version.org.eclipse.jetty>
         <version.org.eclipse.parsson>1.1.0</version.org.eclipse.parsson>
         <version.org.eclipse.yasson>3.0.0</version.org.eclipse.yasson>
-        <version.com.github.tomakehurst.wiremock>2.20.0</version.com.github.tomakehurst.wiremock>
         <version.org.glassfish.jakarta.el>4.0.0</version.org.glassfish.jakarta.el>
         <version.jakarta.persistence.persistence-api>3.0.0</version.jakarta.persistence.persistence-api>
         <version.org.jacoco>0.8.7</version.org.jacoco>
@@ -798,11 +797,6 @@
             </dependency>
 
             <!-- testsuite dependencies -->
-            <dependency>
-                <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock</artifactId>
-                <version>${version.com.github.tomakehurst.wiremock}</version>
-            </dependency>
             <dependency>
                 <groupId>org.jacoco</groupId>
                 <artifactId>org.jacoco.ant</artifactId>


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-3179
Signed-off-by: James R. Perkins <jperkins@redhat.com>