### PR TITLE
add support for returning vertx future type

### DIFF
--- a/resteasy-client-vertx/src/main/java/org/jboss/resteasy/client/jaxrs/internal/VertxFutureRxInvoker.java
+++ b/resteasy-client-vertx/src/main/java/org/jboss/resteasy/client/jaxrs/internal/VertxFutureRxInvoker.java
@@ -1,0 +1,86 @@
+package org.jboss.resteasy.client.jaxrs.internal;
+
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.RxInvoker;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
+
+import io.vertx.core.Future;
+
+public interface VertxFutureRxInvoker extends RxInvoker<Future> {
+
+    @Override
+    Future<Response> get();
+
+    @Override
+    <T> Future<T> get(Class<T> responseType);
+
+    @Override
+    <T> Future<T> get(GenericType<T> responseType);
+
+    @Override
+    Future<Response> put(Entity<?> entity);
+
+    @Override
+    <T> Future<T> put(Entity<?> entity, Class<T> responseType);
+
+    @Override
+    <T> Future<T> put(Entity<?> entity, GenericType<T> responseType);
+
+    @Override
+    Future<Response> post(Entity<?> entity);
+
+    @Override
+    <T> Future<T> post(Entity<?> entity, Class<T> responseType);
+
+    @Override
+    <T> Future<T> post(Entity<?> entity, GenericType<T> responseType);
+
+    @Override
+    Future<Response> delete();
+
+    @Override
+    <T> Future<T> delete(Class<T> responseType);
+
+    @Override
+    <T> Future<T> delete(GenericType<T> responseType);
+
+    @Override
+    Future<Response> head();
+
+    @Override
+    Future<Response> options();
+
+    @Override
+    <T> Future<T> options(Class<T> responseType);
+
+    @Override
+    <T> Future<T> options(GenericType<T> responseType);
+
+    @Override
+    Future<Response> trace();
+
+    @Override
+    <T> Future<T> trace(Class<T> responseType);
+
+    @Override
+    <T> Future<T> trace(GenericType<T> responseType);
+
+    @Override
+    Future<Response> method(String name);
+
+    @Override
+    <T> Future<T> method(String name, Class<T> responseType);
+
+    @Override
+    <T> Future<T> method(String name, GenericType<T> responseType);
+
+    @Override
+    Future<Response> method(String name, Entity<?> entity);
+
+    @Override
+    <T> Future<T> method(String name, Entity<?> entity, Class<T> responseType);
+
+    @Override
+    <T> Future<T> method(String name, Entity<?> entity, GenericType<T> responseType);
+}

