### PR TITLE
[RESTEASY-3443] In the JsonProcessingExceptionMapper currently return…

### DIFF
--- a/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/JsonProcessingExceptionMapper.java
+++ b/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/JsonProcessingExceptionMapper.java
@@ -35,6 +35,6 @@ public class JsonProcessingExceptionMapper implements ExceptionMapper<JsonProces
     @Override
     public Response toResponse(final JsonProcessingException exception) {
         JacksonLogger.LOGGER.logCannotDeserialize(exception);
-        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(JacksonLogger.LOGGER.cannotDeserialize()).build();
+        return Response.status(Response.Status.BAD_REQUEST).entity(JacksonLogger.LOGGER.cannotDeserialize()).build();
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/whitelist/WhiteListPolymorphicTypeValidatorManualOverrideTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/whitelist/WhiteListPolymorphicTypeValidatorManualOverrideTest.java
@@ -91,7 +91,7 @@ public class WhiteListPolymorphicTypeValidatorManualOverrideTest {
         String response = sendPost(new TestPolymorphicType(new Aircraft()));
         logger.info("response: " + response);
         Assert.assertNotNull(response);
-        Assert.assertTrue(response.contains("Response code: " + HttpResponseCodes.SC_INTERNAL_SERVER_ERROR));
+        Assert.assertTrue(response.contains("Response code: " + HttpResponseCodes.SC_BAD_REQUEST));
         Assert.assertTrue("Expected response to contain \"Not able to deserialize data provided\" but was \"" + response + "\"",
                 response.contains("Not able to deserialize data provided"));
     }
@@ -101,7 +101,7 @@ public class WhiteListPolymorphicTypeValidatorManualOverrideTest {
         String response = sendPost(new TestPolymorphicType(new Automobile()));
         logger.info("response: " + response);
         Assert.assertNotNull(response);
-        Assert.assertTrue(response.contains("Response code: " + HttpResponseCodes.SC_INTERNAL_SERVER_ERROR));
+        Assert.assertTrue(response.contains("Response code: " + HttpResponseCodes.SC_BAD_REQUEST));
         Assert.assertTrue("Expected response to contain \"Not able to deserialize data provided\" but was \"" + response + "\"",
                 response.contains("Not able to deserialize data provided"));
     }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/whitelist/WhiteListPolymorphicTypeValidatorTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jackson2/whitelist/WhiteListPolymorphicTypeValidatorTest.java
@@ -109,7 +109,7 @@ public class WhiteListPolymorphicTypeValidatorTest {
         String response = sendPost(new TestPolymorphicType(new Aircraft()));
         logger.info("response: " + response);
         Assert.assertNotNull(response);
-        Assert.assertTrue(response.contains("Response code: " + HttpResponseCodes.SC_INTERNAL_SERVER_ERROR));
+        Assert.assertTrue(response.contains("Response code: " + HttpResponseCodes.SC_BAD_REQUEST));
         Assert.assertTrue("Expected response to contain \"Not able to deserialize data provided\" but was \"" + response + "\"",
                 response.contains("Not able to deserialize data provided"));
     }


### PR DESCRIPTION
…s a 500 status. However, it's more correct to return a 400 as it's a processing error. This is not backwards compatible. It can easily be overridden by creating a custom ExceptionMapper.

https://issues.redhat.com/browse/RESTEASY-3443