### PR TITLE
RESTEASY-3259 Proxy Framework fails to Produce Mono<T> at runtime whe…

### DIFF
--- a/resteasy-reactor/src/main/java/org/jboss/resteasy/reactor/MonoRxInvoker.java
+++ b/resteasy-reactor/src/main/java/org/jboss/resteasy/reactor/MonoRxInvoker.java
@@ -1,13 +1,12 @@
 package org.jboss.resteasy.reactor;
 
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.RxInvoker;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.Response;
-
-import org.jboss.resteasy.client.jaxrs.PublisherRxInvoker;
 import reactor.core.publisher.Mono;
 
-public interface MonoRxInvoker extends PublisherRxInvoker
+public interface MonoRxInvoker extends RxInvoker<Mono<?>>
 {
    @Override
    Mono<Response> get();

--- a/resteasy-reactor/src/main/java/org/jboss/resteasy/reactor/MonoRxInvokerImpl.java
+++ b/resteasy-reactor/src/main/java/org/jboss/resteasy/reactor/MonoRxInvokerImpl.java
@@ -3,146 +3,158 @@ package org.jboss.resteasy.reactor;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.Response;
-
 import org.jboss.resteasy.client.jaxrs.internal.ClientInvocationBuilder;
 import org.jboss.resteasy.client.jaxrs.internal.PublisherRxInvokerImpl;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
+import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 
-public class MonoRxInvokerImpl extends PublisherRxInvokerImpl implements MonoRxInvoker {
+public class MonoRxInvokerImpl implements MonoRxInvoker {
+
+
+    private final MonoPublisherInvoker monoInvoker;
+
+
+    static class MonoPublisherInvoker extends PublisherRxInvokerImpl {
+        MonoPublisherInvoker(final ClientInvocationBuilder builder) {
+            super(builder);
+        }
+
+        @Override
+        protected <T> Publisher<T> toPublisher(CompletionStage<T> completable) {
+            return Mono.fromFuture(completable.toCompletableFuture());
+        }
+    }
 
     public MonoRxInvokerImpl(final ClientInvocationBuilder builder) {
-        super(builder);
+        monoInvoker = new MonoPublisherInvoker(Objects.requireNonNull(builder));
     }
 
-    @Override
-    protected <T> Mono<T> toPublisher(final CompletionStage<T> completable) {
-        return Mono.fromCompletionStage(completable);
-    }
 
     @Override
     public Mono<Response> get() {
-        return Mono.from(super.get());
+        return Mono.from(monoInvoker.get());
     }
 
     @Override
     public <T> Mono<T> get(Class<T> responseType) {
-        return Mono.from(super.get(responseType));
+        return Mono.from(monoInvoker.get(responseType));
     }
 
     @Override
     public <T> Mono<T> get(GenericType<T> responseType) {
-        return Mono.from(super.get(responseType));
+        return Mono.from(monoInvoker.get(responseType));
     }
 
     @Override
     public Mono<Response> put(Entity<?> entity) {
-        return Mono.from(super.put(entity));
+        return Mono.from(monoInvoker.put(entity));
     }
 
     @Override
     public <T> Mono<T> put(Entity<?> entity, Class<T> clazz) {
-        return Mono.from(super.put(entity, clazz));
+        return Mono.from(monoInvoker.put(entity, clazz));
     }
 
     @Override
     public <T> Mono<T> put(Entity<?> entity, GenericType<T> type) {
-        return Mono.from(super.put(entity, type));
+        return Mono.from(monoInvoker.put(entity, type));
     }
 
     @Override
     public Mono<Response> post(Entity<?> entity) {
-        return Mono.from(super.post(entity));
+        return Mono.from(monoInvoker.post(entity));
     }
 
     @Override
     public <T> Mono<T> post(Entity<?> entity, Class<T> clazz) {
-        return Mono.from(super.post(entity, clazz));
+        return Mono.from(monoInvoker.post(entity, clazz));
     }
 
     @Override
     public <T> Mono<T> post(Entity<?> entity, GenericType<T> type) {
-        return Mono.from(super.post(entity, type));
+        return Mono.from(monoInvoker.post(entity, type));
     }
 
     @Override
     public Mono<Response> delete() {
-        return Mono.from(super.delete());
+        return Mono.from(monoInvoker.delete());
     }
 
     @Override
     public <T> Mono<T> delete(Class<T> responseType) {
-        return Mono.from(super.delete(responseType));
+        return Mono.from(monoInvoker.delete(responseType));
     }
 
     @Override
     public <T> Mono<T> delete(GenericType<T> responseType) {
-        return Mono.from(super.delete(responseType));
+        return Mono.from(monoInvoker.delete(responseType));
     }
 
     @Override
     public Mono<Response> head() {
-        return Mono.from(super.head());
+        return Mono.from(monoInvoker.head());
     }
 
     @Override
     public Mono<Response> options() {
-        return Mono.from(super.options());
+        return Mono.from(monoInvoker.options());
     }
 
     @Override
     public <T> Mono<T> options(Class<T> responseType) {
-        return Mono.from(super.options(responseType));
+        return Mono.from(monoInvoker.options(responseType));
     }
 
     @Override
     public <T> Mono<T> options(GenericType<T> responseType) {
-        return Mono.from(super.options(responseType));
+        return Mono.from(monoInvoker.options(responseType));
     }
 
     @Override
     public Mono<Response> trace() {
-        return Mono.from(super.trace());
+        return Mono.from(monoInvoker.trace());
     }
 
     @Override
     public <T> Mono<T> trace(Class<T> responseType) {
-        return Mono.from(super.trace(responseType));
+        return Mono.from(monoInvoker.trace(responseType));
     }
 
     @Override
     public <T> Mono<T> trace(GenericType<T> responseType) {
-        return Mono.from(super.trace(responseType));
+        return Mono.from(monoInvoker.trace(responseType));
     }
 
     @Override
     public Mono<Response> method(String name) {
-        return Mono.from(super.method(name));
+        return Mono.from(monoInvoker.method(name));
     }
 
     @Override
     public <T> Mono<T> method(String name, Class<T> responseType) {
-        return Mono.from(super.method(name, responseType));
+        return Mono.from(monoInvoker.method(name, responseType));
     }
 
     @Override
     public <T> Mono<T> method(String name, GenericType<T> responseType) {
-        return Mono.from(super.method(name, responseType));
+        return Mono.from(monoInvoker.method(name, responseType));
     }
 
     @Override
     public Mono<Response> method(String name, Entity<?> entity) {
-        return Mono.from(super.method(name, entity));
+        return Mono.from(monoInvoker.method(name, entity));
     }
 
     @Override
     public <T> Mono<T> method(String name, Entity<?> entity, Class<T> responseType) {
-        return Mono.from(super.method(name, entity, responseType));
+        return Mono.from(monoInvoker.method(name, entity, responseType));
     }
 
     @Override
     public <T> Mono<T> method(String name, Entity<?> entity, GenericType<T> responseType) {
-        return Mono.from(super.method(name, entity, responseType));
+        return Mono.from(monoInvoker.method(name, entity, responseType));
     }
 }


### PR DESCRIPTION
…n proxying a java Interface

The Providers loading mechanism used by RestEasy client actually goes through the Template Parameters types of The Invokers and guessed that for MonoRxInvoker to be called, return type from a remote Interface method shoudl be reactivestreams.Publisher and not Mono<T>. This is because `MonoRxInvoker extends PublisherRxInvoker` which is RxInvoker<Publisher>, instead of `MonoRxInvoker extends RxInvoker<Mono<?>>` like is already the case for resteasy-rxjava2 plugin for example. This causes the Providers loading mechanism to load MonoRxInvoker only if the remote interface signature has Publisher as a return type...