### PR TITLE
[RESTEASY-3203] Upgrade Arquillian to 1.7.0.Alpha12 and WildFly Arquillian to 5.0.0.Alpha5.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Dependency versions -->
-        <dep.arquillian-bom.version>1.7.0.Alpha10</dep.arquillian-bom.version>
+        <dep.arquillian-bom.version>1.7.0.Alpha12</dep.arquillian-bom.version>
         <version.org.jboss.arquillian.container.arquillian-weld-embedded>2.0.0.Final</version.org.jboss.arquillian.container.arquillian-weld-embedded>
         <version.org.jboss.resteasy.checkstyle>1.0.0.Final</version.org.jboss.resteasy.checkstyle>
         <server.version>27.0.0.Alpha4</server.version>
         <version.org.wildfly>${server.version}</version.org.wildfly>
-        <version.org.wildfly.arquillian.wildfly-arquillian>5.0.0.Alpha3</version.org.wildfly.arquillian.wildfly-arquillian>
+        <version.org.wildfly.arquillian.wildfly-arquillian>5.0.0.Alpha5</version.org.wildfly.arquillian.wildfly-arquillian>
 
         <jboss.home/>
         <!-- print logs to file by default -->

--- a/providers/resteasy-html/pom.xml
+++ b/providers/resteasy-html/pom.xml
@@ -62,7 +62,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-resources-plugin</artifactId>
-                        <version>2.6</version>
                         <executions>
                             <execution>
                                 <id>copy-resources</id>


### PR DESCRIPTION
Remove an override of the maven-resource-plugin.

Upgrade Arquillian and WildFly Arquillian.
https://issues.redhat.com/browse/RESTEASY-3203