### PR TITLE
[RESTEASY-3387] Use java.util.Locale to parse the languages from the Accept-Language header.

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/util/LocaleHelper.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/util/LocaleHelper.java
@@ -11,14 +11,7 @@ public class LocaleHelper {
         int q = lang.indexOf(';');
         if (q > -1)
             lang = lang.substring(0, q);
-        String[] split = lang.trim().split("-");
-        if (split.length == 1)
-            return new Locale(split[0].toLowerCase());
-        else if (split.length == 2)
-            return new Locale(split[0].toLowerCase(), split[1].toLowerCase());
-        else if (split.length > 2)
-            return new Locale(split[0], split[1], split[2]);
-        return null; // unreachable
+        return Locale.forLanguageTag(lang);
     }
 
     /**
@@ -29,9 +22,6 @@ public class LocaleHelper {
      * @return converted language format string
      */
     public static String toLanguageString(Locale value) {
-        StringBuffer buf = new StringBuffer(value.getLanguage().toLowerCase());
-        if (value.getCountry() != null && !value.getCountry().equals(""))
-            buf.append("-").append(value.getCountry().toLowerCase());
-        return buf.toString();
+        return value.toLanguageTag();
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/ContentLanguageHeaderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/ContentLanguageHeaderTest.java
@@ -75,8 +75,8 @@ public class ContentLanguageHeaderTest {
         MultivaluedMap<String, Object> headers = response.getHeaders();
 
         Assert.assertTrue("Content-Language header is not present in response", headers.keySet().contains("Content-Language"));
-        Assert.assertEquals("Content-Language header does not have expected value", "en-us",
-                headers.getFirst("Content-Language"));
+        Assert.assertTrue("Content-Language header does not have expected value",
+                "en-us".equalsIgnoreCase(headers.getFirst("Content-Language").toString()));
     }
 
     /**
@@ -91,8 +91,8 @@ public class ContentLanguageHeaderTest {
         MultivaluedMap<String, Object> headers = response.getHeaders();
 
         Assert.assertTrue("Content-Language header is not present in response", headers.keySet().contains("Content-Language"));
-        Assert.assertEquals("Content-Language header does not have expected value", "en-us",
-                headers.getFirst("Content-Language"));
+        Assert.assertTrue("Content-Language header does not have expected value",
+                "en-us".equalsIgnoreCase(headers.getFirst("Content-Language").toString()));
     }
 
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/VariantsTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/VariantsTest.java
@@ -203,7 +203,7 @@ public class VariantsTest {
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
         Assert.assertEquals("GET", response.readEntity(String.class));
         Assert.assertEquals(MediaType.APPLICATION_XML_TYPE.withCharset("UTF-8"), response.getMediaType());
-        Assert.assertEquals("en-us", new LocaleDelegate().toString(response.getLanguage()));
+        Assert.assertTrue("en-us".equalsIgnoreCase(new LocaleDelegate().toString(response.getLanguage())));
         response.close();
     }
 
@@ -220,7 +220,7 @@ public class VariantsTest {
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
         Assert.assertEquals("GET", response.readEntity(String.class));
         Assert.assertEquals(MediaType.APPLICATION_XML_TYPE.withCharset("UTF-8"), response.getMediaType());
-        Assert.assertEquals("en-us", new LocaleDelegate().toString(response.getLanguage()));
+        Assert.assertTrue("en-us".equalsIgnoreCase(new LocaleDelegate().toString(response.getLanguage())));
         response.close();
     }
 
@@ -237,7 +237,7 @@ public class VariantsTest {
         Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
         Assert.assertEquals("GET", response.readEntity(String.class));
         Assert.assertEquals(MediaType.APPLICATION_XML_TYPE.withCharset("UTF-8"), response.getMediaType());
-        Assert.assertEquals("en-us", new LocaleDelegate().toString(response.getLanguage()));
+        Assert.assertTrue("en-us".equalsIgnoreCase(new LocaleDelegate().toString(response.getLanguage())));
         response.close();
     }
 


### PR DESCRIPTION
Updated the unit tests to check the header with case insensitivity.

This is a fix for https://issues.redhat.com/projects/RESTEASY/issues/RESTEASY-3387. 

Signed-off-by:Nathan Erwin <nathan.d.erwin@gmail.com>