### PR TITLE
Fix client-side ParamConverter retrieval

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/AbstractCollectionProcessor.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/AbstractCollectionProcessor.java
@@ -57,6 +57,10 @@ public abstract class AbstractCollectionProcessor<T> {
                 target = apply(target, arr);
             }
         } else {
+            ParamConverter<Object> paramConverter = config.getParamConverter(object.getClass(), type, annotations);
+            if (paramConverter != null) {
+                object = paramConverter.toString(object);
+            }
             target = apply(target, object);
         }
         return target;


### PR DESCRIPTION
(Not sure if it's necessary to create an issue for this small change so I just created a PR)

At the moment the `resteasy-client` doesn't retrieve `ParamConverter`s for objects different from Collection and array if the `ParamConverterProvider` requires the `genericType` or the `annotations`. This PR fixes the issue.
I haven't found any tests for the retrieval of `ParamConverter`s on client-side. If there are any could you just point me to them so that I can add a test case for this.