### PR TITLE
Add SCM info to the resteasy-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <scm>
         <connection>scm:git:git://github.com/resteasy/Resteasy.git</connection>
         <developerConnection>scm:git:git@github.com:resteasy/Resteasy.git</developerConnection>
-        <url>https://github.com/resteasy/Resteasy/tree/master/</url>
+        <url>https://github.com/resteasy/Resteasy/tree/main/</url>
     </scm>
 
     <issueManagement>

--- a/resteasy-bom/pom.xml
+++ b/resteasy-bom/pom.xml
@@ -19,6 +19,12 @@
     <name>RESTEasy Maven Import (BOM)</name>
     <description/>
 
+    <scm>
+        <connection>scm:git:git://github.com/resteasy/Resteasy.git</connection>
+        <developerConnection>scm:git:git@github.com:resteasy/Resteasy.git</developerConnection>
+        <url>https://github.com/resteasy/Resteasy/tree/main/</url>
+    </scm>
+
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
This adds the missing SCM info to the reasteasy-bom.