### PR TITLE
RESTEASY-2831: Check mediatype before calling isCompatible

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/BaseHttpRequest.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/BaseHttpRequest.java
@@ -46,7 +46,7 @@ public abstract class BaseHttpRequest implements HttpRequest {
             return formParameters;
         }
         MediaType mt = getHttpHeaders().getMediaType();
-        if (mt.isCompatible(MediaType.valueOf("application/x-www-form-urlencoded"))) {
+        if (MediaType.valueOf("application/x-www-form-urlencoded").isCompatible(mt)) {
             try {
                 formParameters = FormUrlEncodedProvider.parseForm(getInputStream(),
                         mt.getParameters().get(MediaType.CHARSET_PARAMETER));


### PR DESCRIPTION
I have got `NPE` when call `logout` method in keycloak 20.0.3. It occurs when calling `BaseHttpRequest.getFormParameters` and `Content-Type` is not set.