### PR TITLE
ResteasyProviderFactoryImpl: try to copy default exception mapping option from parent

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ResteasyProviderFactoryImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ResteasyProviderFactoryImpl.java
@@ -147,7 +147,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory
     protected boolean lockSnapshots;
     protected StatisticsControllerImpl statisticsController = new StatisticsControllerImpl();
 
-    private final boolean defaultExceptionManagerEnabled = getOptionValue(Options.ENABLE_DEFAULT_EXCEPTION_MAPPER);
+    private boolean defaultExceptionManagerEnabled = true;
 
     public ResteasyProviderFactoryImpl() {
         // NOTE!!! It is important to put all initialization into initialize() as ThreadLocalResteasyProviderFactory
@@ -215,6 +215,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory
         enabledFeatures = parent == null ? new SnapshotSet<>(lockSnapshots)
                 : new SnapshotSet<>(parent.enabledFeatures, true, lockSnapshots, snapFirst);
         if (parent != null) {
+            defaultExceptionManagerEnabled = parent.defaultExceptionManagerEnabled;
             if (snapFirst) {
                 // resourcemethod invoker factory
                 // we don't want to copy these
@@ -231,6 +232,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory
                         .synchronizedSortedSet(new TreeSet<>(parent.sortedParamConverterProviders));
             }
         } else {
+            defaultExceptionManagerEnabled = getOptionValue(Options.ENABLE_DEFAULT_EXCEPTION_MAPPER);
             contextResolvers = new ConcurrentHashMap<>();
             sortedParamConverterProviders = Collections.synchronizedSortedSet(new TreeSet<>());
         }


### PR DESCRIPTION
Filed issue: https://issues.redhat.com/browse/RESTEASY-3269

ResteasyProviderFactoryImpl: try to copy default exception mapping option from parent

Calling e.g. `WebTarget.path` ends up creating a new web target, which creates a new configuration, which creates a new provider impl, which looks up this option, which scans the classpath, which triggers disk IO and unzip'ing.

On a JFR profile of a load harness, the majority of allocations in a pure HTTP network request ends up being byte buffers loading classpath data to determine the state of this option, over and over again.

Can we try to copy the parent's setting instead?