### PR TITLE
[RESTEASY-3397] Ensure the InputStream for the JsonBindingProvider do…

### DIFF
--- a/providers/json-binding/src/main/java/org/jboss/resteasy/plugins/providers/jsonb/JsonBindingProvider.java
+++ b/providers/json-binding/src/main/java/org/jboss/resteasy/plugins/providers/jsonb/JsonBindingProvider.java
@@ -135,8 +135,9 @@ public class JsonBindingProvider extends AbstractJsonBindingProvider
         }
 
         @Override
-        public void close() throws IOException {
-            delegate.close();
+        public void close() {
+            // Do not close the stream as per the Jakarta REST specification, currently 3.1, the stream being used
+            // must not be closed in a MessageBodyReader.
         }
 
         @Override


### PR DESCRIPTION
…es not get closed.

https://issues.redhat.com/browse/RESTEASY-3397

Upstream #3826 