--- a/resteasy-client-vertx/src/main/java/org/jboss/resteasy/client/jaxrs/internal/VertxFutureRxInvokerImpl.java
+++ b/resteasy-client-vertx/src/main/java/org/jboss/resteasy/client/jaxrs/internal/VertxFutureRxInvokerImpl.java
@@ -1,0 +1,182 @@
+package org.jboss.resteasy.client.jaxrs.internal;
+
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.SyncInvoker;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+public class VertxFutureRxInvokerImpl implements VertxFutureRxInvoker {
+
+    private final ClientInvocationBuilder builder;
+
+    public VertxFutureRxInvokerImpl(SyncInvoker syncInvoker) {
+        this.builder = (ClientInvocationBuilder) syncInvoker;
+    }
+
+    private ClientInvocation createClientInvocation(String method, Entity<?> entity) {
+        ClientInvocation invocation = builder.createClientInvocation(builder.invocation);
+        invocation.setMethod(method);
+        invocation.setEntity(entity);
+        return invocation;
+    }
+
+    @Override
+    public Future<Response> get() {
+        return method(HttpMethod.GET);
+    }
+
+    @Override
+    public <T> Future<T> get(Class<T> responseType) {
+        return method(HttpMethod.GET, responseType);
+    }
+
+    @Override
+    public <T> Future<T> get(GenericType<T> responseType) {
+        return method(HttpMethod.GET, responseType);
+    }
+
+    @Override
+    public Future<Response> put(Entity<?> entity) {
+        return method(HttpMethod.PUT, entity);
+    }
+
+    @Override
+    public <T> Future<T> put(Entity<?> entity, Class<T> responseType) {
+        return method(HttpMethod.PUT, entity, responseType);
+    }
+
+    @Override
+    public <T> Future<T> put(Entity<?> entity, GenericType<T> responseType) {
+        return method(HttpMethod.PUT, entity, responseType);
+    }
+
+    @Override
+    public Future<Response> post(Entity<?> entity) {
+        return method(HttpMethod.POST, entity);
+    }
+
+    @Override
+    public <T> Future<T> post(Entity<?> entity, Class<T> responseType) {
+        return method(HttpMethod.POST, entity, responseType);
+    }
+
+    @Override
+    public <T> Future<T> post(Entity<?> entity, GenericType<T> responseType) {
+        return method(HttpMethod.POST, entity, responseType);
+    }
+
+    @Override
+    public Future<Response> delete() {
+        return method(HttpMethod.DELETE);
+    }
+
+    @Override
+    public <T> Future<T> delete(Class<T> responseType) {
+        return method(HttpMethod.DELETE, responseType);
+    }
+
+    @Override
+    public <T> Future<T> delete(GenericType<T> responseType) {
+        return method(HttpMethod.DELETE, responseType);
+    }
+
+    @Override
+    public Future<Response> head() {
+        return method(HttpMethod.HEAD);
+    }
+
+    @Override
+    public Future<Response> options() {
+        return method(HttpMethod.OPTIONS);
+    }
+
+    @Override
+    public <T> Future<T> options(Class<T> responseType) {
+        return method(HttpMethod.OPTIONS, responseType);
+    }
+
+    @Override
+    public <T> Future<T> options(GenericType<T> responseType) {
+        return method(HttpMethod.OPTIONS, responseType);
+    }
+
+    @Override
+    public Future<Response> trace() {
+        return method("TRACE");
+    }
+
+    @Override
+    public <T> Future<T> trace(Class<T> responseType) {
+        return method("TRACE", responseType);
+    }
+
+    @Override
+    public <T> Future<T> trace(GenericType<T> responseType) {
+        return method("TRACE", responseType);
+    }
+
+    @Override
+    public Future<Response> method(String name) {
+        Context vertxContext = Vertx.currentContext();
+        if (vertxContext != null) {
+            return Future.fromCompletionStage(createClientInvocation(name, null).submitCF(), vertxContext);
+        } else {
+            return Future.fromCompletionStage(createClientInvocation(name, null).submitCF());
+        }
+    }
+
+    @Override
+    public <T> Future<T> method(String name, Class<T> responseType) {
+        Context vertxContext = Vertx.currentContext();
+        if (vertxContext != null) {
+            return Future.fromCompletionStage(createClientInvocation(name, null).submitCF(responseType), vertxContext);
+        } else {
+            return Future.fromCompletionStage(createClientInvocation(name, null).submitCF(responseType));
+        }
+    }
+
+    @Override
+    public <T> Future<T> method(String name, GenericType<T> responseType) {
+        Context vertxContext = Vertx.currentContext();
+        if (vertxContext != null) {
+            return Future.fromCompletionStage(createClientInvocation(name, null).submitCF(responseType), vertxContext);
+        } else {
+            return Future.fromCompletionStage(createClientInvocation(name, null).submitCF(responseType));
+        }
+    }
+
+    @Override
+    public Future<Response> method(String name, Entity<?> entity) {
+        Context vertxContext = Vertx.currentContext();
+        if (vertxContext != null) {
+            return Future.fromCompletionStage(createClientInvocation(name, entity).submitCF(), vertxContext);
+        } else {
+            return Future.fromCompletionStage(createClientInvocation(name, entity).submitCF());
+        }
+    }
+
+    @Override
+    public <T> Future<T> method(String name, Entity<?> entity, Class<T> responseType) {
+        Context vertxContext = Vertx.currentContext();
+        if (vertxContext != null) {
+            return Future.fromCompletionStage(createClientInvocation(name, entity).submitCF(responseType), vertxContext);
+        } else {
+            return Future.fromCompletionStage(createClientInvocation(name, entity).submitCF(responseType));
+        }
+    }
+
+    @Override
+    public <T> Future<T> method(String name, Entity<?> entity, GenericType<T> responseType) {
+        Context vertxContext = Vertx.currentContext();
+        if (vertxContext != null) {
+            return Future.fromCompletionStage(createClientInvocation(name, entity).submitCF(responseType), vertxContext);
+        } else {
+            return Future.fromCompletionStage(createClientInvocation(name, entity).submitCF(responseType));
+        }
+    }
+}

