### PR TITLE
[RESTEASY-3235] Remove the org.eclipse.yasson dependency form the org…

### DIFF
--- a/resteasy-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-binding-provider/main/module.xml
+++ b/resteasy-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-binding-provider/main/module.xml
@@ -36,7 +36,6 @@
         <module name="jakarta.json.bind.api"/>
         <module name="jakarta.ws.rs.api"/>
         <module name="jakarta.xml.bind.api"/>
-        <module name="org.eclipse.yasson" services="import"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.resteasy.resteasy-core"/>
         <module name="org.jboss.resteasy.resteasy-core-spi"/>


### PR DESCRIPTION
….jboss.resteasy.resteasy-json-binding-provider module.

https://issues.redhat.com/browse/RESTEASY-3235
Signed-off-by: James R. Perkins <jperkins@redhat.com>