### PR TITLE
[RESTEASY-3282] Migrate mime4j from the unsupported 0.6 to 0.8.9. Thi…

### DIFF
--- a/jboss-modules/build.xml
+++ b/jboss-modules/build.xml
@@ -39,6 +39,16 @@
           ~ +++++++   KEEP THIS LIST ALPHABETICAL BY MODULE NAME!   +++++++
           ~ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
           -->
+        <!-- This is required for RESTEASY-3282. Normally this would not be done in a micro release, but we need a CVE fix. -->
+        <module-def name="org.apache.commons.io">
+            <maven-resource group="commons-io" artifact="commons-io"/>
+        </module-def>
+        <module-def name="org.apache.james.mime4j">
+            <maven-resource group="org.apache.james" artifact="apache-mime4j-core"/>
+            <maven-resource group="org.apache.james" artifact="apache-mime4j-dom"/>
+            <maven-resource group="org.apache.james" artifact="apache-mime4j-storage"/>
+        </module-def>
+
         <module-def name="org.codehaus.jackson.jackson-core-asl">
             <maven-resource group="org.codehaus.jackson" artifact="jackson-core-asl"/>
         </module-def>

--- a/jboss-modules/pom.xml
+++ b/jboss-modules/pom.xml
@@ -239,6 +239,23 @@
             <artifactId>yasson</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-mime4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-mime4j-dom</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-mime4j-storage</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/jboss-modules/src/main/resources/modules/org/apache/commons/io/main/module.xml
+++ b/jboss-modules/src/main/resources/modules/org/apache/commons/io/main/module.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.apache.commons.io">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+</module>

--- a/jboss-modules/src/main/resources/modules/org/apache/james/mime4j/main/module.xml
+++ b/jboss-modules/src/main/resources/modules/org/apache/james/mime4j/main/module.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.5" name="org.apache.james.mime4j" >
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="org.apache.commons.io"/>
+        <module name="org.apache.commons.logging"/>
+    </dependencies>
+</module>

--- a/providers/multipart/pom.xml
+++ b/providers/multipart/pom.xml
@@ -34,7 +34,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.james</groupId>
-            <artifactId>apache-mime4j</artifactId>
+            <artifactId>apache-mime4j-dom</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-mime4j-storage</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>

