### PR TITLE
Remove the jboss-jakarta-transform-artifacts option as it's no longer…

### DIFF
--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -487,7 +487,6 @@
                     <plugin-options>
                         <!--<jboss-maven-dist/> -->
                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                        <jboss-jakarta-transform-artifacts>true</jboss-jakarta-transform-artifacts>
                     </plugin-options>
                     <feature-packs>
                         <feature-pack>


### PR DESCRIPTION
… supported. Also use the Maven distribution again for testing.

Signed-off-by: James R. Perkins <jperkins@redhat.com>