### PR TITLE
[RESTEASY-3323] Upgrade Undertow to 2.3.4.Final and Servlet to 6.0

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -52,7 +52,7 @@
         <version.hamcrest>1.3</version.hamcrest>
         <version.io.netty.netty4>4.1.91.Final</version.io.netty.netty4>
         <version.io.vertx>4.3.4</version.io.vertx>
-        <version.io.undertow>2.2.20.Final</version.io.undertow>
+        <version.io.undertow>2.3.4.Final</version.io.undertow>
         <version.jakarta.activation>2.1.0</version.jakarta.activation>
         <version.jakarta.enterprise.cdi-api>4.0.1</version.jakarta.enterprise.cdi-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>
@@ -88,7 +88,7 @@
         <version.jakarta.jms.jms-api>3.1.0</version.jakarta.jms.jms-api>
         <version.jakarta.ws.rs>3.1.0</version.jakarta.ws.rs>
         <version.jakarta.xml.bind.bind-api>3.0.1</version.jakarta.xml.bind.bind-api>
-        <version.jakarta.servlet.servlet-api>5.0.0</version.jakarta.servlet.servlet-api>
+        <version.jakarta.servlet.servlet-api>6.0.0</version.jakarta.servlet.servlet-api>
         <version.org.jboss.shrinkwrap.resolver>3.1.4</version.org.jboss.shrinkwrap.resolver>
         <version.org.mockito>4.9.0</version.org.mockito>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
@@ -525,7 +525,7 @@
             </dependency>
             <dependency>
                 <groupId>io.undertow</groupId>
-                <artifactId>undertow-servlet-jakarta</artifactId>
+                <artifactId>undertow-servlet</artifactId>
                 <version>${version.io.undertow}</version>
                 <exclusions>
                     <exclusion>

--- a/resteasy-wadl-undertow-connector/pom.xml
+++ b/resteasy-wadl-undertow-connector/pom.xml
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>io.undertow</groupId>
-            <artifactId>undertow-servlet-jakarta</artifactId>
+            <artifactId>undertow-servlet</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/server-adapters/resteasy-undertow-cdi/pom.xml
+++ b/server-adapters/resteasy-undertow-cdi/pom.xml
@@ -52,7 +52,7 @@
 
         <dependency>
             <groupId>io.undertow</groupId>
-            <artifactId>undertow-servlet-jakarta</artifactId>
+            <artifactId>undertow-servlet</artifactId>
         </dependency>
         <dependency>
             <groupId>io.undertow</groupId>

--- a/server-adapters/resteasy-undertow-cdi/src/test/resources/logging.properties
+++ b/server-adapters/resteasy-undertow-cdi/src/test/resources/logging.properties
@@ -1,0 +1,39 @@
+#
+# JBoss, Home of Professional Open Source.
+#
+# Copyright 2017 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+loggers=org.jboss.resteasy
+
+logger.level=INFO
+logger.handlers=CONSOLE
+
+logger.org.jboss.resteasy.level=${test.log.level:INFO}
+
+handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.formatter=COLOR-PATTERN
+handler.CONSOLE.properties=autoFlush,target
+handler.CONSOLE.autoFlush=true
+handler.CONSOLE.target=SYSTEM_OUT
+
+formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.COLOR-PATTERN.properties=pattern
+formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n
+
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n

--- a/server-adapters/resteasy-undertow/pom.xml
+++ b/server-adapters/resteasy-undertow/pom.xml
@@ -26,7 +26,7 @@
         </dependency>
         <dependency>
             <groupId>io.undertow</groupId>
-            <artifactId>undertow-servlet-jakarta</artifactId>
+            <artifactId>undertow-servlet</artifactId>
         </dependency>
         <dependency>
             <groupId>io.undertow</groupId>


### PR DESCRIPTION
### **WARNING**
This is a major Servlet upgrade. In most cases this should be backwards compatible. However, Undertow no longer has a Jakarta EE 9.1 variant, [UNDERTOW-2167](https://issues.redhat.com/browse/UNDERTOW-2167). This forces a major Undertow and Servlet bump in 6.2. However, 6.2 supports Jakarta RESTful Web Services 3.1/Jakarta EE 10 so maybe not a huge issue.

https://issues.redhat.com/browse/RESTEASY-3323