--- a/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/Mime4JWorkaround.java
+++ b/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/Mime4JWorkaround.java
@@ -1,0 +1,215 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.jboss.resteasy.plugins.providers.multipart;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.apache.james.mime4j.MimeException;
+import org.apache.james.mime4j.MimeIOException;
+import org.apache.james.mime4j.codec.DecodeMonitor;
+import org.apache.james.mime4j.dom.Message;
+import org.apache.james.mime4j.field.DefaultFieldParser;
+import org.apache.james.mime4j.field.LenientFieldParser;
+import org.apache.james.mime4j.message.BodyFactory;
+import org.apache.james.mime4j.message.DefaultBodyDescriptorBuilder;
+import org.apache.james.mime4j.message.MessageImpl;
+import org.apache.james.mime4j.parser.MimeStreamParser;
+import org.apache.james.mime4j.storage.AbstractStorageProvider;
+import org.apache.james.mime4j.storage.DefaultStorageProvider;
+import org.apache.james.mime4j.storage.Storage;
+import org.apache.james.mime4j.storage.StorageBodyFactory;
+import org.apache.james.mime4j.storage.StorageOutputStream;
+import org.apache.james.mime4j.storage.StorageProvider;
+import org.apache.james.mime4j.storage.ThresholdStorageProvider;
+import org.apache.james.mime4j.stream.BodyDescriptorBuilder;
+import org.apache.james.mime4j.stream.MimeConfig;
+import org.jboss.resteasy.plugins.providers.multipart.i18n.LogMessages;
+
+/**
+ * Copy code from org.apache.james.mime4j.message.DefaultMessageBuilder.parseMessage().
+ * Alter said code to use Mime4JWorkaroundBinaryEntityBuilder instead of EntityBuilder.
+ */
+class Mime4JWorkaround {
+    /**
+     * This is a rough copy of DefaultMessageBuilder.parseMessage() modified to use a Mime4JWorkaround as the contentHandler instead
+     * of an EntityBuilder.
+     * <p>
+     *
+     * @param is
+     *
+     * @return
+     *
+     * @throws IOException
+     * @throws MimeIOException
+     * @see org.apache.james.mime4j.message.DefaultMessageBuilder#parseMessage(java.io.InputStream)
+     */
+    static Message parseMessage(InputStream is) throws IOException, MimeIOException {
+        try {
+            MessageImpl message = new MessageImpl();
+            MimeConfig cfg = MimeConfig.DEFAULT;
+            boolean strict = cfg.isStrictParsing();
+            DecodeMonitor mon = strict ? DecodeMonitor.STRICT : DecodeMonitor.SILENT;
+            BodyDescriptorBuilder bdb = new DefaultBodyDescriptorBuilder(null, strict ? DefaultFieldParser.getParser() : LenientFieldParser.getParser(), mon);
+
+            StorageProvider storageProvider;
+            if (System.getProperty(DefaultStorageProvider.DEFAULT_STORAGE_PROVIDER_PROPERTY) != null) {
+                storageProvider = DefaultStorageProvider.getInstance();
+            } else {
+                StorageProvider backend = new CustomTempFileStorageProvider();
+                storageProvider = new ThresholdStorageProvider(backend, 1024);
+            }
+            BodyFactory bf = new StorageBodyFactory(storageProvider, mon);
+
+            MimeStreamParser parser = new MimeStreamParser(cfg, mon, bdb);
+            // EntityBuilder expect the parser will send ParserFields for the well known fields
+            // It will throw exceptions, otherwise.
+            parser.setContentHandler(new Mime4jWorkaroundBinaryEntityBuilder(message, bf));
+            parser.setContentDecoding(false);
+            parser.setRecurse();
+
+            parser.parse(is);
+            return message;
+        } catch (MimeException e) {
+            throw new MimeIOException(e);
+        }
+    }
+
+
+    /**
+     * A custom TempFileStorageProvider that do no set deleteOnExit on temp files,
+     * to avoid memory leaks (see https://issues.apache.org/jira/browse/MIME4J-251)
+     */
+    private static class CustomTempFileStorageProvider extends AbstractStorageProvider {
+
+        private static final String DEFAULT_PREFIX = "m4j";
+
+        private final String prefix;
+
+        private final String suffix;
+
+        private final File directory;
+
+        CustomTempFileStorageProvider() {
+            this(DEFAULT_PREFIX, null, null);
+        }
+
+        CustomTempFileStorageProvider(final String prefix, final String suffix, final File directory) {
+            if (prefix == null || prefix.length() < 3)
+                throw new IllegalArgumentException("invalid prefix");
+
+            if (directory != null && !directory.isDirectory() && !directory.mkdirs())
+                throw new IllegalArgumentException("invalid directory");
+
+            this.prefix = prefix;
+            this.suffix = suffix;
+            this.directory = directory;
+        }
+
+        public StorageOutputStream createStorageOutputStream() throws IOException {
+            Path file = Files.createTempFile(directory.toPath(), prefix, suffix);
+
+            return new TempFileStorageOutputStream(file);
+        }
+
+        private static final class TempFileStorageOutputStream extends StorageOutputStream {
+            private final Path file;
+
+            private final OutputStream out;
+
+            TempFileStorageOutputStream(final Path file) throws IOException {
+                this.file = file;
+                this.out = Files.newOutputStream(file);
+            }
+
+            @Override
+            public void close() throws IOException {
+                super.close();
+                out.close();
+            }
+
+            @Override
+            protected void write0(byte[] buffer, int offset, int length) throws IOException {
+                out.write(buffer, offset, length);
+            }
+
+            @Override
+            protected Storage toStorage0() throws IOException {
+                // out has already been closed because toStorage calls close
+                return new TempFileStorage(file);
+            }
+        }
+
+        private static final class TempFileStorage implements Storage {
+
+            private Path file;
+
+            private static final Set<Path> filesToDelete = new HashSet<>();
+
+            TempFileStorage(final Path file) {
+                this.file = file;
+            }
+
+            public void delete() {
+                // deleting a file might not immediately succeed if there are still
+                // streams left open (especially under Windows). so we keep track of
+                // the files that have to be deleted and try to delete all these
+                // files each time this method gets invoked.
+
+                // a better but more complicated solution would be to start a
+                // separate thread that tries to delete the files periodically.
+
+                synchronized (filesToDelete) {
+                    if (file != null) {
+                        filesToDelete.add(file);
+                        file = null;
+                    }
+
+                    for (Iterator<Path> iterator = filesToDelete.iterator(); iterator.hasNext(); ) {
+                        Path f = iterator.next();
+                        try {
+                            Files.deleteIfExists(f);
+                            iterator.remove();
+                        } catch (IOException e) {
+                            LogMessages.LOGGER.debugf(e, "Failed to delete file %s", f);
+                        }
+                    }
+                }
+            }
+
+            public InputStream getInputStream() throws IOException {
+                if (file == null)
+                    throw new IllegalStateException("storage has been deleted");
+
+                return new BufferedInputStream(Files.newInputStream(file));
+            }
+
+        }
+    }
+
+}
+

