### PR TITLE
InputStreamAdapter.read() should return unsigned byte

### DIFF
--- a/resteasy-client-vertx/src/main/java/org/jboss/resteasy/client/jaxrs/engines/vertx/InputStreamAdapter.java
+++ b/resteasy-client-vertx/src/main/java/org/jboss/resteasy/client/jaxrs/engines/vertx/InputStreamAdapter.java
@@ -64,7 +64,7 @@ public class InputStreamAdapter extends InputStream {
         if (val == -1) {
             return -1;
         }
-        return buffer[0];
+        return buffer[0] & 0xff;
     }
 
     @Override


### PR DESCRIPTION
returning int sign extends and breaks GzIp header detection