### PR TITLE
[RESTEASY-3436] Do not attempt to set 'Content-Length' header twice when sending an e…

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/InputStreamProvider.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/providers/InputStreamProvider.java
@@ -51,13 +51,6 @@ public class InputStreamProvider implements MessageBodyReader<InputStream>, Asyn
             MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException {
         LogMessages.LOGGER.debugf("Provider : %s,  Method : writeTo", getClass().getName());
         try {
-            int c = inputStream.read();
-            if (c == -1) {
-                httpHeaders.putSingle(HttpHeaderNames.CONTENT_LENGTH, Integer.toString(0));
-                entityStream.write(new byte[0]); // fix RESTEASY-204
-                return;
-            } else
-                entityStream.write(c);
             ProviderHelper.writeTo(inputStream, entityStream);
         } finally {
             inputStream.close();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/InputStreamResourceTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/InputStreamResourceTest.java
@@ -67,5 +67,7 @@ public class InputStreamResourceTest extends ClientTestBase {
         Assert.assertEquals("new value", client.getAsString());
         client.postInputStream(new ByteArrayInputStream("new value 2".getBytes()));
         Assert.assertEquals("new value 2", client.getAsString());
+        client.postInputStream(new ByteArrayInputStream("".getBytes()));
+        Assert.assertEquals("", client.getAsString());
     }
 }


### PR DESCRIPTION
…mpty InputStream.

Fixes RESTEASY-3436 (https://issues.redhat.com/browse/RESTEASY-3436)
Revert workaround introduced in dac290140bd9bc8638849fc90143a28b3bcf3937 which does not appear to be required anymore