### PR TITLE
[RESTEASY-3389] Migrate the resteasy-client tests to use JUnit 5.

### DIFF
--- a/resteasy-client/pom.xml
+++ b/resteasy-client/pom.xml
@@ -77,8 +77,8 @@
 
         <!-- Test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/resteasy-client/src/test/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43EngineTest.java
+++ b/resteasy-client/src/test/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43EngineTest.java
@@ -1,21 +1,21 @@
 package org.jboss.resteasy.client.jaxrs.engines;
 
 import static org.jboss.resteasy.client.jaxrs.engines.ManualClosingApacheHttpClient43Engine.FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ManualClosingApacheHttpClient43EngineTest {
 
     private static final Map<String, String> preTestProperties = new HashMap<>();
 
-    @BeforeClass
+    @BeforeAll
     public static void saveCurrentStateOfMemThresholdProperty() {
         if (System.getProperties().containsKey(FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY)) {
             String value = System.getProperty(FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY);
@@ -23,7 +23,7 @@ public class ManualClosingApacheHttpClient43EngineTest {
         }
     }
 
-    @AfterClass
+    @AfterAll
     public static void resetPropertiesToPreTestValues() {
         if (!preTestProperties.containsKey(FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY)) {
             System.clearProperty(FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY);
@@ -32,7 +32,7 @@ public class ManualClosingApacheHttpClient43EngineTest {
         }
     }
 
-    @Before
+    @BeforeEach
     public void unsetMemThresholdProperty() {
         System.clearProperty(ManualClosingApacheHttpClient43Engine.FILE_UPLOAD_IN_MEMORY_THRESHOLD_PROPERTY);
     }

--- a/resteasy-client/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesAbstract.java
+++ b/resteasy-client/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesAbstract.java
@@ -7,8 +7,8 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.client.jaxrs.i18n.Messages;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -32,13 +32,13 @@ public abstract class TestMessagesAbstract extends TestMessagesParent {
             return;
         }
 
-        Assert.assertEquals(getExpected(BASE + "00", "canOnlySetOneLinkHeaderParam", "abc", "xyz"),
+        Assertions.assertEquals(getExpected(BASE + "00", "canOnlySetOneLinkHeaderParam", "abc", "xyz"),
                 Messages.MESSAGES.canOnlySetOneLinkHeaderParam("abc", "xyz"));
-        Assert.assertEquals(getExpected(BASE + "20", "couldNotCreateURL", "xx", "yy", "zz"),
+        Assertions.assertEquals(getExpected(BASE + "20", "couldNotCreateURL", "xx", "yy", "zz"),
                 Messages.MESSAGES.couldNotCreateURL("xx", "yy", "zz"));
-        Assert.assertEquals(getExpected(BASE + "40", "doesNotSpecifyTypeParameter", var),
+        Assertions.assertEquals(getExpected(BASE + "40", "doesNotSpecifyTypeParameter", var),
                 Messages.MESSAGES.doesNotSpecifyTypeParameter(var));
-        Assert.assertEquals(getExpected(BASE + "60", "failedToBufferAbortedResponseNoWriter", mediaType, "class"),
+        Assertions.assertEquals(getExpected(BASE + "60", "failedToBufferAbortedResponseNoWriter", mediaType, "class"),
                 Messages.MESSAGES.failedToBufferAbortedResponseNoWriter(mediaType, "class"));
     }
 

--- a/resteasy-client/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesParent.java
+++ b/resteasy-client/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesParent.java
@@ -5,8 +5,8 @@ import java.util.Locale;
 import java.util.Properties;
 
 import org.jboss.logging.Logger;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  *
@@ -20,12 +20,12 @@ public abstract class TestMessagesParent {
     protected static Locale savedLocale;
     protected Properties properties = new Properties();
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         savedLocale = Locale.getDefault();
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         Locale.setDefault(savedLocale);
         LOG.info("Reset default locale to: " + savedLocale);

--- a/resteasy-client/src/test/java/org/jboss/resteasy/test/other/DisableAutomaticRetriesTest.java
+++ b/resteasy-client/src/test/java/org/jboss/resteasy/test/other/DisableAutomaticRetriesTest.java
@@ -4,17 +4,17 @@ import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DisableAutomaticRetriesTest {
     @Test
     public void testFlag() throws Exception {
         ResteasyClientBuilder builder = (ResteasyClientBuilder) ClientBuilder.newBuilder();
-        Assert.assertFalse(builder.isDisableAutomaticRetries());
+        Assertions.assertFalse(builder.isDisableAutomaticRetries());
         builder.disableAutomaticRetries();
         Client client = builder.build();
-        Assert.assertTrue(builder.isDisableAutomaticRetries());
+        Assertions.assertTrue(builder.isDisableAutomaticRetries());
         client.close();
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-3389