### PR TITLE
[RESTEASY-2985] Only run the complete listeners if a 204 response is …

### DIFF
--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/config/Options.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/config/Options.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import jakarta.ws.rs.sse.SseEventSink;
+
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.spi.util.Functions;
 
@@ -62,6 +64,18 @@ public class Options<T> {
     public static final Options<Threshold> ENTITY_FILE_THRESHOLD = new Options<>("dev.resteasy.entity.file.threshold",
             Threshold.class,
             Functions.singleton(() -> Threshold.of(50L, SizeUnit.MEGABYTE)));
+
+    /**
+     * An option which allows which HTTP status code should be sent when the {@link SseEventSink#close()} is invoked.
+     * In some implementations 200 (OK) is the default. However, RESTEasy prefers 204 (No Content) as no content has
+     * been sent the response.
+     * <p>
+     * The default is 204 - No Content
+     * </p>
+     */
+    public static final Options<Integer> SSE_CLOSED_RESPONSE_CODE = new Options<>("dev.resteasy.sse.closed.response.code",
+            Integer.class,
+            Functions.singleton(() -> 204));
 
     private final String key;
     private final Class<T> name;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/resource/SseReconnectResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/sse/resource/SseReconnectResource.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.ServiceUnavailableException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -96,7 +97,8 @@ public class SseReconnectResource {
     public void sseLost(@Context SseEventSink sink, @Context Sse sse) {
         if (tryCount != 0) {
             tryCount--;
-            sink.close();
+            // Throw a service unavailable, 503, with a 1 second retry.
+            throw new ServiceUnavailableException(1L);
         } else {
             try (SseEventSink s = sink) {
                 s.send(sse.newEvent("MESSAGE"));


### PR DESCRIPTION
…received. Note that an SseEventSink.close() in RESTEasy will result in a 204. In other implementations, this results in a 200. Add a way to override this with a system property or configuration parameter. See https://github.com/jakartaee/rest/issues/1007 for details.

https://issues.redhat.com/browse/RESTEASY-2985

This potentially replaces #3554. However, there is an attempt to not full undo #1361.

@radcortez Would this work for you as a replacement for #3722?

Note the TCK will fail on `ee.jakarta.tck.ws.rs.jaxrs21.ee.sse.sseeventsource.JAXRSClientIT.connectionLostFor1500msTest`. Locally I've got a simple change to fix this, but I'd like to get an approval on this approach before I send a PR up to fix that test.