### PR TITLE
[RESTEASY-3357] Endpoints returned a status code of 500 if Accept header had badly formatted value

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/ServletContainerDispatcher.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/ServletContainerDispatcher.java
@@ -201,6 +201,11 @@ public class ServletContainerDispatcher {
             try {
                 headers = ServletUtil.extractHttpHeaders(request);
                 uriInfo = ServletUtil.extractUriInfo(request, servletMappingPrefix);
+            } catch (IllegalArgumentException e) {
+                response.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
+                // made it warn so that people can filter this.
+                LogMessages.LOGGER.failedToParseRequest(e);
+                return;
             } catch (Exception e) {
                 response.sendError(HttpServletResponse.SC_BAD_REQUEST);
                 // made it warn so that people can filter this.

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/ClientErrorTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/exception/ClientErrorTest.java
@@ -199,7 +199,7 @@ public class ClientErrorTest {
         Response response = null;
         try {
             response = builder.get();
-            Assertions.assertEquals(HttpServletResponse.SC_BAD_REQUEST, response.getStatus());
+            Assertions.assertEquals(HttpServletResponse.SC_NOT_ACCEPTABLE, response.getStatus());
         } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/InvalidMediaTypeTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/InvalidMediaTypeTest.java
@@ -50,6 +50,9 @@ public class InvalidMediaTypeTest {
         ResteasyClient client = (ResteasyClient) ClientBuilder.newClient();
         Invocation.Builder request = client.target(generateURL("/test")).request();
 
+        // Missing slash
+        doTest(request, "invalid");
+
         // Missing type or subtype
         doTest(request, "/");
         doTest(request, "/*");
@@ -82,7 +85,7 @@ public class InvalidMediaTypeTest {
         Response response = request.get();
         logger.info("mediaType: " + mediaType + "");
         logger.info("status: " + response.getStatus());
-        Assertions.assertEquals(HttpResponseCodes.SC_BAD_REQUEST, response.getStatus());
+        Assertions.assertEquals(HttpResponseCodes.SC_NOT_ACCEPTABLE, response.getStatus());
         response.close();
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/servlet/ServletConfigTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/servlet/ServletConfigTest.java
@@ -86,7 +86,7 @@ public class ServletConfigTest {
     @Test
     public void testBadMediaTypeNoSubtype() throws Exception {
         Response response = client.target(generateURL("/my/application/count")).request().accept("text").get();
-        Assertions.assertEquals(HttpResponseCodes.SC_BAD_REQUEST, response.getStatus());
+        Assertions.assertEquals(HttpResponseCodes.SC_NOT_ACCEPTABLE, response.getStatus());
         response.close();
 
         response = client.target(generateURL("/my/application/count")).request().accept("text/plain; q=bad").get();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/SpecialResourceTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/SpecialResourceTest.java
@@ -118,7 +118,7 @@ public class SpecialResourceTest {
             method.setEntity(
                     new StringEntity("hello", ContentType.create("vnd.net.juniper.space.target-management.targets+xml")));
             response = client.execute(method);
-            Assertions.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseCodes.SC_BAD_REQUEST);
+            Assertions.assertEquals(HttpResponseCodes.SC_NOT_ACCEPTABLE, response.getStatusLine().getStatusCode());
         } catch (IOException e) {
             throw new RuntimeException(e);
         } finally {

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/mediatype/MediaTypeHeaderDelegateTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/mediatype/MediaTypeHeaderDelegateTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.plugins.delegates.MediaTypeHeaderDelegate;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -73,5 +74,12 @@ public class MediaTypeHeaderDelegateTest {
 
         // Verify that getting retrieving the media type returns the expected media type
         assertEquals("application/json", delegate.toString(new MediaType("application", "json")));
+    }
+
+    @Test
+    public void testThrowingIllegalArgumentExceptionWhenNoSlashAndNotMajor() {
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> MediaTypeHeaderDelegate.parse("invalid"));
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/RESTEASY-3357