### PR TITLE
RESTEASY-3302 Make snakeyaml accept tags during parsing.

### DIFF
--- a/providers/yaml/src/main/java/org/jboss/resteasy/plugins/providers/YamlProvider.java
+++ b/providers/yaml/src/main/java/org/jboss/resteasy/plugins/providers/YamlProvider.java
@@ -55,7 +55,7 @@ import static java.security.AccessController.doPrivileged;
 @Produces({"text/yaml", "text/x-yaml", "application/x-yaml"})
 @Deprecated
 public class YamlProvider extends AbstractEntityProvider<Object> {
-   private static final String ALLOWED_LIST = "resteasy.yaml.deserialization.allowed.list.allowIfBaseType";
+   protected static final String ALLOWED_LIST = "resteasy.yaml.deserialization.allowed.list.allowIfBaseType";
    private static final String DISABLE_TYPE_CHECK = "resteasy.yaml.deserialization.disable.type.check";
    // Setting this property tells snakeyaml to allow all tags during parsing. The tags will be instead whitelisted by resteasy
    // provided constructor.
@@ -189,11 +189,13 @@ public class YamlProvider extends AbstractEntityProvider<Object> {
       });
    }
 
-   private static Pattern createAllowPattern() {
+   protected static Pattern createAllowPattern() {
       final String value = getProperty(ALLOWED_LIST);
       final Collection<String> allowed = new ArrayList<>(DEFAULT_ALLOWED_TYPES);
       if (value != null) {
-         Collections.addAll(allowed, value.split(","));
+         for (String className: value.split(",")) {
+            allowed.add(Pattern.quote(className));
+         }
       }
       return Pattern.compile(String.join("|", allowed));
    }
@@ -214,7 +216,7 @@ public class YamlProvider extends AbstractEntityProvider<Object> {
             }
          }
          if (value == null) {
-            System.getProperty(key);
+            value = System.getProperty(key);
          }
          return value;
       } else {

--- a/providers/yaml/src/test/java/org/jboss/resteasy/plugins/providers/YamlProviderTestCase.java
+++ b/providers/yaml/src/test/java/org/jboss/resteasy/plugins/providers/YamlProviderTestCase.java
@@ -1,0 +1,30 @@
+package org.jboss.resteasy.plugins.providers;
+
+import java.util.regex.Pattern;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class YamlProviderTestCase {
+
+    @Test
+    public void testCreateAllowPatternFromSystemProperty() {
+        // set the system property with a class name that should be allowed to be deserialized
+        final String className = "org.jboss.resteasy.TestClass";
+        String originalPropertyValue = System.setProperty(YamlProvider.ALLOWED_LIST, className);
+
+        try {
+            Pattern allowPattern = YamlProvider.createAllowPattern();
+            // assert that resulting pattern does contain the *quoted* class name specified in the system property
+            Assert.assertTrue("The pattern doesn't contain expected class: " + allowPattern,
+                    allowPattern.toString().contains(Pattern.quote(className)));
+        } finally {
+            // reset the original system property value
+            if (originalPropertyValue == null) {
+                System.clearProperty(YamlProvider.ALLOWED_LIST);
+            } else {
+                System.setProperty(YamlProvider.ALLOWED_LIST, originalPropertyValue);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Whitelisting of classes that are allowed to be instantiated is done on the resteasy level instead.

https://issues.redhat.com/browse/RESTEASY-3302