### PR TITLE
[RESTEASY-3221] Do not use values less than 1 when parsing random val…

### DIFF
--- a/resteasy-core-spi/src/test/java/org/jboss/resteasy/spi/config/ThresholdTestCase.java
+++ b/resteasy-core-spi/src/test/java/org/jboss/resteasy/spi/config/ThresholdTestCase.java
@@ -47,12 +47,17 @@ public class ThresholdTestCase {
         // Test each unit
         final Random r = new Random();
         for (SizeUnit unit : SizeUnit.values()) {
-            final long size = r.nextInt(512);
+            final long size = createSize(r);
             test(Threshold.of(size, unit), Threshold.valueOf(size + unit.abbreviation()));
         }
     }
 
     private void test(final Threshold expected, final Threshold tested) {
         Assert.assertEquals(String.format("Expected %s got %s", expected, tested), expected, tested);
+    }
+
+    private static long createSize(final Random r) {
+        final int result = r.nextInt(512);
+        return result < 1 ? 1L : result;
     }
 }


### PR DESCRIPTION
…ues for the threshold.

https://issues.redhat.com/browse/RESTEASY-3221
Signed-off-by: James R. Perkins <jperkins@redhat.com>