### PR TITLE
RESTEASY-3254 / RESTEASY-3255

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -379,6 +379,12 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>${version.org.apache.httpcomponents.httpclient}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-codec</groupId>
+                        <artifactId>commons-codec</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -1013,6 +1019,12 @@
                 <groupId>io.reactivex.rxjava2</groupId>
                 <artifactId>rxjava</artifactId>
                 <version>${version.io.reactivex.rxjava2-rxjava}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.reactivestreams</groupId>
+                        <artifactId>reactive-streams</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/resteasy-rxjava2/pom.xml
+++ b/resteasy-rxjava2/pom.xml
@@ -26,6 +26,10 @@
         <artifactId>rxjava</artifactId>
     </dependency>
     <dependency>
+        <groupId>org.reactivestreams</groupId>
+        <artifactId>reactive-streams</artifactId>
+    </dependency>
+    <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging</artifactId>
     </dependency>


### PR DESCRIPTION
- [RESTEASY-3254](https://issues.redhat.com/browse/RESTEASY-3254) / the `commons-codec` versions are conflict in `resteasy-client`
- [RESTEASY-3255](https://issues.redhat.com/browse/RESTEASY-3255) / the `reactive-streams` versions are conflict in `resteasy-feature-pack-common`