--- a/resteasy-client-vertx/src/main/java/org/jboss/resteasy/client/jaxrs/internal/VertxFutureRxInvokerProvider.java
+++ b/resteasy-client-vertx/src/main/java/org/jboss/resteasy/client/jaxrs/internal/VertxFutureRxInvokerProvider.java
@@ -1,0 +1,19 @@
+package org.jboss.resteasy.client.jaxrs.internal;
+
+import java.util.concurrent.ExecutorService;
+
+import jakarta.ws.rs.client.RxInvokerProvider;
+import jakarta.ws.rs.client.SyncInvoker;
+
+public class VertxFutureRxInvokerProvider implements RxInvokerProvider<VertxFutureRxInvoker> {
+
+    @Override
+    public boolean isProviderFor(Class<?> clazz) {
+        return VertxFutureRxInvoker.class.equals(clazz);
+    }
+
+    @Override
+    public VertxFutureRxInvoker getRxInvoker(SyncInvoker syncInvoker, ExecutorService executorService) {
+        return new VertxFutureRxInvokerImpl(syncInvoker);
+    }
+}

--- a/resteasy-client-vertx/src/main/resources/META-INF/services/jakarta.ws.rs.ext.Providers
+++ b/resteasy-client-vertx/src/main/resources/META-INF/services/jakarta.ws.rs.ext.Providers
@@ -1,0 +1,1 @@
+org.jboss.resteasy.client.jaxrs.internal.VertxFutureRxInvokerProvider

--- a/resteasy-client-vertx/src/test/java/org/jboss/resteasy/test/client/vertx/VertxFutureTest.java
+++ b/resteasy-client-vertx/src/test/java/org/jboss/resteasy/test/client/vertx/VertxFutureTest.java
@@ -1,0 +1,103 @@
+package org.jboss.resteasy.test.client.vertx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.*;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.RxInvoker;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.resteasy.client.jaxrs.internal.VertxFutureRxInvoker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+
+class VertxFutureTest {
+
+    Vertx vertx;
+    HttpServer server;
+    ScheduledExecutorService executorService;
+    Client client;
+
+    @BeforeEach
+    void beforeEach() {
+        vertx = Vertx.vertx();
+        server = vertx.createHttpServer();
+        executorService = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    @AfterEach
+    void afterEach() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        vertx.close(ar -> latch.countDown());
+        latch.await(1, TimeUnit.MINUTES);
+        executorService.shutdownNow();
+    }
+
+    private Client client() throws Exception {
+        if (server.actualPort() == 0) {
+            CompletableFuture<Void> fut = new CompletableFuture<>();
+            server.listen(0, ar -> {
+                if (ar.succeeded()) {
+                    fut.complete(null);
+                } else {
+                    fut.completeExceptionally(ar.cause());
+                }
+            });
+            fut.get(2, TimeUnit.MINUTES);
+        }
+        if (client == null) {
+            client = ClientBuilder.newBuilder()
+                    .scheduledExecutorService(executorService)
+                    .build();
+        }
+        return client;
+    }
+
+    URI baseUri() {
+        return URI.create("http://localhost:" + server.actualPort());
+    }
+
+    @Test
+    void testSimple() throws Exception {
+        server.requestHandler(req -> req.response().end("pong"));
+
+        Invocation.Builder builder = client().target(baseUri()).request();
+        RxInvoker<?> invoker = builder.rx(VertxFutureRxInvoker.class);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        Future<Response> future = (Future<Response>) invoker.get();
+        future.onComplete(ar -> latch.countDown());
+
+        latch.await(1, TimeUnit.MINUTES);
+
+        assertTrue(future.succeeded());
+        assertEquals("pong", future.result().readEntity(String.class));
+    }
+
+    @Test
+    void testError() throws Exception {
+        server.requestHandler(req -> req.response().setStatusCode(503).end());
+
+        Invocation.Builder builder = client().target(baseUri()).request();
+        RxInvoker<?> invoker = builder.rx(VertxFutureRxInvoker.class);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        Future<Response> future = (Future<Response>) invoker.get();
+        future.onComplete(ar -> latch.countDown());
+
+        latch.await(1, TimeUnit.MINUTES);
+
+        assertTrue(future.succeeded());
+        assertEquals(503, future.result().getStatus());
+    }
+}


### PR DESCRIPTION
Adds support for a MP rest client implementation to return a Vert.x `Future`. 