### PR TITLE
[RESTEASY-3280] Do not load the ThreadContext's from a service loader…

### DIFF
--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/concurrent/ContextualExecutors.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/concurrent/ContextualExecutors.java
@@ -24,7 +24,6 @@ import java.security.PrivilegedAction;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -323,20 +322,13 @@ public class ContextualExecutors {
     @SuppressWarnings("unchecked")
     private static Map<ThreadContext<Object>, Object> getContexts() {
         final Map<ThreadContext<Object>, Object> contexts = new LinkedHashMap<>();
-        if (System.getSecurityManager() == null) {
-            ServiceLoader.load(ThreadContext.class).forEach(context -> contexts.put(context, context.capture()));
-        } else {
-            AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
-                ServiceLoader.load(ThreadContext.class).forEach(context -> contexts.put(context, context.capture()));
-                return null;
-            });
-        }
         // Load any registered providers
-        final ThreadContexts threadContexts = ResteasyProviderFactory.getInstance().getContextData(ThreadContexts.class);
-        if (threadContexts != null) {
-            for (ThreadContext<Object> context : threadContexts.getThreadContexts()) {
-                contexts.put(context, context.capture());
-            }
+        ThreadContexts threadContexts = ResteasyProviderFactory.getInstance().getContextData(ThreadContexts.class);
+        if (threadContexts == null) {
+            threadContexts = new ThreadContexts();
+        }
+        for (ThreadContext<Object> context : threadContexts.getThreadContexts()) {
+            contexts.put(context, context.capture());
         }
         return contexts;
     }


### PR DESCRIPTION
… each time the contexts are required.

https://issues.redhat.com/browse/RESTEASY-3280

Upstream #3395