### PR TITLE
[RESTEASY-3419] Migrate the resteasy-security-josejwt module to JUnit 5

### DIFF
--- a/security/jose-jwt/pom.xml
+++ b/security/jose-jwt/pom.xml
@@ -72,8 +72,8 @@
 
         <!-- Test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/security/jose-jwt/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesAbstract.java
+++ b/security/jose-jwt/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesAbstract.java
@@ -6,8 +6,8 @@ import org.jboss.logging.Logger;
 import org.jboss.resteasy.jose.i18n.Messages;
 import org.jboss.resteasy.jose.jwe.CompressionAlgorithm;
 import org.jboss.resteasy.jose.jwe.EncryptionMethod;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -29,15 +29,15 @@ public abstract class TestMessagesAbstract extends TestMessagesParent {
             return;
         }
 
-        Assert.assertEquals(getExpected(BASE + "000", "algorithmOfSharedSymmetricKey"),
+        Assertions.assertEquals(getExpected(BASE + "000", "algorithmOfSharedSymmetricKey"),
                 Messages.MESSAGES.algorithmOfSharedSymmetricKey());
-        Assert.assertEquals(getExpected(BASE + "015", "cekKeyLengthMismatch", 3, 7),
+        Assertions.assertEquals(getExpected(BASE + "015", "cekKeyLengthMismatch", 3, 7),
                 Messages.MESSAGES.cekKeyLengthMismatch(3, 7));
-        Assert.assertEquals(getExpected(BASE + "025", "contentEncryptionKeyLength", 11, EncryptionMethod.A256GCM),
+        Assertions.assertEquals(getExpected(BASE + "025", "contentEncryptionKeyLength", 11, EncryptionMethod.A256GCM),
                 Messages.MESSAGES.contentEncryptionKeyLength(11, EncryptionMethod.A256GCM));
-        Assert.assertEquals(getExpected(BASE + "155", "unsupportedCompressionAlgorithm", CompressionAlgorithm.DEF),
+        Assertions.assertEquals(getExpected(BASE + "155", "unsupportedCompressionAlgorithm", CompressionAlgorithm.DEF),
                 Messages.MESSAGES.unsupportedCompressionAlgorithm(CompressionAlgorithm.DEF));
-        Assert.assertEquals(getExpected(BASE + "175", "unsupportedKeyLength"), Messages.MESSAGES.unsupportedKeyLength());
+        Assertions.assertEquals(getExpected(BASE + "175", "unsupportedKeyLength"), Messages.MESSAGES.unsupportedKeyLength());
     }
 
     @Override

--- a/security/jose-jwt/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesParent.java
+++ b/security/jose-jwt/src/test/java/org/jboss/resteasy/test/i18n/TestMessagesParent.java
@@ -5,8 +5,8 @@ import java.util.Locale;
 import java.util.Properties;
 
 import org.jboss.logging.Logger;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  *
@@ -20,12 +20,12 @@ public abstract class TestMessagesParent {
     protected static Locale savedLocale;
     protected Properties properties = new Properties();
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         savedLocale = Locale.getDefault();
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         Locale.setDefault(savedLocale);
         LOG.info("Reset default locale to: " + savedLocale);


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-3419