### PR TITLE
Use two steps when building the JavaDoc. The order of the build matte…

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -127,7 +127,9 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Build Java Docs with Java 11
-        run: mvn clean site install -B -DskipTests
+        run: |
+          mvn clean install -B -DskipTests
+          mvn clean site -B -DskipTests
 
   format-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
…rs with the site plugin. There might be another way to fix this, but for now this will work around the CI issue.