### PR TITLE
[RESTEASY-3283] Do not throw a DefaultOptionsMethodException when no …

### DIFF
--- a/docbook/reference/en/en-US/modules/ExceptionMappers.xml
+++ b/docbook/reference/en/en-US/modules/ExceptionMappers.xml
@@ -132,7 +132,8 @@ If there is an ExceptionMapper for wrapped exception, then that is used to handl
 <row>
 <entry>DefaultOptionsMethodException</entry>
 <entry>N/A</entry>
-<entry>If the user invokes HTTP OPTIONS and no &REST-API; method for it, RESTEasy provides a default behavior by throwing this exception</entry>
+<entry>If the user invokes HTTP OPTIONS and no &REST-API; method for it, RESTEasy provides a default behavior by throwing this exception.
+This is only done if the property <code>dev.resteasy.throw.options.exception</code> is set to true.</entry>
 </row>
 <row>
 <entry>UnrecognizedPropertyExceptionHandler</entry>

--- a/docbook/reference/en/en-US/modules/Installation_Configuration.xml
+++ b/docbook/reference/en/en-US/modules/Installation_Configuration.xml
@@ -1240,6 +1240,21 @@ String value = ConfigProvider.getConfig().getOptionalValue("prop_name", String.c
                                 see section <link linkend='ResteasyWebApplicationException'>Resteasy WebApplicationExceptions</link>
                             </entry>
                         </row>
+                        <row>
+                            <entry>
+                                dev.resteasy.throw.options.exception
+                            </entry>
+                            <entry>
+                                false
+                            </entry>
+                            <entry>
+                                Setting this value to true will throw a <classname>org.jboss.resteasy.spi.DefaultOptionsMethodException</classname>
+                                if the HTTP method "OPTIONS" is sent and the matching method is not annotated with
+                                <classname>@OPTIONS</classname>. This is the original behavior of RESTEasy. However, this
+                                has been changed to return the response so that it&apos;s processed with an
+                                <classname>ExceptionMapper</classname>.
+                            </entry>
+                        </row>
                     </tbody>
                 </tgroup>
             </table>

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/DefaultOptionsMethodException.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/DefaultOptionsMethodException.java
@@ -6,7 +6,12 @@ import jakarta.ws.rs.core.Response;
  * This exception is thrown when the client invokes HTTP OPTIONS operation and the JAX-RS resource
  * does not have a Java method that supports OPTIONS. RESTEasy provides a default behavior for OPTIONS.
  * If you want to override this behavior, write an exception mapper for this exception.
+ * <p>
+ * Note that by default this exception is no longer thrown unless the {@code dev.resteasy.throw.options.exception}
+ * configuration property is set to {@code true}. This exception will be removed in a future release.
+ * </p>
  */
+@Deprecated(forRemoval = true)
 public class DefaultOptionsMethodException extends Failure {
     public DefaultOptionsMethodException(final String s, final Response response) {
         super(s, response);

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/registry/ConstantResourceInvoker.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/registry/ConstantResourceInvoker.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.core.registry;
+
+import java.lang.reflect.Method;
+
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.ResourceInvoker;
+import org.jboss.resteasy.spi.statistics.MethodStatisticsLogger;
+
+/**
+ * A resource invoker which simply returns the given response.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class ConstantResourceInvoker implements ResourceInvoker {
+    private final Response response;
+    private volatile MethodStatisticsLogger logger;
+
+    ConstantResourceInvoker(final Response response) {
+        this.response = response;
+    }
+
+    @Override
+    public Response invoke(final HttpRequest request, final HttpResponse response) {
+        return this.response;
+    }
+
+    @Override
+    public Response invoke(final HttpRequest request, final HttpResponse response, final Object target) {
+        return this.response;
+    }
+
+    @Override
+    public Method getMethod() {
+        return null;
+    }
+
+    @Override
+    public boolean hasProduces() {
+        return false;
+    }
+
+    @Override
+    public void setMethodStatisticsLogger(final MethodStatisticsLogger msLogger) {
+        this.logger = msLogger;
+    }
+
+    @Override
+    public MethodStatisticsLogger getMethodStatisticsLogger() {
+        return logger;
+    }
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/SegmentTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/SegmentTest.java
@@ -8,7 +8,6 @@ import org.jboss.resteasy.core.ResourceLocatorInvoker;
 import org.jboss.resteasy.core.ResourceMethodInvoker;
 import org.jboss.resteasy.core.ResourceMethodRegistry;
 import org.jboss.resteasy.mock.MockHttpRequest;
-import org.jboss.resteasy.spi.DefaultOptionsMethodException;
 import org.jboss.resteasy.spi.ResourceInvoker;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.test.resource.resource.SegmentLocatorComplex;
@@ -52,12 +51,9 @@ public class SegmentTest {
         ResourceMethodRegistry registry = new ResourceMethodRegistry(ResteasyProviderFactory
                 .getInstance());
         registry.addPerRequestResource(SegmentResource.class);
+        ResourceInvoker invoker = registry.getResourceInvoker(MockHttpRequest.options("/resource/sub"));
         try {
-            ResourceInvoker invoker = registry.getResourceInvoker(MockHttpRequest.options("/resource/sub"));
-        } catch (DefaultOptionsMethodException e) {
-        }
-        try {
-            ResourceInvoker invoker = registry.getResourceInvoker(MockHttpRequest.put("/resource/sub"));
+            invoker = registry.getResourceInvoker(MockHttpRequest.put("/resource/sub"));
         } catch (NotAllowedException e) {
         }
     }


### PR DESCRIPTION
…OPTIONS method is found. Instead, just return the created response.

https://issues.redhat.com/browse/RESTEASY-3283

Replacement for #3406 as I mistakenly deleted the branch.