### PR TITLE
[RESTEASY-3354] Upgrade Eclipse Parsson from 1.1.2 to 1.1.3.

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -71,7 +71,7 @@
         <version.org.eclipse.angus.angus-activation>2.0.1</version.org.eclipse.angus.angus-activation>
         <version.org.eclipse.angus.angus-mail>1.1.0</version.org.eclipse.angus.angus-mail>
         <version.org.eclipse.jetty>11.0.15</version.org.eclipse.jetty>
-        <version.org.eclipse.parsson>1.1.2</version.org.eclipse.parsson>
+        <version.org.eclipse.parsson>1.1.3</version.org.eclipse.parsson>
         <version.org.eclipse.yasson>3.0.3</version.org.eclipse.yasson>
         <version.org.glassfish.jakarta.el>4.0.2</version.org.glassfish.jakarta.el>
         <version.jakarta.persistence.persistence-api>3.0.0</version.jakarta.persistence.persistence-api>


### PR DESCRIPTION
- [Release notes](https://github.com/eclipse-ee4j/parsson/releases)
- [Commits](eclipse-ee4j/parsson@1.1.2...1.1.3)

https://issues.redhat.com/browse/RESTEASY-3354