--- a/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/Mime4jWorkaroundBinaryEntityBuilder.java
+++ b/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/Mime4jWorkaroundBinaryEntityBuilder.java
@@ -1,0 +1,248 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.jboss.resteasy.plugins.providers.multipart;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Stack;
+
+import org.apache.james.mime4j.MimeException;
+import org.apache.james.mime4j.dom.Body;
+import org.apache.james.mime4j.dom.Entity;
+import org.apache.james.mime4j.dom.Header;
+import org.apache.james.mime4j.dom.Message;
+import org.apache.james.mime4j.dom.Multipart;
+import org.apache.james.mime4j.message.BodyFactory;
+import org.apache.james.mime4j.message.BodyPart;
+import org.apache.james.mime4j.message.HeaderImpl;
+import org.apache.james.mime4j.message.MessageImpl;
+import org.apache.james.mime4j.message.MultipartImpl;
+import org.apache.james.mime4j.parser.ContentHandler;
+import org.apache.james.mime4j.stream.BodyDescriptor;
+import org.apache.james.mime4j.stream.Field;
+import org.apache.james.mime4j.stream.RawField;
+import org.apache.james.mime4j.util.ByteArrayBuffer;
+import org.apache.james.mime4j.util.ByteSequence;
+
+
+/**
+ * A <code>ContentHandler</code> for building an <code>Entity</code> to be
+ * used in conjunction with a {@link org.apache.james.mime4j.parser.MimeStreamParser}.
+ *
+ * This class was copied nearly verbatim from org.apache.james.mime4j.message.EntityBuilder
+ * It was duplicated because multipart-providers always wants a BinaryBody and never a TextBody.
+ * Unfortunately, there's no easy to get this in apache-mime4j. Further, the
+ * logical place to extend and override, "EntityBuilder", is a package-private class.
+ * <p>
+ * Therefore we duplicate EntityBuilder here.
+ * All code is identical except:
+ * <ul>
+ * <li>package changed</li>
+ * <li>class renamed</li>
+ * <li>constructor renamed</li>
+ * <li>additional imports added due to repackaging of the class</li>
+ * <li>body(BodyDescriptor bd, final InputStream is) - Method which unilaterally returns a BinaryBody.</li>
+ * </ul>
+ * <p>
+ * This file may not follow RESTEasy formatting standards. This is to make it easier to diff against the original EntityBuilder in the future when mime4j is updated again.
+ */
+class Mime4jWorkaroundBinaryEntityBuilder implements ContentHandler {
+
+    private final Entity entity;
+    private final BodyFactory bodyFactory;
+    private final Stack<Object> stack;
+
+    Mime4jWorkaroundBinaryEntityBuilder(
+            final Entity entity,
+            final BodyFactory bodyFactory) {
+        this.entity = entity;
+        this.bodyFactory = bodyFactory;
+        this.stack = new Stack<Object>();
+    }
+
+    private void expect(Class<?> c) {
+        if (!c.isInstance(stack.peek())) {
+            throw new IllegalStateException("Internal stack error: "
+                    + "Expected '" + c.getName() + "' found '"
+                    + stack.peek().getClass().getName() + "'");
+        }
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#startMessage()
+     */
+    public void startMessage() throws MimeException {
+        if (stack.isEmpty()) {
+            stack.push(this.entity);
+        } else {
+            expect(Entity.class);
+            Message m = new MessageImpl();
+            ((Entity) stack.peek()).setBody(m);
+            stack.push(m);
+        }
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#endMessage()
+     */
+    public void endMessage() throws MimeException {
+        expect(Message.class);
+        stack.pop();
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#startHeader()
+     */
+    public void startHeader() throws MimeException {
+        stack.push(new HeaderImpl());
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#field(RawField)
+     */
+    public void field(Field field) throws MimeException {
+        expect(Header.class);
+        ((Header) stack.peek()).addField(field);
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#endHeader()
+     */
+    public void endHeader() throws MimeException {
+        expect(Header.class);
+        Header h = (Header) stack.pop();
+        expect(Entity.class);
+        ((Entity) stack.peek()).setHeader(h);
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#startMultipart(org.apache.james.mime4j.stream.BodyDescriptor)
+     */
+    public void startMultipart(final BodyDescriptor bd) throws MimeException {
+        expect(Entity.class);
+
+        final Entity e = (Entity) stack.peek();
+        final String subType = bd.getSubType();
+        final Multipart multiPart = new MultipartImpl(subType);
+        e.setBody(multiPart);
+        stack.push(multiPart);
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#body(org.apache.james.mime4j.stream.BodyDescriptor, java.io.InputStream)
+     */
+    public void body(BodyDescriptor bd, final InputStream is) throws MimeException, IOException {
+        expect(Entity.class);
+
+        // NO NEED TO MANUALLY RUN DECODING.
+        // The parser has a "setContentDecoding" method. We should
+        // simply instantiate the MimeStreamParser with that method.
+
+        // final String enc = bd.getTransferEncoding();
+
+        final Body body;
+
+        /*
+        final InputStream decodedStream;
+        if (MimeUtil.ENC_BASE64.equals(enc)) {
+            decodedStream = new Base64InputStream(is);
+        } else if (MimeUtil.ENC_QUOTED_PRINTABLE.equals(enc)) {
+            decodedStream = new QuotedPrintableInputStream(is);
+        } else {
+            decodedStream = is;
+        }
+        */
+
+        //Code change here to unilaterally use binaryBody
+        //Code left commented out here to make diffs easy in the future when apache-mime4j updates.
+        //if (bd.getMimeType().startsWith("text/")) {
+        //    body = bodyFactory.textBody(is, bd.getCharset());
+        //} else {
+        body = bodyFactory.binaryBody(is);
+        //}
+
+        Entity entity = ((Entity) stack.peek());
+        entity.setBody(body);
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#endMultipart()
+     */
+    public void endMultipart() throws MimeException {
+        stack.pop();
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#startBodyPart()
+     */
+    public void startBodyPart() throws MimeException {
+        expect(Multipart.class);
+
+        BodyPart bodyPart = new BodyPart();
+        ((Multipart) stack.peek()).addBodyPart(bodyPart);
+        stack.push(bodyPart);
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#endBodyPart()
+     */
+    public void endBodyPart() throws MimeException {
+        expect(BodyPart.class);
+        stack.pop();
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#epilogue(java.io.InputStream)
+     */
+    public void epilogue(InputStream is) throws MimeException, IOException {
+        expect(MultipartImpl.class);
+        ByteSequence bytes = loadStream(is);
+        ((MultipartImpl) stack.peek()).setEpilogueRaw(bytes);
+    }
+
+    /**
+     * @see org.apache.james.mime4j.parser.ContentHandler#preamble(java.io.InputStream)
+     */
+    public void preamble(InputStream is) throws MimeException, IOException {
+        expect(MultipartImpl.class);
+        ByteSequence bytes = loadStream(is);
+        ((MultipartImpl) stack.peek()).setPreambleRaw(bytes);
+    }
+
+    /**
+     * Unsupported.
+     *
+     * @see org.apache.james.mime4j.parser.ContentHandler#raw(java.io.InputStream)
+     */
+    public void raw(InputStream is) throws MimeException, IOException {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    private static ByteSequence loadStream(InputStream in) throws IOException {
+        ByteArrayBuffer bab = new ByteArrayBuffer(64);
+
+        int b;
+        while ((b = in.read()) != -1) {
+            bab.append(b);
+        }
+
+        return bab;
+    }
+
+}

--- a/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartFormDataInputImpl.java
+++ b/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartFormDataInputImpl.java
@@ -1,9 +1,9 @@
 package org.jboss.resteasy.plugins.providers.multipart;
 
-import org.apache.james.mime4j.field.ContentDispositionField;
-import org.apache.james.mime4j.field.FieldName;
+import org.apache.james.mime4j.dom.field.ContentDispositionField;
+import org.apache.james.mime4j.dom.field.FieldName;
 import org.apache.james.mime4j.message.BodyPart;
-import org.apache.james.mime4j.parser.Field;
+import org.apache.james.mime4j.stream.Field;
 import org.jboss.resteasy.plugins.providers.multipart.i18n.Messages;
 
 import javax.ws.rs.core.GenericType;

--- a/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartInputImpl.java
+++ b/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartInputImpl.java
@@ -1,41 +1,18 @@
 package org.jboss.resteasy.plugins.providers.multipart;
 
-import java.util.HashSet;
-
-import org.apache.james.mime4j.MimeException;
-import org.apache.james.mime4j.MimeIOException;
-import org.apache.james.mime4j.codec.Base64InputStream;
-import org.apache.james.mime4j.codec.QuotedPrintableInputStream;
-import org.apache.james.mime4j.descriptor.BodyDescriptor;
-import org.apache.james.mime4j.field.ContentTypeField;
-import org.apache.james.mime4j.message.BinaryBody;
-import org.apache.james.mime4j.message.Body;
-import org.apache.james.mime4j.message.BodyFactory;
-import org.apache.james.mime4j.message.BodyPart;
-import org.apache.james.mime4j.message.Entity;
-import org.apache.james.mime4j.message.Message;
-import org.apache.james.mime4j.message.MessageBuilder;
-import org.apache.james.mime4j.message.Multipart;
-import org.apache.james.mime4j.message.TextBody;
-import org.apache.james.mime4j.parser.Field;
-import org.apache.james.mime4j.parser.MimeStreamParser;
-import org.apache.james.mime4j.storage.AbstractStorageProvider;
-import org.apache.james.mime4j.storage.DefaultStorageProvider;
-import org.apache.james.mime4j.storage.Storage;
-import org.apache.james.mime4j.storage.StorageOutputStream;
-import org.apache.james.mime4j.storage.StorageProvider;
-import org.apache.james.mime4j.storage.ThresholdStorageProvider;
-import org.apache.james.mime4j.util.MimeUtil;
-import org.jboss.logging.Logger;
-import org.jboss.resteasy.core.ProvidersContextRetainer;
-import org.jboss.resteasy.microprofile.config.ResteasyConfigFactory;
-import org.jboss.resteasy.microprofile.config.ResteasyConfig.SOURCE;
-import org.jboss.resteasy.plugins.providers.multipart.i18n.Messages;
-import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
-import org.jboss.resteasy.spi.HttpRequest;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.jboss.resteasy.util.CaseInsensitiveMap;
-
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.io.UnsupportedEncodingException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -43,27 +20,22 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.Providers;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.SequenceInputStream;
-import java.io.UnsupportedEncodingException;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
+import org.apache.james.mime4j.dom.BinaryBody;
+import org.apache.james.mime4j.dom.Body;
+import org.apache.james.mime4j.dom.Entity;
+import org.apache.james.mime4j.dom.Message;
+import org.apache.james.mime4j.dom.Multipart;
+import org.apache.james.mime4j.dom.TextBody;
+import org.apache.james.mime4j.dom.field.ContentTypeField;
+import org.apache.james.mime4j.message.BodyPart;
+import org.apache.james.mime4j.stream.Field;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.core.ProvidersContextRetainer;
+import org.jboss.resteasy.plugins.providers.multipart.i18n.Messages;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.util.CaseInsensitiveMap;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -79,117 +51,6 @@ public class MultipartInputImpl implements MultipartInput, ProvidersContextRetai
    protected MediaType defaultPartContentType = MultipartConstants.TEXT_PLAIN_WITH_CHARSET_US_ASCII_TYPE;
    protected String defaultPartCharset = null;
    protected Providers savedProviders;
-   // We hack MIME4j so that it always returns a BinaryBody so we don't have to deal with Readers and their charset conversions
-   private static class BinaryOnlyMessageBuilder extends MessageBuilder
-   {
-      private Method expectMethod;
-      private java.lang.reflect.Field bodyFactoryField;
-      private java.lang.reflect.Field stackField;
-
-      private void init()
-      {
-         try
-         {
-            expectMethod = MessageBuilder.class.getDeclaredMethod("expect", Class.class);
-            expectMethod.setAccessible(true);
-            bodyFactoryField = MessageBuilder.class.getDeclaredField("bodyFactory");
-            bodyFactoryField.setAccessible(true);
-            stackField = MessageBuilder.class.getDeclaredField("stack");
-            stackField.setAccessible(true);
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(e);
-         }
-      }
-
-      private BinaryOnlyMessageBuilder(final Entity entity)
-      {
-         super(entity);
-         init();
-      }
-
-      private BinaryOnlyMessageBuilder(final Entity entity, final StorageProvider storageProvider)
-      {
-         super(entity, storageProvider);
-         init();
-      }
-
-      @SuppressWarnings(value = "unchecked")
-      @Override
-      public void body(BodyDescriptor bd, InputStream is) throws MimeException, IOException
-      {
-         // the only thing different from the superclass is that we just return a BinaryBody no matter what
-         try
-         {
-            expectMethod.invoke(this, Entity.class);
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(e);
-         }
-
-         final String enc = bd.getTransferEncoding();
-
-         final Body body;
-
-         final InputStream decodedStream;
-         if (MimeUtil.ENC_BASE64.equals(enc)) {
-            decodedStream = new Base64InputStream(is);
-         } else if (MimeUtil.ENC_QUOTED_PRINTABLE.equals(enc)) {
-            decodedStream = new QuotedPrintableInputStream(is);
-         } else {
-            decodedStream = is;
-         }
-
-         BodyFactory factory;
-         try
-         {
-            factory = (BodyFactory)bodyFactoryField.get(this);
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(e);
-         }
-
-         body = factory.binaryBody(decodedStream);
-
-         Stack<Object> st;
-         try
-         {
-            st = (Stack<Object>)stackField.get(this);
-         }
-         catch (Exception e)
-         {
-            throw new RuntimeException(e);
-         }
-         Entity entity = ((Entity) st.peek());
-         entity.setBody(body);
-      }
-   }
-
-   private static class BinaryMessage extends Message
-   {
-      private BinaryMessage(final InputStream is) throws IOException, MimeIOException
-      {
-         try {
-            MimeStreamParser parser = new MimeStreamParser(null);
-
-            StorageProvider storageProvider;
-            if (ResteasyConfigFactory.getConfig().getValue(DefaultStorageProvider.DEFAULT_STORAGE_PROVIDER_PROPERTY, SOURCE.SYSTEM) != null) {
-               storageProvider = DefaultStorageProvider.getInstance();
-            } else {
-               StorageProvider backend = new CustomTempFileStorageProvider();
-               storageProvider = new ThresholdStorageProvider(backend, 1024);
-            }
-            parser.setContentHandler(new BinaryOnlyMessageBuilder(this, storageProvider));
-            parser.parse(is);
-         } catch (MimeException e) {
-            throw new MimeIOException(e);
-         }
-
-      }
-   }
 
    public MultipartInputImpl(final MediaType contentType, final Providers workers)
    {
@@ -227,14 +88,18 @@ public class MultipartInputImpl implements MultipartInput, ProvidersContextRetai
 
    public MultipartInputImpl(final Multipart multipart, final Providers workers) throws IOException
    {
-      for (BodyPart bodyPart : multipart.getBodyParts())
-         parts.add(extractPart(bodyPart));
+      for (Entity entity : multipart.getBodyParts()) {
+         if (entity instanceof BodyPart)
+         {
+            parts.add(extractPart((BodyPart)entity));
+         }
+      }
       this.workers = workers;
    }
 
    public void parse(InputStream is) throws IOException
    {
-      mimeMessage = new BinaryMessage(addHeaderToHeadlessStream(is));
+      mimeMessage = Mime4JWorkaround.parseMessage(addHeaderToHeadlessStream(is));
       extractParts();
    }
 
@@ -265,8 +130,12 @@ public class MultipartInputImpl implements MultipartInput, ProvidersContextRetai
    protected void extractParts() throws IOException
    {
       Multipart multipart = (Multipart) mimeMessage.getBody();
-      for (BodyPart bodyPart : multipart.getBodyParts())
-         parts.add(extractPart(bodyPart));
+      for (Entity entity : multipart.getBodyParts()) {
+         if (entity instanceof BodyPart)
+         {
+            parts.add(extractPart((BodyPart)entity));
+         }
+      }
    }
 
    protected InputPart extractPart(BodyPart bodyPart) throws IOException
@@ -512,131 +381,4 @@ public class MultipartInputImpl implements MultipartInput, ProvidersContextRetai
    {
       savedProviders = providers;
    }
-
-   /**
-    * A custom TempFileStorageProvider that do no set deleteOnExit on temp files,
-    * to avoid memory leaks (see https://issues.apache.org/jira/browse/MIME4J-251)
-    *
-    */
-   private static class CustomTempFileStorageProvider extends AbstractStorageProvider
-   {
-
-      private static final String DEFAULT_PREFIX = "m4j";
-
-      private final String prefix;
-
-      private final String suffix;
-
-      private final File directory;
-
-      CustomTempFileStorageProvider()
-      {
-         this(DEFAULT_PREFIX, null, null);
-      }
-
-      CustomTempFileStorageProvider(final String prefix, final String suffix, final File directory)
-      {
-         if (prefix == null || prefix.length() < 3)
-            throw new IllegalArgumentException("invalid prefix");
-
-         if (directory != null && !directory.isDirectory() && !directory.mkdirs())
-            throw new IllegalArgumentException("invalid directory");
-
-         this.prefix = prefix;
-         this.suffix = suffix;
-         this.directory = directory;
-      }
-
-      public StorageOutputStream createStorageOutputStream() throws IOException
-      {
-         File file = File.createTempFile(prefix, suffix, directory);
-
-         return new TempFileStorageOutputStream(file);
-      }
-
-      private static final class TempFileStorageOutputStream extends StorageOutputStream
-      {
-         private File file;
-
-         private OutputStream out;
-
-         TempFileStorageOutputStream(final File file) throws IOException
-         {
-            this.file = file;
-            this.out = new FileOutputStream(file);
-         }
-
-         @Override
-         public void close() throws IOException
-         {
-            super.close();
-            out.close();
-         }
-
-         @Override
-         protected void write0(byte[] buffer, int offset, int length) throws IOException
-         {
-            out.write(buffer, offset, length);
-         }
-
-         @Override
-         protected Storage toStorage0() throws IOException
-         {
-            // out has already been closed because toStorage calls close
-            return new TempFileStorage(file);
-         }
-      }
-
-      private static final class TempFileStorage implements Storage
-      {
-
-         private File file;
-
-         private static final Set<File> filesToDelete = new HashSet<File>();
-
-         TempFileStorage(final File file)
-         {
-            this.file = file;
-         }
-
-         public void delete()
-         {
-            // deleting a file might not immediately succeed if there are still
-            // streams left open (especially under Windows). so we keep track of
-            // the files that have to be deleted and try to delete all these
-            // files each time this method gets invoked.
-
-            // a better but more complicated solution would be to start a
-            // separate thread that tries to delete the files periodically.
-
-            synchronized (filesToDelete)
-            {
-               if (file != null)
-               {
-                  filesToDelete.add(file);
-                  file = null;
-               }
-
-               for (Iterator<File> iterator = filesToDelete.iterator(); iterator.hasNext();)
-               {
-                  File f = iterator.next();
-                  if (f.delete())
-                  {
-                     iterator.remove();
-                  }
-               }
-            }
-         }
-
-         public InputStream getInputStream() throws IOException
-         {
-            if (file == null)
-               throw new IllegalStateException("storage has been deleted");
-
-            return new BufferedInputStream(new FileInputStream(file));
-         }
-
-      }
-   }
-
 }

--- a/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartRelatedInputImpl.java
+++ b/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/MultipartRelatedInputImpl.java
@@ -1,7 +1,7 @@
 package org.jboss.resteasy.plugins.providers.multipart;
 
-import org.apache.james.mime4j.field.ContentTypeField;
-import org.apache.james.mime4j.field.FieldName;
+import org.apache.james.mime4j.dom.field.ContentTypeField;
+import org.apache.james.mime4j.dom.field.FieldName;
 import org.apache.james.mime4j.message.BodyPart;
 
 import javax.ws.rs.core.MediaType;

--- a/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/i18n/Messages.java
+++ b/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/i18n/Messages.java
@@ -5,7 +5,7 @@ import java.lang.reflect.Type;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.MessageBodyReader;
 
-import org.apache.james.mime4j.parser.Field;
+import org.apache.james.mime4j.stream.Field;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.Message.Format;
 import org.jboss.logging.annotations.MessageBundle;

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -25,7 +25,7 @@
         <version.jakarta.mail>1.6.5</version.jakarta.mail>
         <version.org.glassfish.jaxb.jaxb>2.3.3-b02</version.org.glassfish.jaxb.jaxb>
         <version.com.sun.xml.fastinfoset>1.2.17</version.com.sun.xml.fastinfoset>
-        <version.commons-io.commons-io>2.5</version.commons-io.commons-io>
+        <version.commons-io.commons-io>2.10.0</version.commons-io.commons-io>
         <version.commons-codec.commons-codec>1.15</version.commons-codec.commons-codec>
         <version.hamcrest>1.3</version.hamcrest>
         <version.io.netty.netty>3.10.6.Final</version.io.netty.netty>
@@ -45,7 +45,7 @@
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.13</version.org.apache.httpcomponents.httpcore>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.4</version.org.apache.httpcomponents.httpasyncclient>
-        <version.org.apache.james.apache-mime4j>0.6</version.org.apache.james.apache-mime4j>
+        <version.org.apache.james.apache-mime4j>0.8.9</version.org.apache.james.apache-mime4j>
         <version.org.apache.maven>3.3.9</version.org.apache.maven> <!-- Used to download aether-provider -->
         <version.org.bouncycastle>1.66</version.org.bouncycastle>
         <version.org.codehaus.jackson>1.9.13.redhat-00007</version.org.codehaus.jackson>
@@ -443,14 +443,18 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.james</groupId>
-                <artifactId>apache-mime4j</artifactId>
+                <artifactId>apache-mime4j-core</artifactId>
                 <version>${version.org.apache.james.apache-mime4j}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.james</groupId>
+                <artifactId>apache-mime4j-dom</artifactId>
+                <version>${version.org.apache.james.apache-mime4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.james</groupId>
+                <artifactId>apache-mime4j-storage</artifactId>
+                <version>${version.org.apache.james.apache-mime4j}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/security/resteasy-crypto/pom.xml
+++ b/security/resteasy-crypto/pom.xml
@@ -71,7 +71,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.james</groupId>
-            <artifactId>apache-mime4j</artifactId>
+            <artifactId>apache-mime4j-dom</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.annotation</groupId>


### PR DESCRIPTION
…s dependency change is not backwards compatible. However, it only requires the consumer to upgrade Apache James mime4j and commons-io to a version greater than 0.7.

https://issues.redhat.com/browse/RESTEASY-3282

Note in this PR we were required to also upgrade commons-io. This is no longer compatible with a WildFly version which ships with older versions of mime4j. However, this branch is no longer used in WildFly.
