### PR TITLE
[RESTEASY-3388] code changes supporting junit5.

### DIFF
--- a/testsuite/arquillian-utils/pom.xml
+++ b/testsuite/arquillian-utils/pom.xml
@@ -60,12 +60,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
-            <scope>compile</scope>
-        </dependency>
         <!-- END OF arquillian general -->
 
         <!-- Used to create a web.xml in the TestUtil -->
@@ -98,8 +92,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>compile</scope>
         </dependency>
 

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/AssumeUtils.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/AssumeUtils.java
@@ -19,7 +19,7 @@
 
 package org.jboss.resteasy.utils;
 
-import org.junit.Assume;
+import org.junit.jupiter.api.Assumptions;
 
 /**
  * Utilities for test assumptions.
@@ -49,6 +49,6 @@ public class AssumeUtils {
      * @param msg the message for the assumption
      */
     public static void assumeSecurityManagerDisabled(final String msg) {
-        Assume.assumeTrue(msg, System.getProperty("security.manager") == null);
+        Assumptions.assumeTrue(System.getProperty("security.manager") == null, msg);
     }
 }

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/PermissionUtil.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/PermissionUtil.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import nu.xom.Attribute;
 import nu.xom.Document;
@@ -119,7 +119,7 @@ public final class PermissionUtil {
     public static Collection<FilePermission> createTempDirPermission(final String actions) {
         String tempDir = System.getProperty("java.io.tmpdir");
         // This should never happen, but it's a better error message than an NPE
-        Assert.assertNotNull("The java.io.tmpdir could not be resolved", tempDir);
+        Assertions.assertNotNull(tempDir, "The java.io.tmpdir could not be resolved");
         if (tempDir.charAt(tempDir.length() - 1) != File.separatorChar) {
             tempDir += File.separatorChar;
         }

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/ServerReload.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/ServerReload.java
@@ -19,7 +19,7 @@
 
 package org.jboss.resteasy.utils;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,7 +31,7 @@ import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.ModelControllerClientConfiguration;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.dmr.ModelNode;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Utilities for handling server reloads.
@@ -66,7 +66,7 @@ public class ServerReload {
         try {
             final ModelNode result = client.execute(reloadOp);
             if (!Operations.isSuccessfulOutcome(result)) {
-                Assert.fail(Operations.getFailureDescription(result)
+                Assertions.fail(Operations.getFailureDescription(result)
                         .asString());
             }
         } catch (IOException e) {
@@ -181,7 +181,7 @@ public class ServerReload {
         if ("reload-required".equalsIgnoreCase(runningState)) {
             executeReloadAndWaitForCompletion(client);
         } else {
-            Assert.assertEquals("Server state 'running' is expected", "running", runningState);
+            Assertions.assertEquals("running", runningState, "Server state 'running' is expected");
         }
     }
 
@@ -204,7 +204,7 @@ public class ServerReload {
 
                     final ModelNode result1 = restoreClient.execute(Operations.createOperation("write-config"));
                     if (!Operations.isSuccessfulOutcome(result1)) {
-                        Assert.fail(
+                        Assertions.fail(
                                 "Failed to write config after restoring from snapshot "
                                         + Operations.getFailureDescription(result1)
                                                 .asString());
@@ -234,7 +234,7 @@ public class ServerReload {
 
                 final ModelNode result1 = client.execute(Operations.createOperation("write-config"));
                 if (!Operations.isSuccessfulOutcome(result1)) {
-                    Assert.fail(
+                    Assertions.fail(
                             "Failed to write config after restoring from snapshot " + Operations.getFailureDescription(result1)
                                     .asString());
                 }
@@ -248,7 +248,7 @@ public class ServerReload {
         final ModelNode op = Operations.createOperation("take-snapshot");
         final ModelNode result = client.execute(op);
         if (!Operations.isSuccessfulOutcome(result)) {
-            Assert.fail("Reload operation didn't finish successfully: " + Operations.getFailureDescription(result)
+            Assertions.fail("Reload operation didn't finish successfully: " + Operations.getFailureDescription(result)
                     .asString());
         }
         final String snapshot = Operations.readResult(result)

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/TestUtil.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/TestUtil.java
@@ -39,7 +39,7 @@ import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Base util class for RESTEasy testing.
@@ -407,21 +407,24 @@ public class TestUtil {
      */
     public static void countViolations(ResteasyViolationException e,
             int totalCount, int propertyCount, int classCount, int parameterCount, int returnValueCount) {
-        Assert.assertEquals("Different total count of violations expected", totalCount, e.getViolations().size());
-        Assert.assertEquals("Different count of property violations expected", propertyCount, e.getPropertyViolations().size());
-        Assert.assertEquals("Different count of class violations expected", classCount, e.getClassViolations().size());
-        Assert.assertEquals("Different count of parameter violations expected", parameterCount,
-                e.getParameterViolations().size());
-        Assert.assertEquals("Different count of return value violations expected", returnValueCount,
-                e.getReturnValueViolations().size());
+        Assertions.assertEquals(totalCount, e.getViolations().size(), "Different total count of violations expected");
+        Assertions.assertEquals(propertyCount, e.getPropertyViolations().size(),
+                "Different count of property violations expected");
+        Assertions.assertEquals(classCount, e.getClassViolations().size(), "Different count of class violations expected");
+        Assertions.assertEquals(parameterCount, e.getParameterViolations().size(),
+                "Different count of parameter violations expected");
+        Assertions.assertEquals(returnValueCount, e.getReturnValueViolations().size(),
+                "Different count of return value violations expected");
     }
 
     public static void countViolations(ViolationReport e, int propertyCount, int classCount, int parameterCount,
             int returnValueCount) {
-        Assert.assertEquals("Different count of property violations expected", propertyCount, e.getPropertyViolations().size());
-        Assert.assertEquals("Different count of class violations expected", classCount, e.getClassViolations().size());
-        Assert.assertEquals(parameterCount, e.getParameterViolations().size());
-        Assert.assertEquals(returnValueCount, e.getReturnValueViolations().size());
+        Assertions.assertEquals(propertyCount, e.getPropertyViolations().size(),
+                "Different count of property violations expected");
+        Assertions.assertEquals(classCount, e.getClassViolations().size(),
+                "Different count of class violations expected");
+        Assertions.assertEquals(parameterCount, e.getParameterViolations().size());
+        Assertions.assertEquals(returnValueCount, e.getReturnValueViolations().size());
     }
 
     public static ResteasyConstraintViolation getViolationByMessage(List<ResteasyConstraintViolation> list, String message) {
@@ -486,7 +489,7 @@ public class TestUtil {
     public static boolean isWindows() {
         String osName = System.getProperty("os.name");
         if (osName == null) {
-            Assert.fail("Can't get the operating system name");
+            Assertions.fail("Can't get the operating system name");
         }
         return (osName.indexOf("Windows") > -1) || (osName.indexOf("windows") > -1);
     }

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -149,10 +149,12 @@
             <modules>
                 <module>test-utils</module>
                 <module>arquillian-utils</module>
+                <!-- rls tmp disable (start)
                 <module>unit-tests</module>
                 <module>integration-tests</module>
                 <module>jetty-integration-tests</module>
                 <module>integration-tests-embedded</module>
+                rls tmp disable (end) -->
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
This is the 1st of several (future) PRs in migrating the testsuite
to junit5.  Each module in testsuite will have a separate PR.  This
PR MUST be committed 1st.  The other modules will rely on changes 
made to module, arquillian-utils.  testsuite/pom.xml has been edited
to disable all other testsuite modules except this one, so that
the project will compile and run successfully.