### PR TITLE
[RESTEASY-3385] Async request filters using suspend/resume on `Suspen…

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/AsynchronousResponseInjector.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/AsynchronousResponseInjector.java
@@ -26,8 +26,10 @@ public class AsynchronousResponseInjector implements ValueInjector {
 
     @Override
     public Object inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
-        ResteasyAsynchronousResponse asynchronousResponse = null;
-        if (timeout == -1) {
+        final ResteasyAsynchronousResponse asynchronousResponse;
+        if (request.getAsyncContext().isSuspended()) {
+            asynchronousResponse = request.getAsyncContext().getAsyncResponse();
+        } else if (timeout == -1) {
             asynchronousResponse = request.getAsyncContext().suspend();
         } else {
             asynchronousResponse = request.getAsyncContext().suspend(timeout, unit);


### PR DESCRIPTION
…dableContainerRequestContext` causes 400 BAD REQUEST.

https://issues.redhat.com/browse/RESTEASY-3385