### PR TITLE
Add query params to reqest for VertxClientHttpEngine

### DIFF
--- a/resteasy-client-vertx/src/main/java/org/jboss/resteasy/client/jaxrs/engines/vertx/VertxClientHttpEngine.java
+++ b/resteasy-client-vertx/src/main/java/org/jboss/resteasy/client/jaxrs/engines/vertx/VertxClientHttpEngine.java
@@ -150,7 +150,10 @@ public class VertxClientHttpEngine implements AsyncClientHttpEngine {
         if (body != null) {
             headers.set(HttpHeaders.CONTENT_LENGTH, "" + body.length());
         }
-        options.addHeader(HttpHeaders.USER_AGENT.toString(), "Vertx");
+
+        if (!headers.contains(HttpHeaders.USER_AGENT)) {
+            options.addHeader(HttpHeaders.USER_AGENT.toString(), "Vertx");
+        }
 
         URI uri = request.getUri();
         options.setHost(uri.getHost());
@@ -165,7 +168,11 @@ public class VertxClientHttpEngine implements AsyncClientHttpEngine {
             options.setPort(uri.getPort());
         }
 
-        options.setURI(uri.getRawPath());
+        String relativeUri = uri.getRawPath();
+        if (uri.getRawQuery() != null && !uri.getRawQuery().trim().isEmpty()) {
+            relativeUri = relativeUri + "?" + uri.getRawQuery();
+        }
+        options.setURI(relativeUri);
 
         if (request.getConfiguration().hasProperty(REQUEST_TIMEOUT_MS)) {
             long timeoutMs = unwrapTimeout(

--- a/resteasy-client-vertx/src/test/java/org/jboss/resteasy/test/client/vertx/VertxClientEngineTest.java
+++ b/resteasy-client-vertx/src/test/java/org/jboss/resteasy/test/client/vertx/VertxClientEngineTest.java
@@ -115,6 +115,47 @@ public class VertxClientEngineTest {
     }
 
     @Test
+    public void testQueryParams() throws Exception {
+        final String queryParam = "testQueryParam";
+        final String queryParamValue = "testQueryParamValue";
+        server.requestHandler(req -> {
+            HttpServerResponse response = req.response();
+            if (String.format("%s=%s", queryParam, queryParamValue).equals(req.query())) {
+                response.setStatusCode(200).end("Success");
+            } else {
+                response.setStatusCode(503).end("fail");
+            }
+        });
+
+        final Response response = client().target(baseUri())
+                .queryParam(queryParam, queryParamValue)
+                .request()
+                .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("Success", response.readEntity(String.class));
+    }
+
+    @Test
+    public void testSimpleCustomUserAgent() throws Exception {
+        final String customUserAgent = "CUSTOM_USER_AGENT";
+        server.requestHandler(req -> {
+            HttpServerResponse response = req.response();
+            if (req.getHeader(HttpHeaders.USER_AGENT).equals(customUserAgent)) {
+                response.setStatusCode(200).end("Success");
+            } else {
+                response.setStatusCode(503).end("fail");
+            }
+        });
+
+        final Response response = client().target(baseUri()).request()
+                .header(HttpHeaders.USER_AGENT.toString(), customUserAgent)
+                .get();
+
+        assertEquals(200, response.getStatus());
+        assertEquals("Success", response.readEntity(String.class));
+    }
+
+    @Test
     public void testHTTP() throws Exception {
         server.requestHandler(req -> {
             HttpServerResponse response = req.response();


### PR DESCRIPTION
This pr pulls in a subset of changes from https://github.com/resteasy/resteasy/pull/2890

The changes are
- Add query params to uri if they exist
- Dont add USER_AGENT header if one already exists

https://issues.redhat.com/browse/RESTEASY-3018
