### PR TITLE
[RESTEASY-3384] Improve parsing of malformed MediaTypes in MediaTypeH…

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java
@@ -93,7 +93,11 @@ public class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate<M
         } else {
             major = type.substring(0, typeIndex);
             if (paramIndex > -1) {
-                subtype = type.substring(typeIndex + 1, paramIndex);
+                int beginIndex = typeIndex + 1;
+                if (beginIndex > paramIndex) {
+                    throw new IllegalArgumentException(Messages.MESSAGES.failureParsingMediaType(type));
+                }
+                subtype = type.substring(beginIndex, paramIndex);
             } else {
                 subtype = type.substring(typeIndex + 1);
             }

--- a/resteasy-core/src/test/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegateTest.java
+++ b/resteasy-core/src/test/java/org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegateTest.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.plugins.delegates;
+
+import org.junit.Test;
+
+public class MediaTypeHeaderDelegateTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parsingBrokenMediaTypeShouldThrowIllegalArgumentException_minimized() {
+        MediaTypeHeaderDelegate.parse("x; /x");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parsingBrokenMediaTypeShouldThrowIllegalArgumentException_actual() {
+        MediaTypeHeaderDelegate.parse("() { ::}; echo \"NS:\" $(/bin/sh -c \"expr 123456 - 123456\")");
+    }
+}


### PR DESCRIPTION
…eaderDelegate

Previously, a "broken" MIME-type could trigger an StringIndexOutOfBoundsException instead of the more suitable IllegalArgumentException.

Example: "Accept: x; /x"

This PR now throws an IllegalArgumentException in case of a broken MIME-type.