### PR TITLE
[RESTEASY-3362] Do not depend on Xerces for the JAXP implementation. …

### DIFF
--- a/resteasy-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxb-provider/main/module.xml
+++ b/resteasy-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxb-provider/main/module.xml
@@ -32,10 +32,6 @@
         <module name="jakarta.servlet.api" />
         <module name="jakarta.ws.rs.api" />
         <module name="jakarta.xml.bind.api" />
-        <!-- Some features are used in the SecureUnmarshaller that only work with Xerces. However, it's optional
-             because if these features are not used then it doesn't need to use Xerces.
-        -->
-        <module name="org.apache.xerces" optional="true" services="import" />
         <module name="org.jboss.logging" />
         <module name="org.jboss.resteasy.resteasy-core" />
         <module name="org.jboss.resteasy.resteasy-core-spi" />

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/AssumeUtils.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/AssumeUtils.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.utils;
+
+import org.junit.Assume;
+
+/**
+ * Utilities for test assumptions.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class AssumeUtils {
+
+    /**
+     * Checks to see if the {@link javax.xml.XMLConstants#FEATURE_SECURE_PROCESSING} can be set to {@code false}. This
+     * is not allowed when the security manager is enabled.
+     * From the <a href=
+     * "https://docs.oracle.com/en/java/javase/11/security/java-api-xml-processing-jaxp-security-guide.html#GUID-88B04BE2-35EF-4F61-B4FA-57A0E9102342">docs</a>:
+     * <p>
+     * <i>While FSP can be turned on and off through factories, it is always on when a Java Security Manager is present and
+     * cannot be turned off.</i>
+     * </p>
+     */
+    public static void canDisableFeatureSecureProcessing() {
+        assumeSecurityManagerDisabled(
+                "Cannot disable the XMLConstants.FEATURE_SECURE_PROCESSING when the security manager is enabled");
+    }
+
+    /**
+     * Checks if the {@code security.manager} system property has been set.
+     *
+     * @param msg the message for the assumption
+     */
+    public static void assumeSecurityManagerDisabled(final String msg) {
+        Assume.assumeTrue(msg, System.getProperty("security.manager") == null);
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/xxe/ExternalParameterEntityTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/xxe/ExternalParameterEntityTest.java
@@ -115,7 +115,8 @@ public class ExternalParameterEntityTest {
         logger.info(String.format("Request body: %s", this.request.replace('\r', '\n')));
         Response response = client.target(generateURL("/test", NO_EXPAND)).request()
                 .post(Entity.entity(this.request, MediaType.APPLICATION_XML));
-        Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        // Expect a 500 because resteasy.document.expand.entity.references is set to false
+        Assert.assertEquals(HttpResponseCodes.SC_INTERNAL_SERVER_ERROR, response.getStatus());
         String entity = response.readEntity(String.class);
         logger.info(String.format("Result: \"%s\"", entity.replace('\r', '\n')));
         Assert.assertEquals("", entity.trim());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/xxe/XxeJaxbTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/xxe/XxeJaxbTest.java
@@ -20,6 +20,7 @@ import org.jboss.resteasy.test.xxe.resource.xxeJaxb.XxeJaxbFavoriteMovie;
 import org.jboss.resteasy.test.xxe.resource.xxeJaxb.XxeJaxbFavoriteMovieXmlRootElement;
 import org.jboss.resteasy.test.xxe.resource.xxeJaxb.XxeJaxbFavoriteMovieXmlType;
 import org.jboss.resteasy.test.xxe.resource.xxeJaxb.XxeJaxbMovieResource;
+import org.jboss.resteasy.utils.AssumeUtils;
 import org.jboss.resteasy.utils.PortProviderUtil;
 import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
@@ -158,6 +159,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("f")
     public void testXmlRootElementDefaultFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doTestXmlRootElementDefault("f");
     }
 
@@ -183,6 +185,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("ff")
     public void testXmlRootElementWithoutExpansionFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doTestXmlRootElementWithoutExpansion("ff");
     }
 
@@ -209,6 +212,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("tf")
     public void testXmlRootElementWithExpansionFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doTestXmlRootElementWithExpansion("tf");
     }
 
@@ -234,6 +238,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("f")
     public void testXmlTypeDefaultFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doTestXmlTypeDefault("f");
     }
 
@@ -259,6 +264,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("ff")
     public void testXmlTypeWithoutExpansionFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doTestXmlTypeWithoutExpansion("ff");
     }
 
@@ -285,6 +291,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("tf")
     public void testXmlTypeWithExpansionFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doTestXmlTypeWithExpansion("tf");
     }
 
@@ -310,6 +317,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("f")
     public void testJAXBElementDefaultFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doTestJAXBElementDefault("f");
     }
 
@@ -335,6 +343,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("ff")
     public void testJAXBElementWithoutExpansionFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doTestJAXBElementWithoutExpansion("ff");
     }
 
@@ -361,6 +370,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("tf")
     public void testJAXBElementWithExpansionFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doTestJAXBElementWithExpansion("tf");
     }
 
@@ -388,6 +398,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("f")
     public void testListDefaultFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doCollectionTestWithoutExpansion("f", "list");
     }
 
@@ -417,6 +428,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("ff")
     public void testListWithoutExpansionFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doCollectionTestWithoutExpansion("ff", "list");
     }
 
@@ -447,6 +459,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("tf")
     public void testListWithExpansionFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doCollectionTestWithExpansion("tf", "list");
     }
 
@@ -476,6 +489,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("f")
     public void testSetDefaultFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doCollectionTestWithoutExpansion("f", "set");
     }
 
@@ -505,6 +519,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("ff")
     public void testSetWithoutExpansionFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doCollectionTestWithoutExpansion("ff", "set");
     }
 
@@ -535,6 +550,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("tf")
     public void testSetWithExpansionFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doCollectionTestWithExpansion("tf", "set");
     }
 
@@ -564,6 +580,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("f")
     public void testArrayDefaultFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doCollectionTestWithoutExpansion("f", "array");
     }
 
@@ -593,6 +610,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("ff")
     public void testArrayWithoutExpansionFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doCollectionTestWithoutExpansion("ff", "array");
     }
 
@@ -623,6 +641,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("tf")
     public void testArrayWithExpansionFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doCollectionTestWithExpansion("tf", "array");
     }
 
@@ -651,6 +670,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("f")
     public void testMapDefaultFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doMapTestWithoutExpansion("f");
     }
 
@@ -678,6 +698,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("ff")
     public void testMapWithoutExpansionFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doMapTestWithoutExpansion("ff");
     }
 
@@ -706,6 +727,7 @@ public class XxeJaxbTest {
     @Test
     @OperateOnDeployment("tf")
     public void testMapWithExpansionFalse() throws Exception {
+        AssumeUtils.canDisableFeatureSecureProcessing();
         doMapTestWithExpansion("tf");
     }
 


### PR DESCRIPTION
…This required test changes as when enabling the feature secure processing, this does not allow overriding external connections in the JDK's JAXP implementation.

https://issues.redhat.com/browse/RESTEASY-3362