### PR TITLE
[RESTEASY-3283] Add option to not throw a DefaultOptionsMethodExcepti…

### DIFF
--- a/docbook/reference/en/en-US/modules/ExceptionMappers.xml
+++ b/docbook/reference/en/en-US/modules/ExceptionMappers.xml
@@ -121,7 +121,8 @@ If there is an ExceptionMapper for wrapped exception, then that is used to handl
 <row>
 <entry>DefaultOptionsMethodException</entry>
 <entry>N/A</entry>
-<entry>If the user invokes HTTP OPTIONS and no JAX-RS method for it, RESTEasy provides a default behavior by throwing this exception</entry>
+<entry>If the user invokes HTTP OPTIONS and no JAX-RS method for it, RESTEasy provides a default behavior by throwing this exception.
+   This can be disabled by setting the configuration property <code>dev.resteasy.throw.options.exception</code> is set to false.</entry>
 </row>
 <row>
 <entry>UnrecognizedPropertyExceptionHandler</entry>

--- a/docbook/reference/en/en-US/modules/Installation_Configuration.xml
+++ b/docbook/reference/en/en-US/modules/Installation_Configuration.xml
@@ -1077,6 +1077,21 @@ String s = config.getOptionalValue("prop_name", String.class).orElse("d'oh");
                                 for more information.
                             </entry>
                         </row>
+                        <row>
+                            <entry>
+                                dev.resteasy.throw.options.exception
+                            </entry>
+                            <entry>
+                                false
+                            </entry>
+                            <entry>
+                                Setting this value to true will throw a <classname>org.jboss.resteasy.spi.DefaultOptionsMethodException</classname>
+                                if the HTTP method "OPTIONS" is sent and the matching method is not annotated with
+                                <classname>@OPTIONS</classname>. This is the original behavior of RESTEasy. However, this
+                                has been changed to return the response so that it&apos;s processed with an
+                                <classname>ExceptionMapper</classname>.
+                            </entry>
+                        </row>
                     </tbody>
                 </tgroup>
             </table>

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/registry/ConstantResourceInvoker.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/core/registry/ConstantResourceInvoker.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.core.registry;
+
+import java.lang.reflect.Method;
+
+import org.jboss.resteasy.core.ResourceInvoker;
+import org.jboss.resteasy.specimpl.BuiltResponse;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.statistics.MethodStatisticsLogger;
+
+/**
+ * A resource invoker which simply returns the given response.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class ConstantResourceInvoker implements ResourceInvoker {
+    private final BuiltResponse response;
+    private volatile MethodStatisticsLogger logger;
+
+    ConstantResourceInvoker(final BuiltResponse response) {
+        this.response = response;
+    }
+
+    @Override
+    public BuiltResponse invoke(final HttpRequest request, final HttpResponse response) {
+        return this.response;
+    }
+
+    @Override
+    public BuiltResponse invoke(final HttpRequest request, final HttpResponse response, final Object target) {
+        return this.response;
+    }
+
+    @Override
+    public Method getMethod() {
+        return null;
+    }
+
+    @Override
+    public void setMethodStatisticsLogger(final MethodStatisticsLogger msLogger) {
+        this.logger = msLogger;
+    }
+
+    @Override
+    public MethodStatisticsLogger getMethodStatisticsLogger() {
+        return logger;
+    }
+}

--- a/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/DefaultOptionsMethodException.java
+++ b/resteasy-jaxrs/src/main/java/org/jboss/resteasy/spi/DefaultOptionsMethodException.java
@@ -7,6 +7,7 @@ import javax.ws.rs.core.Response;
  * does not have a Java method that supports OPTIONS.  RESTEasy provides a default behavior for OPTIONS.
  * If you want to override this behavior, write an exception mapper for this exception.
  */
+@Deprecated
 public class DefaultOptionsMethodException extends Failure
 {
    public DefaultOptionsMethodException(final String s, final Response response)


### PR DESCRIPTION
…on when no OPTIONS method is found. Instead, just return the created response.

https://issues.redhat.com/browse/RESTEASY-3283

Upstream: #3406 Note there is different default behavior here. By default the upstream will not throw an exception and you must enable it. It's the opposite here in that an exception will be thrown by default and it needs to be turned off to not throw an exception.