### PR TITLE
[RESTEASY-3272] Move the ResteasyThreadContext to a different package…

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/concurrent/ResteasyThreadContext.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/concurrent/ResteasyThreadContext.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-package org.jboss.resteasy.concurrent;
+package org.jboss.resteasy.core.concurrent;
 
 import java.util.Map;
 

--- a/resteasy-core/src/main/resources/META-INF/services/org.jboss.resteasy.spi.concurrent.ThreadContext
+++ b/resteasy-core/src/main/resources/META-INF/services/org.jboss.resteasy.spi.concurrent.ThreadContext
@@ -17,4 +17,4 @@
 # limitations under the License.
 #
 
-org.jboss.resteasy.concurrent.ResteasyThreadContext
+org.jboss.resteasy.core.concurrent.ResteasyThreadContext


### PR DESCRIPTION
… to avoid package splitting.

https://issues.redhat.com/browse/RESTEASY-3272

Replaces #3398 