### PR TITLE
[RESTEASY-3388] code changes supporting junit5 (unit-tests)

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -149,9 +149,7 @@
             <modules>
                 <module>test-utils</module>
                 <module>arquillian-utils</module>
-                <!-- rls tmp disable (start)
                 <module>unit-tests</module>
-                rls tmp disable (end) -->
                 <module>integration-tests</module>
                 <module>jetty-integration-tests</module>
                 <module>integration-tests-embedded</module>

--- a/testsuite/unit-tests/pom.xml
+++ b/testsuite/unit-tests/pom.xml
@@ -118,5 +118,16 @@
             <groupId>org.eclipse.angus</groupId>
             <artifactId>angus-mail</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ChunkedTransferEncodingUnitTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ChunkedTransferEncodingUnitTest.java
@@ -15,9 +15,9 @@ import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.jboss.resteasy.client.jaxrs.internal.ClientInvocationBuilder;
 import org.jboss.resteasy.test.common.FakeHttpServer;
 import org.jboss.resteasy.utils.TestUtil;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.xnio.streams.Streams;
 
 /**
@@ -28,6 +28,7 @@ import org.xnio.streams.Streams;
  * @tpTestCaseDetails Verify request is sent in chunked format
  * @tpSince RESTEasy 3.1.4
  */
+@Disabled("RESTEASY-3452")
 public class ChunkedTransferEncodingUnitTest {
     private static final String testFilePath;
 
@@ -35,7 +36,7 @@ public class ChunkedTransferEncodingUnitTest {
         testFilePath = TestUtil.getResourcePath(ChunkedTransferEncodingUnitTest.class, "ChunkedTransferEncodingUnitTestFile");
     }
 
-    @Rule
+    //@ExtendWith
     public FakeHttpServer fakeHttpServer = new FakeHttpServer(server -> {
 
         FakeHttpServer.dummyMethods(server);
@@ -89,8 +90,8 @@ public class ChunkedTransferEncodingUnitTest {
         File file = new File(testFilePath);
         Response response = request.post(Entity.entity(file, "text/plain"));
         String header = response.readEntity(String.class);
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("ok", header);
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("ok", header);
         response.close();
         client.close();
     }
@@ -106,8 +107,8 @@ public class ChunkedTransferEncodingUnitTest {
         File file = new File(testFilePath);
         Response response = request.post(Entity.entity(file, "text/plain"));
         String header = response.readEntity(String.class);
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("ok", header);
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("ok", header);
         response.close();
         client.close();
     }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
@@ -16,8 +16,8 @@ import jakarta.ws.rs.ext.ContextResolver;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
 import org.jboss.resteasy.utils.TestUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resteasy-client
@@ -32,10 +32,14 @@ public class ClientBuilderTest {
      * @tpPassCrit IllegalArgumentException is raised
      * @tpSince RESTEasy 3.0.16
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void entityStringThrowsExceptionWhenUnparsableTest() throws Exception {
-        Entity.entity("entity", "\\//\\");
-        Assert.fail();
+        IllegalArgumentException thrown = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> {
+                    Entity.entity("entity", "\\//\\");
+                    Assertions.fail();
+                });
+        Assertions.assertTrue(thrown instanceof IllegalArgumentException);
     }
 
     /**
@@ -66,14 +70,14 @@ public class ClientBuilderTest {
         Client client = ClientBuilder.newClient();
         client.property(property, property);
         Object p = client.getConfiguration().getProperty(property);
-        Assert.assertEquals("prop", (String) p);
+        Assertions.assertEquals("prop", (String) p);
         try {
             client.property(property, null);
         } catch (NullPointerException e) {
-            Assert.fail(TestUtil.getErrorMessageForKnownIssue("JBEAP-324", "Couldn't remove property"));
+            Assertions.fail(TestUtil.getErrorMessageForKnownIssue("JBEAP-324", "Couldn't remove property"));
         }
         p = client.getConfiguration().getProperty(property);
-        Assert.assertEquals(null, p);
+        Assertions.assertEquals(null, p);
     }
 
     /**
@@ -81,11 +85,15 @@ public class ClientBuilderTest {
      * @tpPassCrit IllegalStateException is raised
      * @tpSince RESTEasy 3.0.16
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void closeClientSendRequestTest() throws Exception {
-        Client client = ClientBuilder.newClient();
-        client.close();
-        client.target(generateURL("/"));
+        IllegalStateException thrown = Assertions.assertThrows(IllegalStateException.class,
+                () -> {
+                    Client client = ClientBuilder.newClient();
+                    client.close();
+                    client.target(generateURL("/"));
+                });
+        Assertions.assertTrue(thrown instanceof IllegalStateException);
     }
 
     /**
@@ -94,12 +102,16 @@ public class ClientBuilderTest {
      * @tpPassCrit IllegalStateException is raised
      * @tpSince RESTEasy 3.0.16
      */
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void closeClientWebTargetTest() throws Exception {
-        Client client = ClientBuilder.newClient();
-        WebTarget base = client.target(generateURL("/") + "/test");
-        client.close();
-        Response response = base.request().get();
+        IllegalStateException thrown = Assertions.assertThrows(IllegalStateException.class,
+                () -> {
+                    Client client = ClientBuilder.newClient();
+                    WebTarget base = client.target(generateURL("/") + "/test");
+                    client.close();
+                    Response response = base.request().get();
+                });
+        Assertions.assertTrue(thrown instanceof IllegalStateException);
     }
 
     /**
@@ -113,7 +125,7 @@ public class ClientBuilderTest {
                 .baseUri("http://jboss.org/resteasy").rel("relation relation2").title("titleX")
                 .param("param1", "value1").param("param2", "value2")
                 .type(MediaType.APPLICATION_OCTET_STREAM).build();
-        Assert.assertNotNull("Build link failed", link);
+        Assertions.assertNotNull(link, "Build link failed");
     }
 
     @Test
@@ -137,11 +149,15 @@ public class ClientBuilderTest {
                 .build();
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testRegisterContextResolverLambda() {
-        ClientBuilder.newBuilder()
-                .register((ContextResolver<MyObject>) type -> null)
-                .build();
+        RuntimeException thrown = Assertions.assertThrows(RuntimeException.class,
+                () -> {
+                    ClientBuilder.newBuilder()
+                            .register((ContextResolver<MyObject>) type -> null)
+                            .build();
+                });
+        Assertions.assertTrue(thrown instanceof RuntimeException);
     }
 
     public static class MyObject {

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ClientConfigurationImmutableSetsTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ClientConfigurationImmutableSetsTest.java
@@ -7,10 +7,10 @@ import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.ext.Provider;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resteasy-client
@@ -23,12 +23,12 @@ public class ClientConfigurationImmutableSetsTest {
 
     private static Client client;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         client = ClientBuilder.newClient();
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         client.close();
     }
@@ -51,7 +51,7 @@ public class ClientConfigurationImmutableSetsTest {
             // when adding to this immutable set
             // or it can be a new hard copied set
         }
-        Assert.assertEquals(size, classes.size());
+        Assertions.assertEquals(size, classes.size());
     }
 
     @Test
@@ -65,7 +65,7 @@ public class ClientConfigurationImmutableSetsTest {
             // when adding to this immutable set
             // or it can be a new hard copied set
         }
-        Assert.assertEquals(size, instances.size());
+        Assertions.assertEquals(size, instances.size());
     }
 
     @Test
@@ -79,6 +79,6 @@ public class ClientConfigurationImmutableSetsTest {
             // when adding to this immutable set
             // or it can be a new hard copied set
         }
-        Assert.assertEquals(size, properties.size());
+        Assertions.assertEquals(size, properties.size());
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ClientResponseFilterTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ClientResponseFilterTest.java
@@ -19,10 +19,10 @@ import org.jboss.resteasy.test.client.resource.ClientResponseFilterStatusOverrid
 import org.jboss.resteasy.test.client.resource.NullStringBeanRuntimeDelegate;
 import org.jboss.resteasy.test.client.resource.StringBean;
 import org.jboss.resteasy.test.client.resource.StringBeanRuntimeDelegate;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resteasy-client
@@ -35,13 +35,13 @@ public class ClientResponseFilterTest {
 
     String dummyUrl = "dummyUrl";
 
-    @BeforeClass
+    @BeforeAll
     public static void setupClient() {
         client = ClientBuilder.newClient();
 
     }
 
-    @AfterClass
+    @AfterAll
     public static void close() {
         client.close();
     }
@@ -65,7 +65,7 @@ public class ClientResponseFilterTest {
                     .build();
             Response response = client.target(dummyUrl).register(new ClientResponseFilterAbortWith(abortWith))
                     .register(ClientResponseFilterNullHeaderString.class).request().get();
-            Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+            Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
         } finally {
             RuntimeDelegate.setInstance(original);
             StringBeanRuntimeDelegate.assertNotStringBeanRuntimeDelegate();
@@ -86,7 +86,7 @@ public class ClientResponseFilterTest {
                 .header(HttpHeaders.CONTENT_LENGTH, 10).build();
         Response response = client.target(dummyUrl).register(new ClientResponseFilterAbortWith(abortWith))
                 .register(ClientResponseFilterLength.class).request().get();
-        Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
     }
 
     /**
@@ -102,7 +102,7 @@ public class ClientResponseFilterTest {
                 .header(HttpHeaders.ALLOW, "options").build();
         Response response = client.target(dummyUrl).register(new ClientResponseFilterAbortWith(abortWith))
                 .register(ClientResponseFilterAllowed.class).request().get();
-        Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
 
     }
 
@@ -116,7 +116,7 @@ public class ClientResponseFilterTest {
     public void statusOverrideTest() {
         Response response = client.target(dummyUrl).register(new ClientResponseFilterAbortWith(Response.ok().build()))
                 .register(ClientResponseFilterStatusOverride.class).request().get();
-        Assert.assertEquals(HttpResponseCodes.SC_FORBIDDEN, response.getStatus());
+        Assertions.assertEquals(HttpResponseCodes.SC_FORBIDDEN, response.getStatus());
     }
 
     /**
@@ -133,7 +133,7 @@ public class ClientResponseFilterTest {
         Response abortWith = builder.build();
         Response response = client.target(dummyUrl).register(new ClientResponseFilterAbortWith(abortWith))
                 .register(ClientResponseFilterHeaders.class).request().get();
-        Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
     }
 
     /**
@@ -154,6 +154,7 @@ public class ClientResponseFilterTest {
                 .register(ClientResponseFilterInterceptorReaderOne.class)
                 .request().get();
         String str = response.readEntity(String.class);
-        Assert.assertEquals("First ReaderInterceptor one didn't catch exception raised by ReaderInterceptor two", "OK", str);
+        Assertions.assertEquals("OK", str,
+                "First ReaderInterceptor one didn't catch exception raised by ReaderInterceptor two");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ClientWebTargetTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ClientWebTargetTest.java
@@ -5,8 +5,8 @@ import java.util.Collections;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.internal.ClientWebTarget;
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resteasy-client
@@ -27,20 +27,22 @@ public class ClientWebTargetTest {
         ResteasyClient client = new ResteasyClientBuilderImpl().build();
         ClientWebTarget clientWebTarget = (ClientWebTarget) client.target("");
 
-        Assert.assertTrue("Client properties should not be empty", client.getConfiguration().getProperties().isEmpty());
+        Assertions.assertTrue(client.getConfiguration().getProperties().isEmpty(),
+                "Client properties should not be empty");
 
         clientWebTarget.property(property, property);
 
-        Assert.assertEquals("Add of property faild", Collections.singletonMap(property, property),
-                clientWebTarget.getConfiguration().getProperties());
+        Assertions.assertEquals(Collections.singletonMap(property, property),
+                clientWebTarget.getConfiguration().getProperties(),
+                "Add of property faild");
 
         try {
             clientWebTarget.property(property, null);
         } catch (NullPointerException ex) {
-            Assert.fail("Cannot remove property with null value.");
+            Assertions.fail("Cannot remove property with null value.");
         }
 
         Object value = clientWebTarget.getConfiguration().getProperty(property);
-        Assert.assertNull("Property from webTarget can not be removed", value);
+        Assertions.assertNull(value, "Property from webTarget can not be removed");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ConfigurationInheritanceTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ConfigurationInheritanceTest.java
@@ -54,9 +54,9 @@ import org.jboss.resteasy.test.client.resource.ConfigurationInheritanceTestMessa
 import org.jboss.resteasy.test.client.resource.ConfigurationInheritanceTestMessageBodyReader5;
 import org.jboss.resteasy.test.client.resource.ConfigurationInheritanceTestMessageBodyReader6;
 import org.jboss.resteasy.test.common.FakeHttpServer;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resteasy-client
@@ -64,6 +64,7 @@ import org.junit.Test;
  * @tpTestCaseDetails Regression test for RESTEASY-1345
  * @tpSince RESTEasy 3.0.17
  */
+@Disabled("RESTEASY-3452")
 public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
     private static ConfigurationInheritanceTestFeature2 testFeature2 = new ConfigurationInheritanceTestFeature2();
     private static ConfigurationInheritanceTestFeature4 testFeature4 = new ConfigurationInheritanceTestFeature4();
@@ -77,7 +78,7 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
 
     private static final String ERROR_MSG = "Error during client-side registration";
 
-    @Rule
+    //@ExtendWith
     public FakeHttpServer fakeHttpServer = new FakeHttpServer(FakeHttpServer::dummyMethods);
 
     /**
@@ -160,12 +161,14 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
     @Test
     public void testRuntimeType() {
         ResteasyClientBuilder clientBuilder = new ResteasyClientBuilderImpl();
-        Assert.assertEquals("Wrong RuntimeType in ClientBuilder", RuntimeType.CLIENT,
-                clientBuilder.getConfiguration().getRuntimeType());
+        Assertions.assertEquals(RuntimeType.CLIENT,
+                clientBuilder.getConfiguration().getRuntimeType(), "Wrong RuntimeType in ClientBuilder");
         Client client = clientBuilder.build();
-        Assert.assertEquals("Wrong RuntimeType in Client", RuntimeType.CLIENT, client.getConfiguration().getRuntimeType());
+        Assertions.assertEquals(RuntimeType.CLIENT, client.getConfiguration().getRuntimeType(),
+                "Wrong RuntimeType in Client");
         WebTarget target = client.target("http://localhost:8081");
-        Assert.assertEquals("Wrong RuntimeType in WebTarget", RuntimeType.CLIENT, target.getConfiguration().getRuntimeType());
+        Assertions.assertEquals(RuntimeType.CLIENT,
+                target.getConfiguration().getRuntimeType(), "Wrong RuntimeType in WebTarget");
     }
 
     @Test
@@ -184,7 +187,7 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
             };
             parentWebTarget.register(parentClientRequestFilter);
             childWebTarget.request().get().close();
-            Assert.assertEquals(0, parentRequestFilterCounter.get());
+            Assertions.assertEquals(0, parentRequestFilterCounter.get());
 
             // Child MUST only use the snapshot configuration of the parent
             // taken at child creation time.
@@ -194,8 +197,8 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
             };
             childWebTarget.register(childClientRequestFilter);
             childWebTarget.request().get().close();
-            Assert.assertEquals(1, childRequestFilterCounter.get());
-            Assert.assertEquals(0, parentRequestFilterCounter.get());
+            Assertions.assertEquals(1, childRequestFilterCounter.get());
+            Assertions.assertEquals(0, parentRequestFilterCounter.get());
         } finally {
             client.close();
         }
@@ -217,7 +220,7 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
             };
             parentWebTarget.register(parentClientResponseFilter);
             childWebTarget.request().get().close();
-            Assert.assertEquals(0, parentResponseFilterCounter.get());
+            Assertions.assertEquals(0, parentResponseFilterCounter.get());
 
             // Child MUST only use the snapshot configuration of the parent
             // taken at child creation time.
@@ -227,8 +230,8 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
             };
             childWebTarget.register(childClientResponseFilter);
             childWebTarget.request().get().close();
-            Assert.assertEquals(1, childResponseFilterCounter.get());
-            Assert.assertEquals(0, parentResponseFilterCounter.get());
+            Assertions.assertEquals(1, childResponseFilterCounter.get());
+            Assertions.assertEquals(0, parentResponseFilterCounter.get());
         } finally {
             client.close();
         }
@@ -255,7 +258,7 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
             };
             parentWebTarget.register(parentReaderInterceptor);
             childWebTarget.request().get().readEntity(String.class);
-            Assert.assertEquals(0, parentReaderInterceptorCounter.get());
+            Assertions.assertEquals(0, parentReaderInterceptorCounter.get());
 
             // Child MUST only use the snapshot configuration of the parent
             // taken at child creation time.
@@ -266,8 +269,8 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
             };
             childWebTarget.register(childReaderInterceptor);
             childWebTarget.request().get().readEntity(String.class);
-            Assert.assertEquals(1, childReaderInterceptorCounter.get());
-            Assert.assertEquals(0, parentReaderInterceptorCounter.get());
+            Assertions.assertEquals(1, childReaderInterceptorCounter.get());
+            Assertions.assertEquals(0, parentReaderInterceptorCounter.get());
         } finally {
             client.close();
         }
@@ -290,7 +293,7 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
             };
             parentWebTarget.register(parentWriterInterceptor);
             childWebTarget.request().post(Entity.text("Hello")).close();
-            Assert.assertEquals(0, parentWriterInterceptorCounter.get());
+            Assertions.assertEquals(0, parentWriterInterceptorCounter.get());
 
             // Child MUST only use the snapshot configuration of the parent
             // taken at child creation time.
@@ -301,8 +304,8 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
             };
             childWebTarget.register(childWriterInterceptor);
             childWebTarget.request().post(Entity.text("Hello")).close();
-            Assert.assertEquals(1, childWriterInterceptorCounter.get());
-            Assert.assertEquals(0, parentWriterInterceptorCounter.get());
+            Assertions.assertEquals(1, childWriterInterceptorCounter.get());
+            Assertions.assertEquals(0, parentWriterInterceptorCounter.get());
         } finally {
             client.close();
         }
@@ -339,7 +342,7 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
             };
             parentWebTarget.register(parentMessageBodyReader);
             childWebTarget.request().get().readEntity(String.class);
-            Assert.assertEquals(0, parentMessageBodyReaderCounter.get());
+            Assertions.assertEquals(0, parentMessageBodyReaderCounter.get());
 
             // Child MUST only use the snapshot configuration of the parent
             // taken at child creation time.
@@ -360,8 +363,8 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
             };
             childWebTarget.register(childMessageBodyReader);
             childWebTarget.request().get().readEntity(String.class);
-            Assert.assertEquals(1, childMessageBodyReaderCounter.get());
-            Assert.assertEquals(0, parentMessageBodyReaderCounter.get());
+            Assertions.assertEquals(1, childMessageBodyReaderCounter.get());
+            Assertions.assertEquals(0, parentMessageBodyReaderCounter.get());
         } finally {
             client.close();
         }
@@ -395,7 +398,7 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
             };
             parentWebTarget.register(parentMessageBodyWriter);
             childWebTarget.request().post(Entity.text("Hello")).close();
-            Assert.assertEquals(0, parentMessageBodyWriterCounter.get());
+            Assertions.assertEquals(0, parentMessageBodyWriterCounter.get());
 
             // Child MUST only use the snapshot configuration of the parent
             // taken at child creation time.
@@ -417,8 +420,8 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
             };
             childWebTarget.register(childMessageBodyWriter);
             childWebTarget.request().post(Entity.text("Hello")).close();
-            Assert.assertEquals(1, childMessageBodyWriterCounter.get());
-            Assert.assertEquals(0, parentMessageBodyWriterCounter.get());
+            Assertions.assertEquals(1, childMessageBodyWriterCounter.get());
+            Assertions.assertEquals(0, parentMessageBodyWriterCounter.get());
         } finally {
             client.close();
         }
@@ -459,7 +462,7 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
             };
             parentWebTarget.register(parentContextResolver);
             childWebTarget.request().get().close();
-            Assert.assertTrue(result.isEmpty());
+            Assertions.assertTrue(result.isEmpty());
 
             // Child MUST only use the snapshot configuration of the parent
             // taken at child creation time.
@@ -472,8 +475,8 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
             };
             childWebTarget.register(childContextResolver);
             childWebTarget.request().get().close();
-            Assert.assertEquals(1, result.size());
-            Assert.assertEquals(null, result.get(0));
+            Assertions.assertEquals(1, result.size());
+            Assertions.assertEquals(null, result.get(0));
         } finally {
             client.close();
         }
@@ -481,143 +484,143 @@ public class ConfigurationInheritanceTest extends ResteasyProviderFactoryImpl {
 
     private void checkFirstConfiguration(Configuration config) {
         Set<Class<?>> classes = config.getClasses();
-        Assert.assertTrue(ERROR_MSG, classes.contains(ConfigurationInheritanceTestFeature1.class));
-        Assert.assertFalse(ERROR_MSG, classes.contains(ConfigurationInheritanceTestFeature3.class));
-        Assert.assertTrue(ERROR_MSG, classes.contains(ConfigurationInheritanceTestFeature5.class));
-        Assert.assertFalse(ERROR_MSG, classes.contains(ConfigurationInheritanceTestFilter3.class));
-        Assert.assertFalse(ERROR_MSG, classes.contains(ConfigurationInheritanceTestFilter4.class));
-        Assert.assertFalse(ERROR_MSG, classes.contains(ConfigurationInheritanceTestMessageBodyReader3.class));
-        Assert.assertFalse(ERROR_MSG, classes.contains(ConfigurationInheritanceTestMessageBodyReader4.class));
+        Assertions.assertTrue(classes.contains(ConfigurationInheritanceTestFeature1.class), ERROR_MSG);
+        Assertions.assertFalse(classes.contains(ConfigurationInheritanceTestFeature3.class), ERROR_MSG);
+        Assertions.assertTrue(classes.contains(ConfigurationInheritanceTestFeature5.class), ERROR_MSG);
+        Assertions.assertFalse(classes.contains(ConfigurationInheritanceTestFilter3.class), ERROR_MSG);
+        Assertions.assertFalse(classes.contains(ConfigurationInheritanceTestFilter4.class), ERROR_MSG);
+        Assertions.assertFalse(classes.contains(ConfigurationInheritanceTestMessageBodyReader3.class), ERROR_MSG);
+        Assertions.assertFalse(classes.contains(ConfigurationInheritanceTestMessageBodyReader4.class), ERROR_MSG);
 
-        Assert.assertTrue(ERROR_MSG, config.isEnabled(ConfigurationInheritanceTestFeature1.class));
-        Assert.assertTrue(ERROR_MSG, config.isEnabled(ConfigurationInheritanceTestFeature2.class));
-        Assert.assertFalse(ERROR_MSG, config.isEnabled(ConfigurationInheritanceTestFeature3.class));
-        Assert.assertFalse(ERROR_MSG, config.isEnabled(ConfigurationInheritanceTestFeature4.class));
-        Assert.assertTrue(ERROR_MSG, config.isEnabled(ConfigurationInheritanceTestFeature5.class));
-        Assert.assertTrue(ERROR_MSG, config.isEnabled(ConfigurationInheritanceTestFeature6.class));
+        Assertions.assertTrue(config.isEnabled(ConfigurationInheritanceTestFeature1.class), ERROR_MSG);
+        Assertions.assertTrue(config.isEnabled(ConfigurationInheritanceTestFeature2.class), ERROR_MSG);
+        Assertions.assertFalse(config.isEnabled(ConfigurationInheritanceTestFeature3.class), ERROR_MSG);
+        Assertions.assertFalse(config.isEnabled(ConfigurationInheritanceTestFeature4.class), ERROR_MSG);
+        Assertions.assertTrue(config.isEnabled(ConfigurationInheritanceTestFeature5.class), ERROR_MSG);
+        Assertions.assertTrue(config.isEnabled(ConfigurationInheritanceTestFeature6.class), ERROR_MSG);
 
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFeature1.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFeature2.class));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFeature3.class));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFeature4.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFeature5.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFeature6.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFilter1.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFilter2.class));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFilter3.class));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFilter4.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFilter5.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFilter6.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestMessageBodyReader1.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestMessageBodyReader2.class));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestMessageBodyReader3.class));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestMessageBodyReader4.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestMessageBodyReader5.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestMessageBodyReader6.class));
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFeature1.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFeature2.class), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(ConfigurationInheritanceTestFeature3.class), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(ConfigurationInheritanceTestFeature4.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFeature5.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFeature6.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFilter1.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFilter2.class), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(ConfigurationInheritanceTestFilter3.class), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(ConfigurationInheritanceTestFilter4.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFilter5.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFilter6.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestMessageBodyReader1.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestMessageBodyReader2.class), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(ConfigurationInheritanceTestMessageBodyReader3.class), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(ConfigurationInheritanceTestMessageBodyReader4.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestMessageBodyReader5.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestMessageBodyReader6.class), ERROR_MSG);
 
         Set<Object> instances = config.getInstances();
-        Assert.assertTrue(ERROR_MSG, instances.contains(testFeature2));
-        Assert.assertFalse(ERROR_MSG, instances.contains(testFeature4));
-        Assert.assertTrue(ERROR_MSG, instances.contains(testFeature6));
-        Assert.assertTrue(ERROR_MSG, instances.contains(testFilter2));
-        Assert.assertFalse(ERROR_MSG, instances.contains(testFilter4));
-        Assert.assertTrue(ERROR_MSG, instances.contains(testFilter6));
-        Assert.assertTrue(ERROR_MSG, instances.contains(testMessageBodyReader2));
-        Assert.assertFalse(ERROR_MSG, instances.contains(testMessageBodyReader4));
-        Assert.assertTrue(ERROR_MSG, instances.contains(testMessageBodyReader6));
+        Assertions.assertTrue(instances.contains(testFeature2), ERROR_MSG);
+        Assertions.assertFalse(instances.contains(testFeature4), ERROR_MSG);
+        Assertions.assertTrue(instances.contains(testFeature6), ERROR_MSG);
+        Assertions.assertTrue(instances.contains(testFilter2), ERROR_MSG);
+        Assertions.assertFalse(instances.contains(testFilter4), ERROR_MSG);
+        Assertions.assertTrue(instances.contains(testFilter6), ERROR_MSG);
+        Assertions.assertTrue(instances.contains(testMessageBodyReader2), ERROR_MSG);
+        Assertions.assertFalse(instances.contains(testMessageBodyReader4), ERROR_MSG);
+        Assertions.assertTrue(instances.contains(testMessageBodyReader6), ERROR_MSG);
 
-        Assert.assertTrue(ERROR_MSG, config.isEnabled(testFeature2));
-        Assert.assertFalse(ERROR_MSG, config.isEnabled(testFeature4));
-        Assert.assertTrue(ERROR_MSG, config.isEnabled(testFeature6));
+        Assertions.assertTrue(config.isEnabled(testFeature2), ERROR_MSG);
+        Assertions.assertFalse(config.isEnabled(testFeature4), ERROR_MSG);
+        Assertions.assertTrue(config.isEnabled(testFeature6), ERROR_MSG);
 
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(testFeature2));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(testFeature4));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(testFeature6));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(testFilter2));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(testFilter4));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(testFilter6));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(testMessageBodyReader2));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(testMessageBodyReader4));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(testMessageBodyReader6));
+        Assertions.assertTrue(config.isRegistered(testFeature2), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(testFeature4), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(testFeature6), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(testFilter2), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(testFilter4), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(testFilter6), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(testMessageBodyReader2), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(testMessageBodyReader4), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(testMessageBodyReader6), ERROR_MSG);
 
-        Assert.assertEquals(ERROR_MSG, 2, config.getProperties().size());
-        Assert.assertEquals(ERROR_MSG, "value1", config.getProperty("property1"));
-        Assert.assertEquals(ERROR_MSG, "value3", config.getProperty("property3"));
+        Assertions.assertEquals(2, config.getProperties().size(), ERROR_MSG);
+        Assertions.assertEquals("value1", config.getProperty("property1"), ERROR_MSG);
+        Assertions.assertEquals("value3", config.getProperty("property3"), ERROR_MSG);
 
-        Assert.assertFalse(ERROR_MSG, config.getContracts(ConfigurationInheritanceTestFeature1.class).isEmpty());
-        Assert.assertFalse(ERROR_MSG, config.getContracts(ConfigurationInheritanceTestFeature2.class).isEmpty());
-        Assert.assertTrue(ERROR_MSG, config.getContracts(ConfigurationInheritanceTestFeature3.class).isEmpty());
-        Assert.assertTrue(ERROR_MSG, config.getContracts(ConfigurationInheritanceTestFeature4.class).isEmpty());
-        Assert.assertFalse(ERROR_MSG, config.getContracts(ConfigurationInheritanceTestFeature5.class).isEmpty());
-        Assert.assertFalse(ERROR_MSG, config.getContracts(ConfigurationInheritanceTestFeature6.class).isEmpty());
+        Assertions.assertFalse(config.getContracts(ConfigurationInheritanceTestFeature1.class).isEmpty(), ERROR_MSG);
+        Assertions.assertFalse(config.getContracts(ConfigurationInheritanceTestFeature2.class).isEmpty(), ERROR_MSG);
+        Assertions.assertTrue(config.getContracts(ConfigurationInheritanceTestFeature3.class).isEmpty(), ERROR_MSG);
+        Assertions.assertTrue(config.getContracts(ConfigurationInheritanceTestFeature4.class).isEmpty(), ERROR_MSG);
+        Assertions.assertFalse(config.getContracts(ConfigurationInheritanceTestFeature5.class).isEmpty(), ERROR_MSG);
+        Assertions.assertFalse(config.getContracts(ConfigurationInheritanceTestFeature6.class).isEmpty(), ERROR_MSG);
     }
 
     private void checkSecondConfiguration(Configuration config) {
         Set<Class<?>> classes = config.getClasses();
-        Assert.assertTrue(ERROR_MSG, classes.contains(ConfigurationInheritanceTestFeature1.class));
-        Assert.assertTrue(ERROR_MSG, classes.contains(ConfigurationInheritanceTestFeature3.class));
-        Assert.assertFalse(ERROR_MSG, classes.contains(ConfigurationInheritanceTestFeature5.class));
+        Assertions.assertTrue(classes.contains(ConfigurationInheritanceTestFeature1.class), ERROR_MSG);
+        Assertions.assertTrue(classes.contains(ConfigurationInheritanceTestFeature3.class), ERROR_MSG);
+        Assertions.assertFalse(classes.contains(ConfigurationInheritanceTestFeature5.class), ERROR_MSG);
 
-        Assert.assertTrue(ERROR_MSG, config.isEnabled(ConfigurationInheritanceTestFeature1.class));
-        Assert.assertTrue(ERROR_MSG, config.isEnabled(ConfigurationInheritanceTestFeature2.class));
-        Assert.assertTrue(ERROR_MSG, config.isEnabled(ConfigurationInheritanceTestFeature3.class));
-        Assert.assertTrue(ERROR_MSG, config.isEnabled(ConfigurationInheritanceTestFeature4.class));
-        Assert.assertFalse(ERROR_MSG, config.isEnabled(ConfigurationInheritanceTestFeature5.class));
-        Assert.assertFalse(ERROR_MSG, config.isEnabled(ConfigurationInheritanceTestFeature6.class));
+        Assertions.assertTrue(config.isEnabled(ConfigurationInheritanceTestFeature1.class), ERROR_MSG);
+        Assertions.assertTrue(config.isEnabled(ConfigurationInheritanceTestFeature2.class), ERROR_MSG);
+        Assertions.assertTrue(config.isEnabled(ConfigurationInheritanceTestFeature3.class), ERROR_MSG);
+        Assertions.assertTrue(config.isEnabled(ConfigurationInheritanceTestFeature4.class), ERROR_MSG);
+        Assertions.assertFalse(config.isEnabled(ConfigurationInheritanceTestFeature5.class), ERROR_MSG);
+        Assertions.assertFalse(config.isEnabled(ConfigurationInheritanceTestFeature6.class), ERROR_MSG);
 
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFeature1.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFeature2.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFeature3.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFeature4.class));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFeature5.class));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFeature6.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFilter1.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFilter2.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFilter3.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFilter4.class));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFilter5.class));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestFilter6.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestMessageBodyReader1.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestMessageBodyReader2.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestMessageBodyReader3.class));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestMessageBodyReader4.class));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestMessageBodyReader5.class));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(ConfigurationInheritanceTestMessageBodyReader6.class));
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFeature1.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFeature2.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFeature3.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFeature4.class), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(ConfigurationInheritanceTestFeature5.class), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(ConfigurationInheritanceTestFeature6.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFilter1.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFilter2.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFilter3.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestFilter4.class), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(ConfigurationInheritanceTestFilter5.class), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(ConfigurationInheritanceTestFilter6.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestMessageBodyReader1.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestMessageBodyReader2.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestMessageBodyReader3.class), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(ConfigurationInheritanceTestMessageBodyReader4.class), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(ConfigurationInheritanceTestMessageBodyReader5.class), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(ConfigurationInheritanceTestMessageBodyReader6.class), ERROR_MSG);
 
         Set<Object> instances = config.getInstances();
-        Assert.assertTrue(ERROR_MSG, instances.contains(testFeature2));
-        Assert.assertTrue(ERROR_MSG, instances.contains(testFeature4));
-        Assert.assertFalse(ERROR_MSG, instances.contains(testFeature6));
-        Assert.assertTrue(ERROR_MSG, instances.contains(testFilter2));
-        Assert.assertTrue(ERROR_MSG, instances.contains(testFilter4));
-        Assert.assertFalse(ERROR_MSG, instances.contains(testFilter6));
-        Assert.assertTrue(ERROR_MSG, instances.contains(testMessageBodyReader2));
-        Assert.assertTrue(ERROR_MSG, instances.contains(testMessageBodyReader4));
-        Assert.assertFalse(ERROR_MSG, instances.contains(testMessageBodyReader6));
+        Assertions.assertTrue(instances.contains(testFeature2), ERROR_MSG);
+        Assertions.assertTrue(instances.contains(testFeature4), ERROR_MSG);
+        Assertions.assertFalse(instances.contains(testFeature6), ERROR_MSG);
+        Assertions.assertTrue(instances.contains(testFilter2), ERROR_MSG);
+        Assertions.assertTrue(instances.contains(testFilter4), ERROR_MSG);
+        Assertions.assertFalse(instances.contains(testFilter6), ERROR_MSG);
+        Assertions.assertTrue(instances.contains(testMessageBodyReader2), ERROR_MSG);
+        Assertions.assertTrue(instances.contains(testMessageBodyReader4), ERROR_MSG);
+        Assertions.assertFalse(instances.contains(testMessageBodyReader6), ERROR_MSG);
 
-        Assert.assertTrue(ERROR_MSG, config.isEnabled(testFeature2));
-        Assert.assertTrue(ERROR_MSG, config.isEnabled(testFeature4));
-        Assert.assertFalse(ERROR_MSG, config.isEnabled(testFeature6));
+        Assertions.assertTrue(config.isEnabled(testFeature2), ERROR_MSG);
+        Assertions.assertTrue(config.isEnabled(testFeature4), ERROR_MSG);
+        Assertions.assertFalse(config.isEnabled(testFeature6), ERROR_MSG);
 
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(testFeature2));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(testFeature4));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(testFeature6));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(testFilter2));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(testFilter4));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(testFilter6));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(testMessageBodyReader2));
-        Assert.assertTrue(ERROR_MSG, config.isRegistered(testMessageBodyReader4));
-        Assert.assertFalse(ERROR_MSG, config.isRegistered(testMessageBodyReader6));
+        Assertions.assertTrue(config.isRegistered(testFeature2), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(testFeature4), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(testFeature6), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(testFilter2), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(testFilter4), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(testFilter6), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(testMessageBodyReader2), ERROR_MSG);
+        Assertions.assertTrue(config.isRegistered(testMessageBodyReader4), ERROR_MSG);
+        Assertions.assertFalse(config.isRegistered(testMessageBodyReader6), ERROR_MSG);
 
-        Assert.assertEquals(ERROR_MSG, 2, config.getProperties().size());
-        Assert.assertEquals(ERROR_MSG, "value1", config.getProperty("property1"));
-        Assert.assertEquals(ERROR_MSG, "value2", config.getProperty("property2"));
+        Assertions.assertEquals(2, config.getProperties().size(), ERROR_MSG);
+        Assertions.assertEquals("value1", config.getProperty("property1"), ERROR_MSG);
+        Assertions.assertEquals("value2", config.getProperty("property2"), ERROR_MSG);
 
-        Assert.assertFalse(ERROR_MSG, config.getContracts(ConfigurationInheritanceTestFeature1.class).isEmpty());
-        Assert.assertFalse(ERROR_MSG, config.getContracts(ConfigurationInheritanceTestFeature2.class).isEmpty());
-        Assert.assertFalse(ERROR_MSG, config.getContracts(ConfigurationInheritanceTestFeature3.class).isEmpty());
-        Assert.assertFalse(ERROR_MSG, config.getContracts(ConfigurationInheritanceTestFeature4.class).isEmpty());
-        Assert.assertTrue(ERROR_MSG, config.getContracts(ConfigurationInheritanceTestFeature5.class).isEmpty());
-        Assert.assertTrue(ERROR_MSG, config.getContracts(ConfigurationInheritanceTestFeature6.class).isEmpty());
+        Assertions.assertFalse(config.getContracts(ConfigurationInheritanceTestFeature1.class).isEmpty(), ERROR_MSG);
+        Assertions.assertFalse(config.getContracts(ConfigurationInheritanceTestFeature2.class).isEmpty(), ERROR_MSG);
+        Assertions.assertFalse(config.getContracts(ConfigurationInheritanceTestFeature3.class).isEmpty(), ERROR_MSG);
+        Assertions.assertFalse(config.getContracts(ConfigurationInheritanceTestFeature4.class).isEmpty(), ERROR_MSG);
+        Assertions.assertTrue(config.getContracts(ConfigurationInheritanceTestFeature5.class).isEmpty(), ERROR_MSG);
+        Assertions.assertTrue(config.getContracts(ConfigurationInheritanceTestFeature6.class).isEmpty(), ERROR_MSG);
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ContentEncodingInvocationTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ContentEncodingInvocationTest.java
@@ -11,8 +11,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Variant;
 
 import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Requests
@@ -32,7 +32,7 @@ public class ContentEncodingInvocationTest {
             invocation = (ClientInvocation) builder.buildPost(Entity.entity("entity", variant));
         }
         String contentEncoding = invocation.getHeaders().getHeader("Content-Encoding");
-        Assert.assertEquals(1, countEncoding(contentEncoding));
+        Assertions.assertEquals(1, countEncoding(contentEncoding));
 
     }
 

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/DefaultResteasyProviderFactoryTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/DefaultResteasyProviderFactoryTest.java
@@ -8,8 +8,8 @@ import jakarta.ws.rs.client.Client;
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Client
@@ -27,7 +27,7 @@ public class DefaultResteasyProviderFactoryTest {
         rpf.setProperties(map);
         ResteasyClientBuilderImpl.setProviderFactory(rpf);
         Client client = ResteasyClientBuilderImpl.newClient();
-        Assert.assertEquals("bar", client.getConfiguration().getProperty("foo"));
+        Assertions.assertEquals("bar", client.getConfiguration().getProperty("foo"));
         client.close();
         ResteasyClientBuilderImpl.setProviderFactory(null);
     }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/HttpProxyTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/HttpProxyTest.java
@@ -6,8 +6,8 @@ import org.apache.http.HttpHost;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient43Engine;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resteasy-client
@@ -25,11 +25,11 @@ public class HttpProxyTest {
         ApacheHttpClient43Engine engine = (ApacheHttpClient43Engine) client.httpEngine();
         HttpHost proxy = engine.getDefaultProxy();
 
-        Assert.assertEquals(testProxyHost, proxy.getHostName());
+        Assertions.assertEquals(testProxyHost, proxy.getHostName());
         // since port was not set, it must be -1
-        Assert.assertEquals(-1, proxy.getPort());
+        Assertions.assertEquals(-1, proxy.getPort());
         // since scheme was not set, it must be http
-        Assert.assertEquals("http", proxy.getSchemeName());
+        Assertions.assertEquals("http", proxy.getSchemeName());
         client.close();
     }
 
@@ -46,9 +46,9 @@ public class HttpProxyTest {
         ApacheHttpClient43Engine engine = (ApacheHttpClient43Engine) client.httpEngine();
         HttpHost proxy = engine.getDefaultProxy();
 
-        Assert.assertEquals(testProxyHost, proxy.getHostName());
-        Assert.assertEquals(Integer.parseInt(testProxyPort), proxy.getPort());
-        Assert.assertEquals(testProxyScheme, proxy.getSchemeName());
+        Assertions.assertEquals(testProxyHost, proxy.getHostName());
+        Assertions.assertEquals(Integer.parseInt(testProxyPort), proxy.getPort());
+        Assertions.assertEquals(testProxyScheme, proxy.getSchemeName());
         client.close();
 
         //modify and re-use builder...
@@ -58,9 +58,9 @@ public class HttpProxyTest {
         engine = (ApacheHttpClient43Engine) client.httpEngine();
         proxy = engine.getDefaultProxy();
 
-        Assert.assertEquals(testProxyHost, proxy.getHostName());
-        Assert.assertEquals(8090, proxy.getPort());
-        Assert.assertEquals("http", proxy.getSchemeName());
+        Assertions.assertEquals(testProxyHost, proxy.getHostName());
+        Assertions.assertEquals(8090, proxy.getPort());
+        Assertions.assertEquals("http", proxy.getSchemeName());
         client.close();
     }
 
@@ -75,9 +75,9 @@ public class HttpProxyTest {
         ApacheHttpClient43Engine engine = (ApacheHttpClient43Engine) client.httpEngine();
         HttpHost proxy = engine.getDefaultProxy();
 
-        Assert.assertEquals("myoverrideproxy.com", proxy.getHostName());
-        Assert.assertEquals(-1, proxy.getPort());
-        Assert.assertEquals("http", proxy.getSchemeName());
+        Assertions.assertEquals("myoverrideproxy.com", proxy.getHostName());
+        Assertions.assertEquals(-1, proxy.getPort());
+        Assertions.assertEquals("http", proxy.getSchemeName());
         client.close();
 
         //modify and re-use builder...
@@ -86,9 +86,9 @@ public class HttpProxyTest {
         engine = (ApacheHttpClient43Engine) client.httpEngine();
         proxy = engine.getDefaultProxy();
 
-        Assert.assertEquals("myproxy.com", proxy.getHostName());
-        Assert.assertEquals(8080, proxy.getPort());
-        Assert.assertEquals("https", proxy.getSchemeName());
+        Assertions.assertEquals("myproxy.com", proxy.getHostName());
+        Assertions.assertEquals(8080, proxy.getPort());
+        Assertions.assertEquals("https", proxy.getSchemeName());
         client.close();
 
         //modify and re-use builder...
@@ -99,7 +99,7 @@ public class HttpProxyTest {
         engine = (ApacheHttpClient43Engine) client.httpEngine();
         proxy = engine.getDefaultProxy();
 
-        Assert.assertNull(proxy);
+        Assertions.assertNull(proxy);
         client.close();
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/NoContentStreamingCloseTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/NoContentStreamingCloseTest.java
@@ -14,8 +14,8 @@ import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.jboss.resteasy.test.client.resource.NoContentStreamingCloseTestFilter;
 import org.jboss.resteasy.test.client.resource.NoContentStreamingCloseTestInputStream;
 import org.jboss.resteasy.test.client.resource.NoContentStreamingCloseTestResponse;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resteasy-client
@@ -47,12 +47,12 @@ public class NoContentStreamingCloseTest {
                 .target("http://localhost/uri_is_ignored") //
                 .request() //
                 .get(InputStream.class); // nowhere a response to close
-        Assert.assertNotNull(NULL_STREAM_ERROR_MSG, is);
+        Assertions.assertNotNull(is, NULL_STREAM_ERROR_MSG);
         String str = new String(is.readAllBytes(), StandardCharsets.UTF_8);
         is.close();
-        Assert.assertEquals(RESPONSE_ERROR_MSG, expected, str);
+        Assertions.assertEquals(expected, str, RESPONSE_ERROR_MSG);
         // the stream returned by the internal httpclient must be closed!
-        Assert.assertTrue(CLOSE_ERROR_MSG, testInputStream.isClosed());
+        Assertions.assertTrue(testInputStream.isClosed(), CLOSE_ERROR_MSG);
 
         client.close();
     }
@@ -74,11 +74,11 @@ public class NoContentStreamingCloseTest {
                 .target("http://localhost/uri_is_ignored") //
                 .request() //
                 .get(InputStream.class);
-        Assert.assertNotNull(NULL_STREAM_ERROR_MSG, is);
+        Assertions.assertNotNull(is, NULL_STREAM_ERROR_MSG);
         byte[] readden = is.readAllBytes();
         is.close();
-        Assert.assertEquals(RESPONSE_ERROR_MSG, 0, readden.length);
-        Assert.assertTrue(CLOSE_ERROR_MSG, testInputStream.isClosed());
+        Assertions.assertEquals(0, readden.length, RESPONSE_ERROR_MSG);
+        Assertions.assertTrue(testInputStream.isClosed(), CLOSE_ERROR_MSG);
 
         client.close();
     }
@@ -100,11 +100,11 @@ public class NoContentStreamingCloseTest {
                 .target("http://localhost/uri_is_ignored") //
                 .request() //
                 .get(Reader.class);
-        Assert.assertNotNull("Reader should not be null", in);
+        Assertions.assertNotNull(in, "Reader should not be null");
         String readden = new String(testInputStream.readAllBytes(), StandardCharsets.UTF_8);
         in.close();
-        Assert.assertEquals(RESPONSE_ERROR_MSG, 0, readden.length());
-        Assert.assertTrue(CLOSE_ERROR_MSG, testInputStream.isClosed());
+        Assertions.assertEquals(0, readden.length(), RESPONSE_ERROR_MSG);
+        Assertions.assertTrue(testInputStream.isClosed(), CLOSE_ERROR_MSG);
 
         client.close();
     }
@@ -126,11 +126,11 @@ public class NoContentStreamingCloseTest {
                 .target("http://localhost/uri_is_ignored") //
                 .request() //
                 .get(DataSource.class);
-        Assert.assertNotNull("DataSource should not be null", in);
+        Assertions.assertNotNull(in, "DataSource should not be null");
         InputStream is = in.getInputStream();
-        Assert.assertEquals(RESPONSE_ERROR_MSG, 0, is.readAllBytes().length);
+        Assertions.assertEquals(0, is.readAllBytes().length, RESPONSE_ERROR_MSG);
         is.close();
-        Assert.assertTrue(CLOSE_ERROR_MSG, testInputStream.isClosed());
+        Assertions.assertTrue(testInputStream.isClosed(), CLOSE_ERROR_MSG);
 
         client.close();
     }
@@ -153,11 +153,11 @@ public class NoContentStreamingCloseTest {
                 .target("http://localhost/uri_is_ignored") //
                 .request() //
                 .get(Source.class);
-        Assert.assertNotNull("Source should not be null", in);
+        Assertions.assertNotNull(in, "Source should not be null");
         InputStream is = ((StreamSource) in).getInputStream();
-        Assert.assertEquals(RESPONSE_ERROR_MSG, 0, is.readAllBytes().length);
+        Assertions.assertEquals(0, is.readAllBytes().length, RESPONSE_ERROR_MSG);
         is.close();
-        Assert.assertTrue(CLOSE_ERROR_MSG, testInputStream.isClosed());
+        Assertions.assertTrue(testInputStream.isClosed(), CLOSE_ERROR_MSG);
 
         client.close();
     }
@@ -179,9 +179,9 @@ public class NoContentStreamingCloseTest {
                 .target("http://localhost/uri_is_ignored") //
                 .request() //
                 .get(byte[].class);
-        Assert.assertNotNull("Byte array should not be null", in);
-        Assert.assertEquals(RESPONSE_ERROR_MSG, 0, in.length);
-        Assert.assertTrue(CLOSE_ERROR_MSG, testInputStream.isClosed());
+        Assertions.assertNotNull(in, "Byte array should not be null");
+        Assertions.assertEquals(0, in.length, RESPONSE_ERROR_MSG);
+        Assertions.assertTrue(testInputStream.isClosed(), CLOSE_ERROR_MSG);
 
         client.close();
     }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ProxyEqualsTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ProxyEqualsTest.java
@@ -6,8 +6,8 @@ import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resteasy-client proxy
@@ -31,9 +31,9 @@ public class ProxyEqualsTest {
         ResteasyWebTarget target = (ResteasyWebTarget) client.target(generateURL("/"));
         I proxy1 = target.proxy(I.class);
         I proxy2 = target.proxy(I.class);
-        Assert.assertTrue("proxy1 == proxy1", proxy1.equals(proxy1));
-        Assert.assertFalse("proxy1 != proxy2", proxy1.equals(proxy2));
-        Assert.assertTrue(proxy1.hashCode() == proxy1.hashCode());
+        Assertions.assertTrue(proxy1.equals(proxy1), "proxy1 == proxy1");
+        Assertions.assertFalse(proxy1.equals(proxy2), "proxy1 != proxy2");
+        Assertions.assertTrue(proxy1.hashCode() == proxy1.hashCode());
         client.close();
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/RequestFilterTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/RequestFilterTest.java
@@ -20,10 +20,10 @@ import org.jboss.resteasy.test.client.resource.RequestFilterAnnotation;
 import org.jboss.resteasy.test.client.resource.RequestFilterGetEntity;
 import org.jboss.resteasy.test.client.resource.RequestFilterSetEntity;
 import org.jboss.resteasy.test.client.resource.RequestFilterThrowCustomException;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resteasy-client
@@ -37,13 +37,13 @@ public class RequestFilterTest {
     static Client client;
     String dummyUrl = "dummyUrl";
 
-    @BeforeClass
+    @BeforeAll
     public static void setupClient() {
         client = ClientBuilder.newClient();
 
     }
 
-    @AfterClass
+    @AfterAll
     public static void close() {
         client.close();
     }
@@ -59,7 +59,8 @@ public class RequestFilterTest {
     public void AbortWithTest() {
         Response response = client.target(dummyUrl).register(RequestFilterAbortWith.class).request().get();
         String str = response.readEntity(String.class);
-        Assert.assertEquals("String returned from ClientRequest filter doesn't contain the expected value", "42", str);
+        Assertions.assertEquals("42", str,
+                "String returned from ClientRequest filter doesn't contain the expected value");
     }
 
     /**
@@ -79,8 +80,8 @@ public class RequestFilterTest {
         String str = response.readEntity(String.class);
         logger.info("The locale from the response: " + str);
         logger.info("The expected locale: " + Locale.CANADA_FRENCH.toString());
-        Assert.assertTrue("String returned from ClientRequest filter doesn't contain accepted locale",
-                str.contains(Locale.CANADA_FRENCH.toString()));
+        Assertions.assertTrue(str.contains(Locale.CANADA_FRENCH.toString()),
+                "String returned from ClientRequest filter doesn't contain accepted locale");
 
     }
 
@@ -99,7 +100,7 @@ public class RequestFilterTest {
                 "test".getBytes()), MediaType.WILDCARD_TYPE);
         Response response = client.target(dummyUrl).register(RequestFilterSetEntity.class)
                 .register(RequestFilterGetEntity.class).request().post(entity);
-        Assert.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
     }
 
     /**
@@ -114,8 +115,8 @@ public class RequestFilterTest {
         Entity<String> post = Entity.entity("test", MediaType.WILDCARD_TYPE,
                 RequestFilterAnnotation.class.getAnnotations());
         Response response = client.target(dummyUrl).register(RequestFilterAnnotation.class).request().post(post);
-        Assert.assertEquals("The response doesn't contain the expexted provider name",
-                Provider.class.getName(), response.readEntity(String.class));
+        Assertions.assertEquals(Provider.class.getName(), response.readEntity(String.class),
+                "The response doesn't contain the expexted provider name");
     }
 
     /**
@@ -129,9 +130,9 @@ public class RequestFilterTest {
     public void ThrowCustomExceptionFilterTest() {
         try {
             client.target(dummyUrl).register(RequestFilterThrowCustomException.class).request().get();
-            Assert.fail();
+            Assertions.fail();
         } catch (ProcessingException pe) {
-            Assert.assertEquals(ClientCustomException.class, pe.getCause().getClass());
+            Assertions.assertEquals(ClientCustomException.class, pe.getCause().getClass());
         }
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ResponseBuilderImplTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ResponseBuilderImplTest.java
@@ -3,8 +3,8 @@ package org.jboss.resteasy.test.client;
 import jakarta.ws.rs.core.EntityTag;
 import jakarta.ws.rs.core.Response;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resteasy-client
@@ -25,7 +25,8 @@ public class ResponseBuilderImplTest {
     @Test
     public void testObjectEntityTagValue() throws Exception {
         Response response = Response.ok("entityValue").tag(new EntityTag("etagValue")).build();
-        Assert.assertEquals(ERROR_MESSAGE, "\"etagValue\"", response.getHeaderString("ETag"));
+        Assertions.assertEquals("\"etagValue\"", response.getHeaderString("ETag"),
+                ERROR_MESSAGE);
     }
 
     /**
@@ -37,7 +38,8 @@ public class ResponseBuilderImplTest {
     @Test
     public void testStringEntityTagValue() throws Exception {
         Response response = Response.ok("entityValue").tag("etagValue").build();
-        Assert.assertEquals(ERROR_MESSAGE, "\"etagValue\"", response.getHeaderString("ETag"));
+        Assertions.assertEquals("\"etagValue\"", response.getHeaderString("ETag"),
+                ERROR_MESSAGE);
     }
 
     /**
@@ -48,7 +50,8 @@ public class ResponseBuilderImplTest {
     @Test
     public void testNotModifiedWithObjectEntityTagValue() throws Exception {
         Response response = Response.notModified(new EntityTag("etagValue")).build();
-        Assert.assertEquals(ERROR_MESSAGE, "\"etagValue\"", response.getHeaderString("ETag"));
+        Assertions.assertEquals("\"etagValue\"", response.getHeaderString("ETag"),
+                ERROR_MESSAGE);
     }
 
     /**
@@ -60,7 +63,8 @@ public class ResponseBuilderImplTest {
     @Test
     public void testNotModifiedWithStringEntityTagValue() throws Exception {
         Response response = Response.notModified("etagValue").build();
-        Assert.assertEquals(ERROR_MESSAGE, "\"etagValue\"", response.getHeaderString("ETag"));
+        Assertions.assertEquals("\"etagValue\"", response.getHeaderString("ETag"),
+                ERROR_MESSAGE);
     }
 
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ResponseTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/ResponseTest.java
@@ -12,8 +12,8 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.logging.Logger;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resteasy-client
@@ -34,7 +34,7 @@ public class ResponseTest {
         Date responseDate = response.getLastModified();
         logger.info(String.format("Date: %s", date));
         logger.info(String.format("Response data: %s", responseDate));
-        Assert.assertTrue("Wrong response data", date.equals(responseDate));
+        Assertions.assertTrue(date.equals(responseDate), "Wrong response data");
     }
 
     /**
@@ -48,9 +48,9 @@ public class ResponseTest {
         rs.expires(now);
         Response response = rs.build();
         MultivaluedMap<String, Object> metadata = response.getMetadata();
-        Assert.assertNotNull("Response metatada should not be null", metadata);
+        Assertions.assertNotNull(metadata, "Response metatada should not be null");
         List<Object> expires = response.getMetadata().get("Expires");
-        Assert.assertNotNull("Missing expires item in metadata", expires);
+        Assertions.assertNotNull(expires, "Missing expires item in metadata");
         boolean condition;
         Object fetched = expires.iterator().next();
         if (Date.class.isInstance(fetched)) {
@@ -60,7 +60,7 @@ public class ResponseTest {
         } else {
             throw new RuntimeException("Fetched object not recognised");
         }
-        Assert.assertTrue("Wrong fetched object", condition);
+        Assertions.assertTrue(condition, "Wrong fetched object");
     }
 
     public static final DateFormat createDateFormat(TimeZone timezone) {

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/SelfExpandingBufferredInputStreamTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/SelfExpandingBufferredInputStreamTest.java
@@ -1,13 +1,14 @@
 package org.jboss.resteasy.test.client;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 import org.jboss.resteasy.client.jaxrs.engines.SelfExpandingBufferredInputStream;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resteasy-client
@@ -21,7 +22,7 @@ public class SelfExpandingBufferredInputStreamTest {
     SelfExpandingBufferredInputStream stream;
     InputStream control;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         input = new ByteArrayInputStream(data.getBytes());
         control = new ByteArrayInputStream(data.getBytes());
@@ -32,9 +33,13 @@ public class SelfExpandingBufferredInputStreamTest {
      * @tpTestDetails Test not supported mark
      * @tpSince RESTEasy 3.0.16
      */
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testMarkNotSupported() {
-        stream.mark(256);
+        UnsupportedOperationException thrown = Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> {
+                    stream.mark(256);
+                });
+        Assertions.assertTrue(thrown instanceof UnsupportedOperationException);
     }
 
     /**

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/WebTargetUnitTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/WebTargetUnitTest.java
@@ -9,10 +9,10 @@ import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:kanovotn@redhat.com">Katerina Novotna</a>
@@ -27,14 +27,14 @@ public class WebTargetUnitTest {
     static WebTarget base;
     static WebTarget created;
 
-    @BeforeClass
+    @BeforeAll
     public static void setupClient() {
         client = ClientBuilder.newClient();
         base = client.target(generateURL("/") + "users/{username}");
         created = base.path("{id}");
     }
 
-    @AfterClass
+    @AfterAll
     public static void close() {
         client.close();
     }
@@ -55,8 +55,8 @@ public class WebTargetUnitTest {
         // The asserted string "a%2520%253F%2F*%2F/%2Fb%2F" is made from "a%20%3F/*//b// as:
         // % stands for %25 in hex ASCII
         // / stands for %2F in hex ASCII
-        Assert.assertEquals("The parameters were not treated as decoded correctly",
-                generateURL("/") + "users/a%2520%253F%2F*%2F/%2Fb%2F", result);
+        Assertions.assertEquals(generateURL("/") + "users/a%2520%253F%2F*%2F/%2Fb%2F", result,
+                "The parameters were not treated as decoded correctly");
     }
 
     /**
@@ -72,8 +72,8 @@ public class WebTargetUnitTest {
 
         String result = created.resolveTemplateFromEncoded("username", usernameEncoded)
                 .resolveTemplateFromEncoded("id", idEncoded).getUri().toString();
-        Assert.assertEquals("The parameters were not treated as encoded correctly",
-                generateURL("/") + "users/a%20%3F%2F*%2F/%2Fb%2F", result);
+        Assertions.assertEquals(generateURL("/") + "users/a%20%3F%2F*%2F/%2Fb%2F", result,
+                "The parameters were not treated as encoded correctly");
     }
 
     /**
@@ -89,7 +89,7 @@ public class WebTargetUnitTest {
         Map<String, Object> values = new HashMap<String, Object>();
 
         WebTarget result = created.resolveTemplates(values);
-        Assert.assertEquals(result, created);
+        Assertions.assertEquals(result, created);
     }
 
     /**
@@ -98,9 +98,13 @@ public class WebTargetUnitTest {
      * @tpPassCrit NullPointerException is raised
      * @tpSince RESTEasy 3.0.16
      */
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testResolveTemplateNull() {
-        created.resolveTemplate(null, null);
+        NullPointerException thrown = Assertions.assertThrows(NullPointerException.class,
+                () -> {
+                    created.resolveTemplate(null, null);
+                });
+        Assertions.assertTrue(thrown instanceof NullPointerException);
     }
 
     /**
@@ -109,11 +113,15 @@ public class WebTargetUnitTest {
      * @tpPassCrit NullPointerException is raised
      * @tpSince RESTEasy 3.0.16
      */
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testQueryParamNullPointer() {
-        WebTarget created = base.path("param/{id}");
+        NullPointerException thrown = Assertions.assertThrows(NullPointerException.class,
+                () -> {
+                    WebTarget created = base.path("param/{id}");
 
-        created.queryParam("q", "a", null, "b", null);
+                    created.queryParam("q", "a", null, "b", null);
+                });
+        Assertions.assertTrue(thrown instanceof NullPointerException);
     }
 
     /**
@@ -121,10 +129,14 @@ public class WebTargetUnitTest {
      * @tpPassCrit NullPointerException is raised
      * @tpSince RESTEasy 3.0.16
      */
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testMatrixParamNullPointer() {
-        WebTarget created = base.path("matrix/{id}");
+        NullPointerException thrown = Assertions.assertThrows(NullPointerException.class,
+                () -> {
+                    WebTarget created = base.path("matrix/{id}");
 
-        created.matrixParam("m1", "a", null, "b", null);
+                    created.matrixParam("m1", "a", null, "b", null);
+                });
+        Assertions.assertTrue(thrown instanceof NullPointerException);
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/ClientResponseFilterAllowed.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/ClientResponseFilterAllowed.java
@@ -7,12 +7,12 @@ import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientResponseContext;
 import jakarta.ws.rs.client.ClientResponseFilter;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class ClientResponseFilterAllowed implements ClientResponseFilter {
     @Override
     public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
         Set<String> allowed = responseContext.getAllowedMethods();
-        Assert.assertTrue(allowed.contains("OPTIONS"));
+        Assertions.assertTrue(allowed.contains("OPTIONS"));
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/ClientResponseFilterLength.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/ClientResponseFilterLength.java
@@ -6,11 +6,12 @@ import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientResponseContext;
 import jakarta.ws.rs.client.ClientResponseFilter;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class ClientResponseFilterLength implements ClientResponseFilter {
     @Override
     public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
-        Assert.assertEquals("The length of the response is not the expected one", 10, responseContext.getLength());
+        Assertions.assertEquals(10, responseContext.getLength(),
+                "The length of the response is not the expected one");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/ClientResponseFilterNullHeaderString.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/ClientResponseFilterNullHeaderString.java
@@ -6,13 +6,14 @@ import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientResponseContext;
 import jakarta.ws.rs.client.ClientResponseFilter;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class ClientResponseFilterNullHeaderString implements ClientResponseFilter {
     @Override
     public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
         String header = responseContext.getHeaderString("header1");
-        Assert.assertNotNull("The header is empty", header);
-        Assert.assertTrue("The header value doesn't match the expected one", header.equals(""));
+        Assertions.assertNotNull(header, "The header is empty");
+        Assertions.assertTrue(header.equals(""),
+                "The header value doesn't match the expected one");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/NoContentStreamingCloseTestResponse.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/NoContentStreamingCloseTestResponse.java
@@ -7,7 +7,7 @@ import java.lang.reflect.Type;
 import org.jboss.resteasy.core.Headers;
 import org.jboss.resteasy.specimpl.BuiltResponse;
 import org.jboss.resteasy.spi.HttpResponseCodes;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class NoContentStreamingCloseTestResponse extends BuiltResponse {
 
@@ -43,7 +43,7 @@ public class NoContentStreamingCloseTestResponse extends BuiltResponse {
 
     @Override
     public void close() {
-        Assert.fail("Due to the InputStream-Entity the Response must not be closed but the Inputstream");
+        Assertions.fail("Due to the InputStream-Entity the Response must not be closed but the Inputstream");
         super.close();
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/RequestFilterAnnotation.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/RequestFilterAnnotation.java
@@ -9,7 +9,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 
 import org.jboss.logging.Logger;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 @Provider
 public class RequestFilterAnnotation implements ClientRequestFilter {
@@ -20,7 +20,7 @@ public class RequestFilterAnnotation implements ClientRequestFilter {
     public void filter(ClientRequestContext requestContext) throws IOException {
         logger.info("  ** ANnotation Filter");
         Annotation[] annotations = requestContext.getEntityAnnotations();
-        Assert.assertNotNull("RequestContext doesn't contain annotations", annotations);
+        Assertions.assertNotNull(annotations, "RequestContext doesn't contain annotations");
         requestContext.abortWith(Response.ok(annotations[0].annotationType().getName()).build());
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/RequestFilterGetEntity.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/client/resource/RequestFilterGetEntity.java
@@ -8,7 +8,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.logging.Logger;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class RequestFilterGetEntity implements ClientRequestFilter {
 
@@ -18,10 +18,10 @@ public class RequestFilterGetEntity implements ClientRequestFilter {
     public void filter(ClientRequestContext requestContext) throws IOException {
         logger.info("*** filter 2 ***");
         Object entity = requestContext.getEntity();
-        Assert.assertEquals("The requestContext doesn't contain the correct entity", "test", entity);
+        Assertions.assertEquals("test", entity, "The requestContext doesn't contain the correct entity");
         MediaType mt = requestContext.getMediaType();
-        Assert.assertEquals(MediaType.APPLICATION_JSON_TYPE, mt);
-        Assert.assertEquals(String.class, requestContext.getEntityType());
+        Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, mt);
+        Assertions.assertEquals(String.class, requestContext.getEntityType());
         requestContext.abortWith(Response.ok().build());
 
     }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/common/FakeHttpServer.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/common/FakeHttpServer.java
@@ -5,7 +5,8 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.rules.ExternalResource;
+import org.junit.jupiter.api.Disabled;
+//import org.junit.rules.ExternalResource;
 import org.xnio.streams.Streams;
 
 import com.sun.net.httpserver.HttpServer;
@@ -13,7 +14,8 @@ import com.sun.net.httpserver.HttpServer;
 /**
  * Tiny fake HTTP server providing a target for testing the RESTEasy client.
  */
-public class FakeHttpServer extends ExternalResource {
+@Disabled("RESTEASY-3452")
+public class FakeHttpServer /* extends ExternalResource */ {
 
     private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 
@@ -50,7 +52,7 @@ public class FakeHttpServer extends ExternalResource {
         server.start();
     }
 
-    @Override
+    // @Override
     protected void before() throws Throwable {
         HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
 
@@ -108,7 +110,7 @@ public class FakeHttpServer extends ExternalResource {
         void apply(HttpServer server);
     }
 
-    @Override
+    //@Override
     protected void after() {
         server.stop(1);
     }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/cookie/NewCookieHeaderDelegateTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/cookie/NewCookieHeaderDelegateTest.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.test.cookie;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.text.SimpleDateFormat;
 import java.time.Duration;
@@ -13,15 +13,15 @@ import java.util.TimeZone;
 import jakarta.ws.rs.core.NewCookie;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class NewCookieHeaderDelegateTest {
 
     private RuntimeDelegate.HeaderDelegate<NewCookie> delegate;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         delegate = RuntimeDelegate.getInstance().createHeaderDelegate(NewCookie.class);
     }
@@ -64,7 +64,7 @@ public class NewCookieHeaderDelegateTest {
         final var expected = "test-cookie=\"Test Value\";Version=1;Comment=\"Test Comment\";Domain=local-domain;Path=/test;Max-Age="
                 + maxAge + ";Expires=" + sdf.format(expires)
                 + ";Secure;HttpOnly;SameSite=Strict";
-        Assert.assertEquals(expected, delegate.toString(newCookie));
+        Assertions.assertEquals(expected, delegate.toString(newCookie));
     }
 
     @Test
@@ -93,7 +93,7 @@ public class NewCookieHeaderDelegateTest {
         final var value = "test-cookie=\"Test Value\";Version=1;Comment=\"Test Comment\";Domain=local-domain;Path=/test;Max-Age="
                 + maxAge + ";Expires=" + sdf.format(expires)
                 + ";Secure;HttpOnly;SameSite=Strict";
-        Assert.assertEquals(expected, delegate.fromString(value));
+        Assertions.assertEquals(expected, delegate.fromString(value));
     }
 
     private static SimpleDateFormat createDateFormatter() {

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/crypto/EnvelopedTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/crypto/EnvelopedTest.java
@@ -39,9 +39,9 @@ import org.bouncycastle.operator.OutputEncryptor;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.security.PemUtils;
 import org.jboss.resteasy.utils.TestUtil;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Crypto
@@ -65,7 +65,7 @@ public class EnvelopedTest {
     static final String certPemPath = TestUtil.getResourcePath(EnvelopedTest.class, "SignedMycert.pem");
     static final String certPrivatePemPath = TestUtil.getResourcePath(EnvelopedTest.class, "MycertPrivate.pem");
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         Security.addProvider(new BouncyCastleProvider());
 
@@ -110,10 +110,12 @@ public class EnvelopedTest {
 
         newMimeBodyPart = decode2Mime(newMimeBodyPart);
 
-        Assert.assertEquals("Wrong type of mimeBodyPart content", "application/xml", newMimeBodyPart.getContentType());
+        Assertions.assertEquals("application/xml", newMimeBodyPart.getContentType(),
+                "Wrong type of mimeBodyPart content");
 
         String body = toString(newMimeBodyPart.getInputStream());
-        Assert.assertEquals("Wrong decoded content", "<customer name=\"bill\"/>", body.trim());
+        Assertions.assertEquals("<customer name=\"bill\"/>", body.trim(),
+                "Wrong decoded content");
     }
 
     /**
@@ -166,19 +168,23 @@ public class EnvelopedTest {
             logger.info("------------");
             mp = decode2Mime(mp);
 
-            Assert.assertEquals("Wrong media type of content", "application/xml", mp.getContentType());
+            Assertions.assertEquals("application/xml", mp.getContentType(),
+                    "Wrong media type of content");
 
             String body = toString(mp.getInputStream());
-            Assert.assertEquals("Wrong decoded content", "<customer name=\"bill\"/>", body.trim());
+            Assertions.assertEquals("<customer name=\"bill\"/>", body.trim(),
+                    "Wrong decoded content");
         }
         {
             ByteArrayInputStream is = new ByteArrayInputStream(python_smime.getBytes(StandardCharsets.UTF_8));
             MimeBodyPart mp = decode2Mime(is);
 
-            Assert.assertEquals("Wrong media type of content", "application/xml", mp.getContentType());
+            Assertions.assertEquals("application/xml", mp.getContentType(),
+                    "Wrong media type of content");
 
             String body = toString(mp.getInputStream());
-            Assert.assertEquals("Wrong decoded content", "<customer name=\"bill\"/>", body.trim());
+            Assertions.assertEquals("<customer name=\"bill\"/>", body.trim(),
+                    "Wrong decoded content");
         }
     }
 

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/crypto/ExampleSignTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/crypto/ExampleSignTest.java
@@ -13,8 +13,8 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 
 import org.jboss.resteasy.utils.TestUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Crypto
@@ -75,6 +75,6 @@ public class ExampleSignTest {
         Signature verify = Signature.getInstance("SHA256withRSA");
         verify.initVerify(publicKey);
         verify.update("from-java".getBytes());
-        Assert.assertTrue("Sign was unsuccessful", verify.verify(signatureBytes));
+        Assertions.assertTrue(verify.verify(signatureBytes), "Sign was unsuccessful");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/crypto/GenericTypeCryptoTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/crypto/GenericTypeCryptoTest.java
@@ -8,8 +8,8 @@ import jakarta.ws.rs.core.GenericType;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.security.smime.PKCS7SignatureInput;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Crypto
@@ -39,6 +39,6 @@ public class GenericTypeCryptoTest {
         field.set(input, list);
         List<String> list2 = input.getEntity(stringListType, null);
         logger.info("list2: " + list2);
-        Assert.assertEquals("Wrong decryption and encryption of list", list, list2);
+        Assertions.assertEquals(list, list2, "Wrong decryption and encryption of list");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/crypto/LocalTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/crypto/LocalTest.java
@@ -17,9 +17,9 @@ import org.jboss.resteasy.security.doseta.DosetaKeyRepository;
 import org.jboss.resteasy.security.doseta.Verification;
 import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
 import org.jboss.resteasy.utils.TestUtil;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Crypto
@@ -34,7 +34,7 @@ public class LocalTest {
     static final String filePath = TestUtil.getResourcePath(LocalTest.class, "LocalTest.jks");
     private static final String ERROR_MSG = "DosetaKeyRepository works incorrectly";
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         repository = new DosetaKeyRepository();
         repository.setKeyStoreFile(filePath);
@@ -78,13 +78,13 @@ public class LocalTest {
         verification.getRequiredAttributes().put("path", "/hello/world");
 
         MultivaluedMap<String, String> verifiedHeaders = verification.verify(verified, headers, null, keys.getPublic());
-        Assert.assertEquals(verifiedHeaders.size(), 1);
+        Assertions.assertEquals(verifiedHeaders.size(), 1);
         List<String> visas = verifiedHeaders.get("Visa");
-        Assert.assertNotNull(ERROR_MSG, visas);
-        Assert.assertEquals(ERROR_MSG, visas.size(), 2);
+        Assertions.assertNotNull(visas, ERROR_MSG);
+        Assertions.assertEquals(visas.size(), 2, ERROR_MSG);
         logger.info(visas);
-        Assert.assertEquals(ERROR_MSG, visas.get(0), "v3");
-        Assert.assertEquals(ERROR_MSG, visas.get(1), "v2");
+        Assertions.assertEquals(visas.get(0), "v3", ERROR_MSG);
+        Assertions.assertEquals(visas.get(1), "v2", ERROR_MSG);
     }
 
     @Test
@@ -114,7 +114,7 @@ public class LocalTest {
 
         try {
             verification.verify(verified, headers, null, keys.getPublic());
-            Assert.fail("Verification was successful, but it shoudn't be");
+            Assertions.fail("Verification was successful, but it shoudn't be");
         } catch (SignatureException e) {
         }
     }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/crypto/SignedTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/crypto/SignedTest.java
@@ -28,9 +28,9 @@ import org.jboss.logging.Logger;
 import org.jboss.resteasy.security.DerUtils;
 import org.jboss.resteasy.security.PemUtils;
 import org.jboss.resteasy.utils.TestUtil;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Crypto
@@ -57,7 +57,7 @@ public class SignedTest {
         pythonPath = new StringBuilder().append(base).append("SignedPython.txt").toString();
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         Security.addProvider(new BouncyCastleProvider());
         InputStream certIs = new FileInputStream(certPemPath);
@@ -142,10 +142,11 @@ public class SignedTest {
         SMIMESigned signed = new SMIMESigned(mm);
 
         SignerInformationStore signers = signed.getSignerInfos();
-        Assert.assertEquals("Wrong count of signers", 1, signers.size());
+        Assertions.assertEquals(1, signers.size(), "Wrong count of signers");
         SignerInformation signer = signers.getSigners().iterator().next();
-        Assert.assertTrue("Unsuccessful verification of signer",
-                signer.verify(new JcaSimpleSignerInfoVerifierBuilder().setProvider("BC").build(cert.getPublicKey())));
+        Assertions.assertTrue(
+                signer.verify(new JcaSimpleSignerInfoVerifierBuilder().setProvider("BC").build(cert.getPublicKey())),
+                "Unsuccessful verification of signer");
     }
 
     /**

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/injection/JaxrsComponentDetectionTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/injection/JaxrsComponentDetectionTest.java
@@ -1,12 +1,12 @@
 package org.jboss.resteasy.test.injection;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jboss.resteasy.cdi.Utils;
 import org.jboss.resteasy.test.injection.resource.JaxrsComponentDetectionRootResource;
 import org.jboss.resteasy.test.injection.resource.JaxrsComponentDetectionSampleProvider;
 import org.jboss.resteasy.test.injection.resource.JaxrsComponentDetectionSubresource;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Injection tests
@@ -24,8 +24,10 @@ public class JaxrsComponentDetectionTest {
      */
     @Test
     public void testRootResource() {
-        assertTrue(WRONG_RESOURCE, Utils.isJaxrsResource(JaxrsComponentDetectionRootResource.class));
-        assertTrue(WRONG_COMPONENT, Utils.isJaxrsComponent(JaxrsComponentDetectionRootResource.class));
+        assertTrue(Utils.isJaxrsResource(JaxrsComponentDetectionRootResource.class),
+                WRONG_RESOURCE);
+        assertTrue(Utils.isJaxrsComponent(JaxrsComponentDetectionRootResource.class),
+                WRONG_COMPONENT);
     }
 
     /**
@@ -34,8 +36,10 @@ public class JaxrsComponentDetectionTest {
      */
     @Test
     public void testSubresource() {
-        assertTrue(WRONG_RESOURCE, Utils.isJaxrsResource(JaxrsComponentDetectionSubresource.class));
-        assertTrue(WRONG_COMPONENT, Utils.isJaxrsComponent(JaxrsComponentDetectionSubresource.class));
+        assertTrue(Utils.isJaxrsResource(JaxrsComponentDetectionSubresource.class),
+                WRONG_RESOURCE);
+        assertTrue(Utils.isJaxrsComponent(JaxrsComponentDetectionSubresource.class),
+                WRONG_COMPONENT);
     }
 
     /**
@@ -44,7 +48,8 @@ public class JaxrsComponentDetectionTest {
      */
     @Test
     public void testApplicationSubclass() {
-        assertTrue(WRONG_COMPONENT, Utils.isJaxrsComponent(JaxrsComponentDetectionSubresource.class));
+        assertTrue(Utils.isJaxrsComponent(JaxrsComponentDetectionSubresource.class),
+                WRONG_COMPONENT);
     }
 
     /**
@@ -53,6 +58,7 @@ public class JaxrsComponentDetectionTest {
      */
     @Test
     public void testProvider() {
-        assertTrue(WRONG_COMPONENT, Utils.isJaxrsComponent(JaxrsComponentDetectionSampleProvider.class));
+        assertTrue(Utils.isJaxrsComponent(JaxrsComponentDetectionSampleProvider.class),
+                WRONG_COMPONENT);
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/injection/PostConstructInjectionTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/injection/PostConstructInjectionTest.java
@@ -3,8 +3,8 @@ package org.jboss.resteasy.test.injection;
 import jakarta.annotation.PostConstruct;
 
 import org.jboss.resteasy.spi.util.Types;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Test checking for @PostConstruct methods
@@ -64,7 +64,7 @@ public class PostConstructInjectionTest {
      */
     @Test
     public void testValid() throws Exception {
-        Assert.assertTrue(Types.hasPostConstruct(TC0.class));
+        Assertions.assertTrue(Types.hasPostConstruct(TC0.class));
     }
 
     /**
@@ -73,7 +73,7 @@ public class PostConstructInjectionTest {
      */
     @Test
     public void testNumberOfParameters() {
-        Assert.assertFalse(Types.hasPostConstruct(TC1.class));
+        Assertions.assertFalse(Types.hasPostConstruct(TC1.class));
     }
 
     /**
@@ -82,7 +82,7 @@ public class PostConstructInjectionTest {
      */
     @Test
     public void testReturnType() {
-        Assert.assertFalse(Types.hasPostConstruct(TC2.class));
+        Assertions.assertFalse(Types.hasPostConstruct(TC2.class));
     }
 
     /**
@@ -91,7 +91,7 @@ public class PostConstructInjectionTest {
      */
     @Test
     public void testThrowsCheckedException() throws Exception {
-        Assert.assertFalse(Types.hasPostConstruct(TC3.class));
+        Assertions.assertFalse(Types.hasPostConstruct(TC3.class));
     }
 
     /**
@@ -100,7 +100,7 @@ public class PostConstructInjectionTest {
      */
     @Test
     public void testStaticMethod() throws Exception {
-        Assert.assertFalse(Types.hasPostConstruct(TC4.class));
+        Assertions.assertFalse(Types.hasPostConstruct(TC4.class));
     }
 
     /**
@@ -109,7 +109,7 @@ public class PostConstructInjectionTest {
      */
     @Test
     public void testPrivateMethod() throws Exception {
-        Assert.assertTrue(Types.hasPostConstruct(TC5.class));
+        Assertions.assertTrue(Types.hasPostConstruct(TC5.class));
     }
 
     /**
@@ -118,6 +118,6 @@ public class PostConstructInjectionTest {
      */
     @Test
     public void testInheritedMethod() throws Exception {
-        Assert.assertTrue(Types.hasPostConstruct(TC6.class));
+        Assertions.assertTrue(Types.hasPostConstruct(TC6.class));
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/injection/ProviderInjectionTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/injection/ProviderInjectionTest.java
@@ -3,8 +3,8 @@ package org.jboss.resteasy.test.injection;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.test.injection.resource.ProviderInjectionProviderReader;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Injection tests
@@ -27,8 +27,8 @@ public class ProviderInjectionTest {
         RegisterBuiltin.register(factory);
         factory.registerProviderInstance(reader);
 
-        Assert.assertNotNull(ERROR_MSG, reader.headers);
-        Assert.assertNotNull(ERROR_MSG, reader.workers);
+        Assertions.assertNotNull(reader.headers, ERROR_MSG);
+        Assertions.assertNotNull(reader.workers, ERROR_MSG);
     }
 
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/injection/SessionBeanInterfaceTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/injection/SessionBeanInterfaceTest.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.test.injection;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Type;
 import java.util.HashSet;
@@ -15,8 +15,8 @@ import org.jboss.resteasy.test.injection.resource.SessionBeanInterfaceFooLocal2;
 import org.jboss.resteasy.test.injection.resource.SessionBeanInterfaceFooLocal3;
 import org.jboss.resteasy.test.injection.resource.SessionBeanInterfaceMockBean;
 import org.jboss.resteasy.test.injection.resource.SessionBeanInterfaceMockProcessSessionBean;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Injection tests
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class SessionBeanInterfaceTest {
     private ResteasyCdiExtension extension;
 
-    @Before
+    @BeforeEach
     public void prepare() {
         extension = new ResteasyCdiExtension();
     }
@@ -45,8 +45,9 @@ public class SessionBeanInterfaceTest {
         types.add(Object.class);
         Bean<Object> bean = new SessionBeanInterfaceMockBean<>(SessionBeanInterfaceFoo.class, types);
         extension.observeSessionBeans(new SessionBeanInterfaceMockProcessSessionBean<>(bean));
-        assertTrue("Wrong interface was return by ResteasyCdiExtension", extension.getSessionBeanInterface()
-                .get(SessionBeanInterfaceFoo.class).equals(SessionBeanInterfaceFooLocal3.class));
+        assertTrue(extension.getSessionBeanInterface()
+                .get(SessionBeanInterfaceFoo.class).equals(SessionBeanInterfaceFooLocal3.class),
+                "Wrong interface was return by ResteasyCdiExtension");
     }
 
     /**
@@ -60,7 +61,7 @@ public class SessionBeanInterfaceTest {
         types.add(Object.class);
         Bean<Object> bean = new SessionBeanInterfaceMockBean<>(SessionBeanInterfaceFoo.class, types);
         extension.observeSessionBeans(new SessionBeanInterfaceMockProcessSessionBean<>(bean));
-        assertTrue("Any interface should not be returned by ResteasyCdiExtension",
-                extension.getSessionBeanInterface().isEmpty());
+        assertTrue(extension.getSessionBeanInterface().isEmpty(),
+                "Any interface should not be returned by ResteasyCdiExtension");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/injection/StringParameterInjectorTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/injection/StringParameterInjectorTest.java
@@ -1,7 +1,7 @@
 package org.jboss.resteasy.test.injection;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -14,7 +14,7 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.test.injection.resource.StringParameterInjectorGenericType;
 import org.jboss.resteasy.test.injection.resource.StringParameterInjectorInjected;
 import org.jboss.resteasy.test.injection.resource.StringParameterInjectorType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Injection tests
@@ -40,7 +40,7 @@ public class StringParameterInjectorTest {
                 StringParameterInjectorType.class, null, declaredField,
                 declaredField.getAnnotations(), ResteasyProviderFactory.newInstance());
 
-        assertSame("Ignored annotation missing", MY_SPECIAL_STRING, injector.extractValue("ignored"));
+        assertSame(MY_SPECIAL_STRING, injector.extractValue("ignored"), "Ignored annotation missing");
     }
 
     /**
@@ -54,7 +54,7 @@ public class StringParameterInjectorTest {
                 List.class, type, "ignored", String.class, null, null,
                 new Annotation[0], ResteasyProviderFactory.newInstance());
         final Object result = injector.extractValue("");
-        assertNotNull("Injector should not return null", result);
+        assertNotNull(result, "Injector should not return null");
     }
 
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/injection/WeldInitCDITest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/injection/WeldInitCDITest.java
@@ -5,8 +5,8 @@ import jakarta.enterprise.inject.spi.BeanManager;
 import org.jboss.resteasy.cdi.CdiInjectorFactory;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Injection tests
@@ -24,7 +24,7 @@ public class WeldInitCDITest {
         Weld weld = new Weld();
         WeldContainer weldContainer = weld.initialize(); // next assert fails without initialized weld
         BeanManager bm = CdiInjectorFactory.lookupBeanManagerCDIUtil();
-        Assert.assertNotNull("Bean manager was not initialized successfully", bm);
+        Assertions.assertNotNull(bm, "Bean manager was not initialized successfully");
         weld.shutdown();
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/interception/DecoratorMatcherTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/interception/DecoratorMatcherTest.java
@@ -15,9 +15,9 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import org.jboss.resteasy.annotations.Decorator;
 import org.jboss.resteasy.core.interception.jaxrs.DecoratorMatcher;
 import org.jboss.resteasy.spi.DecoratorProcessor;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Interception tests
@@ -30,7 +30,7 @@ public class DecoratorMatcherTest {
     private JAXBContext jaxbContext;
     private DecoratorMatcher decoratorMatcher;
 
-    @Before
+    @BeforeEach
     public void init() throws JAXBException {
         called.set(false);
         jaxbContext = JAXBContext.newInstance(AnObject.class);
@@ -45,7 +45,7 @@ public class DecoratorMatcherTest {
     public void shouldNotThrowOnUnmarshaller() throws JAXBException {
         decoratorMatcher.decorate(Unmarshaller.class, jaxbContext.createUnmarshaller(), AnObject.class, new Annotation[0],
                 MediaType.APPLICATION_XML_TYPE);
-        Assert.assertFalse("Decorate method was called", called.get());
+        Assertions.assertFalse(called.get(), "Decorate method was called");
     }
 
     /**
@@ -56,7 +56,7 @@ public class DecoratorMatcherTest {
     public void shouldCallOnMarshaller() throws JAXBException {
         decoratorMatcher.decorate(Marshaller.class, jaxbContext.createMarshaller(), AnObject.class, new Annotation[0],
                 MediaType.APPLICATION_XML_TYPE);
-        Assert.assertTrue("Decorate method was not called", called.get());
+        Assertions.assertTrue(called.get(), "Decorate method was not called");
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/interception/JaxrsInterceptorRegistryTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/interception/JaxrsInterceptorRegistryTest.java
@@ -1,7 +1,7 @@
 package org.jboss.resteasy.test.interception;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -19,8 +19,8 @@ import jakarta.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.core.interception.jaxrs.JaxrsInterceptorRegistryImpl;
 import org.jboss.resteasy.spi.interception.JaxrsInterceptorRegistry;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Interception tests
@@ -55,8 +55,8 @@ public class JaxrsInterceptorRegistryTest {
             }
         };
 
-        assertEquals("JaxrsInterceptorRegistryTestNameBinding was not used", JaxrsInterceptorRegistryTestNameBinding.class,
-                bound.get(0));
+        assertEquals(JaxrsInterceptorRegistryTestNameBinding.class, bound.get(0),
+                "JaxrsInterceptorRegistryTestNameBinding was not used");
     }
 
     /**
@@ -69,8 +69,8 @@ public class JaxrsInterceptorRegistryTest {
         matches.add(new JaxrsInterceptorRegistry.Match(null, 200));
         matches.add(new JaxrsInterceptorRegistry.Match(null, 100));
         Collections.sort(matches, new JaxrsInterceptorRegistry.AscendingPrecedenceComparator());
-        Assert.assertEquals("Wrong order in list", matches.get(0).order, 100);
-        Assert.assertEquals("Wrong order in list", matches.get(1).order, 200);
+        Assertions.assertEquals(matches.get(0).order, 100, "Wrong order in list");
+        Assertions.assertEquals(matches.get(1).order, 200, "Wrong order in list");
 
     }
 

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/interception/MessageSanitizerMediaTypeTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/interception/MessageSanitizerMediaTypeTest.java
@@ -9,8 +9,8 @@ import org.jboss.resteasy.plugins.interceptors.MessageSanitizerContainerResponse
 import org.jboss.resteasy.specimpl.BuiltResponse;
 import org.jboss.resteasy.specimpl.BuiltResponseEntityNotBacked;
 import org.jboss.resteasy.spi.HttpResponseCodes;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Providers - MessageSanitizerContainerResponseFilter
@@ -47,6 +47,6 @@ public class MessageSanitizerMediaTypeTest {
         ContainerResponseContext responseContext = new TestContainerResponseContext(response);
         MessageSanitizerContainerResponseFilter filter = new MessageSanitizerContainerResponseFilter();
         filter.filter(null, responseContext);
-        Assert.assertEquals(output, responseContext.getEntity());
+        Assertions.assertEquals(output, responseContext.getEntity());
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/interception/PriorityTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/interception/PriorityTest.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.test.interception;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -47,9 +47,9 @@ import org.jboss.resteasy.test.interception.resource.PriorityClientResponseFilte
 import org.jboss.resteasy.test.interception.resource.PriorityContainerResponseFilter1;
 import org.jboss.resteasy.test.interception.resource.PriorityContainerResponseFilter2;
 import org.jboss.resteasy.test.interception.resource.PriorityContainerResponseFilter3;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Interception tests
@@ -58,11 +58,12 @@ import org.junit.Test;
  *                    Priority annotation.
  * @tpSince RESTEasy 3.0.16
  */
+@Disabled("RESTEASY-3452")
 public class PriorityTest {
 
     private static final String ERROR_MESSAGE = "RESTEasy uses filter in wrong older";
 
-    @Rule
+    //@ExtendWith
     public FakeHttpServer fakeHttpServer = new FakeHttpServer(FakeHttpServer::dummyMethods);
 
     /**
@@ -83,27 +84,27 @@ public class PriorityTest {
         containerResponseFilterRegistry.registerClass(PriorityContainerResponseFilter3.class);
 
         ContainerResponseFilter[] containerResponseFilters = containerResponseFilterRegistry.postMatch(null, null);
-        assertTrue(ERROR_MESSAGE, containerResponseFilters[0] instanceof PriorityContainerResponseFilter3);
-        assertTrue(ERROR_MESSAGE, containerResponseFilters[1] instanceof PriorityContainerResponseFilter2);
-        assertTrue(ERROR_MESSAGE, containerResponseFilters[2] instanceof PriorityContainerResponseFilter1);
+        assertTrue(containerResponseFilters[0] instanceof PriorityContainerResponseFilter3, ERROR_MESSAGE);
+        assertTrue(containerResponseFilters[1] instanceof PriorityContainerResponseFilter2, ERROR_MESSAGE);
+        assertTrue(containerResponseFilters[2] instanceof PriorityContainerResponseFilter1, ERROR_MESSAGE);
 
         clientResponseFilterRegistry.registerClass(PriorityClientResponseFilter3.class);
         clientResponseFilterRegistry.registerClass(PriorityClientResponseFilter1.class);
         clientResponseFilterRegistry.registerClass(PriorityClientResponseFilter2.class);
 
         ClientResponseFilter[] clientResponseFilters = clientResponseFilterRegistry.postMatch(null, null);
-        assertTrue(ERROR_MESSAGE, clientResponseFilters[0] instanceof PriorityClientResponseFilter3);
-        assertTrue(ERROR_MESSAGE, clientResponseFilters[1] instanceof PriorityClientResponseFilter2);
-        assertTrue(ERROR_MESSAGE, clientResponseFilters[2] instanceof PriorityClientResponseFilter1);
+        assertTrue(clientResponseFilters[0] instanceof PriorityClientResponseFilter3, ERROR_MESSAGE);
+        assertTrue(clientResponseFilters[1] instanceof PriorityClientResponseFilter2, ERROR_MESSAGE);
+        assertTrue(clientResponseFilters[2] instanceof PriorityClientResponseFilter1, ERROR_MESSAGE);
 
         clientRequestFilterRegistry.registerClass(PriorityClientRequestFilter3.class);
         clientRequestFilterRegistry.registerClass(PriorityClientRequestFilter1.class);
         clientRequestFilterRegistry.registerClass(PriorityClientRequestFilter2.class);
 
         ClientRequestFilter[] clientRequestFilters = clientRequestFilterRegistry.postMatch(null, null);
-        assertTrue(ERROR_MESSAGE, clientRequestFilters[0] instanceof PriorityClientRequestFilter1);
-        assertTrue(ERROR_MESSAGE, clientRequestFilters[1] instanceof PriorityClientRequestFilter2);
-        assertTrue(ERROR_MESSAGE, clientRequestFilters[2] instanceof PriorityClientRequestFilter3);
+        assertTrue(clientRequestFilters[0] instanceof PriorityClientRequestFilter1, ERROR_MESSAGE);
+        assertTrue(clientRequestFilters[1] instanceof PriorityClientRequestFilter2, ERROR_MESSAGE);
+        assertTrue(clientRequestFilters[2] instanceof PriorityClientRequestFilter3, ERROR_MESSAGE);
 
     }
 
@@ -121,9 +122,9 @@ public class PriorityTest {
         clientRequestFilterRegistry.registerClass(PriorityClientRequestFilter2.class, 300);
 
         ClientRequestFilter[] clientRequestFilters = clientRequestFilterRegistry.postMatch(null, null);
-        assertTrue(ERROR_MESSAGE, clientRequestFilters[0] instanceof PriorityClientRequestFilter3);
-        assertTrue(ERROR_MESSAGE, clientRequestFilters[1] instanceof PriorityClientRequestFilter1);
-        assertTrue(ERROR_MESSAGE, clientRequestFilters[2] instanceof PriorityClientRequestFilter2);
+        assertTrue(clientRequestFilters[0] instanceof PriorityClientRequestFilter3, ERROR_MESSAGE);
+        assertTrue(clientRequestFilters[1] instanceof PriorityClientRequestFilter1, ERROR_MESSAGE);
+        assertTrue(clientRequestFilters[2] instanceof PriorityClientRequestFilter2, ERROR_MESSAGE);
     }
 
     @Test
@@ -147,7 +148,7 @@ public class PriorityTest {
                 }
             }, 0);
             webTarget.request().get().close();
-            Assert.assertEquals("OK", result.toString());
+            Assertions.assertEquals("OK", result.toString());
         } finally {
             client.close();
         }
@@ -176,7 +177,7 @@ public class PriorityTest {
                 }
             }, 0);
             webTarget.request().get().close();
-            Assert.assertEquals("OK", result.toString());
+            Assertions.assertEquals("OK", result.toString());
         } finally {
             client.close();
         }
@@ -210,7 +211,7 @@ public class PriorityTest {
                 }
             }, 0);
             webTarget.request().get().readEntity(String.class);
-            Assert.assertEquals("OK", result.toString());
+            Assertions.assertEquals("OK", result.toString());
         } finally {
             client.close();
         }
@@ -239,7 +240,7 @@ public class PriorityTest {
                 }
             }, 0);
             webTarget.request().post(Entity.text("Hello")).close();
-            Assert.assertEquals("OK", result.toString());
+            Assertions.assertEquals("OK", result.toString());
         } finally {
             client.close();
         }
@@ -286,7 +287,7 @@ public class PriorityTest {
                 }
             }, 0);
             webTarget.request().get().readEntity(String.class);
-            Assert.assertEquals("OK", result.toString());
+            Assertions.assertEquals("OK", result.toString());
         } finally {
             client.close();
         }
@@ -327,7 +328,7 @@ public class PriorityTest {
                 }
             }, 0);
             webTarget.request().post(Entity.text("Hello")).close();
-            Assert.assertEquals("OK", result.toString());
+            Assertions.assertEquals("OK", result.toString());
         } finally {
             client.close();
         }
@@ -365,7 +366,7 @@ public class PriorityTest {
                 }
             }, 1);
             webTarget.request().get().close();
-            Assert.assertEquals("OK", result.toString());
+            Assertions.assertEquals("OK", result.toString());
         } finally {
             client.close();
         }
@@ -403,7 +404,7 @@ public class PriorityTest {
                 }
             }, 0);
             webTarget.request().get().close();
-            Assert.assertEquals("OK", result.toString());
+            Assertions.assertEquals("OK", result.toString());
         } finally {
             client.close();
         }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/jose/JWETest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/jose/JWETest.java
@@ -9,11 +9,11 @@ import org.jboss.logging.Logger;
 import org.jboss.resteasy.jose.jwe.JWEBuilder;
 import org.jboss.resteasy.jose.jwe.JWEInput;
 import org.jboss.resteasy.utils.TestUtil;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 /**
  * @tpSubChapter Jose tests
@@ -21,7 +21,7 @@ import org.junit.runners.MethodSorters;
  * @tpTestCaseDetails Test for JWE
  * @tpSince RESTEasy 3.0.16
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodName.class)
 public class JWETest {
     private static final String ERROR_MSG = "Wrong conversion";
     private static final String BOUNCY_CASTLE_ERROR = "BouncyCastle security provider can't be used in non-OpenJDK (missing signatures)";
@@ -33,7 +33,7 @@ public class JWETest {
      */
     @Test
     public void testRSA() throws Exception {
-        Assume.assumeTrue(TestUtil.getErrorMessageForKnownIssue("JBEAP-3550", BOUNCY_CASTLE_ERROR), TestUtil.isOpenJDK());
+        Assumptions.assumeTrue(TestUtil.isOpenJDK(), TestUtil.getErrorMessageForKnownIssue("JBEAP-3550", BOUNCY_CASTLE_ERROR));
         KeyPair keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
 
         String content = "Live long and prosper.";
@@ -43,14 +43,14 @@ public class JWETest {
             logger.info("encoded: " + encoded);
             byte[] raw = new JWEInput(encoded).decrypt((RSAPrivateKey) keyPair.getPrivate()).getRawContent();
             String from = new String(raw);
-            Assert.assertEquals(ERROR_MSG, content, from);
+            Assertions.assertEquals(content, from, ERROR_MSG);
         }
         {
             String encoded = new JWEBuilder().contentBytes(content.getBytes()).RSA_OAEP((RSAPublicKey) keyPair.getPublic());
             logger.info("encoded: " + encoded);
             byte[] raw = new JWEInput(encoded).decrypt((RSAPrivateKey) keyPair.getPrivate()).getRawContent();
             String from = new String(raw);
-            Assert.assertEquals(ERROR_MSG, content, from);
+            Assertions.assertEquals(content, from, ERROR_MSG);
         }
         {
             String encoded = new JWEBuilder().contentBytes(content.getBytes()).A128CBC_HS256()
@@ -58,7 +58,7 @@ public class JWETest {
             logger.info("encoded: " + encoded);
             byte[] raw = new JWEInput(encoded).decrypt((RSAPrivateKey) keyPair.getPrivate()).getRawContent();
             String from = new String(raw);
-            Assert.assertEquals(ERROR_MSG, content, from);
+            Assertions.assertEquals(content, from, ERROR_MSG);
         }
         {
             String encoded = new JWEBuilder().contentBytes(content.getBytes()).A128CBC_HS256()
@@ -66,7 +66,7 @@ public class JWETest {
             logger.info("encoded: " + encoded);
             byte[] raw = new JWEInput(encoded).decrypt((RSAPrivateKey) keyPair.getPrivate()).getRawContent();
             String from = new String(raw);
-            Assert.assertEquals(ERROR_MSG, content, from);
+            Assertions.assertEquals(content, from, ERROR_MSG);
         }
     }
 
@@ -76,13 +76,14 @@ public class JWETest {
      */
     @Test
     public void testDirect() throws Exception {
-        Assume.assumeTrue(TestUtil.getErrorMessageForKnownIssue("JBEAP-3550", BOUNCY_CASTLE_ERROR), TestUtil.isOpenJDK());
+        Assumptions.assumeTrue(TestUtil.isOpenJDK(),
+                TestUtil.getErrorMessageForKnownIssue("JBEAP-3550", BOUNCY_CASTLE_ERROR));
         String content = "Live long and prosper.";
         String encoded = new JWEBuilder().contentBytes(content.getBytes()).dir("geheim");
         logger.info("encoded: " + encoded);
         byte[] raw = new JWEInput(encoded).decrypt("geheim").getRawContent();
         String from = new String(raw);
-        Assert.assertEquals(ERROR_MSG, content, from);
+        Assertions.assertEquals(content, from, ERROR_MSG);
 
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/jose/JWSTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/jose/JWSTest.java
@@ -24,10 +24,10 @@ import org.jboss.resteasy.jose.jws.JWSInput;
 import org.jboss.resteasy.jose.jws.crypto.HMACProvider;
 import org.jboss.resteasy.jose.jws.crypto.RSAProvider;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.junit.Assert;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,7 +39,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
  * @tpTestCaseDetails Test for JWS
  * @tpSince RESTEasy 3.0.16
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+//@Disabled("RESTEASY-3450")
+@TestMethodOrder(MethodName.class)
 public class JWSTest {
     protected static final Logger logger = Logger.getLogger(JWSTest.class.getName());
     private static final String HEADER_ERROR_MSG = "Wrong algorithm header";
@@ -83,8 +84,8 @@ public class JWSTest {
 
         JWSInput input = new JWSInput(encoded, ResteasyProviderFactory.getInstance());
         String msg = (String) input.readContent(String.class, null, null, MediaType.TEXT_PLAIN_TYPE);
-        Assert.assertEquals(RESPONSE_ERROR_MSG, "Hello World", msg);
-        Assert.assertTrue(VERIFY_ERROR_MSG, RSAProvider.verify(input, keyPair.getPublic()));
+        Assertions.assertEquals("Hello World", msg, RESPONSE_ERROR_MSG);
+        Assertions.assertTrue(RSAProvider.verify(input, keyPair.getPublic()), VERIFY_ERROR_MSG);
 
     }
 
@@ -108,8 +109,8 @@ public class JWSTest {
         JWSInput input = new JWSInput(encoded, ResteasyProviderFactory.getInstance());
         logger.info(input.getHeader());
         String msg = input.readContent(String.class);
-        Assert.assertEquals(RESPONSE_ERROR_MSG, "Hello World", msg);
-        Assert.assertTrue(VERIFY_ERROR_MSG, RSAProvider.verify(input, keyPair.getPublic()));
+        Assertions.assertEquals("Hello World", msg, RESPONSE_ERROR_MSG);
+        Assertions.assertTrue(RSAProvider.verify(input, keyPair.getPublic()), VERIFY_ERROR_MSG);
 
     }
 
@@ -131,8 +132,8 @@ public class JWSTest {
         JWSInput input = new JWSInput(encoded, ResteasyProviderFactory.getInstance());
         logger.info(input.getHeader());
         String msg = input.readContent(String.class);
-        Assert.assertEquals(RESPONSE_ERROR_MSG, "Hello World", msg);
-        Assert.assertTrue(VERIFY_ERROR_MSG, HMACProvider.verify(input, key));
+        Assertions.assertEquals("Hello World", msg, RESPONSE_ERROR_MSG);
+        Assertions.assertTrue(HMACProvider.verify(input, key), VERIFY_ERROR_MSG);
     }
 
     @Test
@@ -156,7 +157,7 @@ public class JWSTest {
 
         JWSInput input = new JWSInput(encoded, ResteasyProviderFactory.getInstance());
         String msg = (String) input.readContent(String.class, null, null, MediaType.TEXT_PLAIN_TYPE);
-        Assert.assertEquals(RESPONSE_ERROR_MSG, content, msg);
-        Assert.assertTrue(VERIFY_ERROR_MSG, RSAProvider.verify(input, keyPair.getPublic()));
+        Assertions.assertEquals(content, msg, RESPONSE_ERROR_MSG);
+        Assertions.assertTrue(RSAProvider.verify(input, keyPair.getPublic()), VERIFY_ERROR_MSG);
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/jose/JWTTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/jose/JWTTest.java
@@ -7,7 +7,8 @@ import org.hamcrest.MatcherAssert;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.jwt.JsonSerialization;
 import org.jboss.resteasy.jwt.JsonWebToken;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Jose tests
@@ -15,6 +16,7 @@ import org.junit.Test;
  * @tpTestCaseDetails Test for JWT
  * @tpSince RESTEasy 3.0.16
  */
+@Disabled("RESTEASY-3450")
 public class JWTTest {
     protected static final Logger logger = Logger.getLogger(JWTTest.class.getName());
     private static final String ERROR_MSG = "Wrong JsonWebToken conversion";

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/mapper/ExceptionHandlerTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/mapper/ExceptionHandlerTest.java
@@ -20,8 +20,8 @@ import org.jboss.resteasy.test.mapper.resource.ApplicationExceptionMapper;
 import org.jboss.resteasy.test.mapper.resource.IOExceptionMapper;
 import org.jboss.resteasy.test.mapper.resource.SprocketDBException;
 import org.jboss.resteasy.test.mapper.resource.SprocketDBExceptionMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test that the Exception processing and ExceptionMapper handling rules defined in
@@ -48,8 +48,8 @@ public class ExceptionHandlerTest {
         Response result = eHandler.handleException(request,
                 new SprocketDBException("SprocketDBException test"));
 
-        Assert.assertEquals("SprocketDBExceptionMapper: incorrect status code returned",
-                result.getStatus(), SprocketDBExceptionMapper.STATUS_CODE);
+        Assertions.assertEquals(result.getStatus(), SprocketDBExceptionMapper.STATUS_CODE,
+                "SprocketDBExceptionMapper: incorrect status code returned");
     }
 
     @Test
@@ -69,16 +69,16 @@ public class ExceptionHandlerTest {
         ApplicationException appE = new ApplicationException("ApplicationException test", webAppE);
         Response result = eHandler.handleException(request, appE);
 
-        Assert.assertEquals("First ApplicationException: incorrect status code returned",
-                result.getStatus(), statusCode);
+        Assertions.assertEquals(result.getStatus(), statusCode,
+                "First ApplicationException: incorrect status code returned");
 
         // ApplicationException is a 'final' class and can not be subclasses.
         factory.registerProvider(ApplicationExceptionMapper.class);
         Response resultOne = eHandler.handleException(request,
                 new ApplicationException("ApplicationException test", new SprocketDBException()));
 
-        Assert.assertEquals("Second ApplicationException: incorrect status code returned",
-                resultOne.getStatus(), ApplicationExceptionMapper.STATUS_CODE);
+        Assertions.assertEquals(resultOne.getStatus(), ApplicationExceptionMapper.STATUS_CODE,
+                "Second ApplicationException: incorrect status code returned");
     }
 
     @Test
@@ -96,10 +96,10 @@ public class ExceptionHandlerTest {
 
         try {
             Response result = eHandler.handleException(request, sdbe);
-            Assert.assertEquals(Response.Status.INTERNAL_SERVER_ERROR, result.getStatusInfo());
-            Assert.assertEquals("SprocketDBException test", result.readEntity(String.class));
+            Assertions.assertEquals(Response.Status.INTERNAL_SERVER_ERROR, result.getStatusInfo());
+            Assertions.assertEquals("SprocketDBException test", result.readEntity(String.class));
         } catch (UnhandledException ue) {
-            Assert.fail("Test failed to properly handle the exception with the default exception handler");
+            Assertions.fail("Test failed to properly handle the exception with the default exception handler");
         }
     }
 
@@ -117,8 +117,8 @@ public class ExceptionHandlerTest {
         ExceptionHandler eHandler = new ExceptionHandler(factory, unwrappedExceptions);
         Response result = eHandler.handleException(request, nlwae);
 
-        Assert.assertEquals("One WebApplicationException: incorrect status code returned",
-                result.getStatus(), statusCode);
+        Assertions.assertEquals(result.getStatus(), statusCode,
+                "One WebApplicationException: incorrect status code returned");
 
         // When WebApplicationException and response is null an or entity is null
         // use custom internal mapper to produce response.
@@ -127,8 +127,8 @@ public class ExceptionHandlerTest {
                 Response.status(statusCode).build());
         Response resultOne = eHandler.handleException(request, nlwaeOne);
 
-        Assert.assertEquals("One WebApplicationException: incorrect status code returned",
-                resultOne.getStatus(), statusCode);
+        Assertions.assertEquals(resultOne.getStatus(), statusCode,
+                "One WebApplicationException: incorrect status code returned");
     }
 
     @Test
@@ -144,8 +144,8 @@ public class ExceptionHandlerTest {
         ExceptionHandler eHandler = new ExceptionHandler(factory, unwrappedExceptions);
         Response result = eHandler.handleException(request, lf);
 
-        Assert.assertEquals("One LoggableFailure: incorrect status code returned",
-                result.getStatus(), statusCode);
+        Assertions.assertEquals(result.getStatus(), statusCode,
+                "One LoggableFailure: incorrect status code returned");
     }
 
     @Test
@@ -161,8 +161,8 @@ public class ExceptionHandlerTest {
         ExceptionHandler eHandler = new ExceptionHandler(factory, unwrappedExceptions);
         Response result = eHandler.handleException(request, ioe);
 
-        Assert.assertEquals("IOException: incorrect status code returned",
-                result.getStatus(), HttpResponseCodes.SC_NO_CONTENT);
+        Assertions.assertEquals(result.getStatus(), HttpResponseCodes.SC_NO_CONTENT,
+                "IOException: incorrect status code returned");
 
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/mapper/ReadWriterExceptionTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/mapper/ReadWriterExceptionTest.java
@@ -18,8 +18,8 @@ import org.jboss.resteasy.test.mapper.resource.ReaderExceptionMapper;
 import org.jboss.resteasy.test.mapper.resource.SprocketDBException;
 import org.jboss.resteasy.test.mapper.resource.SprocketDBExceptionMapper;
 import org.jboss.resteasy.test.mapper.resource.WriterExceptionMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test that the Exception processing and ExceptionMapper handling rules defined in
@@ -46,8 +46,8 @@ public class ReadWriterExceptionTest {
         // no exception cause object, return status code SC_INTERNAL_SERVER_ERROR.
         JAXBMarshalException jaxbEOne = new JAXBMarshalException("JAXBMarshalException's WriterException test one");
         Response resultOne = eHandler.handleException(request, jaxbEOne);
-        Assert.assertEquals("First WriterExceptionMapper: incorrect status code returned",
-                resultOne.getStatus(), HttpResponseCodes.SC_INTERNAL_SERVER_ERROR);
+        Assertions.assertEquals(resultOne.getStatus(), HttpResponseCodes.SC_INTERNAL_SERVER_ERROR,
+                "First WriterExceptionMapper: incorrect status code returned");
 
         // When exception response object is NULL and exception errorCode is -1 and
         // there is an exception cause object, return status code for the cause when
@@ -56,16 +56,16 @@ public class ReadWriterExceptionTest {
                 new SprocketDBException());
         factory.registerProvider(SprocketDBExceptionMapper.class);
         Response resultTwo = eHandler.handleException(request, jaxbETwo);
-        Assert.assertEquals("Second WriterExceptionMapper: incorrect status code returned",
-                resultTwo.getStatus(), SprocketDBExceptionMapper.STATUS_CODE);
+        Assertions.assertEquals(resultTwo.getStatus(), SprocketDBExceptionMapper.STATUS_CODE,
+                "Second WriterExceptionMapper: incorrect status code returned");
 
         // When there is no mapper for WriterException and exception errorCode is
         // greater than -1 return a response with that error code
         int customErrorCode = 111222333;
         WriterException wEOne = new WriterException("WriterException test", customErrorCode);
         Response resultThree = eHandler.handleException(request, wEOne);
-        Assert.assertEquals("Third WriterExceptionMapper: incorrect status code returned",
-                resultThree.getStatus(), customErrorCode);
+        Assertions.assertEquals(resultThree.getStatus(), customErrorCode,
+                "Third WriterExceptionMapper: incorrect status code returned");
 
         // JAXBMarshalException is a subclass of WriterException
         // A WriterException mapper is provided
@@ -76,8 +76,8 @@ public class ReadWriterExceptionTest {
         factory.registerProvider(WriterExceptionMapper.class);
         Response result = eHandler.handleException(request, jaxbE);
 
-        Assert.assertEquals("WriterExceptionMapper: incorrect status code returned",
-                result.getStatus(), WriterExceptionMapper.STATUS_CODE);
+        Assertions.assertEquals(result.getStatus(), WriterExceptionMapper.STATUS_CODE,
+                "WriterExceptionMapper: incorrect status code returned");
     }
 
     @Test
@@ -92,8 +92,8 @@ public class ReadWriterExceptionTest {
         // no exception cause object, return status code SC_BAD_REQUEST.
         JAXBUnmarshalException jaxbEOne = new JAXBUnmarshalException("JAXBUnmarshalException's ReaderException test one");
         Response resultOne = eHandler.handleException(request, jaxbEOne);
-        Assert.assertEquals("First ReaderExceptionMapper: incorrect status code returned",
-                resultOne.getStatus(), HttpResponseCodes.SC_BAD_REQUEST);
+        Assertions.assertEquals(resultOne.getStatus(), HttpResponseCodes.SC_BAD_REQUEST,
+                "First ReaderExceptionMapper: incorrect status code returned");
 
         // When exception response object is NULL and exception errorCode is -1 and
         // there is an exception cause object, return status code for the cause when
@@ -102,16 +102,16 @@ public class ReadWriterExceptionTest {
                 new SprocketDBException());
         factory.registerProvider(SprocketDBExceptionMapper.class);
         Response resultTwo = eHandler.handleException(request, jaxbETwo);
-        Assert.assertEquals("Second ReaderExceptionMapper: incorrect status code returned",
-                resultTwo.getStatus(), SprocketDBExceptionMapper.STATUS_CODE);
+        Assertions.assertEquals(resultTwo.getStatus(), SprocketDBExceptionMapper.STATUS_CODE,
+                "Second ReaderExceptionMapper: incorrect status code returned");
 
         // When exception errorCode is greater than -1 return a response with that error code
         // and there is no mapper for WriterException.
         int customErrorCode = 444555666;
         ReaderException wEOne = new ReaderException("ReaderException test", customErrorCode);
         Response resultThree = eHandler.handleException(request, wEOne);
-        Assert.assertEquals("Third ReaderExceptionMapper: incorrect status code returned",
-                resultThree.getStatus(), customErrorCode);
+        Assertions.assertEquals(resultThree.getStatus(), customErrorCode,
+                "Third ReaderExceptionMapper: incorrect status code returned");
 
         // JAXBUnmarshalException is a subclass of ReaderException
         // A ReaderException mapper is provided
@@ -122,8 +122,8 @@ public class ReadWriterExceptionTest {
         factory.registerProvider(ReaderExceptionMapper.class);
         Response result = eHandler.handleException(request, jaxbE);
 
-        Assert.assertEquals("ReaderExceptionMapper: incorrect status code returned",
-                result.getStatus(), ReaderExceptionMapper.STATUS_CODE);
+        Assertions.assertEquals(result.getStatus(), ReaderExceptionMapper.STATUS_CODE,
+                "ReaderExceptionMapper: incorrect status code returned");
     }
 
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/mediatype/MediaTypeHeaderDelegateTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/mediatype/MediaTypeHeaderDelegateTest.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.test.mediatype;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -8,14 +8,14 @@ import java.util.Map;
 import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.plugins.delegates.MediaTypeHeaderDelegate;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MediaTypeHeaderDelegateTest {
 
     private MediaTypeHeaderDelegate delegate;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         delegate = new MediaTypeHeaderDelegate();
 

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/mediatype/MediaTypeHeaderTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/mediatype/MediaTypeHeaderTest.java
@@ -1,14 +1,19 @@
 package org.jboss.resteasy.test.mediatype;
 
 import org.jboss.resteasy.plugins.delegates.MediaTypeHeaderDelegate;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class MediaTypeHeaderTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNewLineInHeaderValueIsRejected() {
-        MediaTypeHeaderDelegate delegate = new MediaTypeHeaderDelegate();
+        IllegalArgumentException thrown = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> {
+                    MediaTypeHeaderDelegate delegate = new MediaTypeHeaderDelegate();
 
-        delegate.fromString("foo/bar\n");
+                    delegate.fromString("foo/bar\n");
+                });
+        Assertions.assertTrue(thrown instanceof IllegalArgumentException);
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/mediatype/MediaTypeMapTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/mediatype/MediaTypeMapTest.java
@@ -5,8 +5,8 @@ import java.util.List;
 import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.core.MediaTypeMap;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Media type
@@ -74,38 +74,42 @@ public class MediaTypeMapTest {
     private void evalMapping(MediaTypeMap<String> map, String defaultPlainText, String jaxb, String wildcard, String allText,
             String allXML, String app) {
         List<String> list = map.getPossible(new MediaType("text", "plain"));
-        Assert.assertNotNull("Media types for \"text, plain\" is empty", list);
-        Assert.assertEquals("The list of media types doesn't contain expected number of elements", 3, list.size());
-        Assert.assertTrue("Unexpected item in the list", list.get(0) == defaultPlainText);
-        Assert.assertTrue("Unexpected item in the list", list.get(1) == allText);
-        Assert.assertTrue("Unexpected item in the list", list.get(2) == wildcard);
+        Assertions.assertNotNull(list, "Media types for \"text, plain\" is empty");
+        Assertions.assertEquals(3, list.size(),
+                "The list of media types doesn't contain expected number of elements");
+        Assertions.assertTrue(list.get(0) == defaultPlainText, "Unexpected item in the list");
+        Assertions.assertTrue(list.get(1) == allText, "Unexpected item in the list");
+        Assertions.assertTrue(list.get(2) == wildcard, "Unexpected item in the list");
 
         list = map.getPossible(new MediaType("*", "*"));
-        Assert.assertNotNull("Media types for \"*, *\" is empty", list);
-        Assert.assertEquals("The list of media types doesn't contain expected number of elements", 6, list.size());
-        Assert.assertTrue(list.get(0), list.get(0) == defaultPlainText || list.get(0) == jaxb);
-        Assert.assertTrue(list.get(1), list.get(1) == defaultPlainText || list.get(1) == jaxb);
-        Assert.assertTrue(list.get(2), list.get(2) == allXML);
-        Assert.assertTrue(list.get(3), list.get(3) == allText || list.get(3) == app);
-        Assert.assertTrue(list.get(4), list.get(4) == allText || list.get(4) == app);
-        Assert.assertTrue(list.get(5), list.get(5) == wildcard);
+        Assertions.assertNotNull(list, "Media types for \"*, *\" is empty");
+        Assertions.assertEquals(6, list.size(),
+                "The list of media types doesn't contain expected number of elements");
+        Assertions.assertTrue(list.get(0) == defaultPlainText || list.get(0) == jaxb, list.get(0));
+        Assertions.assertTrue(list.get(1) == defaultPlainText || list.get(1) == jaxb, list.get(1));
+        Assertions.assertTrue(list.get(2) == allXML, list.get(2));
+        Assertions.assertTrue(list.get(3) == allText || list.get(3) == app, list.get(3));
+        Assertions.assertTrue(list.get(4) == allText || list.get(4) == app, list.get(4));
+        Assertions.assertTrue(list.get(5) == wildcard, list.get(5));
 
         list = map.getPossible(new MediaType("text", "*"));
-        Assert.assertNotNull("Media types for \"text, *\" is empty", list);
-        Assert.assertEquals("The list of media types doesn't contain expected number of elements", 5, list.size());
-        Assert.assertTrue(list.get(0), list.get(0) == defaultPlainText || list.get(0) == jaxb);
-        Assert.assertTrue(list.get(1), list.get(1) == defaultPlainText || list.get(1) == jaxb);
-        Assert.assertTrue(list.get(2), list.get(2) == allXML);
-        Assert.assertTrue(list.get(3), list.get(3) == allText);
-        Assert.assertTrue(list.get(4), list.get(4) == wildcard);
+        Assertions.assertNotNull(list, "Media types for \"text, *\" is empty");
+        Assertions.assertEquals(5, list.size(),
+                "The list of media types doesn't contain expected number of elements");
+        Assertions.assertTrue(list.get(0) == defaultPlainText || list.get(0) == jaxb, list.get(0));
+        Assertions.assertTrue(list.get(1) == defaultPlainText || list.get(1) == jaxb, list.get(1));
+        Assertions.assertTrue(list.get(2) == allXML, list.get(2));
+        Assertions.assertTrue(list.get(3) == allText, list.get(3));
+        Assertions.assertTrue(list.get(4) == wildcard, list.get(4));
 
         list = map.getPossible(new MediaType("text", "xml"));
-        Assert.assertNotNull("Media types for \"text, xml\" is empty", list);
-        Assert.assertEquals("The list of media types doesn't contain expected number of elements", 4, list.size());
-        Assert.assertTrue(list.get(0) == jaxb);
-        Assert.assertTrue(list.get(1) == allXML);
-        Assert.assertTrue(list.get(2) == allText);
-        Assert.assertTrue(list.get(3) == wildcard);
+        Assertions.assertNotNull(list, "Media types for \"text, xml\" is empty");
+        Assertions.assertEquals(4, list.size(),
+                "The list of media types doesn't contain expected number of elements");
+        Assertions.assertTrue(list.get(0) == jaxb);
+        Assertions.assertTrue(list.get(1) == allXML);
+        Assertions.assertTrue(list.get(2) == allText);
+        Assertions.assertTrue(list.get(3) == wildcard);
     }
 
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/multipart/Base64EncoderMultiPartTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/multipart/Base64EncoderMultiPartTest.java
@@ -11,8 +11,8 @@ import jakarta.ws.rs.core.MediaType;
 import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.plugins.providers.multipart.InputPart;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartInputImpl;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class Base64EncoderMultiPartTest {
 
@@ -38,7 +38,7 @@ public class Base64EncoderMultiPartTest {
             InputStream inputStream = ((MultipartInputImpl.PartImpl) part).getBody();
             byte[] bytes = inputStream.readAllBytes();
             String base64bytes = Base64.getEncoder().encodeToString(bytes);
-            Assert.assertEquals(body, base64bytes);
+            Assertions.assertEquals(body, base64bytes);
         }
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/AppCategoriesTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/AppCategoriesTest.java
@@ -13,8 +13,8 @@ import jakarta.xml.bind.Unmarshaller;
 
 import org.jboss.resteasy.plugins.providers.atom.Category;
 import org.jboss.resteasy.plugins.providers.atom.app.AppCategories;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Providers
@@ -67,7 +67,7 @@ public class AppCategoriesTest {
 
         marshaller.marshal(element, writer);
         String actualXml = writer.toString();
-        Assert.assertTrue("Categories are missing", actualXml.contains("atom:category"));
+        Assertions.assertTrue(actualXml.contains("atom:category"), "Categories are missing");
     }
 
     /**
@@ -79,6 +79,6 @@ public class AppCategoriesTest {
         JAXBContext ctx = JAXBContext.newInstance(AppCategories.class);
         Unmarshaller unmarshaller = ctx.createUnmarshaller();
         AppCategories categories = (AppCategories) unmarshaller.unmarshal(new StringReader(XML));
-        Assert.assertTrue("Wrong categories", categories.isFixed());
+        Assertions.assertTrue(categories.isFixed(), "Wrong categories");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/AtomProviderAppServiceTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/AtomProviderAppServiceTest.java
@@ -18,8 +18,8 @@ import org.jboss.resteasy.plugins.providers.atom.app.AppCategories;
 import org.jboss.resteasy.plugins.providers.atom.app.AppCollection;
 import org.jboss.resteasy.plugins.providers.atom.app.AppService;
 import org.jboss.resteasy.plugins.providers.atom.app.AppWorkspace;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Providers
@@ -140,7 +140,8 @@ public class AtomProviderAppServiceTest {
 
         marshaller.marshal(element, writer);
         String actualXml = writer.toString();
-        Assert.assertTrue("Wrong serialization of atom provider", actualXml.contains("atom:category"));
+        Assertions.assertTrue(actualXml.contains("atom:category"),
+                "Wrong serialization of atom provider");
     }
 
     /**
@@ -153,6 +154,7 @@ public class AtomProviderAppServiceTest {
         Unmarshaller unmarshaller = ctx.createUnmarshaller();
         AppService service = (AppService) unmarshaller
                 .unmarshal(new StringReader(XML));
-        Assert.assertEquals("Wrong deserialization of atom provider", 2, service.getWorkspace().size());
+        Assertions.assertEquals(2, service.getWorkspace().size(),
+                "Wrong deserialization of atom provider");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/AtomProviderModelTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/AtomProviderModelTest.java
@@ -22,7 +22,7 @@ import org.jboss.resteasy.plugins.providers.atom.Link;
 import org.jboss.resteasy.plugins.providers.atom.Person;
 import org.jboss.resteasy.plugins.providers.atom.Text;
 import org.jboss.resteasy.test.providers.resource.AtomProviderModelCustomerAtom;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Providers

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/ContractsTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/ContractsTest.java
@@ -10,8 +10,8 @@ import jakarta.ws.rs.ext.MessageBodyWriter;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.test.providers.resource.ContractsData;
 import org.jboss.resteasy.test.providers.resource.ContractsDataReaderWriter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Providers
@@ -31,10 +31,10 @@ public class ContractsTest {
         factory.register(ContractsDataReaderWriter.class, MessageBodyReader.class);
         MessageBodyReader reader = factory.getMessageBodyReader(ContractsData.class, ContractsData.class, null,
                 MediaType.APPLICATION_ATOM_XML_TYPE);
-        Assert.assertNotNull("Reader is not assigned", reader);
+        Assertions.assertNotNull(reader, "Reader is not assigned");
         MessageBodyWriter writer = factory.getMessageBodyWriter(ContractsData.class, ContractsData.class, null,
                 MediaType.APPLICATION_ATOM_XML_TYPE);
-        Assert.assertNull("Writer is not assigned", writer);
+        Assertions.assertNull(writer, "Writer is not assigned");
     }
 
     /**
@@ -49,10 +49,10 @@ public class ContractsTest {
         factory.register(ContractsDataReaderWriter.class, contract);
         MessageBodyReader reader = factory.getMessageBodyReader(ContractsData.class, ContractsData.class, null,
                 MediaType.APPLICATION_ATOM_XML_TYPE);
-        Assert.assertNotNull("Reader is not assigned", reader);
+        Assertions.assertNotNull(reader, "Reader is not assigned");
         MessageBodyWriter writer = factory.getMessageBodyWriter(ContractsData.class, ContractsData.class, null,
                 MediaType.APPLICATION_ATOM_XML_TYPE);
-        Assert.assertNull("Writer is not assigned", writer);
+        Assertions.assertNull(writer, "Writer is not assigned");
     }
 
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/HeaderDelegateTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/HeaderDelegateTest.java
@@ -4,8 +4,8 @@ import jakarta.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
 
 import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Providers
@@ -41,7 +41,7 @@ public class HeaderDelegateTest {
         ResteasyProviderFactory factory = new ResteasyProviderFactoryImpl();
         factory.register(TestHeaderDelegate.class);
         HeaderDelegate<?> delegate = factory.getHeaderDelegate(TestHeader.class);
-        Assert.assertTrue(delegate instanceof TestHeaderDelegate);
+        Assertions.assertTrue(delegate instanceof TestHeaderDelegate);
     }
 
     /**
@@ -53,6 +53,6 @@ public class HeaderDelegateTest {
         ResteasyProviderFactory factory = new ResteasyProviderFactoryImpl();
         factory.register(new TestHeaderDelegate());
         HeaderDelegate<?> delegate = factory.getHeaderDelegate(TestHeader.class);
-        Assert.assertTrue(delegate instanceof TestHeaderDelegate);
+        Assertions.assertTrue(delegate instanceof TestHeaderDelegate);
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/JaxbNamespacePrefixTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/JaxbNamespacePrefixTest.java
@@ -15,8 +15,8 @@ import org.jboss.resteasy.test.providers.resource.jaxbNameSpacePrefix.JaxbNameSp
 import org.jboss.resteasy.test.providers.resource.jaxbNameSpacePrefix.JaxbNameSpacePrefixItems;
 import org.jboss.resteasy.test.providers.resource.jaxbNameSpacePrefix.JaxbNameSpacePrefixPurchaseOrderType;
 import org.jboss.resteasy.test.providers.resource.jaxbNameSpacePrefix.ObjectFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Providers - jaxb
@@ -47,7 +47,7 @@ public class JaxbNamespacePrefixTest {
         po.setJaxbNameSpacePrefixItems(jaxbNameSpacePrefixItems);
         Marshaller marshaller = ctx.createMarshaller();
         XmlSchema xmlSchema = JaxbNameSpacePrefixPurchaseOrderType.class.getPackage().getAnnotation(XmlSchema.class);
-        Assert.assertNotNull("Couldn't create xml schema for JaxbNameSpacePrefixPurchaseOrderType class", xmlSchema);
+        Assertions.assertNotNull(xmlSchema, "Couldn't create xml schema for JaxbNameSpacePrefixPurchaseOrderType class");
         XmlNamespacePrefixMapper mapper = new XmlNamespacePrefixMapper(xmlSchema.xmlns());
         try {
             marshaller.setProperty("org.glassfish.jaxb.namespacePrefixMapper", mapper);

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/JsonBindingTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/JsonBindingTest.java
@@ -1,13 +1,13 @@
 package org.jboss.resteasy.test.providers;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.plugins.providers.jsonb.JsonBindingProvider;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Check when ResteasyConfiguration.class is null in JsonBindingProvider

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/MultipurtContainsJsonTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/MultipurtContainsJsonTest.java
@@ -22,7 +22,7 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.test.providers.resource.ProviderFactoryPrecedenceIntegerPlainTextWriter;
 import org.jboss.resteasy.test.providers.resource.ProviderFactoryPrecendencePlainTextWriter;
 import org.jboss.resteasy.util.DelegatingOutputStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Providers

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/PriorityEqualityTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/PriorityEqualityTest.java
@@ -13,8 +13,8 @@ import jakarta.ws.rs.ext.Provider;
 import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Providers
@@ -115,8 +115,8 @@ public class PriorityEqualityTest {
 
         factory.register(ParamConverterProvider1.class);
         factory.register(ParamConverterProvider2.class);
-        Assert.assertTrue(factory.getProviderClasses().contains(ParamConverterProvider1.class));
-        Assert.assertTrue(factory.getProviderClasses().contains(ParamConverterProvider2.class));
+        Assertions.assertTrue(factory.getProviderClasses().contains(ParamConverterProvider1.class));
+        Assertions.assertTrue(factory.getProviderClasses().contains(ParamConverterProvider2.class));
         ResteasyProviderFactory.clearInstanceIfEqual(factory);
     }
 
@@ -135,8 +135,8 @@ public class PriorityEqualityTest {
         ParamConverterProvider p2 = new ParamConverterProvider2();
         factory.registerProviderInstance(p1);
         factory.registerProviderInstance(p2);
-        Assert.assertTrue(factory.getProviderInstances().contains(p1));
-        Assert.assertTrue(factory.getProviderInstances().contains(p2));
+        Assertions.assertTrue(factory.getProviderInstances().contains(p1));
+        Assertions.assertTrue(factory.getProviderInstances().contains(p2));
 
         ResteasyProviderFactory.clearInstanceIfEqual(factory);
     }
@@ -151,7 +151,7 @@ public class PriorityEqualityTest {
         ResteasyProviderFactoryImpl factory = new ResteasyProviderFactoryImpl();
         factory.register(ExceptionMapper1.class);
         factory.register(ExceptionMapper2.class);
-        Assert.assertEquals(ExceptionMapper2.class, factory.getExceptionMapper(TestException.class).getClass());
+        Assertions.assertEquals(ExceptionMapper2.class, factory.getExceptionMapper(TestException.class).getClass());
     }
 
     /**
@@ -164,6 +164,6 @@ public class PriorityEqualityTest {
         ResteasyProviderFactoryImpl factory = new ResteasyProviderFactoryImpl();
         factory.registerProviderInstance(new ExceptionMapper1());
         factory.registerProviderInstance(new ExceptionMapper2());
-        Assert.assertEquals(ExceptionMapper2.class, factory.getExceptionMapper(TestException.class).getClass());
+        Assertions.assertEquals(ExceptionMapper2.class, factory.getExceptionMapper(TestException.class).getClass());
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/ProviderFactoryPrecedenceTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/ProviderFactoryPrecedenceTest.java
@@ -12,8 +12,8 @@ import org.jboss.resteasy.spi.util.Types;
 import org.jboss.resteasy.test.providers.resource.ProviderFactoryPrecedenceBase;
 import org.jboss.resteasy.test.providers.resource.ProviderFactoryPrecedenceIntegerPlainTextWriter;
 import org.jboss.resteasy.test.providers.resource.ProviderFactoryPrecendencePlainTextWriter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Providers
@@ -44,18 +44,20 @@ public class ProviderFactoryPrecedenceTest {
      */
     @Test
     public void testTypes() {
-        Assert.assertNull("PlainTextWriter is should be of generic type",
-                Types.getTemplateParameterOfInterface(ProviderFactoryPrecendencePlainTextWriter.class,
-                        MessageBodyWriter.class));
-        Assert.assertEquals("IntegerPlainTextWriter should be Integer type",
-                Integer.class, Types.getTemplateParameterOfInterface(ProviderFactoryPrecedenceIntegerPlainTextWriter.class,
-                        MessageBodyWriter.class));
-        Assert.assertEquals("Concrete class should be Double type",
-                Double.class, Types.getTemplateParameterOfInterface(Concrete.class, MessageBodyWriter.class));
-        Assert.assertEquals("Concrete2 class should be Double type",
-                Boolean.class, Types.getTemplateParameterOfInterface(Concrete2.class, MessageBodyWriter.class));
-        Assert.assertEquals("ConcreteMultiple class should be Short type",
-                Short.class, Types.getTemplateParameterOfInterface(ConcreteMultiple.class, MessageBodyWriter.class));
+        Assertions.assertNull(Types.getTemplateParameterOfInterface(ProviderFactoryPrecendencePlainTextWriter.class,
+                MessageBodyWriter.class),
+                "PlainTextWriter is should be of generic type");
+        Assertions.assertEquals(Integer.class,
+                Types.getTemplateParameterOfInterface(ProviderFactoryPrecedenceIntegerPlainTextWriter.class,
+                        MessageBodyWriter.class),
+                "IntegerPlainTextWriter should be Integer type");
+        Assertions.assertEquals(Double.class, Types.getTemplateParameterOfInterface(Concrete.class, MessageBodyWriter.class),
+                "Concrete class should be Double type");
+        Assertions.assertEquals(Boolean.class, Types.getTemplateParameterOfInterface(Concrete2.class, MessageBodyWriter.class),
+                "Concrete2 class should be Double type");
+        Assertions.assertEquals(Short.class,
+                Types.getTemplateParameterOfInterface(ConcreteMultiple.class, MessageBodyWriter.class),
+                "ConcreteMultiple class should be Short type");
     }
 
     /**
@@ -70,8 +72,8 @@ public class ProviderFactoryPrecedenceTest {
 
         MessageBodyWriter<Boolean> writer = factory.getMessageBodyWriter(Boolean.class, null, null,
                 new MediaType("text", "plain"));
-        Assert.assertNotNull("No writer exists for the given media type", writer);
-        Assert.assertEquals("The type of the writer is incorrect", writer.getClass(), DefaultBooleanWriter.class);
+        Assertions.assertNotNull(writer, "No writer exists for the given media type");
+        Assertions.assertEquals(writer.getClass(), DefaultBooleanWriter.class, "The type of the writer is incorrect");
     }
 
     /**
@@ -134,16 +136,17 @@ public class ProviderFactoryPrecedenceTest {
 
     private void verifyPlainWriter(ResteasyProviderFactory factory) {
         MessageBodyWriter writer2 = factory.getMessageBodyWriter(Character.class, null, null, MediaType.TEXT_PLAIN_TYPE);
-        Assert.assertNotNull("No writer exists for the given media type", writer2);
-        Assert.assertTrue("The type of the writer is incorrect", writer2 instanceof ProviderFactoryPrecendencePlainTextWriter);
+        Assertions.assertNotNull(writer2, "No writer exists for the given media type");
+        Assertions.assertTrue(writer2 instanceof ProviderFactoryPrecendencePlainTextWriter,
+                "The type of the writer is incorrect");
     }
 
     private void verifyIntegerWriter(ResteasyProviderFactory factory) {
         MessageBodyWriter writer2;
         // Test that type specific template providers take precedence over others
         writer2 = factory.getMessageBodyWriter(Integer.class, null, null, MediaType.TEXT_PLAIN_TYPE);
-        Assert.assertNotNull("No writer exists for the given media type", writer2);
-        Assert.assertTrue("The type of the writer is incorrect",
-                writer2 instanceof ProviderFactoryPrecedenceIntegerPlainTextWriter);
+        Assertions.assertNotNull(writer2, "No writer exists for the given media type");
+        Assertions.assertTrue(writer2 instanceof ProviderFactoryPrecedenceIntegerPlainTextWriter,
+                "The type of the writer is incorrect");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/ProviderFactoryTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/ProviderFactoryTest.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.test.providers;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -28,9 +28,9 @@ import org.jboss.resteasy.spi.ResteasyDeployment;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.spi.interception.JaxrsInterceptorRegistry;
 import org.jboss.resteasy.test.providers.resource.ProviderFactoryStrParamUnmarshaller;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Providers
@@ -42,7 +42,7 @@ public class ProviderFactoryTest {
 
     private ResteasyProviderFactory factory;
 
-    @Before
+    @BeforeEach
     public void createBean() {
         factory = ResteasyProviderFactory.newInstance();
     }
@@ -54,7 +54,8 @@ public class ProviderFactoryTest {
     @Test
     public void shouldReturnStringParameterUnmarshallerAddedForType() {
         factory.registerProvider(ProviderFactoryStrParamUnmarshaller.class);
-        assertNotNull("Null StringParameterUnmarshaller object", factory.createStringParameterUnmarshaller(Date.class));
+        assertNotNull(factory.createStringParameterUnmarshaller(Date.class),
+                "Null StringParameterUnmarshaller object");
     }
 
     /**
@@ -103,7 +104,7 @@ public class ProviderFactoryTest {
         Field orderField = interceptors.get(0).getClass().getSuperclass().getDeclaredField("order");
         orderField.setAccessible(true);
         int order = (Integer) orderField.get(interceptors.get(0));
-        Assert.assertEquals(priorityOverride, order);
+        Assertions.assertEquals(priorityOverride, order);
     }
 
     @Test
@@ -126,7 +127,7 @@ public class ProviderFactoryTest {
                 @Override
                 public void configure(ResourceInfo resourceInfo, FeatureContext context) {
                     if (ResteasyProviderFactory.getInstance().isRegistered(MyInterceptor.class)) {
-                        Assert.fail("Second deployment consuming provider factory from first deployment");
+                        Assertions.fail("Second deployment consuming provider factory from first deployment");
                     }
 
                 }
@@ -151,49 +152,49 @@ public class ProviderFactoryTest {
 
         // test that getClasses() behavior is spec compliant
         Set<Class<?>> emptyProviderFactoryClasses = emptyResteasyProviderFactory.getClasses();
-        Assert.assertFalse("Configuration.getClasses() MUST never be null.", emptyProviderFactoryClasses == null);
-        Assert.assertTrue("Configuration.getClasses() MUST be empty.", emptyProviderFactoryClasses.isEmpty());
+        Assertions.assertFalse(emptyProviderFactoryClasses == null, "Configuration.getClasses() MUST never be null.");
+        Assertions.assertTrue(emptyProviderFactoryClasses.isEmpty(), "Configuration.getClasses() MUST be empty.");
         try {
             emptyProviderFactoryClasses.add(Object.class);
-            Assert.fail("Configuration.getClasses() MUST return an immutable set");
+            Assertions.fail("Configuration.getClasses() MUST return an immutable set");
         } catch (UnsupportedOperationException e) {
         }
 
         Set<Class<?>> providerFactoryClasses = resteasyProviderFactory.getClasses();
-        Assert.assertTrue(providerFactoryClasses.size() == 1);
-        Assert.assertTrue(providerFactoryClasses.contains(MyInterceptor.class));
+        Assertions.assertTrue(providerFactoryClasses.size() == 1);
+        Assertions.assertTrue(providerFactoryClasses.contains(MyInterceptor.class));
         try {
             providerFactoryClasses.add(Object.class);
-            Assert.fail("Configuration.getClasses() MUST return an immutable set");
+            Assertions.fail("Configuration.getClasses() MUST return an immutable set");
         } catch (UnsupportedOperationException e) {
         }
 
         // test that getInstances() behavior is spec compliant
         Set<Object> emptyProviderFactoryInstances = emptyResteasyProviderFactory.getInstances();
-        Assert.assertFalse("Configuration.getInstances() MUST never be null.", emptyProviderFactoryInstances == null);
-        Assert.assertTrue("Configuration.getInstances() MUST be empty.", emptyProviderFactoryInstances.isEmpty());
+        Assertions.assertFalse(emptyProviderFactoryInstances == null, "Configuration.getInstances() MUST never be null.");
+        Assertions.assertTrue(emptyProviderFactoryInstances.isEmpty(), "Configuration.getInstances() MUST be empty.");
         try {
             emptyProviderFactoryInstances.add(new Object());
-            Assert.fail("Configuration.getInstances() MUST return an immutable set");
+            Assertions.fail("Configuration.getInstances() MUST return an immutable set");
         } catch (UnsupportedOperationException e) {
         }
 
         Set<Object> providerFactoryInstances = resteasyProviderFactory.getInstances();
-        Assert.assertTrue(providerFactoryInstances.size() == 2);
-        Assert.assertTrue(providerFactoryInstances.contains(new MyFeature()));
+        Assertions.assertTrue(providerFactoryInstances.size() == 2);
+        Assertions.assertTrue(providerFactoryInstances.contains(new MyFeature()));
         try {
             providerFactoryInstances.add(new Object());
-            Assert.fail("Configuration.getInstances() MUST return an immutable set");
+            Assertions.fail("Configuration.getInstances() MUST return an immutable set");
         } catch (UnsupportedOperationException e) {
         }
 
         // test that isEnabled(Feature feature) behavior is spec compliant
-        Assert.assertFalse(emptyResteasyProviderFactory.isEnabled(new MyFeature()));
-        Assert.assertTrue(resteasyProviderFactory.isEnabled(new MyFeature()));
+        Assertions.assertFalse(emptyResteasyProviderFactory.isEnabled(new MyFeature()));
+        Assertions.assertTrue(resteasyProviderFactory.isEnabled(new MyFeature()));
 
         // test that isEnabled(Class<Feature> featureClass) behavior is spec compliant
-        Assert.assertFalse(emptyResteasyProviderFactory.isEnabled(MyFeature.class));
-        Assert.assertTrue(resteasyProviderFactory.isEnabled(MyFeature.class));
+        Assertions.assertFalse(emptyResteasyProviderFactory.isEnabled(MyFeature.class));
+        Assertions.assertTrue(resteasyProviderFactory.isEnabled(MyFeature.class));
     }
 
     @Provider

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/UserDefinedContextResolverTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/UserDefinedContextResolverTest.java
@@ -10,8 +10,8 @@ import jakarta.xml.bind.JAXBException;
 
 import org.jboss.resteasy.plugins.providers.jaxb.JAXBContextFinder;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Providers
@@ -68,11 +68,11 @@ public class UserDefinedContextResolverTest {
         ResteasyProviderFactory providerFactory = ResteasyProviderFactory.getInstance();
         ContextResolver<JAXBContextFinder> finder1 = providerFactory.getContextResolver(JAXBContextFinder.class,
                 MediaType.TEXT_XML_TYPE);
-        Assert.assertNotNull(finder1);
+        Assertions.assertNotNull(finder1);
         providerFactory.register(TestContextResolver.class);
         ContextResolver<JAXBContextFinder> finder2 = providerFactory.getContextResolver(JAXBContextFinder.class,
                 MediaType.TEXT_XML_TYPE);
         JAXBContextFinder finder = finder2.getContext(JAXBContextFinder.class);
-        Assert.assertTrue(finder instanceof TestContextFinder);
+        Assertions.assertTrue(finder instanceof TestContextFinder);
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/sse/OutboundSseEventImplTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/sse/OutboundSseEventImplTest.java
@@ -10,8 +10,8 @@ import jakarta.ws.rs.sse.OutboundSseEvent;
 
 import org.jboss.resteasy.plugins.providers.sse.OutboundSseEventImpl;
 import org.jboss.resteasy.test.providers.resource.ContractsData;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /***
  *
@@ -23,19 +23,23 @@ public class OutboundSseEventImplTest {
     @Test
     public void Should_ReturnTextPlainMediaType_When_MediaTypeIsNotSet() throws Exception {
         OutboundSseEvent outboundSseEvent = new OutboundSseEventImpl.BuilderImpl().comment("comment").build();
-        Assert.assertEquals(MediaType.TEXT_PLAIN_TYPE, outboundSseEvent.getMediaType());
+        Assertions.assertEquals(MediaType.TEXT_PLAIN_TYPE, outboundSseEvent.getMediaType());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void Should_ThrowNullPointerException_When_MediaTypeIsNull() throws Exception {
-        new OutboundSseEventImpl.BuilderImpl().mediaType(null).build();
+        NullPointerException thrown = Assertions.assertThrows(NullPointerException.class,
+                () -> {
+                    new OutboundSseEventImpl.BuilderImpl().mediaType(null).build();
+                });
+        Assertions.assertTrue(thrown instanceof NullPointerException);
     }
 
     @Test
     public void testGetOutboundSseEventGetMediaType() throws Exception {
         OutboundSseEvent outboundSseEvent = new OutboundSseEventImpl.BuilderImpl()
                 .mediaType(MediaType.APPLICATION_XML_TYPE).comment("comment").build();
-        Assert.assertEquals(MediaType.APPLICATION_XML_TYPE, outboundSseEvent.getMediaType());
+        Assertions.assertEquals(MediaType.APPLICATION_XML_TYPE, outboundSseEvent.getMediaType());
     }
 
     @Test()
@@ -43,18 +47,18 @@ public class OutboundSseEventImplTest {
         OutboundSseEvent.Builder builder = new OutboundSseEventImpl.BuilderImpl();
         try {
             builder.data(String.class, null);
-            Assert.fail("A NullPointerException was expected");
+            Assertions.fail("A NullPointerException was expected");
         } catch (NullPointerException e) {
         }
         try {
             builder.data(new GenericType<String>() {
             }, null);
-            Assert.fail("A NullPointerException was expected");
+            Assertions.fail("A NullPointerException was expected");
         } catch (NullPointerException e) {
         }
         try {
             builder.data(null);
-            Assert.fail("A NullPointerException was expected");
+            Assertions.fail("A NullPointerException was expected");
         } catch (NullPointerException e) {
         }
     }
@@ -64,21 +68,25 @@ public class OutboundSseEventImplTest {
         OutboundSseEvent.Builder builder = new OutboundSseEventImpl.BuilderImpl();
         try {
             builder.data((Class<?>) null, "data");
-            Assert.fail("A NullPointerException was expected");
+            Assertions.fail("A NullPointerException was expected");
         } catch (NullPointerException e) {
         }
         try {
             builder.data((GenericType<?>) null, "data");
-            Assert.fail("A NullPointerException was expected");
+            Assertions.fail("A NullPointerException was expected");
         } catch (NullPointerException e) {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void Should_ThrowIllegalArgumentException_When_CommentAndDataAreNull() throws Exception {
-        OutboundSseEvent.Builder builder = new OutboundSseEventImpl.BuilderImpl();
-        builder.comment("comment").build();
-        builder.comment(null).build();
+        IllegalArgumentException thrown = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> {
+                    OutboundSseEvent.Builder builder = new OutboundSseEventImpl.BuilderImpl();
+                    builder.comment("comment").build();
+                    builder.comment(null).build();
+                });
+        Assertions.assertTrue(thrown instanceof IllegalArgumentException);
     }
 
     @Test()
@@ -86,23 +94,23 @@ public class OutboundSseEventImplTest {
         GenericEntity<List<String>> genericEntity = new GenericEntity<List<String>>(new ArrayList<>()) {
         };
         OutboundSseEvent outboundSseEvent = new OutboundSseEventImpl.BuilderImpl().data(genericEntity).build();
-        Assert.assertEquals(ArrayList.class, genericEntity.getRawType());
-        Assert.assertEquals(genericEntity.getRawType(), outboundSseEvent.getType());
-        Assert.assertEquals(genericEntity.getType(), outboundSseEvent.getGenericType());
+        Assertions.assertEquals(ArrayList.class, genericEntity.getRawType());
+        Assertions.assertEquals(genericEntity.getRawType(), outboundSseEvent.getType());
+        Assertions.assertEquals(genericEntity.getType(), outboundSseEvent.getGenericType());
     }
 
     @Test
     public void testGetOutboundSseEventGetType() throws Exception {
         OutboundSseEvent outboundSseEvent = new OutboundSseEventImpl.BuilderImpl()
                 .data(ContractsData.class, new ContractsData()).build();
-        Assert.assertEquals(ContractsData.class, outboundSseEvent.getType());
-        Assert.assertEquals(ContractsData.class, outboundSseEvent.getGenericType());
+        Assertions.assertEquals(ContractsData.class, outboundSseEvent.getType());
+        Assertions.assertEquals(ContractsData.class, outboundSseEvent.getGenericType());
     }
 
     @Test
     public void testGetOutboundSseEventGetTypeNull() throws Exception {
         OutboundSseEvent outboundSseEvent = new OutboundSseEventImpl.BuilderImpl()
                 .comment("comment").build();
-        Assert.assertEquals(null, outboundSseEvent.getType());
+        Assertions.assertEquals(null, outboundSseEvent.getType());
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/validation/NoFieldValidationEJBTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/providers/validation/NoFieldValidationEJBTest.java
@@ -13,9 +13,9 @@ import jakarta.validation.ConstraintValidatorContext;
 import jakarta.validation.constraints.Min;
 
 import org.jboss.resteasy.plugins.validation.GeneralValidatorImpl;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Internal validation methods
@@ -33,7 +33,7 @@ public class NoFieldValidationEJBTest {
     private static Method isGetter;
     private static Method classHasAnnotations;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         try {
             hasNoClassOrFieldOrPropertyConstraints = GeneralValidatorImpl.class
@@ -135,19 +135,19 @@ public class NoFieldValidationEJBTest {
      */
     @Test
     public void testClassConstraints() throws Exception {
-        Assert.assertTrue(isInited());
-        Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, Ic_w.class)));
-        Assert.assertTrue(Boolean.FALSE.equals(hasClassConstraint.invoke(null, Ic_wo.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, Cc_w.class)));
-        Assert.assertTrue(Boolean.FALSE.equals(hasClassConstraint.invoke(null, Cc_wo.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, CIc_w_wo.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, CIc_wo_wwo.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, CIc_wo_w.class)));
-        Assert.assertTrue(Boolean.FALSE.equals(hasClassConstraint.invoke(null, CIc_wo_wo.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, SCc_w_wo.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, SCc_wo_w.class)));
-        Assert.assertTrue(Boolean.FALSE.equals(hasClassConstraint.invoke(null, SCc_wo_wo.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, SCc_wo_wo_w.class)));
+        Assertions.assertTrue(isInited());
+        Assertions.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, Ic_w.class)));
+        Assertions.assertTrue(Boolean.FALSE.equals(hasClassConstraint.invoke(null, Ic_wo.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, Cc_w.class)));
+        Assertions.assertTrue(Boolean.FALSE.equals(hasClassConstraint.invoke(null, Cc_wo.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, CIc_w_wo.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, CIc_wo_wwo.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, CIc_wo_w.class)));
+        Assertions.assertTrue(Boolean.FALSE.equals(hasClassConstraint.invoke(null, CIc_wo_wo.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, SCc_w_wo.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, SCc_wo_w.class)));
+        Assertions.assertTrue(Boolean.FALSE.equals(hasClassConstraint.invoke(null, SCc_wo_wo.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasClassConstraint.invoke(null, SCc_wo_wo_w.class)));
     }
 
     //////////////////////////////////////////////////////////////////////////////////////
@@ -179,12 +179,12 @@ public class NoFieldValidationEJBTest {
      */
     @Test
     public void testFieldConstraints() throws Exception {
-        Assert.assertTrue(isInited());
-        Assert.assertTrue(Boolean.TRUE.equals(hasFieldConstraint.invoke(null, Cf_w.class)));
-        Assert.assertTrue(Boolean.FALSE.equals(hasFieldConstraint.invoke(null, Cf_wo.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasFieldConstraint.invoke(null, SCf_wo_w.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasFieldConstraint.invoke(null, SCf_w_wo.class)));
-        Assert.assertTrue(Boolean.FALSE.equals(hasFieldConstraint.invoke(null, SCf_wo_wo.class)));
+        Assertions.assertTrue(isInited());
+        Assertions.assertTrue(Boolean.TRUE.equals(hasFieldConstraint.invoke(null, Cf_w.class)));
+        Assertions.assertTrue(Boolean.FALSE.equals(hasFieldConstraint.invoke(null, Cf_wo.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasFieldConstraint.invoke(null, SCf_wo_w.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasFieldConstraint.invoke(null, SCf_w_wo.class)));
+        Assertions.assertTrue(Boolean.FALSE.equals(hasFieldConstraint.invoke(null, SCf_wo_wo.class)));
     }
 
     //////////////////////////////////////////////////////////////////////////////////////
@@ -246,19 +246,19 @@ public class NoFieldValidationEJBTest {
      */
     @Test
     public void testPropertyConstraints() throws Exception {
-        Assert.assertTrue(isInited());
-        Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, Ip_w.class)));
-        Assert.assertTrue(Boolean.FALSE.equals(hasPropertyConstraint.invoke(null, Ip_wo.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, Cp_w.class)));
-        Assert.assertTrue(Boolean.FALSE.equals(hasPropertyConstraint.invoke(null, Cp_wo.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, CIp_w_wo.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, CIp_wo_wwo.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, CIp_wo_w.class)));
-        Assert.assertTrue(Boolean.FALSE.equals(hasPropertyConstraint.invoke(null, CIp_wo_wo.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, SCp_w_wo.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, SCp_wo_w.class)));
-        Assert.assertTrue(Boolean.FALSE.equals(hasPropertyConstraint.invoke(null, SCc_wo_wo.class)));
-        Assert.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, SCp_wo_wo_w.class)));
+        Assertions.assertTrue(isInited());
+        Assertions.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, Ip_w.class)));
+        Assertions.assertTrue(Boolean.FALSE.equals(hasPropertyConstraint.invoke(null, Ip_wo.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, Cp_w.class)));
+        Assertions.assertTrue(Boolean.FALSE.equals(hasPropertyConstraint.invoke(null, Cp_wo.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, CIp_w_wo.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, CIp_wo_wwo.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, CIp_wo_w.class)));
+        Assertions.assertTrue(Boolean.FALSE.equals(hasPropertyConstraint.invoke(null, CIp_wo_wo.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, SCp_w_wo.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, SCp_wo_w.class)));
+        Assertions.assertTrue(Boolean.FALSE.equals(hasPropertyConstraint.invoke(null, SCc_wo_wo.class)));
+        Assertions.assertTrue(Boolean.TRUE.equals(hasPropertyConstraint.invoke(null, SCp_wo_wo_w.class)));
     }
 
     //////////////////////////////////////////////////////////////////////////////////////
@@ -266,9 +266,9 @@ public class NoFieldValidationEJBTest {
     //////////////////////////////////////////////////////////////////////////////////////
     @Test
     public void test() throws Exception {
-        Assert.assertEquals(Boolean.TRUE,
+        Assertions.assertEquals(Boolean.TRUE,
                 classHasAnnotations.invoke(null, SCc_wo_wo_w.class, new String[] { ClassConstraint.class.getName() }));
-        Assert.assertEquals(Boolean.FALSE,
+        Assertions.assertEquals(Boolean.FALSE,
                 classHasAnnotations.invoke(null, SCc_wo_wo_w.class, new String[] { Min.class.getName() }));
     }
 

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/AcceptTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/AcceptTest.java
@@ -18,8 +18,8 @@ import org.jboss.resteasy.test.request.resource.AcceptMultipleResource;
 import org.jboss.resteasy.test.request.resource.AcceptResource;
 import org.jboss.resteasy.test.request.resource.AcceptXmlResource;
 import org.jboss.resteasy.test.request.resource.AcceptXmlResourceSecond;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Requests
@@ -58,8 +58,9 @@ public class AcceptTest {
             accepts.add(MediaType.valueOf("application/foo"));
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("GET", "/", contentType, accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptResource.class.getMethod("doGetFoo"), method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptResource.class.getMethod("doGetFoo"), method.getMethod(),
+                    METHOD_ERROR_MESSAGE);
         }
 
         {
@@ -67,8 +68,9 @@ public class AcceptTest {
             accepts.add(MediaType.valueOf("application/foo;q=0.1"));
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("GET", "/", contentType, accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptResource.class.getMethod("doGetFoo"), method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptResource.class.getMethod("doGetFoo"), method.getMethod(),
+                    METHOD_ERROR_MESSAGE);
         }
 
         {
@@ -78,8 +80,9 @@ public class AcceptTest {
             accepts.add(MediaType.valueOf("application/baz;q=0.2"));
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("GET", "/", contentType, accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptResource.class.getMethod("doGetFoo"), method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptResource.class.getMethod("doGetFoo"), method.getMethod(),
+                    METHOD_ERROR_MESSAGE);
         }
 
         {
@@ -89,8 +92,9 @@ public class AcceptTest {
             accepts.add(MediaType.valueOf("application/baz;q=0.2"));
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("GET", "/", contentType, accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptResource.class.getMethod("doGetBar"), method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptResource.class.getMethod("doGetBar"), method.getMethod(),
+                    METHOD_ERROR_MESSAGE);
         }
 
         {
@@ -100,8 +104,9 @@ public class AcceptTest {
             accepts.add(MediaType.valueOf("application/baz"));
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("GET", "/", contentType, accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptResource.class.getMethod("doGetBaz"), method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptResource.class.getMethod("doGetBaz"), method.getMethod(),
+                    METHOD_ERROR_MESSAGE);
         }
     }
 
@@ -120,9 +125,9 @@ public class AcceptTest {
             ArrayList<MediaType> accepts = new ArrayList<MediaType>();
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("PUT", "/xml", contentType, accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptXmlResource.class.getMethod("putBar", String.class),
-                    method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptXmlResource.class.getMethod("putBar", String.class),
+                    method.getMethod(), METHOD_ERROR_MESSAGE);
         }
     }
 
@@ -143,9 +148,9 @@ public class AcceptTest {
             accepts.add(MediaType.valueOf("application/xml;schema=stuff;q=0.5"));
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("PUT", "/xml", contentType, accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptXmlResourceSecond.class.getMethod("putBar", String.class),
-                    method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptXmlResourceSecond.class.getMethod("putBar", String.class),
+                    method.getMethod(), METHOD_ERROR_MESSAGE);
         }
     }
 
@@ -166,9 +171,9 @@ public class AcceptTest {
             accepts.add(MediaType.valueOf("application/xml;schema=stuff;q=0.5"));
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("PUT", "/xml", contentType, accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptXmlResourceSecond.class.getMethod("put", String.class),
-                    method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptXmlResourceSecond.class.getMethod("put", String.class),
+                    method.getMethod(), METHOD_ERROR_MESSAGE);
         }
     }
 
@@ -191,8 +196,9 @@ public class AcceptTest {
             accepts.add(MediaType.valueOf("application/baz;q=0.2"));
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("GET", "/", contentType, accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptResource.class.getMethod("doGetWildCard"), method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptResource.class.getMethod("doGetWildCard"), method.getMethod(),
+                    METHOD_ERROR_MESSAGE);
         }
     }
 
@@ -215,32 +221,36 @@ public class AcceptTest {
             accepts.add(foo);
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("GET", "/", contentType, accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptMultipleResource.class.getMethod("get"), method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptMultipleResource.class.getMethod("get"), method.getMethod(),
+                    METHOD_ERROR_MESSAGE);
         }
         {
             ArrayList<MediaType> accepts = new ArrayList<MediaType>();
             accepts.add(bar);
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("GET", "/", contentType, accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptMultipleResource.class.getMethod("get"), method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptMultipleResource.class.getMethod("get"), method.getMethod(),
+                    METHOD_ERROR_MESSAGE);
         }
         {
             ArrayList<MediaType> accepts = new ArrayList<MediaType>();
             accepts.add(MediaType.valueOf("*/*"));
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("GET", "/", contentType, accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptMultipleResource.class.getMethod("get"), method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptMultipleResource.class.getMethod("get"), method.getMethod(),
+                    METHOD_ERROR_MESSAGE);
         }
         {
             ArrayList<MediaType> accepts = new ArrayList<MediaType>();
             accepts.add(MediaType.valueOf("application/*"));
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("GET", "/", contentType, accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptMultipleResource.class.getMethod("get"), method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptMultipleResource.class.getMethod("get"), method.getMethod(),
+                    METHOD_ERROR_MESSAGE);
         }
     }
 
@@ -258,27 +268,30 @@ public class AcceptTest {
         {
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("GET", "/", MediaType.valueOf("text/plain"), accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptConsumeResource.class.getMethod("doGetWildCard"),
-                    method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptConsumeResource.class.getMethod("doGetWildCard"),
+                    method.getMethod(), METHOD_ERROR_MESSAGE);
         }
         {
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("GET", "/", MediaType.valueOf("application/foo"), accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptConsumeResource.class.getMethod("doGetFoo"), method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptConsumeResource.class.getMethod("doGetFoo"),
+                    method.getMethod(), METHOD_ERROR_MESSAGE);
         }
         {
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("GET", "/", MediaType.valueOf("application/bar"), accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptConsumeResource.class.getMethod("doGetBar"), method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptConsumeResource.class.getMethod("doGetBar"),
+                    method.getMethod(), METHOD_ERROR_MESSAGE);
         }
         {
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("GET", "/", MediaType.valueOf("application/baz"), accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptConsumeResource.class.getMethod("doGetBaz"), method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptConsumeResource.class.getMethod("doGetBaz"),
+                    method.getMethod(), METHOD_ERROR_MESSAGE);
         }
     }
 
@@ -300,8 +313,9 @@ public class AcceptTest {
         {
             ResourceMethodInvoker method = (ResourceMethodInvoker) registry
                     .getResourceInvoker(createRequest("GET", "/", contentType, accepts));
-            Assert.assertNotNull(METHOD_ERROR_MESSAGE, method);
-            Assert.assertEquals(METHOD_ERROR_MESSAGE, AcceptComplexResource.class.getMethod("method2"), method.getMethod());
+            Assertions.assertNotNull(method, METHOD_ERROR_MESSAGE);
+            Assertions.assertEquals(AcceptComplexResource.class.getMethod("method2"), method.getMethod(),
+                    METHOD_ERROR_MESSAGE);
         }
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/ContainerRequestContextTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/ContainerRequestContextTest.java
@@ -1,7 +1,7 @@
 package org.jboss.resteasy.test.request;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -15,8 +15,8 @@ import org.jboss.logging.Logger;
 import org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext;
 import org.jboss.resteasy.mock.MockHttpRequest;
 import org.jboss.resteasy.spi.HttpRequest;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Request
@@ -29,7 +29,7 @@ public class ContainerRequestContextTest {
     private HttpRequest request;
     protected static final Logger logger = Logger.getLogger(ContainerRequestContextTest.class.getName());
 
-    @Before
+    @BeforeEach
     public void before() throws URISyntaxException {
         request = MockHttpRequest.create("GET", "http://foo.bar?foo=foo&bar=bar");
     }
@@ -44,21 +44,21 @@ public class ContainerRequestContextTest {
 
         logger.info("request uri: " + containerRequestContext.getUriInfo().getRequestUri());
 
-        assertEquals("Wrong count of parameters in getUriInfo response", 2,
-                containerRequestContext.getUriInfo().getQueryParameters().size());
+        assertEquals(2, containerRequestContext.getUriInfo().getQueryParameters().size(),
+                "Wrong count of parameters in getUriInfo response");
 
         MultivaluedMap<String, String> expected = new MultivaluedHashMap<>();
         expected.put("foo", Collections.singletonList("foo"));
         expected.put("bar", Collections.singletonList("bar"));
 
         MultivaluedMap<String, String> queryParameters = containerRequestContext.getUriInfo().getQueryParameters();
-        assertEquals("Wrong parameter in getUriInfo response", expected, queryParameters);
+        assertEquals(expected, queryParameters, "Wrong parameter in getUriInfo response");
 
         containerRequestContext.setRequestUri(new URI("http://foo.bar"));
         logger.info("request uri: " + containerRequestContext.getUriInfo().getRequestUri());
 
-        assertTrue("Wrong count of parameters in getUriInfo response",
-                containerRequestContext.getUriInfo().getQueryParameters().isEmpty());
+        assertTrue(containerRequestContext.getUriInfo().getQueryParameters().isEmpty(),
+                "Wrong count of parameters in getUriInfo response");
 
         containerRequestContext.setRequestUri(new URI("http://foo.bar?foo=foo"));
         logger.info("request uri: " + containerRequestContext.getUriInfo().getRequestUri());
@@ -66,7 +66,7 @@ public class ContainerRequestContextTest {
         expected = new MultivaluedHashMap<>();
         expected.put("foo", Collections.singletonList("foo"));
 
-        assertEquals("Wrong parameter in getUriInfo response", expected,
-                containerRequestContext.getUriInfo().getQueryParameters());
+        assertEquals(expected, containerRequestContext.getUriInfo().getQueryParameters(),
+                "Wrong parameter in getUriInfo response");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/CookieNullValueTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/CookieNullValueTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 
 import org.hamcrest.MatcherAssert;
 import org.jboss.resteasy.plugins.delegates.NewCookieHeaderDelegate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Requests
@@ -12,6 +12,7 @@ import org.junit.Test;
  * @tpTestCaseDetails Regression test for JBEAP-4712
  * @tpSince RESTEasy 3.0.17
  */
+//@Disabled("RESTEASY-3450")
 public class CookieNullValueTest {
 
     /**

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/LocaleQualityValueTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/LocaleQualityValueTest.java
@@ -1,7 +1,7 @@
 package org.jboss.resteasy.test.request;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,7 +11,7 @@ import java.util.Map;
 
 import org.jboss.resteasy.core.request.AcceptHeaders;
 import org.jboss.resteasy.core.request.QualityValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Requests
@@ -25,8 +25,8 @@ public class LocaleQualityValueTest {
         Map<Locale, QualityValue> map = AcceptHeaders.getLocaleQualityValues(header);
         List<Locale> expectedKeys = Arrays.asList(fields);
         List<QualityValue> expectedValues = Arrays.asList(qualities);
-        assertEquals("Wrong keys in map", expectedKeys, new ArrayList<>(map.keySet()));
-        assertEquals("Wrong values in map", expectedValues, new ArrayList<>(map.values()));
+        assertEquals(expectedKeys, new ArrayList<>(map.keySet()), "Wrong keys in map");
+        assertEquals(expectedValues, new ArrayList<>(map.values()), "Wrong values in map");
     }
 
     /**
@@ -86,9 +86,9 @@ public class LocaleQualityValueTest {
     @Test
     public void empty() {
         final String ERROR_MSG = "Local quality values should not be null";
-        assertNull(ERROR_MSG, AcceptHeaders.getLocaleQualityValues(null));
-        assertNull(ERROR_MSG, AcceptHeaders.getLocaleQualityValues(""));
-        assertNull(ERROR_MSG, AcceptHeaders.getLocaleQualityValues(" "));
+        assertNull(AcceptHeaders.getLocaleQualityValues(null), ERROR_MSG);
+        assertNull(AcceptHeaders.getLocaleQualityValues(""), ERROR_MSG);
+        assertNull(AcceptHeaders.getLocaleQualityValues(" "), ERROR_MSG);
     }
 
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/MediaTypeQualityValueTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/MediaTypeQualityValueTest.java
@@ -1,8 +1,8 @@
 package org.jboss.resteasy.test.request;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,7 +14,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.core.request.AcceptHeaders;
 import org.jboss.resteasy.core.request.QualityValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Requests
@@ -28,8 +28,10 @@ public class MediaTypeQualityValueTest {
         Map<MediaType, QualityValue> map = AcceptHeaders.getMediaTypeQualityValues(header);
         List<MediaType> expectedKeys = Arrays.asList(fields);
         List<QualityValue> expectedValues = Arrays.asList(qualities);
-        assertEquals("Wrong keys in map", expectedKeys, new ArrayList<MediaType>(map.keySet()));
-        assertEquals("Wrong values in map", expectedValues, new ArrayList<QualityValue>(map.values()));
+        assertEquals(expectedKeys, new ArrayList<MediaType>(map.keySet()),
+                "Wrong keys in map");
+        assertEquals(expectedValues, new ArrayList<QualityValue>(map.values()),
+                "Wrong values in map");
     }
 
     /**
@@ -114,9 +116,9 @@ public class MediaTypeQualityValueTest {
     @Test
     public void empty() {
         final String ERROR_MSG = "Local quality values should not be null";
-        assertNull(ERROR_MSG, AcceptHeaders.getMediaTypeQualityValues(null));
-        assertNull(ERROR_MSG, AcceptHeaders.getMediaTypeQualityValues(""));
-        assertNull(ERROR_MSG, AcceptHeaders.getMediaTypeQualityValues(" "));
+        assertNull(AcceptHeaders.getMediaTypeQualityValues(null), ERROR_MSG);
+        assertNull(AcceptHeaders.getMediaTypeQualityValues(""), ERROR_MSG);
+        assertNull(AcceptHeaders.getMediaTypeQualityValues(" "), ERROR_MSG);
     }
 
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/MediaTypeTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/MediaTypeTest.java
@@ -9,8 +9,8 @@ import jakarta.ws.rs.core.MediaType;
 import org.jboss.resteasy.plugins.delegates.MediaTypeHeaderDelegate;
 import org.jboss.resteasy.util.MediaTypeHelper;
 import org.jboss.resteasy.util.WeightedMediaType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Requests
@@ -30,52 +30,52 @@ public class MediaTypeTest {
         MediaType mediaType;
 
         mediaType = MediaType.valueOf("application/xml");
-        Assert.assertEquals(errorMsg, "application", mediaType.getType());
-        Assert.assertEquals(errorMsg, "xml", mediaType.getSubtype());
+        Assertions.assertEquals("application", mediaType.getType(), errorMsg);
+        Assertions.assertEquals("xml", mediaType.getSubtype(), errorMsg);
 
         mediaType = MediaType.valueOf("text/*;q=0.3");
-        Assert.assertEquals(errorMsg, "text", mediaType.getType());
-        Assert.assertEquals(errorMsg, "*", mediaType.getSubtype());
-        Assert.assertTrue(errorMsg, mediaType.isWildcardSubtype());
-        Assert.assertEquals(errorMsg, 1, mediaType.getParameters().size());
-        Assert.assertEquals(errorMsg, "0.3", mediaType.getParameters().get("q"));
+        Assertions.assertEquals("text", mediaType.getType(), errorMsg);
+        Assertions.assertEquals("*", mediaType.getSubtype(), errorMsg);
+        Assertions.assertTrue(mediaType.isWildcardSubtype(), errorMsg);
+        Assertions.assertEquals(1, mediaType.getParameters().size(), errorMsg);
+        Assertions.assertEquals("0.3", mediaType.getParameters().get("q"), errorMsg);
 
         mediaType = MediaType.valueOf("text/html;level=2;q=0.4");
-        Assert.assertEquals(errorMsg, "text", mediaType.getType());
-        Assert.assertEquals(errorMsg, "html", mediaType.getSubtype());
-        Assert.assertEquals(errorMsg, 2, mediaType.getParameters().size());
-        Assert.assertEquals(errorMsg, "0.4", mediaType.getParameters().get("q"));
-        Assert.assertEquals(errorMsg, "2", mediaType.getParameters().get("level"));
+        Assertions.assertEquals("text", mediaType.getType(), errorMsg);
+        Assertions.assertEquals("html", mediaType.getSubtype(), errorMsg);
+        Assertions.assertEquals(2, mediaType.getParameters().size(), errorMsg);
+        Assertions.assertEquals("0.4", mediaType.getParameters().get("q"), errorMsg);
+        Assertions.assertEquals("2", mediaType.getParameters().get("level"), errorMsg);
 
         MediaTypeHeaderDelegate delegate = new MediaTypeHeaderDelegate();
         String str = delegate.toString(mediaType);
         mediaType = MediaType.valueOf(str);
-        Assert.assertEquals(errorMsg, "text", mediaType.getType());
-        Assert.assertEquals(errorMsg, "html", mediaType.getSubtype());
-        Assert.assertEquals(errorMsg, 2, mediaType.getParameters().size());
-        Assert.assertEquals(errorMsg, "0.4", mediaType.getParameters().get("q"));
-        Assert.assertEquals(errorMsg, "2", mediaType.getParameters().get("level"));
+        Assertions.assertEquals("text", mediaType.getType(), errorMsg);
+        Assertions.assertEquals("html", mediaType.getSubtype(), errorMsg);
+        Assertions.assertEquals(2, mediaType.getParameters().size(), errorMsg);
+        Assertions.assertEquals("0.4", mediaType.getParameters().get("q"), errorMsg);
+        Assertions.assertEquals("2", mediaType.getParameters().get("level"), errorMsg);
 
         mediaType = MediaType.valueOf("text/html;level=  \"2\";q=0.4");
-        Assert.assertEquals(errorMsg, "text", mediaType.getType());
-        Assert.assertEquals(errorMsg, "html", mediaType.getSubtype());
-        Assert.assertEquals(errorMsg, 2, mediaType.getParameters().size());
-        Assert.assertEquals(errorMsg, "0.4", mediaType.getParameters().get("q"));
-        Assert.assertEquals(errorMsg, "2", mediaType.getParameters().get("level"));
+        Assertions.assertEquals("text", mediaType.getType(), errorMsg);
+        Assertions.assertEquals("html", mediaType.getSubtype(), errorMsg);
+        Assertions.assertEquals(2, mediaType.getParameters().size(), errorMsg);
+        Assertions.assertEquals("0.4", mediaType.getParameters().get("q"), errorMsg);
+        Assertions.assertEquals("2", mediaType.getParameters().get("level"), errorMsg);
 
         mediaType = MediaType.valueOf("text/html;level=  \"2\";q=  \"0.4\"   ");
-        Assert.assertEquals(errorMsg, "text", mediaType.getType());
-        Assert.assertEquals(errorMsg, "html", mediaType.getSubtype());
-        Assert.assertEquals(errorMsg, 2, mediaType.getParameters().size());
-        Assert.assertEquals(errorMsg, "0.4", mediaType.getParameters().get("q"));
-        Assert.assertEquals(errorMsg, "2", mediaType.getParameters().get("level"));
+        Assertions.assertEquals("text", mediaType.getType(), errorMsg);
+        Assertions.assertEquals("html", mediaType.getSubtype(), errorMsg);
+        Assertions.assertEquals(2, mediaType.getParameters().size(), errorMsg);
+        Assertions.assertEquals("0.4", mediaType.getParameters().get("q"), errorMsg);
+        Assertions.assertEquals("2", mediaType.getParameters().get("level"), errorMsg);
 
         mediaType = MediaType.valueOf("text/html;level=  \"2\";q=  \"0.4;\"   ");
-        Assert.assertEquals(errorMsg, "text", mediaType.getType());
-        Assert.assertEquals(errorMsg, "html", mediaType.getSubtype());
-        Assert.assertEquals(errorMsg, 2, mediaType.getParameters().size());
-        Assert.assertEquals(errorMsg, "0.4;", mediaType.getParameters().get("q"));
-        Assert.assertEquals(errorMsg, "2", mediaType.getParameters().get("level"));
+        Assertions.assertEquals("text", mediaType.getType(), errorMsg);
+        Assertions.assertEquals("html", mediaType.getSubtype(), errorMsg);
+        Assertions.assertEquals(2, mediaType.getParameters().size(), errorMsg);
+        Assertions.assertEquals("0.4;", mediaType.getParameters().get("q"), errorMsg);
+        Assertions.assertEquals("2", mediaType.getParameters().get("level"), errorMsg);
 
     }
 
@@ -101,10 +101,10 @@ public class MediaTypeTest {
 
             MediaTypeHelper.sortByWeight(list);
 
-            Assert.assertTrue(errorMsg + list.get(0).toString(), array[2] == list.get(0));
-            Assert.assertTrue(errorMsg, array[1] == list.get(1));
-            Assert.assertTrue(errorMsg, array[0] == list.get(2));
-            Assert.assertTrue(errorMsg, array[3] == list.get(3));
+            Assertions.assertTrue(array[2] == list.get(0), errorMsg + list.get(0).toString());
+            Assertions.assertTrue(array[1] == list.get(1), errorMsg);
+            Assertions.assertTrue(array[0] == list.get(2), errorMsg);
+            Assertions.assertTrue(array[3] == list.get(3), errorMsg);
         }
         {
             MediaType[] array = {
@@ -123,11 +123,11 @@ public class MediaTypeTest {
 
             MediaTypeHelper.sortByWeight(list);
 
-            Assert.assertTrue(errorMsg, array[2] == list.get(0));
-            Assert.assertTrue(errorMsg, array[1] == list.get(1));
-            Assert.assertTrue(errorMsg, array[4] == list.get(2));
-            Assert.assertTrue(errorMsg, array[3] == list.get(3));
-            Assert.assertTrue(errorMsg, array[0] == list.get(4));
+            Assertions.assertTrue(array[2] == list.get(0), errorMsg);
+            Assertions.assertTrue(array[1] == list.get(1), errorMsg);
+            Assertions.assertTrue(array[4] == list.get(2), errorMsg);
+            Assertions.assertTrue(array[3] == list.get(3), errorMsg);
+            Assertions.assertTrue(array[0] == list.get(4), errorMsg);
 
         }
     }
@@ -154,10 +154,10 @@ public class MediaTypeTest {
 
             Collections.sort(list);
 
-            Assert.assertTrue(errorMsg + list.get(0).toString(), array[2] == list.get(0));
-            Assert.assertTrue(errorMsg, array[1] == list.get(1));
-            Assert.assertTrue(errorMsg, array[0] == list.get(2));
-            Assert.assertTrue(errorMsg, array[3] == list.get(3));
+            Assertions.assertTrue(array[2] == list.get(0), errorMsg + list.get(0).toString());
+            Assertions.assertTrue(array[1] == list.get(1), errorMsg);
+            Assertions.assertTrue(array[0] == list.get(2), errorMsg);
+            Assertions.assertTrue(array[3] == list.get(3), errorMsg);
 
         }
         {
@@ -177,11 +177,11 @@ public class MediaTypeTest {
 
             Collections.sort(list);
 
-            Assert.assertTrue(errorMsg, array[2] == list.get(0));
-            Assert.assertTrue(errorMsg, array[1] == list.get(1));
-            Assert.assertTrue(errorMsg, array[4] == list.get(2));
-            Assert.assertTrue(errorMsg, array[3] == list.get(3));
-            Assert.assertTrue(errorMsg, array[0] == list.get(4));
+            Assertions.assertTrue(array[2] == list.get(0), errorMsg);
+            Assertions.assertTrue(array[1] == list.get(1), errorMsg);
+            Assertions.assertTrue(array[4] == list.get(2), errorMsg);
+            Assertions.assertTrue(array[3] == list.get(3), errorMsg);
+            Assertions.assertTrue(array[0] == list.get(4), errorMsg);
         }
     }
 
@@ -209,13 +209,13 @@ public class MediaTypeTest {
 
         MediaTypeHelper.sortByWeight(list);
 
-        Assert.assertTrue(errorMsg, array[3] == list.get(0) || array[5] == list.get(0));
-        Assert.assertTrue(errorMsg, array[3] == list.get(1) || array[5] == list.get(1));
-        Assert.assertTrue(errorMsg, array[0] == list.get(2) || array[6] == list.get(2));
-        Assert.assertTrue(errorMsg, array[0] == list.get(3) || array[6] == list.get(3));
-        Assert.assertTrue(errorMsg, array[2] == list.get(4) || array[4] == list.get(4));
-        Assert.assertTrue(errorMsg, array[2] == list.get(5) || array[4] == list.get(5));
-        Assert.assertTrue(errorMsg, array[1] == list.get(6));
-        Assert.assertTrue(errorMsg, array[7] == list.get(7));
+        Assertions.assertTrue(array[3] == list.get(0) || array[5] == list.get(0), errorMsg);
+        Assertions.assertTrue(array[3] == list.get(1) || array[5] == list.get(1), errorMsg);
+        Assertions.assertTrue(array[0] == list.get(2) || array[6] == list.get(2), errorMsg);
+        Assertions.assertTrue(array[0] == list.get(3) || array[6] == list.get(3), errorMsg);
+        Assertions.assertTrue(array[2] == list.get(4) || array[4] == list.get(4), errorMsg);
+        Assertions.assertTrue(array[2] == list.get(5) || array[4] == list.get(5), errorMsg);
+        Assertions.assertTrue(array[1] == list.get(6), errorMsg);
+        Assertions.assertTrue(array[7] == list.get(7), errorMsg);
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/QualityValueTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/QualityValueTest.java
@@ -1,11 +1,14 @@
 package org.jboss.resteasy.test.request;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.ws.rs.BadRequestException;
 
 import org.jboss.resteasy.core.request.QualityValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Requests
@@ -23,11 +26,11 @@ public class QualityValueTest {
      */
     @Test
     public void zero() {
-        assertEquals(ERROR_MSG, 0, QualityValue.valueOf("0").intValue());
-        assertEquals(ERROR_MSG, 0, QualityValue.valueOf("0.").intValue());
-        assertEquals(ERROR_MSG, 0, QualityValue.valueOf("0.0").intValue());
-        assertEquals(ERROR_MSG, 0, QualityValue.valueOf("0.00").intValue());
-        assertEquals(ERROR_MSG, 0, QualityValue.valueOf("0.000").intValue());
+        assertEquals(0, QualityValue.valueOf("0").intValue(), ERROR_MSG);
+        assertEquals(0, QualityValue.valueOf("0.").intValue(), ERROR_MSG);
+        assertEquals(0, QualityValue.valueOf("0.0").intValue(), ERROR_MSG);
+        assertEquals(0, QualityValue.valueOf("0.00").intValue(), ERROR_MSG);
+        assertEquals(0, QualityValue.valueOf("0.000").intValue(), ERROR_MSG);
     }
 
     /**
@@ -36,11 +39,11 @@ public class QualityValueTest {
      */
     @Test
     public void one() {
-        assertEquals(ERROR_MSG, 1000, QualityValue.valueOf("1").intValue());
-        assertEquals(ERROR_MSG, 1000, QualityValue.valueOf("1.").intValue());
-        assertEquals(ERROR_MSG, 1000, QualityValue.valueOf("1.0").intValue());
-        assertEquals(ERROR_MSG, 1000, QualityValue.valueOf("1.00").intValue());
-        assertEquals(ERROR_MSG, 1000, QualityValue.valueOf("1.000").intValue());
+        assertEquals(1000, QualityValue.valueOf("1").intValue(), ERROR_MSG);
+        assertEquals(1000, QualityValue.valueOf("1.").intValue(), ERROR_MSG);
+        assertEquals(1000, QualityValue.valueOf("1.0").intValue(), ERROR_MSG);
+        assertEquals(1000, QualityValue.valueOf("1.00").intValue(), ERROR_MSG);
+        assertEquals(1000, QualityValue.valueOf("1.000").intValue(), ERROR_MSG);
     }
 
     /**
@@ -49,11 +52,11 @@ public class QualityValueTest {
      */
     @Test
     public void fractions() {
-        assertEquals(ERROR_MSG, 1, QualityValue.valueOf("0.001").intValue());
-        assertEquals(ERROR_MSG, 12, QualityValue.valueOf("0.012").intValue());
-        assertEquals(ERROR_MSG, 123, QualityValue.valueOf("0.123").intValue());
-        assertEquals(ERROR_MSG, 120, QualityValue.valueOf("0.12").intValue());
-        assertEquals(ERROR_MSG, 100, QualityValue.valueOf("0.1").intValue());
+        assertEquals(1, QualityValue.valueOf("0.001").intValue(), ERROR_MSG);
+        assertEquals(12, QualityValue.valueOf("0.012").intValue(), ERROR_MSG);
+        assertEquals(123, QualityValue.valueOf("0.123").intValue(), ERROR_MSG);
+        assertEquals(120, QualityValue.valueOf("0.12").intValue(), ERROR_MSG);
+        assertEquals(100, QualityValue.valueOf("0.1").intValue(), ERROR_MSG);
     }
 
     /**
@@ -62,8 +65,8 @@ public class QualityValueTest {
      */
     @Test
     public void equivalent() {
-        assertEquals(ERROR_MSG, QualityValue.valueOf("0.1"), QualityValue.valueOf("0.10"));
-        assertNotEquals(ERROR_MSG, QualityValue.valueOf("1."), QualityValue.valueOf("0.999"));
+        assertEquals(QualityValue.valueOf("0.1"), QualityValue.valueOf("0.10"), ERROR_MSG);
+        assertNotEquals(QualityValue.valueOf("1."), QualityValue.valueOf("0.999"), ERROR_MSG);
     }
 
     /**
@@ -72,54 +75,74 @@ public class QualityValueTest {
      */
     @Test
     public void comparison() {
-        assertTrue(ERROR_MSG, QualityValue.LOWEST.compareTo(QualityValue.HIGHEST) < 0);
-        assertTrue(ERROR_MSG, QualityValue.DEFAULT.compareTo(QualityValue.HIGHEST) == 0);
-        assertTrue(ERROR_MSG, QualityValue.LOWEST.compareTo(QualityValue.NOT_ACCEPTABLE) > 0);
+        assertTrue(QualityValue.LOWEST.compareTo(QualityValue.HIGHEST) < 0, ERROR_MSG);
+        assertTrue(QualityValue.DEFAULT.compareTo(QualityValue.HIGHEST) == 0, ERROR_MSG);
+        assertTrue(QualityValue.LOWEST.compareTo(QualityValue.NOT_ACCEPTABLE) > 0, ERROR_MSG);
     }
 
     /**
      * @tpTestDetails Check 1.001 value.
      * @tpSince RESTEasy 3.0.16
      */
-    @Test(expected = BadRequestException.class)
+    @Test
     public void tooLarge() {
-        QualityValue.valueOf("1.001");
+        BadRequestException thrown = Assertions.assertThrows(BadRequestException.class,
+                () -> {
+                    QualityValue.valueOf("1.001");
+                });
+        Assertions.assertTrue(thrown instanceof BadRequestException);
     }
 
     /**
      * @tpTestDetails Check -0.001 value (exception expected).
      * @tpSince RESTEasy 3.0.16
      */
-    @Test(expected = BadRequestException.class)
+    @Test
     public void tooSmall() {
-        QualityValue.valueOf("-0.001");
+        BadRequestException thrown = Assertions.assertThrows(BadRequestException.class,
+                () -> {
+                    QualityValue.valueOf("-0.001");
+                });
+        Assertions.assertTrue(thrown instanceof BadRequestException);
     }
 
     /**
      * @tpTestDetails Check 0.1234 value (exception expected).
      * @tpSince RESTEasy 3.0.16
      */
-    @Test(expected = BadRequestException.class)
+    @Test
     public void tooLong() {
-        QualityValue.valueOf("0.1234");
+        BadRequestException thrown = Assertions.assertThrows(BadRequestException.class,
+                () -> {
+                    QualityValue.valueOf("0.1234");
+                });
+        Assertions.assertTrue(thrown instanceof BadRequestException);
     }
 
     /**
      * @tpTestDetails Check "" value (exception expected).
      * @tpSince RESTEasy 3.0.16
      */
-    @Test(expected = BadRequestException.class)
+    @Test
     public void tooShort() {
-        QualityValue.valueOf("");
+        BadRequestException thrown = Assertions.assertThrows(BadRequestException.class,
+                () -> {
+                    QualityValue.valueOf("");
+                });
+        Assertions.assertTrue(thrown instanceof BadRequestException);
     }
 
     /**
      * @tpTestDetails Check 0,2F value (exception expected).
      * @tpSince RESTEasy 3.0.16
      */
-    @Test(expected = BadRequestException.class)
+    @Test
     public void wrongContent() {
-        QualityValue.valueOf("0,2F");
+        BadRequestException thrown = Assertions.assertThrows(BadRequestException.class,
+                () -> {
+                    QualityValue.valueOf("0,2F");
+                });
+        Assertions.assertTrue(thrown instanceof BadRequestException);
     }
 
     /**
@@ -128,7 +151,7 @@ public class QualityValueTest {
      */
     @Test
     public void nullContent() {
-        assertEquals(ERROR_MSG, QualityValue.DEFAULT, QualityValue.valueOf(null));
+        assertEquals(QualityValue.DEFAULT, QualityValue.valueOf(null), ERROR_MSG);
     }
 
     /**
@@ -138,10 +161,10 @@ public class QualityValueTest {
     @Test
     public void numbers() {
         QualityValue x = QualityValue.valueOf("0.08");
-        assertEquals(ERROR_MSG, 80, x.intValue());
-        assertEquals(ERROR_MSG, 80L, x.longValue());
-        assertEquals(ERROR_MSG, 0.08f, x.floatValue(), 0);
-        assertEquals(ERROR_MSG, 0.08d, x.doubleValue(), 0);
+        assertEquals(80, x.intValue(), ERROR_MSG);
+        assertEquals(80L, x.longValue(), ERROR_MSG);
+        assertEquals(0.08f, x.floatValue(), 0, ERROR_MSG);
+        assertEquals(0.08d, x.doubleValue(), 0, ERROR_MSG);
     }
 
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/StringQualityValueTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/StringQualityValueTest.java
@@ -1,8 +1,8 @@
 package org.jboss.resteasy.test.request;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -13,7 +13,7 @@ import jakarta.ws.rs.BadRequestException;
 
 import org.jboss.resteasy.core.request.AcceptHeaders;
 import org.jboss.resteasy.core.request.QualityValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Requests
@@ -27,8 +27,8 @@ public class StringQualityValueTest {
         Map<String, QualityValue> map = AcceptHeaders.getStringQualityValues(header);
         List<String> expectedKeys = Arrays.asList(fields);
         List<QualityValue> expectedValues = Arrays.asList(qualities);
-        assertEquals("Wrong keys in map", expectedKeys, new ArrayList<String>(map.keySet()));
-        assertEquals("Wrong values in map", expectedValues, new ArrayList<QualityValue>(map.values()));
+        assertEquals(expectedKeys, new ArrayList<String>(map.keySet()), "Wrong keys in map");
+        assertEquals(expectedValues, new ArrayList<QualityValue>(map.values()), "Wrong values in map");
     }
 
     /**

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/VariantQualityTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/VariantQualityTest.java
@@ -1,12 +1,12 @@
 package org.jboss.resteasy.test.request;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 
 import org.jboss.resteasy.core.request.QualityValue;
 import org.jboss.resteasy.core.request.VariantQuality;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Requests
@@ -25,12 +25,12 @@ public class VariantQualityTest {
     @Test
     public void defaultQuality() {
         VariantQuality q = new VariantQuality();
-        assertEquals(ERROR_MSG, new BigDecimal("1.00000"), q.getOverallQuality());
+        assertEquals(new BigDecimal("1.00000"), q.getOverallQuality(), ERROR_MSG);
         q.setMediaTypeQualityValue(null);
         q.setCharacterSetQualityValue(null);
         q.setEncodingQualityValue(null);
         q.setLanguageQualityValue(null);
-        assertEquals(ERROR_MSG, new BigDecimal("1.00000"), q.getOverallQuality());
+        assertEquals(new BigDecimal("1.00000"), q.getOverallQuality(), ERROR_MSG);
     }
 
     /**
@@ -41,13 +41,13 @@ public class VariantQualityTest {
     public void qualitySetters() {
         VariantQuality q = new VariantQuality();
         q.setMediaTypeQualityValue(QualityValue.valueOf("0.1"));
-        assertEquals(ERROR_MSG, new BigDecimal("0.10000"), q.getOverallQuality());
+        assertEquals(new BigDecimal("0.10000"), q.getOverallQuality(), ERROR_MSG);
         q.setCharacterSetQualityValue(QualityValue.valueOf("0.2"));
-        assertEquals(ERROR_MSG, new BigDecimal("0.02000"), q.getOverallQuality());
+        assertEquals(new BigDecimal("0.02000"), q.getOverallQuality(), ERROR_MSG);
         q.setEncodingQualityValue(QualityValue.valueOf("0.4"));
-        assertEquals(ERROR_MSG, new BigDecimal("0.00800"), q.getOverallQuality());
+        assertEquals(new BigDecimal("0.00800"), q.getOverallQuality(), ERROR_MSG);
         q.setLanguageQualityValue(QualityValue.valueOf("0.8"));
-        assertEquals(ERROR_MSG, new BigDecimal("0.00640"), q.getOverallQuality());
+        assertEquals(new BigDecimal("0.00640"), q.getOverallQuality(), ERROR_MSG);
     }
 
     @Test
@@ -55,7 +55,7 @@ public class VariantQualityTest {
         VariantQuality q = new VariantQuality();
         q.setMediaTypeQualityValue(QualityValue.valueOf("0.004"));
         q.setEncodingQualityValue(QualityValue.valueOf("0.008"));
-        assertEquals(ERROR_MSG, new BigDecimal("0.00003"), q.getOverallQuality());
+        assertEquals(new BigDecimal("0.00003"), q.getOverallQuality(), ERROR_MSG);
     }
 
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/VariantSelectionTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/request/VariantSelectionTest.java
@@ -1,7 +1,7 @@
 package org.jboss.resteasy.test.request;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -13,7 +13,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Variant;
 
 import org.jboss.resteasy.core.request.ServerDrivenNegotiation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Requests
@@ -57,10 +57,10 @@ public class VariantSelectionTest {
         }
 
         Variant best = negotiation.getBestMatch(available);
-        assertNotNull("Variant should not be null", best);
-        assertEquals("Wrong media type", mediaTypeWithCharset, best.getMediaType());
-        assertEquals("Wrong encoding", encoding, best.getEncoding());
-        assertEquals("Wrong locale", locale, best.getLanguage());
+        assertNotNull(best, "Variant should not be null");
+        assertEquals(mediaTypeWithCharset, best.getMediaType(), "Wrong media type");
+        assertEquals(encoding, best.getEncoding(), "Wrong encoding");
+        assertEquals(locale, best.getLanguage(), "Wrong locale");
     }
 
     @Test
@@ -76,13 +76,13 @@ public class VariantSelectionTest {
 
         List<Variant> available = new ArrayList<>();
         available.add(o4);
-        assertEquals(ERROR_MSG, o4, negotiation.getBestMatch(available));
+        assertEquals(o4, negotiation.getBestMatch(available), ERROR_MSG);
         available.add(o3);
-        assertEquals(ERROR_MSG, o3, negotiation.getBestMatch(available));
+        assertEquals(o3, negotiation.getBestMatch(available), ERROR_MSG);
         available.add(o2);
-        assertEquals(ERROR_MSG, o2, negotiation.getBestMatch(available));
+        assertEquals(o2, negotiation.getBestMatch(available), ERROR_MSG);
         available.add(o1);
-        assertEquals(ERROR_MSG, o1, negotiation.getBestMatch(available));
+        assertEquals(o1, negotiation.getBestMatch(available), ERROR_MSG);
     }
 
     @Test
@@ -103,17 +103,17 @@ public class VariantSelectionTest {
 
         List<Variant> available = new ArrayList<Variant>();
         available.add(q03);
-        assertEquals(ERROR_MSG, q03, negotiation.getBestMatch(available));
+        assertEquals(q03, negotiation.getBestMatch(available), ERROR_MSG);
         available.add(q04);
-        assertEquals(ERROR_MSG, q04, negotiation.getBestMatch(available));
+        assertEquals(q04, negotiation.getBestMatch(available), ERROR_MSG);
         available.add(q05);
-        assertEquals(ERROR_MSG, q05, negotiation.getBestMatch(available));
+        assertEquals(q05, negotiation.getBestMatch(available), ERROR_MSG);
         available.add(q07);
-        assertEquals(ERROR_MSG, q07, negotiation.getBestMatch(available));
+        assertEquals(q07, negotiation.getBestMatch(available), ERROR_MSG);
         available.add(q07plus);
-        assertEquals(ERROR_MSG, q07plus, negotiation.getBestMatch(available));
+        assertEquals(q07plus, negotiation.getBestMatch(available), ERROR_MSG);
         available.add(q10);
-        assertEquals(ERROR_MSG, q10, negotiation.getBestMatch(available));
+        assertEquals(q10, negotiation.getBestMatch(available), ERROR_MSG);
     }
 
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/AcceptParameterHttpPreprocessorTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/AcceptParameterHttpPreprocessorTest.java
@@ -11,8 +11,8 @@ import org.jboss.resteasy.core.AcceptParameterHttpPreprocessor;
 import org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext;
 import org.jboss.resteasy.mock.MockHttpRequest;
 import org.jboss.resteasy.spi.HttpRequest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resource tests
@@ -43,8 +43,8 @@ public class AcceptParameterHttpPreprocessorTest {
 
         List<MediaType> list = request.getHttpHeaders().getAcceptableMediaTypes();
 
-        Assert.assertEquals("Incorrect acceptable list size", 1, list.size());
-        Assert.assertEquals("Incorrect media type extracted", mediaType, list.get(0));
+        Assertions.assertEquals(1, list.size(), "Incorrect acceptable list size");
+        Assertions.assertEquals(mediaType, list.get(0), "Incorrect media type extracted");
     }
 
     /**
@@ -71,7 +71,7 @@ public class AcceptParameterHttpPreprocessorTest {
         List<MediaType> actual = request.getHttpHeaders().getAcceptableMediaTypes();
 
         for (MediaType expect : expected) {
-            Assert.assertTrue(actual.contains(expect));
+            Assertions.assertTrue(actual.contains(expect));
         }
 
     }
@@ -98,7 +98,7 @@ public class AcceptParameterHttpPreprocessorTest {
         List<MediaType> actual = request.getHttpHeaders().getAcceptableMediaTypes();
 
         for (MediaType expect : expected) {
-            Assert.assertTrue(actual.contains(expect));
+            Assertions.assertTrue(actual.contains(expect));
         }
     }
 
@@ -130,6 +130,6 @@ public class AcceptParameterHttpPreprocessorTest {
 
         List<MediaType> actual = request.getHttpHeaders().getAcceptableMediaTypes();
 
-        Assert.assertEquals("Incorrect acceptable media type extracted", expected, actual);
+        Assertions.assertEquals(expected, actual, "Incorrect acceptable media type extracted");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/BenchmarkTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/BenchmarkTest.java
@@ -13,8 +13,8 @@ import org.jboss.resteasy.mock.MockDispatcherFactory;
 import org.jboss.resteasy.mock.MockHttpRequest;
 import org.jboss.resteasy.mock.MockHttpResponse;
 import org.jboss.resteasy.spi.Dispatcher;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @tpSubChapter Profiler helper tests
@@ -26,13 +26,13 @@ public class BenchmarkTest {
 
     private static Dispatcher dispatcher;
 
-    @BeforeClass
+    @BeforeAll
     public static void BeforeClass() {
         dispatcher = MockDispatcherFactory.createDispatcher();
         dispatcher.getRegistry().addPerRequestResource(HelloResource.class);
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         ResteasyContext.getContextDataMap().put(Configurable.class, dispatcher.getProviderFactory());
     }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/ContextResolverTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/ContextResolverTest.java
@@ -10,9 +10,9 @@ import org.jboss.resteasy.test.resource.resource.ContextResolver3;
 import org.jboss.resteasy.test.resource.resource.ContextResolver4;
 import org.jboss.resteasy.test.resource.resource.ContextResolver5;
 import org.jboss.resteasy.test.resource.resource.ContextResolver6;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resource
@@ -21,7 +21,7 @@ import org.junit.Test;
  * @tpSince RESTEasy 3.0.16
  */
 public class ContextResolverTest {
-    @BeforeClass
+    @BeforeAll
     public static void before() {
         ResteasyProviderFactory factory = ResteasyProviderFactory.getInstance();
         factory.registerProvider(ContextResolver1.class);
@@ -41,18 +41,18 @@ public class ContextResolverTest {
         String errMsg = "Failed to get context by ContextResolver";
         ResteasyProviderFactory factory = ResteasyProviderFactory.getInstance();
         ContextResolver<String> resolver = factory.getContextResolver(String.class, MediaType.TEXT_PLAIN_TYPE);
-        Assert.assertEquals(errMsg, resolver.getContext(int.class), "2");
-        Assert.assertEquals(errMsg, resolver.getContext(float.class), "5");
+        Assertions.assertEquals(resolver.getContext(int.class), "2", errMsg);
+        Assertions.assertEquals(resolver.getContext(float.class), "5", errMsg);
         resolver = factory.getContextResolver(String.class, MediaType.TEXT_XML_TYPE);
-        Assert.assertEquals(errMsg, resolver.getContext(int.class), "3");
-        Assert.assertEquals(errMsg, resolver.getContext(float.class), "6");
+        Assertions.assertEquals(resolver.getContext(int.class), "3", errMsg);
+        Assertions.assertEquals(resolver.getContext(float.class), "6", errMsg);
         resolver = factory.getContextResolver(String.class, MediaType.APPLICATION_ATOM_XML_TYPE);
-        Assert.assertEquals(errMsg, resolver.getContext(int.class), "1");
-        Assert.assertEquals(errMsg, resolver.getContext(float.class), "4");
-        Assert.assertNull("Unexpected context was returned by ContextResolver",
-                resolver.getContext(double.class));
-        Assert.assertNull("Unexpected context was returned by ContextResolver",
-                factory.getContextResolver(Double.class, MediaType.APPLICATION_ATOM_XML_TYPE));
+        Assertions.assertEquals(resolver.getContext(int.class), "1", errMsg);
+        Assertions.assertEquals(resolver.getContext(float.class), "4", errMsg);
+        Assertions.assertNull(resolver.getContext(double.class),
+                "Unexpected context was returned by ContextResolver");
+        Assertions.assertNull(factory.getContextResolver(Double.class, MediaType.APPLICATION_ATOM_XML_TYPE),
+                "Unexpected context was returned by ContextResolver");
     }
 
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/CookieObjectTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/CookieObjectTest.java
@@ -16,8 +16,8 @@ import jakarta.ws.rs.core.Response;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.utils.CookieUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resource tests
@@ -103,7 +103,7 @@ public class CookieObjectTest {
                 "", -1, null, false, false);
 
         // check round-tripping
-        Assert.assertEquals(nck26, CookieUtil.valueOf(NewCookie.class,
+        Assertions.assertEquals(nck26, CookieUtil.valueOf(NewCookie.class,
                 CookieUtil.toString(NewCookie.class, nck26)));
     }
 
@@ -128,7 +128,7 @@ public class CookieObjectTest {
                 "", -1, null, false, false);
 
         // check round-tripping
-        Assert.assertEquals(nck27, CookieUtil.valueOf(NewCookie.class,
+        Assertions.assertEquals(nck27, CookieUtil.valueOf(NewCookie.class,
                 CookieUtil.toString(NewCookie.class, nck27)));
     }
 
@@ -175,7 +175,7 @@ public class CookieObjectTest {
                 comment, maxAge, expiry, secure, httpOnly);
 
         // check round-tripping
-        Assert.assertEquals(nck28, CookieUtil.valueOf(NewCookie.class,
+        Assertions.assertEquals(nck28, CookieUtil.valueOf(NewCookie.class,
                 CookieUtil.toString(NewCookie.class, nck28)));
     }
 

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/FormParamInjectionTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/FormParamInjectionTest.java
@@ -7,9 +7,9 @@ import org.jboss.resteasy.mock.MockHttpRequest;
 import org.jboss.resteasy.mock.MockHttpResponse;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.test.resource.resource.FormParamResource;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resource tests
@@ -21,7 +21,7 @@ public class FormParamInjectionTest {
     ResourceMethodRegistry registry = new ResourceMethodRegistry(ResteasyProviderFactory.getInstance());
     MockHttpResponse resp = new MockHttpResponse();
 
-    @Before
+    @BeforeEach
     public void setup() {
         registry.addPerRequestResource(FormParamResource.class);
     }
@@ -29,7 +29,7 @@ public class FormParamInjectionTest {
     @Test
     public void testNoSplitAtSuccessiveEqualSign() throws Exception {
         MockHttpRequest req = createMockHttpRequest("/form/split", "valueA=v1%3Dv2=v3");
-        Assert.assertEquals("v1=v2=v3", registry.getResourceInvoker(req).invoke(req, resp)
+        Assertions.assertEquals("v1=v2=v3", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
 

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/OptionalInjectionTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/OptionalInjectionTest.java
@@ -10,9 +10,9 @@ import org.jboss.resteasy.mock.MockHttpResponse;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.test.resource.resource.NotSupportedOpitionalPathParamResource;
 import org.jboss.resteasy.test.resource.resource.OptionalResource;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resource tests
@@ -24,7 +24,7 @@ public class OptionalInjectionTest {
     ResourceMethodRegistry registry = new ResourceMethodRegistry(ResteasyProviderFactory.getInstance());
     MockHttpResponse resp = new MockHttpResponse();
 
-    @Before
+    @BeforeEach
     public void setup() {
         registry.addPerRequestResource(OptionalResource.class);
     }
@@ -32,28 +32,28 @@ public class OptionalInjectionTest {
     @Test
     public void testOptionalStringAbsent() throws Exception {
         MockHttpRequest req = createMockHttpRequest("/optional/string");
-        Assert.assertEquals("none", registry.getResourceInvoker(req).invoke(req, resp)
+        Assertions.assertEquals("none", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
 
     @Test
     public void testOptionalStringPresent() throws Exception {
         MockHttpRequest req = createMockHttpRequest("/optional/string?valueQ1=88");
-        Assert.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
+        Assertions.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
 
     @Test
     public void testOptionalHolderAbsent() throws Exception {
         MockHttpRequest req = createMockHttpRequest("/optional/holder");
-        Assert.assertEquals("none", registry.getResourceInvoker(req).invoke(req, resp)
+        Assertions.assertEquals("none", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
 
     @Test
     public void testOptionalHolderPresent() throws Exception {
         MockHttpRequest req = createMockHttpRequest("/optional/holder?valueQ2=88");
-        Assert.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
+        Assertions.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
 
@@ -63,14 +63,14 @@ public class OptionalInjectionTest {
         req.addFormHeader("notvalue", "badness");
         req.setInputStream(new ByteArrayInputStream(new byte[0]));
 
-        Assert.assertEquals("42", registry.getResourceInvoker(req).invoke(req, resp)
+        Assertions.assertEquals("42", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
 
     @Test
     public void testMatrixParamAbsent() throws Exception {
         MockHttpRequest httpRequest = createMockHttpRequest("/optional/matrix", false);
-        Assert.assertEquals("42", registry
+        Assertions.assertEquals("42", registry
                 .getResourceInvoker(httpRequest)
                 .invoke(httpRequest, resp)
                 .getEntity());
@@ -79,29 +79,37 @@ public class OptionalInjectionTest {
     @Test
     public void testMatrixParamPresent() throws Exception {
         MockHttpRequest httpRequest = createMockHttpRequest("/optional/matrix;valueM=24", false);
-        Assert.assertEquals("24", registry
+        Assertions.assertEquals("24", registry
                 .getResourceInvoker(httpRequest)
                 .invoke(httpRequest, resp)
                 .getEntity());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testPathParamNotSupportedAndBehavedSameAsBeforeAsDiscussedInEAP7_1248() throws Exception {
-        registry.addPerRequestResource(NotSupportedOpitionalPathParamResource.class);
+        RuntimeException thrown = Assertions.assertThrows(RuntimeException.class,
+                () -> {
+                    registry.addPerRequestResource(NotSupportedOpitionalPathParamResource.class);
+                });
+        Assertions.assertTrue(thrown instanceof RuntimeException);
     }
 
-    @Test(expected = NotFoundException.class)
+    @Test
     public void testPathParamNeverAbsentThrowsException() throws Exception {
-        MockHttpRequest httpRequest = createMockHttpRequest("/optional/path/");
-        registry.getResourceInvoker(httpRequest)
-                .invoke(httpRequest, resp)
-                .getEntity();
+        NotFoundException thrown = Assertions.assertThrows(NotFoundException.class,
+                () -> {
+                    MockHttpRequest httpRequest = createMockHttpRequest("/optional/path/");
+                    registry.getResourceInvoker(httpRequest)
+                            .invoke(httpRequest, resp)
+                            .getEntity();
+                });
+        Assertions.assertTrue(thrown instanceof NotFoundException);
     }
 
     @Test
     public void testHeaderParamAbsent() throws Exception {
         MockHttpRequest httpRequest = createMockHttpRequest("/optional/header");
-        Assert.assertEquals("42", registry
+        Assertions.assertEquals("42", registry
                 .getResourceInvoker(httpRequest)
                 .invoke(httpRequest, resp)
                 .getEntity());
@@ -111,7 +119,7 @@ public class OptionalInjectionTest {
     public void testHeaderParamPresent() throws Exception {
         MockHttpRequest httpRequest = createMockHttpRequest("/optional/header");
         httpRequest.header("valueH", "24");
-        Assert.assertEquals("24", registry
+        Assertions.assertEquals("24", registry
                 .getResourceInvoker(httpRequest)
                 .invoke(httpRequest, resp)
                 .getEntity());
@@ -120,7 +128,7 @@ public class OptionalInjectionTest {
     @Test
     public void testCookieParamAbsent() throws Exception {
         MockHttpRequest httpRequest = createMockHttpRequest("/optional/cookie");
-        Assert.assertEquals("42", registry
+        Assertions.assertEquals("42", registry
                 .getResourceInvoker(httpRequest)
                 .invoke(httpRequest, resp)
                 .getEntity());
@@ -130,7 +138,7 @@ public class OptionalInjectionTest {
     public void testCookieParamPresent() throws Exception {
         MockHttpRequest httpRequest = createMockHttpRequest("/optional/cookie");
         httpRequest.cookie("valueC", "24");
-        Assert.assertEquals("24", registry
+        Assertions.assertEquals("24", registry
                 .getResourceInvoker(httpRequest)
                 .invoke(httpRequest, resp)
                 .getEntity());
@@ -141,7 +149,7 @@ public class OptionalInjectionTest {
         MockHttpRequest req = createMockHttpRequest("/optional/long", false);
         req.addFormHeader("valueF", "88");
 
-        Assert.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
+        Assertions.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
 
@@ -149,7 +157,7 @@ public class OptionalInjectionTest {
     public void testOptionalIntAbsent() throws Exception {
         MockHttpRequest req = createMockHttpRequest("/optional/int");
 
-        Assert.assertEquals("424242", registry.getResourceInvoker(req).invoke(req, resp)
+        Assertions.assertEquals("424242", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
 
@@ -157,7 +165,7 @@ public class OptionalInjectionTest {
     public void testOptionalIntPresent() throws Exception {
         MockHttpRequest req = createMockHttpRequest("/optional/int?valueQ4=88");
 
-        Assert.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
+        Assertions.assertEquals("88", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
 
@@ -165,7 +173,7 @@ public class OptionalInjectionTest {
     public void testOptionalDoubleAbsent() throws Exception {
         MockHttpRequest req = createMockHttpRequest("/optional/double");
 
-        Assert.assertEquals("4242.0", registry.getResourceInvoker(req).invoke(req, resp)
+        Assertions.assertEquals("4242.0", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
 
@@ -173,7 +181,7 @@ public class OptionalInjectionTest {
     public void testOptionalDoublePresent() throws Exception {
         MockHttpRequest req = createMockHttpRequest("/optional/double?valueQ3=88.88");
 
-        Assert.assertEquals("88.88", registry.getResourceInvoker(req).invoke(req, resp)
+        Assertions.assertEquals("88.88", registry.getResourceInvoker(req).invoke(req, resp)
                 .getEntity());
     }
 

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/ProgrammaticTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/ProgrammaticTest.java
@@ -15,10 +15,10 @@ import org.jboss.resteasy.spi.Dispatcher;
 import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.spi.metadata.ResourceClass;
 import org.jboss.resteasy.test.resource.resource.ProgrammaticResource;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resource tests
@@ -30,12 +30,12 @@ public class ProgrammaticTest {
 
     private static Dispatcher dispatcher;
 
-    @BeforeClass
+    @BeforeAll
     public static void BeforeClass() {
         dispatcher = MockDispatcherFactory.createDispatcher();
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         ResteasyContext.getContextDataMap().put(Configurable.class, dispatcher.getProviderFactory());
     }
@@ -66,12 +66,12 @@ public class ProgrammaticTest {
         MockHttpRequest request = MockHttpRequest.get("/test?a=hello");
         MockHttpResponse response = new MockHttpResponse();
         dispatcher.invoke(request, response);
-        Assert.assertEquals(response.getContentAsString(), "hello");
+        Assertions.assertEquals(response.getContentAsString(), "hello");
 
         request = MockHttpRequest.put("/test").content("hello".getBytes()).contentType("text/plain");
         response = new MockHttpResponse();
         dispatcher.invoke(request, response);
-        Assert.assertEquals(204, response.getStatus());
+        Assertions.assertEquals(204, response.getStatus());
         dispatcher.getRegistry().removeRegistrations(resourceclass);
 
     }
@@ -99,8 +99,8 @@ public class ProgrammaticTest {
         MockHttpRequest request = MockHttpRequest.get("/test?a=hello");
         MockHttpResponse response = new MockHttpResponse();
         dispatcher.invoke(request, response);
-        Assert.assertEquals("hello", response.getContentAsString());
-        Assert.assertEquals(1, resource.counter);
+        Assertions.assertEquals("hello", response.getContentAsString());
+        Assertions.assertEquals(1, resource.counter);
         dispatcher.getRegistry().removeRegistrations(resourceclass);
     }
 
@@ -129,7 +129,7 @@ public class ProgrammaticTest {
         MockHttpRequest request = MockHttpRequest.get("/test?a=hello");
         MockHttpResponse response = new MockHttpResponse();
         dispatcher.invoke(request, response);
-        Assert.assertEquals(response.getContentAsString(), "hello");
+        Assertions.assertEquals(response.getContentAsString(), "hello");
 
     }
 

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/SegmentTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/SegmentTest.java
@@ -14,8 +14,8 @@ import org.jboss.resteasy.test.resource.resource.SegmentLocatorComplex;
 import org.jboss.resteasy.test.resource.resource.SegmentNullResource;
 import org.jboss.resteasy.test.resource.resource.SegmentResource;
 import org.jboss.resteasy.test.resource.resource.SegmentResourceSwitch;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resource tests
@@ -69,8 +69,8 @@ public class SegmentTest {
         registry.addPerRequestResource(SegmentResourceSwitch.class);
         ResourceLocatorInvoker invoker = (ResourceLocatorInvoker) registry
                 .getResourceInvoker(MockHttpRequest.options("/resource/sub"));
-        Assert.assertNotNull("Wrong ResourceLocatorInvoker response", invoker);
-        Assert.assertEquals("Wrong ResourceLocatorInvoker response", invoker.getMethod().getName(), "locator");
+        Assertions.assertNotNull(invoker, "Wrong ResourceLocatorInvoker response");
+        Assertions.assertEquals(invoker.getMethod().getName(), "locator", "Wrong ResourceLocatorInvoker response");
     }
 
     /**
@@ -84,15 +84,16 @@ public class SegmentTest {
         registry.addPerRequestResource(SegmentLocatorComplex.class);
         ResourceLocatorInvoker invoker = (ResourceLocatorInvoker) registry
                 .getResourceInvoker(MockHttpRequest.get("/locator/responseok/responseok"));
-        Assert.assertNotNull("Wrong ResourceLocatorInvoker response", invoker);
-        Assert.assertEquals("Wrong ResourceLocatorInvoker response", invoker.getMethod().getName(), "responseOk");
+        Assertions.assertNotNull(invoker, "Wrong ResourceLocatorInvoker response");
+        Assertions.assertEquals(invoker.getMethod().getName(), "responseOk",
+                "Wrong ResourceLocatorInvoker response");
     }
 
     private void assertMatchRoot(ResourceMethodRegistry registry, final String url, final String methodName,
             final Class<?> clazz) throws URISyntaxException {
         ResourceMethodInvoker matchRoot = getResourceMethod(url, registry);
-        Assert.assertEquals("Wrong ResourceLocatorInvoker response", clazz, matchRoot.getResourceClass());
-        Assert.assertEquals("Wrong ResourceLocatorInvoker response", methodName, matchRoot.getMethod().getName());
+        Assertions.assertEquals(clazz, matchRoot.getResourceClass(), "Wrong ResourceLocatorInvoker response");
+        Assertions.assertEquals(methodName, matchRoot.getMethod().getName(), "Wrong ResourceLocatorInvoker response");
     }
 
     private ResourceMethodInvoker getResourceMethod(String url, ResourceMethodRegistry registry)

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/TrailingSlashTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/TrailingSlashTest.java
@@ -4,8 +4,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import org.jboss.resteasy.specimpl.ResteasyUriInfo;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Resource tests
@@ -28,11 +28,12 @@ public class TrailingSlashTest {
 
     void doOneArgConstructorTest(URI uri, String path) {
         ResteasyUriInfo ruri = new ResteasyUriInfo(uri);
-        Assert.assertEquals(ERROR_MSG, path, ruri.getPath());
-        Assert.assertEquals(ERROR_MSG, path, ruri.getPath(true));
-        Assert.assertEquals(ERROR_MSG, path, ruri.getPath(false));
-        Assert.assertEquals(ERROR_MSG, uri, ruri.getAbsolutePath());
-        Assert.assertEquals(ERROR_MSG, uri, ruri.getBaseUri().resolve(ruri.getPath(false)));
+        Assertions.assertEquals(path, ruri.getPath(), ERROR_MSG);
+        Assertions.assertEquals(path, ruri.getPath(true), ERROR_MSG);
+        Assertions.assertEquals(path, ruri.getPath(false), ERROR_MSG);
+        Assertions.assertEquals(uri, ruri.getAbsolutePath(), ERROR_MSG);
+        Assertions.assertEquals(uri, ruri.getBaseUri().resolve(ruri.getPath(false)),
+                ERROR_MSG);
     }
 
     /**
@@ -47,16 +48,16 @@ public class TrailingSlashTest {
 
     void doTwoArgConstructorTest(URI base, URI relative, String path) throws URISyntaxException {
         ResteasyUriInfo ruri = new ResteasyUriInfo(base, relative);
-        Assert.assertEquals(ERROR_MSG, path, ruri.getPath());
-        Assert.assertEquals(ERROR_MSG, path, ruri.getPath(true));
-        Assert.assertEquals(ERROR_MSG, path, ruri.getPath(false));
+        Assertions.assertEquals(path, ruri.getPath(), ERROR_MSG);
+        Assertions.assertEquals(path, ruri.getPath(true), ERROR_MSG);
+        Assertions.assertEquals(path, ruri.getPath(false), ERROR_MSG);
         URI newUri;
         if (base.toString().endsWith("/")) {
             newUri = new URI(base.toString().substring(0, base.toString().length() - 1) + path);
         } else {
             newUri = new URI(base.toString() + path);
         }
-        Assert.assertEquals(ERROR_MSG, newUri, ruri.getAbsolutePath());
+        Assertions.assertEquals(newUri, ruri.getAbsolutePath(), ERROR_MSG);
     }
 
     /**
@@ -72,10 +73,11 @@ public class TrailingSlashTest {
     void doTwoStringArgConstructorTest(String s, String path) throws URISyntaxException {
         ResteasyUriInfo ruri = new ResteasyUriInfo(s, "");
         URI uri = new URI(s);
-        Assert.assertEquals(ERROR_MSG, path, ruri.getPath());
-        Assert.assertEquals(ERROR_MSG, path, ruri.getPath(true));
-        Assert.assertEquals(ERROR_MSG, path, ruri.getPath(false));
-        Assert.assertEquals(ERROR_MSG, uri, ruri.getAbsolutePath());
-        Assert.assertEquals(ERROR_MSG, uri, ruri.getBaseUri().resolve(ruri.getPath(false)));
+        Assertions.assertEquals(path, ruri.getPath(), ERROR_MSG);
+        Assertions.assertEquals(path, ruri.getPath(true), ERROR_MSG);
+        Assertions.assertEquals(path, ruri.getPath(false), ERROR_MSG);
+        Assertions.assertEquals(uri, ruri.getAbsolutePath(), ERROR_MSG);
+        Assertions.assertEquals(uri, ruri.getBaseUri().resolve(ruri.getPath(false)),
+                ERROR_MSG);
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/ProgrammaticResource.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/ProgrammaticResource.java
@@ -4,7 +4,7 @@ import jakarta.ws.rs.core.Configurable;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.UriInfo;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class ProgrammaticResource {
 
@@ -28,7 +28,7 @@ public class ProgrammaticResource {
     }
 
     public String get(String param) {
-        Assert.assertEquals("hello", param);
+        Assertions.assertEquals("hello", param);
         uriInfo.getBaseUri();
         headers.getCookies();
         configurable.getConfiguration();
@@ -37,6 +37,6 @@ public class ProgrammaticResource {
     }
 
     public void put(String value) {
-        Assert.assertEquals("hello", value);
+        Assertions.assertEquals("hello", value);
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/CacheControlTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/CacheControlTest.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.test.util;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.ws.rs.core.CacheControl;
 import jakarta.ws.rs.ext.RuntimeDelegate;
@@ -9,8 +9,8 @@ import org.jboss.resteasy.core.ExtendedCacheControl;
 import org.jboss.resteasy.plugins.delegates.CacheControlDelegate;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -40,33 +40,33 @@ public class CacheControlTest {
         CacheControl serialized = hdcc.fromString(toString);
 
         String errMsg = "Wrong serialization";
-        Assert.assertTrue(errMsg, serialized.getMaxAge() == 1000);
-        Assert.assertTrue(errMsg, serialized.getSMaxAge() == 500);
-        Assert.assertFalse(errMsg, serialized.isNoTransform());
-        Assert.assertTrue(errMsg, serialized.isPrivate());
+        Assertions.assertTrue(serialized.getMaxAge() == 1000, errMsg);
+        Assertions.assertTrue(serialized.getSMaxAge() == 500, errMsg);
+        Assertions.assertFalse(serialized.isNoTransform(), errMsg);
+        Assertions.assertTrue(serialized.isPrivate(), errMsg);
     }
 
     void assertEqual(String errorMsg, CacheControl first, CacheControl second) {
-        Assert.assertEquals(errorMsg, first.isMustRevalidate(), second.isMustRevalidate());
-        Assert.assertEquals(errorMsg, first.isNoCache(), second.isNoCache());
-        Assert.assertEquals(errorMsg, first.isNoStore(), second.isNoStore());
-        Assert.assertEquals(errorMsg, first.isNoTransform(), second.isNoTransform());
-        Assert.assertEquals(errorMsg, first.isPrivate(), second.isPrivate());
-        Assert.assertEquals(errorMsg, first.isProxyRevalidate(), second.isProxyRevalidate());
-        Assert.assertEquals(errorMsg, first.isPrivate(), second.isPrivate());
-        Assert.assertEquals(errorMsg, first.getMaxAge(), second.getMaxAge());
-        Assert.assertEquals(errorMsg, first.getSMaxAge(), second.getSMaxAge());
-        Assert.assertEquals(errorMsg, first.getNoCacheFields().size(), second.getNoCacheFields().size());
-        Assert.assertEquals(errorMsg, first.getPrivateFields().size(), second.getPrivateFields().size());
+        Assertions.assertEquals(first.isMustRevalidate(), second.isMustRevalidate(), errorMsg);
+        Assertions.assertEquals(first.isNoCache(), second.isNoCache(), errorMsg);
+        Assertions.assertEquals(first.isNoStore(), second.isNoStore(), errorMsg);
+        Assertions.assertEquals(first.isNoTransform(), second.isNoTransform(), errorMsg);
+        Assertions.assertEquals(first.isPrivate(), second.isPrivate(), errorMsg);
+        Assertions.assertEquals(first.isProxyRevalidate(), second.isProxyRevalidate(), errorMsg);
+        Assertions.assertEquals(first.isPrivate(), second.isPrivate(), errorMsg);
+        Assertions.assertEquals(first.getMaxAge(), second.getMaxAge(), errorMsg);
+        Assertions.assertEquals(first.getSMaxAge(), second.getSMaxAge(), errorMsg);
+        Assertions.assertEquals(first.getNoCacheFields().size(), second.getNoCacheFields().size(), errorMsg);
+        Assertions.assertEquals(first.getPrivateFields().size(), second.getPrivateFields().size(), errorMsg);
         for (int i = 0; i < first.getNoCacheFields().size(); i++) {
-            Assert.assertEquals(errorMsg, first.getNoCacheFields().get(i), second.getNoCacheFields().get(i));
+            Assertions.assertEquals(first.getNoCacheFields().get(i), second.getNoCacheFields().get(i), errorMsg);
         }
         for (int i = 0; i < first.getPrivateFields().size(); i++) {
-            Assert.assertEquals(errorMsg, first.getPrivateFields().get(i), second.getPrivateFields().get(i));
+            Assertions.assertEquals(first.getPrivateFields().get(i), second.getPrivateFields().get(i), errorMsg);
         }
-        Assert.assertEquals(errorMsg, first.getCacheExtension().size(), second.getCacheExtension().size());
+        Assertions.assertEquals(first.getCacheExtension().size(), second.getCacheExtension().size(), errorMsg);
         for (String key : first.getCacheExtension().keySet()) {
-            Assert.assertEquals(errorMsg, first.getCacheExtension().get(key), second.getCacheExtension().get(key));
+            Assertions.assertEquals(first.getCacheExtension().get(key), second.getCacheExtension().get(key), errorMsg);
         }
     }
 
@@ -116,12 +116,12 @@ public class CacheControlTest {
         cc.setPrivate(true);
         cc.setNoStore(true);
         String value = cc.toString();
-        assertTrue("Missing no-cache property in String representation of CacheControl",
-                value.contains("no-cache"));
-        assertTrue("Missing no-store property in String representation of CacheControl",
-                value.contains("no-store"));
-        assertTrue("Missing private property in String representation of CacheControl",
-                value.contains("private"));
+        assertTrue(value.contains("no-cache"),
+                "Missing no-cache property in String representation of CacheControl");
+        assertTrue(value.contains("no-store"),
+                "Missing no-store property in String representation of CacheControl");
+        assertTrue(value.contains("private"),
+                "Missing private property in String representation of CacheControl");
     }
 
     /**
@@ -135,12 +135,12 @@ public class CacheControlTest {
         cc.setPublic(true);
         cc.setNoStore(true);
         String value = cc.toString();
-        assertTrue("Missing no-cache property in String representation of ExtendedCacheControl",
-                value.contains("no-cache"));
-        assertTrue("Missing no-store property in String representation of ExtendedCacheControl",
-                value.contains("no-store"));
-        assertTrue("Missing private property in String representation of ExtendedCacheControl",
-                value.contains("public"));
+        assertTrue(value.contains("no-cache"),
+                "Missing no-cache property in String representation of ExtendedCacheControl");
+        assertTrue(value.contains("no-store"),
+                "Missing no-store property in String representation of ExtendedCacheControl");
+        assertTrue(value.contains("public"),
+                "Missing private property in String representation of ExtendedCacheControl");
     }
 
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/CaseInsentiveMapTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/CaseInsentiveMapTest.java
@@ -1,8 +1,8 @@
 package org.jboss.resteasy.test.util;
 
 import org.jboss.resteasy.util.CaseInsensitiveMap;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -20,6 +20,7 @@ public class CaseInsentiveMapTest {
     public void testMap() {
         CaseInsensitiveMap<String> map = new CaseInsensitiveMap<>();
         map.add("Cache-Control", "nocache");
-        Assert.assertEquals("key of map should be case insensitive", "nocache", map.getFirst("caChe-CONTROL"));
+        Assertions.assertEquals("nocache", map.getFirst("caChe-CONTROL"),
+                "key of map should be case insensitive");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/GroupParameterParserTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/GroupParameterParserTest.java
@@ -6,8 +6,8 @@ import java.util.Map;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.util.GroupParameterParser;
 import org.jboss.resteasy.util.ParameterParser;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -29,7 +29,7 @@ public class GroupParameterParserTest {
         GroupParameterParser parser = new GroupParameterParser();
         List<Map<String, String>> groups = parser.parse(params, ';', ',');
         logger.debug(String.format("Groups: %s", groups));
-        Assert.assertEquals("Wrong number of groups", 2, groups.size());
+        Assertions.assertEquals(2, groups.size(), "Wrong number of groups");
     }
 
     /**
@@ -42,7 +42,7 @@ public class GroupParameterParserTest {
         ParameterParser parser = new ParameterParser();
         String output = parser.setAttribute(header.toCharArray(), 0, header.length(), ';', "b", "");
         logger.debug(String.format("Parsed output: <%s>", output));
-        Assert.assertEquals("Parsed output is wrong", "v=1   ;z=33333   ;b=", output);
+        Assertions.assertEquals("v=1   ;z=33333   ;b=", output, "Parsed output is wrong");
     }
 
     /**
@@ -55,7 +55,7 @@ public class GroupParameterParserTest {
         ParameterParser parser = new ParameterParser();
         String output = parser.setAttribute(header.toCharArray(), 0, header.length(), ';', "b", "");
         logger.debug(String.format("Parsed output: <%s>", output));
-        Assert.assertEquals("Parsed output is wrong", "v=1   ;z=33333   ;b=;   foo=bar   ", output);
+        Assertions.assertEquals("v=1   ;z=33333   ;b=;   foo=bar   ", output, "Parsed output is wrong");
     }
 
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/InterfaceTypeUtilTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/InterfaceTypeUtilTest.java
@@ -6,8 +6,8 @@ import org.jboss.resteasy.test.util.resource.InterfaceTypeUtilD;
 import org.jboss.resteasy.test.util.resource.InterfaceTypeUtilE;
 import org.jboss.resteasy.test.util.resource.InterfaceTypeUtilI;
 import org.jboss.resteasy.test.util.resource.InterfaceTypeUtilJ;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -23,9 +23,10 @@ public class InterfaceTypeUtilTest {
      */
     @Test
     public void testType() throws Exception {
-        Assert.assertNull("Types util class works incorrectly",
-                Types.getTemplateParameterOfInterface(InterfaceTypeUtilD.class, InterfaceTypeUtilJ.class));
-        Assert.assertEquals("Types util class works incorrectly", InterfaceTypeUtilC.class,
-                Types.getTemplateParameterOfInterface(InterfaceTypeUtilE.class, InterfaceTypeUtilI.class));
+        Assertions.assertNull(Types.getTemplateParameterOfInterface(InterfaceTypeUtilD.class, InterfaceTypeUtilJ.class),
+                "Types util class works incorrectly");
+        Assertions.assertEquals(InterfaceTypeUtilC.class,
+                Types.getTemplateParameterOfInterface(InterfaceTypeUtilE.class, InterfaceTypeUtilI.class),
+                "Types util class works incorrectly");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/LinkTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/LinkTest.java
@@ -8,8 +8,8 @@ import jakarta.ws.rs.core.UriBuilderException;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.test.util.resource.LinkResource;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -57,7 +57,7 @@ public class LinkTest {
                 String string = link.toString();
                 logger.info("initial: " + string);
                 Link fromValueOf = Link.valueOf(string);
-                Assert.assertEquals(string, fromValueOf.toString());
+                Assertions.assertEquals(string, fromValueOf.toString());
             }
         }
     }
@@ -71,7 +71,7 @@ public class LinkTest {
         Link.Builder builder = Link.fromUri("http://:@");
         try {
             builder.build();
-            Assert.fail();
+            Assertions.fail();
         } catch (UriBuilderException e) {
         }
     }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/MultivaluedMapTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/MultivaluedMapTest.java
@@ -7,8 +7,8 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -39,9 +39,9 @@ public class MultivaluedMapTest {
         map.add(null, vec);
         map.add(null, this);
         List<Object> objects = map.get(null);
-        Assert.assertTrue(defaultErrMsg, objects.size() == 2);
-        Assert.assertTrue(defaultErrMsg, map.size() == 2);
-        Assert.assertTrue(defaultErrMsg, map.getFirst(null).getClass() == Vector.class);
+        Assertions.assertTrue(objects.size() == 2, defaultErrMsg);
+        Assertions.assertTrue(map.size() == 2, defaultErrMsg);
+        Assertions.assertTrue(map.getFirst(null).getClass() == Vector.class, defaultErrMsg);
 
         map = Response.ok().build().getMetadata();
         Object o1 = new StringBuilder().append(KEYS[0]);
@@ -59,7 +59,7 @@ public class MultivaluedMapTest {
         MultivaluedHashMap<String, Object> map2 = new MultivaluedHashMap<String, Object>();
         map2.addAll(KEYS[0], o3, o1, o2);
 
-        Assert.assertTrue(hashErrMsg, map.equalsIgnoreValueOrder(map2));
-        Assert.assertFalse(hashErrMsg, map.equals(map2));
+        Assertions.assertTrue(map.equalsIgnoreValueOrder(map2), hashErrMsg);
+        Assertions.assertFalse(map.equals(map2), hashErrMsg);
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/ObjectToURITest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/ObjectToURITest.java
@@ -6,8 +6,8 @@ import org.jboss.resteasy.test.util.resource.ObjectToURICustomURIableObject;
 import org.jboss.resteasy.test.util.resource.ObjectToURIMappedByObject;
 import org.jboss.resteasy.test.util.resource.ObjectToURITemplateObject;
 import org.jboss.resteasy.test.util.resource.ObjectToURIableObject;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -25,9 +25,12 @@ public class ObjectToURITest {
     @Test
     public void testDefaultResolvers() {
         ObjectToURI instance = ObjectToURI.getInstance();
-        Assert.assertEquals(ERROR_MSG, "/foo/123", instance.resolveURI(new ObjectToURITemplateObject(123)));
-        Assert.assertEquals(ERROR_MSG, "/my-url", instance.resolveURI(new ObjectToURIableObject()));
-        Assert.assertEquals(ERROR_MSG, "/foo/123", instance.resolveURI(new ObjectToURIMappedByObject(123)));
+        Assertions.assertEquals("/foo/123", instance.resolveURI(new ObjectToURITemplateObject(123)),
+                ERROR_MSG);
+        Assertions.assertEquals("/my-url", instance.resolveURI(new ObjectToURIableObject()),
+                ERROR_MSG);
+        Assertions.assertEquals("/foo/123", instance.resolveURI(new ObjectToURIMappedByObject(123)),
+                ERROR_MSG);
     }
 
     /**
@@ -38,7 +41,7 @@ public class ObjectToURITest {
     public void testCustomResolver() {
         ObjectToURI instance = ObjectToURI.getInstance();
         ObjectToURICustomURIableObject custom = new ObjectToURICustomURIableObject();
-        Assert.assertEquals(ERROR_MSG, "/my-url", instance.resolveURI(custom));
+        Assertions.assertEquals("/my-url", instance.resolveURI(custom), ERROR_MSG);
 
         instance.registerURIResolver(new URIResolver() {
             public boolean handles(Class<?> type) {
@@ -50,6 +53,6 @@ public class ObjectToURITest {
             }
         });
 
-        Assert.assertEquals(ERROR_MSG, "/some-other-uri", instance.resolveURI(custom));
+        Assertions.assertEquals("/some-other-uri", instance.resolveURI(custom), ERROR_MSG);
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/PasswordColonTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/PasswordColonTest.java
@@ -1,8 +1,8 @@
 package org.jboss.resteasy.test.util;
 
 import org.jboss.resteasy.util.BasicAuthHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -19,7 +19,7 @@ public class PasswordColonTest {
     public void testPasswordWithColon() {
         String header = BasicAuthHelper.createHeader("user", "pass:word");
         String[] credentials = BasicAuthHelper.parseHeader(header);
-        Assert.assertEquals("Wrong user", "user", credentials[0]);
-        Assert.assertEquals("Wrong password", "pass:word", credentials[1]);
+        Assertions.assertEquals("user", credentials[0], "Wrong user");
+        Assertions.assertEquals("pass:word", credentials[1], "Wrong password");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/ResponseBuilderTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/ResponseBuilderTest.java
@@ -13,10 +13,10 @@ import org.jboss.resteasy.mock.MockHttpRequest;
 import org.jboss.resteasy.specimpl.ResponseBuilderImpl;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.test.util.resource.ResponseBuilderRequest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -31,7 +31,7 @@ public class ResponseBuilderTest {
 
     private Response.ResponseBuilder builder;
 
-    @Before
+    @BeforeEach
     public void before() throws URISyntaxException {
         HttpRequest httpRequest = MockHttpRequest.create("GET", REQUEST_URI,
                 BASE_URI);
@@ -42,7 +42,7 @@ public class ResponseBuilderTest {
         builder = new ResponseBuilderImpl();
     }
 
-    @After
+    @AfterEach
     public void after() throws Exception {
         ResteasyContext.removeContextDataLevel();
     }
@@ -58,17 +58,17 @@ public class ResponseBuilderTest {
             Response r = builder.location(URI.create("/res")).build();
             String actualUri = r.getMetadata().getFirst("Location").toString();
 
-            Assert.assertEquals(ERROR_MSG, "http://localhost/res", actualUri);
+            Assertions.assertEquals("http://localhost/res", actualUri, ERROR_MSG);
         }
 
         // testAllowed
         {
             Response response = Response.status(Response.Status.OK).allow("GET", "POST", "DELETE").build();
             Set<String> allowedMethods = response.getAllowedMethods();
-            Assert.assertEquals(ERROR_MSG, allowedMethods.size(), 3);
-            Assert.assertTrue(ERROR_MSG, allowedMethods.contains("GET"));
-            Assert.assertTrue(ERROR_MSG, allowedMethods.contains("POST"));
-            Assert.assertTrue(ERROR_MSG, allowedMethods.contains("DELETE"));
+            Assertions.assertEquals(allowedMethods.size(), 3, ERROR_MSG);
+            Assertions.assertTrue(allowedMethods.contains("GET"), ERROR_MSG);
+            Assertions.assertTrue(allowedMethods.contains("POST"), ERROR_MSG);
+            Assertions.assertTrue(allowedMethods.contains("DELETE"), ERROR_MSG);
         }
 
         // testLocationPath
@@ -76,7 +76,7 @@ public class ResponseBuilderTest {
             Response r = builder.location(URI.create("/a/res")).build();
             String actualUri = r.getMetadata().getFirst("Location").toString();
 
-            Assert.assertEquals(ERROR_MSG, "http://localhost/a/res", actualUri);
+            Assertions.assertEquals("http://localhost/a/res", actualUri, ERROR_MSG);
         }
 
         // testLocationQueryString
@@ -84,7 +84,7 @@ public class ResponseBuilderTest {
             Response r = builder.location(URI.create("/res?query")).build();
             String actualUri = r.getMetadata().getFirst("Location").toString();
 
-            Assert.assertEquals(ERROR_MSG, "http://localhost/res?query", actualUri);
+            Assertions.assertEquals("http://localhost/res?query", actualUri, ERROR_MSG);
         }
 
         // testLocationFragment
@@ -92,7 +92,7 @@ public class ResponseBuilderTest {
             Response r = builder.location(URI.create("/res#frag")).build();
             String actualUri = r.getMetadata().getFirst("Location").toString();
 
-            Assert.assertEquals(ERROR_MSG, "http://localhost/res#frag", actualUri);
+            Assertions.assertEquals("http://localhost/res#frag", actualUri, ERROR_MSG);
         }
 
         // testContentLocationSimple
@@ -100,7 +100,7 @@ public class ResponseBuilderTest {
             Response r = builder.contentLocation(URI.create("/res")).build();
             String actualUri = r.getMetadata().getFirst("Content-Location").toString();
 
-            Assert.assertEquals(ERROR_MSG, "http://localhost/res", actualUri);
+            Assertions.assertEquals("http://localhost/res", actualUri, ERROR_MSG);
         }
 
         // testContentLocationPath
@@ -108,7 +108,7 @@ public class ResponseBuilderTest {
             Response r = builder.contentLocation(URI.create("/a/res")).build();
             String actualUri = r.getMetadata().getFirst("Content-Location").toString();
 
-            Assert.assertEquals(ERROR_MSG, "http://localhost/a/res", actualUri);
+            Assertions.assertEquals("http://localhost/a/res", actualUri, ERROR_MSG);
         }
 
         // testContentLocationQueryString
@@ -116,7 +116,7 @@ public class ResponseBuilderTest {
             Response r = builder.location(URI.create("/res?query")).build();
             String actualUri = r.getMetadata().getFirst("Location").toString();
 
-            Assert.assertEquals(ERROR_MSG, "http://localhost/res?query", actualUri);
+            Assertions.assertEquals("http://localhost/res?query", actualUri, ERROR_MSG);
         }
 
         // testContentLocationFragment
@@ -124,7 +124,7 @@ public class ResponseBuilderTest {
             Response r = builder.contentLocation(URI.create("/res#frag")).build();
             String actualUri = r.getMetadata().getFirst("Content-Location").toString();
 
-            Assert.assertEquals(ERROR_MSG, "http://localhost/res#frag", actualUri);
+            Assertions.assertEquals("http://localhost/res#frag", actualUri, ERROR_MSG);
         }
 
         // testReplace
@@ -134,7 +134,7 @@ public class ResponseBuilderTest {
                     .header(headers[1], headers[1]).header(headers[2], headers[2])
                     .replaceAll(null).build();
             for (String header : headers) {
-                Assert.assertTrue(ERROR_MSG, response.getHeaderString(header) == null);
+                Assertions.assertTrue(response.getHeaderString(header) == null, ERROR_MSG);
             }
         }
 
@@ -145,8 +145,8 @@ public class ResponseBuilderTest {
                     .createResponseBuilder();
             Response response = rb.allow(methods).build();
             Set<String> set = response.getAllowedMethods();
-            Assert.assertEquals(ERROR_MSG, 1, set.size());
-            Assert.assertEquals(ERROR_MSG, set.iterator().next(), ResponseBuilderRequest.OPTIONS.name());
+            Assertions.assertEquals(1, set.size(), ERROR_MSG);
+            Assertions.assertEquals(set.iterator().next(), ResponseBuilderRequest.OPTIONS.name(), ERROR_MSG);
         }
 
         // testLinkHeaders
@@ -158,11 +158,11 @@ public class ResponseBuilderTest {
                             Link.fromUri("Link3").rel("rel3").build())
                     .link("Link4", "rel4").build();
 
-            Assert.assertEquals(ERROR_MSG, 4, r1.getLinks().size());
-            Assert.assertNotNull("Link-Header 'Link1' missing", r1.getLink("rel1"));
-            Assert.assertNotNull("Link-Header 'Link2' missing", r1.getLink("rel2"));
-            Assert.assertNotNull("Link-Header 'Link3' missing", r1.getLink("rel3"));
-            Assert.assertNotNull("Link-Header 'Link4' missing", r1.getLink("rel4"));
+            Assertions.assertEquals(4, r1.getLinks().size(), ERROR_MSG);
+            Assertions.assertNotNull(r1.getLink("rel1"), "Link-Header 'Link1' missing");
+            Assertions.assertNotNull(r1.getLink("rel2"), "Link-Header 'Link2' missing");
+            Assertions.assertNotNull(r1.getLink("rel3"), "Link-Header 'Link3' missing");
+            Assertions.assertNotNull(r1.getLink("rel4"), "Link-Header 'Link4' missing");
 
             @SuppressWarnings(value = "unchecked")
             Response r2 = Response.ok()
@@ -170,9 +170,9 @@ public class ResponseBuilderTest {
                     .links((Link[]) null)
                     .link("Link2", "rel2").build();
 
-            Assert.assertEquals(ERROR_MSG, 1, r2.getLinks().size());
-            Assert.assertNull("Link-Header 'Link1' was not removed", r2.getLink("rel1"));
-            Assert.assertNotNull("Link-Header 'Link2' missing", r2.getLink("rel2"));
+            Assertions.assertEquals(1, r2.getLinks().size(), ERROR_MSG);
+            Assertions.assertNull(r2.getLink("rel1"), "Link-Header 'Link1' was not removed");
+            Assertions.assertNotNull(r2.getLink("rel2"), "Link-Header 'Link2' missing");
         }
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/ResteasyHttpHeadersTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/ResteasyHttpHeadersTest.java
@@ -10,8 +10,8 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -30,12 +30,12 @@ public class ResteasyHttpHeadersTest {
         ResteasyHttpHeaders httpHeaders = new ResteasyHttpHeaders(modifiableMultivaluedMap);
         try {
             httpHeaders.getRequestHeader("Hello").add("Interdit");
-            Assert.fail("getRequestHeader() must return a read-only List");
+            Assertions.fail("getRequestHeader() must return a read-only List");
         } catch (UnsupportedOperationException e) {
         }
         try {
             httpHeaders.getRequestHeaders().clear();
-            Assert.fail("getRequestHeaders() must return a read-only Map");
+            Assertions.fail("getRequestHeaders() must return a read-only Map");
         } catch (UnsupportedOperationException e) {
         }
     }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/ResteasyUriBuilderTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/ResteasyUriBuilderTest.java
@@ -1,14 +1,14 @@
 package org.jboss.resteasy.test.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.net.URI;
 
 import jakarta.ws.rs.core.UriBuilder;
 
 import org.jboss.resteasy.specimpl.ResteasyUriBuilderImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -28,15 +28,15 @@ public class ResteasyUriBuilderTest {
     @Test
     public void testParseHierarchicalUri() {
         ResteasyUriBuilderImpl builder = new ResteasyUriBuilderImpl();
-        assertSame(URI_ERROR, builder, builder.uri("foo/bar:id"));
+        assertSame(builder, builder.uri("foo/bar:id"), URI_ERROR);
         builder = new ResteasyUriBuilderImpl();
-        assertSame(URI_ERROR, builder, builder.uri("/bar:id"));
+        assertSame(builder, builder.uri("/bar:id"), URI_ERROR);
         builder = new ResteasyUriBuilderImpl();
-        assertSame(URI_ERROR, builder, builder.uri("foo:bar/bar:id"));
+        assertSame(builder, builder.uri("foo:bar/bar:id"), URI_ERROR);
         builder = new ResteasyUriBuilderImpl();
-        assertSame(URI_ERROR, builder, builder.uri("foo:/bar"));
+        assertSame(builder, builder.uri("foo:/bar"), URI_ERROR);
         builder = new ResteasyUriBuilderImpl();
-        assertSame(URI_ERROR, builder, builder.uri("foo:bar"));
+        assertSame(builder, builder.uri("foo:bar"), URI_ERROR);
     }
 
     /**
@@ -47,12 +47,12 @@ public class ResteasyUriBuilderTest {
     @Test
     public void testUriWithFragment() {
         UriBuilder builder = ResteasyUriBuilderImpl.fromTemplate("http://domain.com/path#fragment=with/allowed/special-chars");
-        assertEquals(URI_FRAGMENT_ERROR, "http://domain.com/path#fragment=with/allowed/special-chars",
-                builder.build().toString());
+        assertEquals("http://domain.com/path#fragment=with/allowed/special-chars",
+                builder.build().toString(), URI_FRAGMENT_ERROR);
 
         builder = ResteasyUriBuilderImpl.fromTemplate("http://domain.com/path#fragment%with[forbidden}special<chars");
-        assertEquals(URI_FRAGMENT_ERROR, "http://domain.com/path#fragment%25with%5Bforbidden%7Dspecial%3Cchars",
-                builder.build().toString());
+        assertEquals("http://domain.com/path#fragment%25with%5Bforbidden%7Dspecial%3Cchars",
+                builder.build().toString(), URI_FRAGMENT_ERROR);
     }
 
     @Test
@@ -64,13 +64,13 @@ public class ResteasyUriBuilderTest {
                 .fromUri(baseAddr + "?foo=bar")
                 .replaceQueryParam("foo")
                 .build();
-        assertEquals(errorMsg, baseAddr, oneUri.toString());
+        assertEquals(baseAddr, oneUri.toString(), errorMsg);
 
         uBuilder = new ResteasyUriBuilderImpl();
         URI twoUri = uBuilder
                 .fromUri(baseAddr + "?foo=bar&foobar=qux")
                 .replaceQueryParam("foo")
                 .build();
-        assertEquals(errorMsg, baseAddr + "?foobar=qux", twoUri.toString());
+        assertEquals(baseAddr + "?foobar=qux", twoUri.toString(), errorMsg);
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/TypeConverterTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/TypeConverterTest.java
@@ -1,14 +1,14 @@
 package org.jboss.resteasy.test.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Date;
 
 import org.jboss.resteasy.util.TypeConverter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -26,23 +26,23 @@ public class TypeConverterTest {
      */
     @Test
     public void testBooleanTypes() {
-        assertTrue(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "T"));
-        assertTrue(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "t"));
-        assertTrue(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "Y"));
-        assertTrue(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "y"));
-        assertTrue(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "Yes"));
-        assertTrue(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "YES"));
-        assertTrue(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "TRUE"));
-        assertTrue(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "true"));
+        assertTrue(TypeConverter.getType(Boolean.class, "T"), CONVERSION_ERROR);
+        assertTrue(TypeConverter.getType(Boolean.class, "t"), CONVERSION_ERROR);
+        assertTrue(TypeConverter.getType(Boolean.class, "Y"), CONVERSION_ERROR);
+        assertTrue(TypeConverter.getType(Boolean.class, "y"), CONVERSION_ERROR);
+        assertTrue(TypeConverter.getType(Boolean.class, "Yes"), CONVERSION_ERROR);
+        assertTrue(TypeConverter.getType(Boolean.class, "YES"), CONVERSION_ERROR);
+        assertTrue(TypeConverter.getType(Boolean.class, "TRUE"), CONVERSION_ERROR);
+        assertTrue(TypeConverter.getType(Boolean.class, "true"), CONVERSION_ERROR);
 
-        assertFalse(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "F"));
-        assertFalse(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "f"));
-        assertFalse(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "N"));
-        assertFalse(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "n"));
-        assertFalse(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "No"));
-        assertFalse(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "No"));
-        assertFalse(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "FALSE"));
-        assertFalse(CONVERSION_ERROR, TypeConverter.getType(Boolean.class, "False"));
+        assertFalse(TypeConverter.getType(Boolean.class, "F"), CONVERSION_ERROR);
+        assertFalse(TypeConverter.getType(Boolean.class, "f"), CONVERSION_ERROR);
+        assertFalse(TypeConverter.getType(Boolean.class, "N"), CONVERSION_ERROR);
+        assertFalse(TypeConverter.getType(Boolean.class, "n"), CONVERSION_ERROR);
+        assertFalse(TypeConverter.getType(Boolean.class, "No"), CONVERSION_ERROR);
+        assertFalse(TypeConverter.getType(Boolean.class, "No"), CONVERSION_ERROR);
+        assertFalse(TypeConverter.getType(Boolean.class, "FALSE"), CONVERSION_ERROR);
+        assertFalse(TypeConverter.getType(Boolean.class, "False"), CONVERSION_ERROR);
     }
 
     /**
@@ -51,8 +51,8 @@ public class TypeConverterTest {
      */
     @Test
     public void testIntegerTypes() {
-        assertEquals(CONVERSION_ERROR, 11, (int) TypeConverter.getType(int.class, "11"));
-        assertEquals(CONVERSION_ERROR, 11, (int) TypeConverter.getType(Integer.class, "11"));
+        assertEquals(11, (int) TypeConverter.getType(int.class, "11"), CONVERSION_ERROR);
+        assertEquals(11, (int) TypeConverter.getType(Integer.class, "11"), CONVERSION_ERROR);
     }
 
     /**
@@ -61,8 +61,10 @@ public class TypeConverterTest {
      */
     @Test
     public void testDoubleTypes() {
-        assertEquals(CONVERSION_ERROR, 20.15d, TypeConverter.getType(double.class, "20.15"), 0);
-        assertEquals(CONVERSION_ERROR, 20.15d, TypeConverter.getType(Double.class, "20.15"), 0);
+        assertEquals(20.15d, TypeConverter.getType(double.class, "20.15"), 0,
+                CONVERSION_ERROR);
+        assertEquals(20.15d, TypeConverter.getType(Double.class, "20.15"), 0,
+                CONVERSION_ERROR);
     }
 
     /**
@@ -71,8 +73,8 @@ public class TypeConverterTest {
      */
     @Test
     public void testFloatTypes() {
-        assertEquals(CONVERSION_ERROR, 23.44f, TypeConverter.getType(float.class, "23.44"), 0);
-        assertEquals(CONVERSION_ERROR, 23.44f, TypeConverter.getType(Float.class, "23.44"), 0);
+        assertEquals(23.44f, TypeConverter.getType(float.class, "23.44"), 0, CONVERSION_ERROR);
+        assertEquals(23.44f, TypeConverter.getType(Float.class, "23.44"), 0, CONVERSION_ERROR);
     }
 
     /**
@@ -81,8 +83,8 @@ public class TypeConverterTest {
      */
     @Test
     public void testLongTypes() {
-        assertEquals(CONVERSION_ERROR, 23L, (long) TypeConverter.getType(long.class, "23"));
-        assertEquals(CONVERSION_ERROR, 23L, (long) TypeConverter.getType(Long.class, "23"));
+        assertEquals(23L, (long) TypeConverter.getType(long.class, "23"), CONVERSION_ERROR);
+        assertEquals(23L, (long) TypeConverter.getType(Long.class, "23"), CONVERSION_ERROR);
     }
 
     /**
@@ -90,8 +92,8 @@ public class TypeConverterTest {
      */
     @Test
     public void testCharacterTypes() {
-        assertEquals(CONVERSION_ERROR, 'A', TypeConverter.getType(Character.class, "A").charValue());
-        assertEquals(CONVERSION_ERROR, 'A', (char) TypeConverter.getType(char.class, "A"));
+        assertEquals('A', TypeConverter.getType(Character.class, "A").charValue(), CONVERSION_ERROR);
+        assertEquals('A', (char) TypeConverter.getType(char.class, "A"), CONVERSION_ERROR);
     }
 
     /**
@@ -102,7 +104,7 @@ public class TypeConverterTest {
     public void testDate() {
         try {
             TypeConverter.getType(Date.class, "07/04/2008");
-            Assert.fail("Exception was excepted.");
+            Assertions.fail("Exception was excepted.");
         } catch (IllegalArgumentException e) {
             // ok
         }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/TypesBuiltInTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/TypesBuiltInTest.java
@@ -1,6 +1,6 @@
 package org.jboss.resteasy.test.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.Type;
 
@@ -12,7 +12,7 @@ import org.jboss.resteasy.spi.util.Types;
 import org.jboss.resteasy.test.util.resource.TypesParamConverterPOJO;
 import org.jboss.resteasy.test.util.resource.TypesTestProvider;
 import org.jboss.resteasy.test.util.resource.TypesTestProviderSubclass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -29,16 +29,16 @@ public class TypesBuiltInTest {
     @Test
     public void testGetInterfaceArgumentFromSimpleType() {
         Type[] parameters = Types.getActualTypeArgumentsOfAnInterface(TypesTestProvider.class, ExceptionMapper.class);
-        assertEquals("Wrong count of parameters", 1, parameters.length);
-        assertEquals("Wrong type of exception", NullPointerException.class, (Class<?>) parameters[0]);
+        assertEquals(1, parameters.length, "Wrong count of parameters");
+        assertEquals(NullPointerException.class, (Class<?>) parameters[0], "Wrong type of exception");
 
         parameters = Types.getActualTypeArgumentsOfAnInterface(TypesTestProvider.class, MarshalledEntity.class);
-        assertEquals("Wrong count of parameters", 1, parameters.length);
-        assertEquals("Wrong type of parameter", Integer.class, (Class<?>) parameters[0]);
+        assertEquals(1, parameters.length, "Wrong count of parameters");
+        assertEquals(Integer.class, (Class<?>) parameters[0], "Wrong type of parameter");
 
         parameters = Types.getActualTypeArgumentsOfAnInterface(TypesTestProvider.class, ParamConverter.class);
-        assertEquals("Wrong count of parameters", 1, parameters.length);
-        assertEquals("Wrong type of parameter", TypesParamConverterPOJO.class, (Class<?>) parameters[0]);
+        assertEquals(1, parameters.length, "Wrong count of parameters");
+        assertEquals(TypesParamConverterPOJO.class, (Class<?>) parameters[0], "Wrong type of parameter");
     }
 
     /**
@@ -50,15 +50,15 @@ public class TypesBuiltInTest {
     @Test
     public void testGetInterfaceArgumentFromSubclass() {
         Type[] parameters = Types.getActualTypeArgumentsOfAnInterface(TypesTestProviderSubclass.class, ExceptionMapper.class);
-        assertEquals("Wrong count of parameters", 1, parameters.length);
-        assertEquals("Wrong type of exception", NullPointerException.class, (Class<?>) parameters[0]);
+        assertEquals(1, parameters.length, "Wrong count of parameters");
+        assertEquals(NullPointerException.class, (Class<?>) parameters[0], "Wrong type of exception");
 
         parameters = Types.getActualTypeArgumentsOfAnInterface(TypesTestProviderSubclass.class, MarshalledEntity.class);
-        assertEquals("Wrong count of parameters", 1, parameters.length);
-        assertEquals("Wrong type of parameter", Integer.class, (Class<?>) parameters[0]);
+        assertEquals(1, parameters.length, "Wrong count of parameters");
+        assertEquals(Integer.class, (Class<?>) parameters[0], "Wrong type of parameter");
 
         parameters = Types.getActualTypeArgumentsOfAnInterface(TypesTestProviderSubclass.class, ParamConverter.class);
-        assertEquals("Wrong count of parameters", 1, parameters.length);
-        assertEquals("Wrong type of parameter", TypesParamConverterPOJO.class, (Class<?>) parameters[0]);
+        assertEquals(1, parameters.length, "Wrong count of parameters");
+        assertEquals(TypesParamConverterPOJO.class, (Class<?>) parameters[0], "Wrong type of parameter");
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/TypesGenericTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/TypesGenericTest.java
@@ -14,8 +14,8 @@ import org.jboss.resteasy.test.util.resource.TypesGenericClassSub;
 import org.jboss.resteasy.test.util.resource.TypesGenericFooBar;
 import org.jboss.resteasy.test.util.resource.TypesGenericSub;
 import org.jboss.resteasy.test.util.resource.TypesGenericSubClass;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -38,24 +38,24 @@ public class TypesGenericTest {
             logger.debug(t);
         }
 
-        Assert.assertEquals("Expected type for the class doesn't match", types[0], Float.class);
+        Assertions.assertEquals(types[0], Float.class, "Expected type for the class doesn't match");
 
         types = Types.findParameterizedTypes(TypesGenericSubClass.class, TypesGenericBar.class);
         for (Type t : types) {
             logger.debug(t);
         }
 
-        Assert.assertEquals("Expected type for the class doesn't match", types[0], Float.class);
+        Assertions.assertEquals(types[0], Float.class, "Expected type for the class doesn't match");
 
         types = Types.findParameterizedTypes(TypesGenericSub.class, TypesGenericBar.class);
         for (Type t : types) {
             logger.debug(t);
         }
 
-        Assert.assertEquals("Expected type for the class doesn't match", types[0], Float.class);
+        Assertions.assertEquals(types[0], Float.class, "Expected type for the class doesn't match");
 
         types = Types.findParameterizedTypes(TypesGenericAnotherFooBar.class, TypesGenericAnotherBar.class);
-        Assert.assertEquals("No parametrized type expected", 0, types.length);
+        Assertions.assertEquals(0, types.length, "No parametrized type expected");
     }
 
     /**
@@ -83,9 +83,8 @@ public class TypesGenericTest {
             }
         }
 
-        Assert.assertEquals(
-                "The method implemented by the class an returned by getImplementingMethod() is not the expected one",
-                implented, actual);
+        Assertions.assertEquals(implented, actual,
+                "The method implemented by the class an returned by getImplementingMethod() is not the expected one");
     }
 
     /**
@@ -99,14 +98,14 @@ public class TypesGenericTest {
             logger.debug(t);
         }
 
-        Assert.assertEquals("Expected type for the class doesn't match", types[0], Float.class);
+        Assertions.assertEquals(types[0], Float.class, "Expected type for the class doesn't match");
 
         types = Types.findParameterizedTypes(TypesGenericClassSub.class, TypesGenericClassBar.class);
         for (Type t : types) {
             logger.debug(t);
         }
 
-        Assert.assertEquals("Expected type for the class doesn't match", types[0], Float.class);
+        Assertions.assertEquals(types[0], Float.class, "Expected type for the class doesn't match");
 
     }
 }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/UnmodifiableMultivaluedMapTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/UnmodifiableMultivaluedMapTest.java
@@ -15,8 +15,8 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.jboss.resteasy.specimpl.UnmodifiableMultivaluedMap;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -52,79 +52,79 @@ public class UnmodifiableMultivaluedMapTest {
     private void doTest(UnmodifiableMultivaluedMap<String, String> unmodifiableMultivaluedMap) {
         try {
             unmodifiableMultivaluedMap.add("Forbidden", "Interdit");
-            Assert.fail("Add() must not be supported on an unmodifiable multi valued map");
+            Assertions.fail("Add() must not be supported on an unmodifiable multi valued map");
         } catch (UnsupportedOperationException e) {
         }
 
         try {
             unmodifiableMultivaluedMap.addAll("Forbidden", Arrays.asList("Interdit"));
-            Assert.fail("addAll() must not be supported on an unmodifiable multi valued Map");
+            Assertions.fail("addAll() must not be supported on an unmodifiable multi valued Map");
         } catch (UnsupportedOperationException e) {
         }
 
         try {
             unmodifiableMultivaluedMap.addAll("Forbidden", "Interdit");
-            Assert.fail("addAll() must not be supported on an unmodifiable multi valued Map");
+            Assertions.fail("addAll() must not be supported on an unmodifiable multi valued Map");
         } catch (UnsupportedOperationException e) {
         }
 
         try {
             unmodifiableMultivaluedMap.addFirst("Forbidden", "Interdit");
-            Assert.fail("addFirst() must not be supported on an unmodifiable multi valued Map");
+            Assertions.fail("addFirst() must not be supported on an unmodifiable multi valued Map");
         } catch (UnsupportedOperationException e) {
         }
 
         try {
             unmodifiableMultivaluedMap.clear();
-            Assert.fail("clear() must not be supported on an unmodifiable multi valued Map");
+            Assertions.fail("clear() must not be supported on an unmodifiable multi valued Map");
         } catch (UnsupportedOperationException e) {
         }
 
         try {
             unmodifiableMultivaluedMap.remove("Hello");
-            Assert.fail("remove() must not be supported on an unmodifiable multi valued Map");
+            Assertions.fail("remove() must not be supported on an unmodifiable multi valued Map");
         } catch (UnsupportedOperationException e) {
         }
 
         try {
             unmodifiableMultivaluedMap.put("Forbidden", Arrays.asList("Interdit"));
-            Assert.fail("put() must not be supported on an unmodifiable multi valued Map");
+            Assertions.fail("put() must not be supported on an unmodifiable multi valued Map");
         } catch (UnsupportedOperationException e) {
         }
 
         try {
             unmodifiableMultivaluedMap.putSingle("Forbidden", "Interdit");
-            Assert.fail("putSingle() must not be supported on an unmodifiable multi valued Map");
+            Assertions.fail("putSingle() must not be supported on an unmodifiable multi valued Map");
         } catch (UnsupportedOperationException e) {
         }
 
         try {
             unmodifiableMultivaluedMap.putAll(Collections.singletonMap("Forbidden", Arrays.asList("Interdit")));
-            Assert.fail("putAll() must not be supported on an unmodifiable multi valued Map");
+            Assertions.fail("putAll() must not be supported on an unmodifiable multi valued Map");
         } catch (UnsupportedOperationException e) {
         }
 
         try {
             unmodifiableMultivaluedMap.keySet().add("Forbidden");
-            Assert.fail("keySet() must return an unmodifiable Set");
+            Assertions.fail("keySet() must return an unmodifiable Set");
         } catch (UnsupportedOperationException e) {
         }
 
         try {
             unmodifiableMultivaluedMap.values().add(Arrays.asList("Interdit"));
-            Assert.fail("values() must return an unmodifiable Collection");
+            Assertions.fail("values() must return an unmodifiable Collection");
         } catch (UnsupportedOperationException e) {
         }
 
         try {
             unmodifiableMultivaluedMap.get("Hello").add("Interdit");
-            Assert.fail("get() must return an unmodifiable List");
+            Assertions.fail("get() must return an unmodifiable List");
         } catch (UnsupportedOperationException e) {
         }
 
         try {
             unmodifiableMultivaluedMap.entrySet().clear();
-            Assert.fail("entrySet() must return an unmodifiable Set");
+            Assertions.fail("entrySet() must return an unmodifiable Set");
         } catch (UnsupportedOperationException e) {
         }
 
@@ -132,7 +132,7 @@ public class UnmodifiableMultivaluedMapTest {
             for (Entry<String, List<String>> entry : unmodifiableMultivaluedMap.entrySet()) {
                 entry.setValue(Arrays.asList("Interdit"));
             }
-            Assert.fail("entry must be unmodifiable");
+            Assertions.fail("entry must be unmodifiable");
         } catch (UnsupportedOperationException e) {
         }
 
@@ -140,7 +140,7 @@ public class UnmodifiableMultivaluedMapTest {
             for (Entry<String, List<String>> entry : unmodifiableMultivaluedMap.entrySet()) {
                 entry.getValue().add("Interdit");
             }
-            Assert.fail("entry must be unmodifiable");
+            Assertions.fail("entry must be unmodifiable");
         } catch (UnsupportedOperationException e) {
         }
     }

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/UriBuilderTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/UriBuilderTest.java
@@ -12,8 +12,8 @@ import jakarta.ws.rs.core.UriBuilder;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.spi.ResteasyUriBuilder;
 import org.jboss.resteasy.test.util.resource.UriBuilderResource;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -42,7 +42,7 @@ public class UriBuilderTest {
         {
             try {
                 UriBuilder.fromUri(":cts:8080//tck:90090//jaxrs ");
-                Assert.fail(ERROR_MSG);
+                Assertions.fail(ERROR_MSG);
             } catch (IllegalArgumentException e) {
                 // ok
             }
@@ -75,7 +75,7 @@ public class UriBuilderTest {
             builder.host(null);
             URI uri = builder.build();
             logger.info(uri.toString());
-            Assert.assertEquals(ERROR_MSG, uri.toString(), "/foo/bar");
+            Assertions.assertEquals(uri.toString(), "/foo/bar", ERROR_MSG);
 
         }
 
@@ -83,31 +83,31 @@ public class UriBuilderTest {
         {
             UriBuilder builder = UriBuilder.fromUri("http://{host}/x/y/{path}?{q}={qval}");
             String template = builder.toTemplate();
-            Assert.assertEquals(ERROR_MSG, template, "http://{host}/x/y/{path}?{q}={qval}");
+            Assertions.assertEquals(template, "http://{host}/x/y/{path}?{q}={qval}", ERROR_MSG);
             builder = builder.resolveTemplate("host", "localhost");
             template = builder.toTemplate();
-            Assert.assertEquals(ERROR_MSG, template, "http://localhost/x/y/{path}?{q}={qval}");
+            Assertions.assertEquals(template, "http://localhost/x/y/{path}?{q}={qval}", ERROR_MSG);
 
             builder = builder.resolveTemplate("q", "name");
             template = builder.toTemplate();
-            Assert.assertEquals(ERROR_MSG, template, "http://localhost/x/y/{path}?name={qval}");
+            Assertions.assertEquals(template, "http://localhost/x/y/{path}?name={qval}", ERROR_MSG);
             Map<String, Object> values = new HashMap<>();
             values.put("path", "z");
             values.put("qval", 42);
             builder = builder.resolveTemplates(values);
             template = builder.toTemplate();
-            Assert.assertEquals(ERROR_MSG, template, "http://localhost/x/y/z?name=42");
+            Assertions.assertEquals(template, "http://localhost/x/y/z?name=42", ERROR_MSG);
 
             // RESTEASY-1878 - test if regex templates work
             // see jakarta.ws.rs.core.UriBuilder class description for info about regex template parameters
             builder = UriBuilder.fromUri("{id: [0-9]+}");
-            Assert.assertEquals(new URI("123"), builder.build("123"));
+            Assertions.assertEquals(new URI("123"), builder.build("123"));
 
             builder = UriBuilder.fromUri("{id: [a-z]+}");
-            Assert.assertEquals(new URI("abcd"), builder.build("abcd"));
+            Assertions.assertEquals(new URI("abcd"), builder.build("abcd"));
 
             builder = UriBuilder.fromUri("/resources/{id: [0-9]+}");
-            Assert.assertEquals(new URI("/resources/123"), builder.build("123"));
+            Assertions.assertEquals(new URI("/resources/123"), builder.build("123"));
             // end of RESTEASY-1878
         }
 
@@ -130,7 +130,7 @@ public class UriBuilderTest {
             builder.queryParam("msg", "emoji stuff %EE%81%96%EE%90%8F");
             URI uri = builder.build();
             logger.info(uri);
-            Assert.assertEquals(ERROR_MSG, "/my/url?msg=emoji+stuff+%EE%81%96%EE%90%8F", uri.toString());
+            Assertions.assertEquals("/my/url?msg=emoji+stuff+%EE%81%96%EE%90%8F", uri.toString(), ERROR_MSG);
 
         }
 
@@ -138,7 +138,7 @@ public class UriBuilderTest {
         {
             UriBuilder builder = UriBuilder.fromPath("/foo");
             builder.queryParam("mama", "   ");
-            Assert.assertEquals(ERROR_MSG, builder.build().toString(), "/foo?mama=+++");
+            Assertions.assertEquals(builder.build().toString(), "/foo?mama=+++", ERROR_MSG);
         }
 
         // testQuery2
@@ -146,73 +146,73 @@ public class UriBuilderTest {
             UriBuilder builder = UriBuilder.fromUri("http://localhost/test");
             builder.replaceQuery("a={b}");
             URI uri = builder.build("=");
-            Assert.assertEquals(ERROR_MSG, uri.toString(), "http://localhost/test?a=%3D");
+            Assertions.assertEquals(uri.toString(), "http://localhost/test?a=%3D", ERROR_MSG);
         }
 
         // testReplaceScheme
         {
             URI bu = UriBuilder.fromUri("http://localhost:8080/a/b/c").scheme("https").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("https://localhost:8080/a/b/c"), bu);
+            Assertions.assertEquals(URI.create("https://localhost:8080/a/b/c"), bu, ERROR_MSG);
         }
 
         // testReplaceUserInfo
         {
             URI bu = UriBuilder.fromUri("http://bob@localhost:8080/a/b/c").userInfo("sue").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://sue@localhost:8080/a/b/c"), bu);
+            Assertions.assertEquals(URI.create("http://sue@localhost:8080/a/b/c"), bu, ERROR_MSG);
         }
 
         // testReplaceHost
         {
             URI bu = UriBuilder.fromUri("http://localhost:8080/a/b/c").host("a.com").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://a.com:8080/a/b/c"), bu);
+            Assertions.assertEquals(URI.create("http://a.com:8080/a/b/c"), bu, ERROR_MSG);
         }
 
         // testReplacePort
         {
             URI bu = UriBuilder.fromUri("http://localhost:8080/a/b/c").port(9090).build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:9090/a/b/c"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:9090/a/b/c"), bu, ERROR_MSG);
 
             bu = UriBuilder.fromUri("http://localhost:8080/a/b/c").port(-1).build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost/a/b/c"), bu);
+            Assertions.assertEquals(URI.create("http://localhost/a/b/c"), bu, ERROR_MSG);
         }
 
         // testReplacePath
         {
             URI bu = UriBuilder.fromUri("http://localhost:8080/a/b/c").replacePath("/x/y/z").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/x/y/z"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/x/y/z"), bu, ERROR_MSG);
         }
 
         // testReplaceMatrixParam
         {
             URI bu = UriBuilder.fromUri("http://localhost:8080/a/b/c;a=x;b=y").replaceMatrix("x=a;y=b").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c;x=a;y=b"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c;x=a;y=b"), bu, ERROR_MSG);
             UriBuilder builder = UriBuilder.fromUri("http://localhost:8080/a").path("/{b:B{0,10}}/c;a=x;b=y");
             builder.replaceMatrixParam("a", "1", "2");
             bu = builder.build("B");
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/B/c;b=y;a=1;a=2"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/B/c;b=y;a=1;a=2"), bu, ERROR_MSG);
 
             // test removal
 
             bu = UriBuilder.fromUri("http://localhost:8080/a/b/c;a=x;b=y").replaceMatrixParam("a", (Object[]) null).build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c;b=y"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c;b=y"), bu, ERROR_MSG);
         }
 
         // testReplaceQueryParams
         {
             URI bu = UriBuilder.fromUri("http://localhost:8080/a/b/c?a=x&b=y").replaceQuery("x=a&y=b").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c?x=a&y=b"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c?x=a&y=b"), bu, ERROR_MSG);
 
             UriBuilder builder = UriBuilder.fromUri("http://localhost:8080/a/b/c?a=x&b=y");
             builder.replaceQueryParam("a", "1", "2");
             bu = builder.build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c?b=y&a=1&a=2"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c?b=y&a=1&a=2"), bu, ERROR_MSG);
 
         }
 
         // testReplaceFragment
         {
             URI bu = UriBuilder.fromUri("http://localhost:8080/a/b/c?a=x&b=y#frag").fragment("ment").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c?a=x&b=y#ment"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c?a=x&b=y#ment"), bu, ERROR_MSG);
         }
 
         // testReplaceUri
@@ -221,22 +221,22 @@ public class UriBuilderTest {
 
             UriBuilder uriBuilder = UriBuilder.fromUri(u);
             URI bu = uriBuilder.uri(URI.create("https://bob@localhost:8080")).build();
-            Assert.assertEquals(ERROR_MSG, URI.create("https://bob@localhost:8080/a/b/c?a=x&b=y#frag"), bu);
+            Assertions.assertEquals(URI.create("https://bob@localhost:8080/a/b/c?a=x&b=y#frag"), bu, ERROR_MSG);
 
             bu = UriBuilder.fromUri(u).uri(URI.create("https://sue@localhost:8080")).build();
-            Assert.assertEquals(ERROR_MSG, URI.create("https://sue@localhost:8080/a/b/c?a=x&b=y#frag"), bu);
+            Assertions.assertEquals(URI.create("https://sue@localhost:8080/a/b/c?a=x&b=y#frag"), bu, ERROR_MSG);
 
             bu = UriBuilder.fromUri(u).uri(URI.create("https://sue@localhost:9090")).build();
-            Assert.assertEquals(ERROR_MSG, URI.create("https://sue@localhost:9090/a/b/c?a=x&b=y#frag"), bu);
+            Assertions.assertEquals(URI.create("https://sue@localhost:9090/a/b/c?a=x&b=y#frag"), bu, ERROR_MSG);
 
             bu = UriBuilder.fromUri(u).uri(URI.create("/x/y/z")).build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://bob@localhost:8080/x/y/z?a=x&b=y#frag"), bu);
+            Assertions.assertEquals(URI.create("http://bob@localhost:8080/x/y/z?a=x&b=y#frag"), bu, ERROR_MSG);
 
             bu = UriBuilder.fromUri(u).uri(URI.create("?x=a&b=y")).build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://bob@localhost:8080/a/b/c?x=a&b=y#frag"), bu);
+            Assertions.assertEquals(URI.create("http://bob@localhost:8080/a/b/c?x=a&b=y#frag"), bu, ERROR_MSG);
 
             bu = UriBuilder.fromUri(u).uri(URI.create("#ment")).build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://bob@localhost:8080/a/b/c?a=x&b=y#ment"), bu);
+            Assertions.assertEquals(URI.create("http://bob@localhost:8080/a/b/c?a=x&b=y#ment"), bu, ERROR_MSG);
         }
 
         // testSchemeSpecificPart
@@ -244,76 +244,76 @@ public class UriBuilderTest {
             URI u = URI.create("http://bob@localhost:8080/a/b/c?a=x&b=y#frag");
 
             URI bu = UriBuilder.fromUri(u).schemeSpecificPart("//sue@remotehost:9090/x/y/z?x=a&y=b").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://sue@remotehost:9090/x/y/z?x=a&y=b#frag"), bu);
+            Assertions.assertEquals(URI.create("http://sue@remotehost:9090/x/y/z?x=a&y=b#frag"), bu, ERROR_MSG);
         }
 
         // testAppendPath
         {
             URI bu = UriBuilder.fromUri("http://localhost:8080/a/b/c/").path("/").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c/"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c/"), bu, ERROR_MSG);
 
             bu = UriBuilder.fromUri("http://localhost:8080/a/b/c/").path("/x/y/z").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c/x/y/z"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c/x/y/z"), bu, ERROR_MSG);
 
             bu = UriBuilder.fromUri("http://localhost:8080/a/b/c").path("/x/y/z").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c/x/y/z"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c/x/y/z"), bu, ERROR_MSG);
 
             bu = UriBuilder.fromUri("http://localhost:8080/a/b/c").path("x/y/z").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c/x/y/z"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c/x/y/z"), bu, ERROR_MSG);
 
             bu = UriBuilder.fromUri("http://localhost:8080/a/b/c").path("/").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c/"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c/"), bu, ERROR_MSG);
 
             bu = UriBuilder.fromUri("http://localhost:8080/a/b/c").path("").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c"), bu, ERROR_MSG);
 
             bu = UriBuilder.fromUri("http://localhost:8080/a%20/b%20/c%20").path("/x /y /z ").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a%20/b%20/c%20/x%20/y%20/z%20"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a%20/b%20/c%20/x%20/y%20/z%20"), bu, ERROR_MSG);
         }
 
         // testAppendQueryParams
         {
             URI bu = UriBuilder.fromUri("http://localhost:8080/a/b/c?a=x&b=y").queryParam("c", "z").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c?a=x&b=y&c=z"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c?a=x&b=y&c=z"), bu, ERROR_MSG);
         }
 
         // testQueryParamsEncoding
         {
             URI bu = UriBuilder.fromUri("http://localhost:8080/a/b/c?a=x&b=y").queryParam("c", "z=z/z").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c?a=x&b=y&c=z%3Dz%2Fz"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c?a=x&b=y&c=z%3Dz%2Fz"), bu, ERROR_MSG);
         }
 
         // testAppendMatrixParams
         {
             URI bu = UriBuilder.fromUri("http://localhost:8080/a/b/c;a=x;b=y").matrixParam("c", "z").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c;a=x;b=y;c=z"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c;a=x;b=y;c=z"), bu, ERROR_MSG);
         }
 
         // testResourceAppendPath
         {
             URI ub = UriBuilder.fromUri("http://localhost:8080/base").path(UriBuilderResource.class).build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/base/resource"), ub);
+            Assertions.assertEquals(URI.create("http://localhost:8080/base/resource"), ub, ERROR_MSG);
 
             ub = UriBuilder.fromUri("http://localhost:8080/base").path(UriBuilderResource.class, "get").build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/base/method"), ub);
+            Assertions.assertEquals(URI.create("http://localhost:8080/base/method"), ub, ERROR_MSG);
 
             Method get = UriBuilderResource.class.getMethod("get");
             Method locator = UriBuilderResource.class.getMethod("locator");
             ub = UriBuilder.fromUri("http://localhost:8080/base").path(get).path(locator).build();
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/base/method/locator"), ub);
+            Assertions.assertEquals(URI.create("http://localhost:8080/base/method/locator"), ub, ERROR_MSG);
         }
 
         // testTemplates
         {
             URI bu = UriBuilder.fromUri("http://localhost:8080/a/b/c").path("/{foo}/{bar}/{baz}/{foo}").build("x", "y", "z");
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c/x/y/z/x"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c/x/y/z/x"), bu, ERROR_MSG);
 
             Map<String, Object> m = new HashMap<>();
             m.put("foo", "x");
             m.put("bar", "y");
             m.put("baz", "z");
             bu = UriBuilder.fromUri("http://localhost:8080/a/b/c").path("/{foo}/{bar}/{baz}/{foo}").buildFromMap(m);
-            Assert.assertEquals(ERROR_MSG, URI.create("http://localhost:8080/a/b/c/x/y/z/x"), bu);
+            Assertions.assertEquals(URI.create("http://localhost:8080/a/b/c/x/y/z/x"), bu, ERROR_MSG);
         }
 
         // testClone
@@ -322,8 +322,8 @@ public class UriBuilderTest {
             URI full = ub.clone().path("b").build();
             URI base = ub.build();
 
-            Assert.assertEquals(ERROR_MSG, URI.create("http://user@localhost:8080/a?query#fragment"), base);
-            Assert.assertEquals(ERROR_MSG, URI.create("http://user@localhost:8080/a/b?query#fragment"), full);
+            Assertions.assertEquals(URI.create("http://user@localhost:8080/a?query#fragment"), base, ERROR_MSG);
+            Assertions.assertEquals(URI.create("http://user@localhost:8080/a/b?query#fragment"), full, ERROR_MSG);
         }
 
         // FromUriTest3 - Create an UriBuilder instance using uriBuilder.fromUri(String)
@@ -364,21 +364,21 @@ public class UriBuilderTest {
                 map.put("id", "something %%20something");
 
                 URI uri = impl.buildFromMap(map);
-                Assert.assertEquals(ERROR_MSG, "/foo/something%20%25%2520something", uri.toString());
+                Assertions.assertEquals("/foo/something%20%25%2520something", uri.toString(), ERROR_MSG);
             }
             {
                 ResteasyUriBuilder impl = (ResteasyUriBuilder) UriBuilder.fromPath("/foo/{id}");
                 map.clear();
                 map.put("id", "something something");
                 URI uri = impl.buildFromMap(map);
-                Assert.assertEquals(ERROR_MSG, "/foo/something%20something", uri.toString());
+                Assertions.assertEquals("/foo/something%20something", uri.toString(), ERROR_MSG);
             }
             {
                 ResteasyUriBuilder impl = (ResteasyUriBuilder) UriBuilder.fromPath("/foo/{id}");
                 map.clear();
                 map.put("id", "something%20something");
                 URI uri = impl.buildFromEncodedMap(map);
-                Assert.assertEquals(ERROR_MSG, "/foo/something%20something", uri.toString());
+                Assertions.assertEquals("/foo/something%20something", uri.toString(), ERROR_MSG);
             }
 
             {
@@ -386,21 +386,21 @@ public class UriBuilderTest {
 
                 impl.substitutePathParam("id", "something %%20something", false);
                 URI uri = impl.build();
-                Assert.assertEquals(ERROR_MSG, "/foo/something%20%25%20something", uri.toString());
+                Assertions.assertEquals("/foo/something%20%25%20something", uri.toString(), ERROR_MSG);
             }
             {
                 ResteasyUriBuilder impl = (ResteasyUriBuilder) UriBuilder.fromPath("/foo/{id}");
 
                 impl.substitutePathParam("id", "something something", false);
                 URI uri = impl.build();
-                Assert.assertEquals(ERROR_MSG, "/foo/something%20something", uri.toString());
+                Assertions.assertEquals("/foo/something%20something", uri.toString(), ERROR_MSG);
             }
             {
                 ResteasyUriBuilder impl = (ResteasyUriBuilder) UriBuilder.fromPath("/foo/{id}");
 
                 impl.substitutePathParam("id", "something%20something", true);
                 URI uri = impl.build();
-                Assert.assertEquals(ERROR_MSG, "/foo/something%20something", uri.toString());
+                Assertions.assertEquals("/foo/something%20something", uri.toString(), ERROR_MSG);
             }
         }
 
@@ -435,7 +435,7 @@ public class UriBuilderTest {
             if (!pass) {
                 logger.info(sb.toString());
             }
-            Assert.assertTrue(ERROR_MSG, pass);
+            Assertions.assertTrue(pass, ERROR_MSG);
         }
 
         // testEncodedMapTest3 - from TCK 1.1
@@ -769,24 +769,24 @@ public class UriBuilderTest {
             builder.path("{d}");
 
             URI uri = builder.build("A/B", "C/D");
-            Assert.assertEquals(ERROR_MSG, "http://A%2FB/C%2FD", uri.toString());
+            Assertions.assertEquals("http://A%2FB/C%2FD", uri.toString(), ERROR_MSG);
 
             uri = builder.buildFromEncoded("A/B", "C/D");
-            Assert.assertEquals(ERROR_MSG, "http://A/B/C/D", uri.toString());
+            Assertions.assertEquals("http://A/B/C/D", uri.toString(), ERROR_MSG);
             Object[] params = { "A/B", "C/D" };
             uri = builder.build(params, false);
-            Assert.assertEquals(ERROR_MSG, "http://A/B/C/D", uri.toString());
+            Assertions.assertEquals("http://A/B/C/D", uri.toString(), ERROR_MSG);
 
             HashMap<String, Object> map = new HashMap<>();
             map.put("host", "A/B");
             map.put("d", "C/D");
 
             uri = builder.buildFromMap(map);
-            Assert.assertEquals(ERROR_MSG, "http://A%2FB/C%2FD", uri.toString());
+            Assertions.assertEquals("http://A%2FB/C%2FD", uri.toString(), ERROR_MSG);
             uri = builder.buildFromEncodedMap(map);
-            Assert.assertEquals(ERROR_MSG, "http://A/B/C/D", uri.toString());
+            Assertions.assertEquals("http://A/B/C/D", uri.toString(), ERROR_MSG);
             uri = builder.buildFromMap(map, false);
-            Assert.assertEquals(ERROR_MSG, "http://A/B/C/D", uri.toString());
+            Assertions.assertEquals("http://A/B/C/D", uri.toString(), ERROR_MSG);
 
         }
 
@@ -795,22 +795,22 @@ public class UriBuilderTest {
             URI from = URI.create("a/b/c");
             URI to = URI.create("a/b/c/d/e");
             URI relativized = ResteasyUriBuilder.relativize(from, to);
-            Assert.assertEquals(ERROR_MSG, relativized.toString(), "d/e");
+            Assertions.assertEquals(relativized.toString(), "d/e", ERROR_MSG);
 
             from = URI.create("a/b/c");
             to = URI.create("d/e");
             relativized = ResteasyUriBuilder.relativize(from, to);
-            Assert.assertEquals(ERROR_MSG, relativized.toString(), "../../../d/e");
+            Assertions.assertEquals(relativized.toString(), "../../../d/e", ERROR_MSG);
 
             from = URI.create("a/b/c");
             to = URI.create("a/b/c");
             relativized = ResteasyUriBuilder.relativize(from, to);
-            Assert.assertEquals(ERROR_MSG, relativized.toString(), "");
+            Assertions.assertEquals(relativized.toString(), "", ERROR_MSG);
 
             from = URI.create("a");
             to = URI.create("d/e");
             relativized = ResteasyUriBuilder.relativize(from, to);
-            Assert.assertEquals(ERROR_MSG, relativized.toString(), "../d/e");
+            Assertions.assertEquals(relativized.toString(), "../d/e", ERROR_MSG);
         }
 
         // testPercentage
@@ -828,7 +828,7 @@ public class UriBuilderTest {
                     .build(new Object[] { s[0], s[1], s[2], s[3], s[1] }, true);
             logger.info(uri.getRawPath());
             logger.info(ENCODED_EXPECTED_PATH);
-            Assert.assertEquals(ERROR_MSG, uri.getRawPath(), ENCODED_EXPECTED_PATH);
+            Assertions.assertEquals(uri.getRawPath(), ENCODED_EXPECTED_PATH, ERROR_MSG);
         }
 
         // testNull
@@ -837,7 +837,7 @@ public class UriBuilderTest {
 
             try {
                 UriBuilder.fromUri(uri);
-                Assert.fail("expected IllegalArgumentException");
+                Assertions.fail("expected IllegalArgumentException");
             } catch (IllegalArgumentException ilex) {
             }
 
@@ -847,13 +847,13 @@ public class UriBuilderTest {
         {
             try {
                 UriBuilder.fromPath("http://localhost:8080").matrixParam(null, "x", "y");
-                Assert.fail(ERROR_MSG);
+                Assertions.fail(ERROR_MSG);
             } catch (IllegalArgumentException e) {
 
             }
             try {
                 UriBuilder.fromPath("http://localhost:8080").matrixParam("name", (Object) null);
-                Assert.fail(ERROR_MSG);
+                Assertions.fail(ERROR_MSG);
             } catch (IllegalArgumentException e) {
 
             }
@@ -870,7 +870,7 @@ public class UriBuilderTest {
                             "http://localhost:8080;name=x=;name=y?;name=x y;name=&")
                     .replaceMatrixParam(name, "x", "y", "y x", "x%y", "%20")
                     .build();
-            Assert.assertEquals(ERROR_MSG, uri.toString(), expected);
+            Assertions.assertEquals(uri.toString(), expected, ERROR_MSG);
 
         }
 
@@ -884,7 +884,7 @@ public class UriBuilderTest {
                             "http://localhost:8080;name=x=;name=y?;name=x y;name=&")
                     .replaceMatrixParam(name, "x", "y", "y x", "x%y", "%20")
                     .build();
-            Assert.assertEquals(ERROR_MSG, uri.toString(), expected);
+            Assertions.assertEquals(uri.toString(), expected, ERROR_MSG);
 
         }
 
@@ -896,7 +896,7 @@ public class UriBuilderTest {
             URI uri = UriBuilder.fromPath("http://localhost:8080")
                     .matrixParam(name, "x=", "y?", "x y", "&")
                     .replaceMatrix(null).build();
-            Assert.assertEquals(ERROR_MSG, uri.toString(), expected1);
+            Assertions.assertEquals(uri.toString(), expected1, ERROR_MSG);
 
         }
 
@@ -909,7 +909,7 @@ public class UriBuilderTest {
                     .fromPath(
                             "http://localhost:8080;name=x=;name=y?;name=x y;name=&")
                     .replaceMatrix(value).build();
-            Assert.assertEquals(ERROR_MSG, uri.toString(), expected);
+            Assertions.assertEquals(uri.toString(), expected, ERROR_MSG);
 
         }
 
@@ -922,7 +922,7 @@ public class UriBuilderTest {
                     .fromPath(
                             "http://localhost:8080;name=x=;name=y?;name=x y;name=&")
                     .replaceMatrix(value).build();
-            Assert.assertEquals(ERROR_MSG, uri.toString(), expected);
+            Assertions.assertEquals(uri.toString(), expected, ERROR_MSG);
 
         }
 
@@ -935,7 +935,7 @@ public class UriBuilderTest {
 
             URI uri = UriBuilder.fromUri(new URI(orig))
                     .uri(replacement.toASCIIString()).build();
-            Assert.assertEquals(ERROR_MSG, uri.toString(), expected);
+            Assertions.assertEquals(uri.toString(), expected, ERROR_MSG);
 
         }
 
@@ -948,7 +948,7 @@ public class UriBuilderTest {
             UriBuilder uriBuilder = UriBuilder.fromUri(new URI(orig));
             URI uri = uriBuilder
                     .uri(replacement.toASCIIString()).build();
-            Assert.assertEquals(ERROR_MSG, uri.toString(), expected);
+            Assertions.assertEquals(uri.toString(), expected, ERROR_MSG);
 
         }
 
@@ -961,7 +961,7 @@ public class UriBuilderTest {
             UriBuilder uriBuilder = UriBuilder.fromUri(new URI(orig));
             URI uri = uriBuilder
                     .uri(replacement.toASCIIString()).build();
-            Assert.assertEquals(ERROR_MSG, uri.toString(), expected);
+            Assertions.assertEquals(uri.toString(), expected, ERROR_MSG);
 
         }
 
@@ -977,7 +977,7 @@ public class UriBuilderTest {
             String hierarchical = "http://foo.com";
             matcher = ResteasyUriBuilder.opaqueUri.matcher(hierarchical);
             if (matcher.matches()) {
-                Assert.fail(ERROR_MSG);
+                Assertions.fail(ERROR_MSG);
             }
         }
 
@@ -989,16 +989,17 @@ public class UriBuilderTest {
 
         // RESTEASY-1718 checks
         {
-            Assert.assertEquals("http://foo", UriBuilder.fromUri("http://foo").build().toString());
-            Assert.assertEquals("http://foo:8080", UriBuilder.fromUri("http://foo:8080").build().toString());
-            Assert.assertEquals("http://[::1]", UriBuilder.fromUri("http://[::1]").build().toString());
-            Assert.assertEquals("http://[::1]:8080", UriBuilder.fromUri("http://[::1]:8080").build().toString());
+            Assertions.assertEquals("http://foo", UriBuilder.fromUri("http://foo").build().toString());
+            Assertions.assertEquals("http://foo:8080", UriBuilder.fromUri("http://foo:8080").build().toString());
+            Assertions.assertEquals("http://[::1]", UriBuilder.fromUri("http://[::1]").build().toString());
+            Assertions.assertEquals("http://[::1]:8080", UriBuilder.fromUri("http://[::1]:8080").build().toString());
 
-            Assert.assertEquals("http://[0:0:0:0:0:0:0:1]", UriBuilder.fromUri("http://[0:0:0:0:0:0:0:1]").build().toString());
-            Assert.assertEquals("http://[0:0:0:0:0:0:0:1]:8080",
+            Assertions.assertEquals("http://[0:0:0:0:0:0:0:1]",
+                    UriBuilder.fromUri("http://[0:0:0:0:0:0:0:1]").build().toString());
+            Assertions.assertEquals("http://[0:0:0:0:0:0:0:1]:8080",
                     UriBuilder.fromUri("http://[0:0:0:0:0:0:0:1]:8080").build().toString());
-            Assert.assertEquals("http://foo", UriBuilder.fromUri("http://{host}").build("foo").toString());
-            Assert.assertEquals("http://foo:8080", UriBuilder.fromUri("http://{host}:8080").build("foo").toString());
+            Assertions.assertEquals("http://foo", UriBuilder.fromUri("http://{host}").build("foo").toString());
+            Assertions.assertEquals("http://foo:8080", UriBuilder.fromUri("http://{host}:8080").build("foo").toString());
         }
 
     }
@@ -1006,56 +1007,57 @@ public class UriBuilderTest {
     @Test
     public void additionalCheckForIPv6() throws Exception {
 
-        Assert.assertEquals("http://[0:0:0:0:0:0:0:1]", UriBuilder.fromUri("http://[0:0:0:0:0:0:0:1]").build().toString());
-        Assert.assertEquals("http://[::1]", UriBuilder.fromUri("http://[::1]").build().toString());
+        Assertions.assertEquals("http://[0:0:0:0:0:0:0:1]", UriBuilder.fromUri("http://[0:0:0:0:0:0:0:1]").build().toString());
+        Assertions.assertEquals("http://[::1]", UriBuilder.fromUri("http://[::1]").build().toString());
 
         // URI substitues square brackets with their escaped representation
-        Assert.assertEquals("http://%5B0:0:0:0:0:0:0:1%5D",
+        Assertions.assertEquals("http://%5B0:0:0:0:0:0:0:1%5D",
                 UriBuilder.fromUri("http://{host}").build("[0:0:0:0:0:0:0:1]").toString());
-        Assert.assertEquals("http://%5B0:0:0:0:0:0:0:1%5D:8080",
+        Assertions.assertEquals("http://%5B0:0:0:0:0:0:0:1%5D:8080",
                 UriBuilder.fromUri("http://{host}:8080").build("[0:0:0:0:0:0:0:1]").toString());
 
         // inspiration from https://stackoverflow.com/a/17871737
-        Assert.assertEquals("http://[1:2:3:4:5:6:7:8]", UriBuilder.fromUri("http://[1:2:3:4:5:6:7:8]").build().toString());
-        Assert.assertEquals("http://[1::]", UriBuilder.fromUri("http://[1::]").build().toString());
-        Assert.assertEquals("http://[1:2:3:4:5:6:7::]", UriBuilder.fromUri("http://[1:2:3:4:5:6:7::]").build().toString());
-        Assert.assertEquals("http://[1::8]", UriBuilder.fromUri("http://[1::8]").build().toString());
-        Assert.assertEquals("http://[1:2:3:4:5:6::8]", UriBuilder.fromUri("http://[1:2:3:4:5:6::8]").build().toString());
-        Assert.assertEquals("http://[1::7:8]", UriBuilder.fromUri("http://[1::7:8]").build().toString());
-        Assert.assertEquals("http://[1:2:3:4:5::7:8]", UriBuilder.fromUri("http://[1:2:3:4:5::7:8]").build().toString());
-        Assert.assertEquals("http://[1:2:3:4:5::8]", UriBuilder.fromUri("http://[1:2:3:4:5::8]").build().toString());
-        Assert.assertEquals("http://[1::6:7:8]", UriBuilder.fromUri("http://[1::6:7:8]").build().toString());
-        Assert.assertEquals("http://[1:2:3:4::6:7:8]", UriBuilder.fromUri("http://[1:2:3:4::6:7:8]").build().toString());
-        Assert.assertEquals("http://[1:2:3:4::8]", UriBuilder.fromUri("http://[1:2:3:4::8]").build().toString());
-        Assert.assertEquals("http://[1::5:6:7:8]", UriBuilder.fromUri("http://[1::5:6:7:8]").build().toString());
-        Assert.assertEquals("http://[1:2:3::5:6:7:8]", UriBuilder.fromUri("http://[1:2:3::5:6:7:8]").build().toString());
-        Assert.assertEquals("http://[1:2:3::8]", UriBuilder.fromUri("http://[1:2:3::8]").build().toString());
-        Assert.assertEquals("http://[1::4:5:6:7:8]", UriBuilder.fromUri("http://[1::4:5:6:7:8]").build().toString());
-        Assert.assertEquals("http://[1:2::4:5:6:7:8]", UriBuilder.fromUri("http://[1:2::4:5:6:7:8]").build().toString());
-        Assert.assertEquals("http://[1:2::8]", UriBuilder.fromUri("http://[1:2::8]").build().toString());
-        Assert.assertEquals("http://[1::3:4:5:6:7:8]", UriBuilder.fromUri("http://[1::3:4:5:6:7:8]").build().toString());
-        Assert.assertEquals("http://[1::8]", UriBuilder.fromUri("http://[1::8]").build().toString());
-        Assert.assertEquals("http://[::2:3:4:5:6:7:8]", UriBuilder.fromUri("http://[::2:3:4:5:6:7:8]").build().toString());
-        Assert.assertEquals("http://[::3:4:5:6:7:8]", UriBuilder.fromUri("http://[::3:4:5:6:7:8]").build().toString());
-        Assert.assertEquals("http://[::8]", UriBuilder.fromUri("http://[::8]").build().toString());
-        Assert.assertEquals("http://[::]", UriBuilder.fromUri("http://[::]").build().toString());
+        Assertions.assertEquals("http://[1:2:3:4:5:6:7:8]", UriBuilder.fromUri("http://[1:2:3:4:5:6:7:8]").build().toString());
+        Assertions.assertEquals("http://[1::]", UriBuilder.fromUri("http://[1::]").build().toString());
+        Assertions.assertEquals("http://[1:2:3:4:5:6:7::]", UriBuilder.fromUri("http://[1:2:3:4:5:6:7::]").build().toString());
+        Assertions.assertEquals("http://[1::8]", UriBuilder.fromUri("http://[1::8]").build().toString());
+        Assertions.assertEquals("http://[1:2:3:4:5:6::8]", UriBuilder.fromUri("http://[1:2:3:4:5:6::8]").build().toString());
+        Assertions.assertEquals("http://[1::7:8]", UriBuilder.fromUri("http://[1::7:8]").build().toString());
+        Assertions.assertEquals("http://[1:2:3:4:5::7:8]", UriBuilder.fromUri("http://[1:2:3:4:5::7:8]").build().toString());
+        Assertions.assertEquals("http://[1:2:3:4:5::8]", UriBuilder.fromUri("http://[1:2:3:4:5::8]").build().toString());
+        Assertions.assertEquals("http://[1::6:7:8]", UriBuilder.fromUri("http://[1::6:7:8]").build().toString());
+        Assertions.assertEquals("http://[1:2:3:4::6:7:8]", UriBuilder.fromUri("http://[1:2:3:4::6:7:8]").build().toString());
+        Assertions.assertEquals("http://[1:2:3:4::8]", UriBuilder.fromUri("http://[1:2:3:4::8]").build().toString());
+        Assertions.assertEquals("http://[1::5:6:7:8]", UriBuilder.fromUri("http://[1::5:6:7:8]").build().toString());
+        Assertions.assertEquals("http://[1:2:3::5:6:7:8]", UriBuilder.fromUri("http://[1:2:3::5:6:7:8]").build().toString());
+        Assertions.assertEquals("http://[1:2:3::8]", UriBuilder.fromUri("http://[1:2:3::8]").build().toString());
+        Assertions.assertEquals("http://[1::4:5:6:7:8]", UriBuilder.fromUri("http://[1::4:5:6:7:8]").build().toString());
+        Assertions.assertEquals("http://[1:2::4:5:6:7:8]", UriBuilder.fromUri("http://[1:2::4:5:6:7:8]").build().toString());
+        Assertions.assertEquals("http://[1:2::8]", UriBuilder.fromUri("http://[1:2::8]").build().toString());
+        Assertions.assertEquals("http://[1::3:4:5:6:7:8]", UriBuilder.fromUri("http://[1::3:4:5:6:7:8]").build().toString());
+        Assertions.assertEquals("http://[1::8]", UriBuilder.fromUri("http://[1::8]").build().toString());
+        Assertions.assertEquals("http://[::2:3:4:5:6:7:8]", UriBuilder.fromUri("http://[::2:3:4:5:6:7:8]").build().toString());
+        Assertions.assertEquals("http://[::3:4:5:6:7:8]", UriBuilder.fromUri("http://[::3:4:5:6:7:8]").build().toString());
+        Assertions.assertEquals("http://[::8]", UriBuilder.fromUri("http://[::8]").build().toString());
+        Assertions.assertEquals("http://[::]", UriBuilder.fromUri("http://[::]").build().toString());
 
         // link-local format
-        Assert.assertEquals("http://[fe80::7:8%eth0]", UriBuilder.fromUri("http://[fe80::7:8%eth0]").build().toString());
-        Assert.assertEquals("http://[fe80::7:8%1]", UriBuilder.fromUri("http://[fe80::7:8%1]").build().toString());
-        Assert.assertEquals("http://[fe80::7:8%eth0]:8080",
+        Assertions.assertEquals("http://[fe80::7:8%eth0]", UriBuilder.fromUri("http://[fe80::7:8%eth0]").build().toString());
+        Assertions.assertEquals("http://[fe80::7:8%1]", UriBuilder.fromUri("http://[fe80::7:8%1]").build().toString());
+        Assertions.assertEquals("http://[fe80::7:8%eth0]:8080",
                 UriBuilder.fromUri("http://[fe80::7:8%eth0]:8080").build().toString());
-        Assert.assertEquals("http://[fe80::7:8%1]:80", UriBuilder.fromUri("http://[fe80::7:8%1]:80").build().toString());
+        Assertions.assertEquals("http://[fe80::7:8%1]:80", UriBuilder.fromUri("http://[fe80::7:8%1]:80").build().toString());
 
-        Assert.assertEquals("http://[::255.255.255.255]", UriBuilder.fromUri("http://[::255.255.255.255]").build().toString());
-        Assert.assertEquals("http://[::ffff:255.255.255.255]",
+        Assertions.assertEquals("http://[::255.255.255.255]",
+                UriBuilder.fromUri("http://[::255.255.255.255]").build().toString());
+        Assertions.assertEquals("http://[::ffff:255.255.255.255]",
                 UriBuilder.fromUri("http://[::ffff:255.255.255.255]").build().toString());
-        Assert.assertEquals("http://[::ffff:0:255.255.255.255]",
+        Assertions.assertEquals("http://[::ffff:0:255.255.255.255]",
                 UriBuilder.fromUri("http://[::ffff:0:255.255.255.255]").build().toString());
 
-        Assert.assertEquals("http://[2001:db8:3:4::192.0.2.33]",
+        Assertions.assertEquals("http://[2001:db8:3:4::192.0.2.33]",
                 UriBuilder.fromUri("http://[2001:db8:3:4::192.0.2.33]").build().toString());
-        Assert.assertEquals("http://[64:ff9b::192.0.2.33]",
+        Assertions.assertEquals("http://[64:ff9b::192.0.2.33]",
                 UriBuilder.fromUri("http://[64:ff9b::192.0.2.33]").build().toString());
     }
 

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/WildcardTypeTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/util/WildcardTypeTest.java
@@ -9,8 +9,8 @@ import jakarta.ws.rs.core.GenericType;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.spi.util.Types;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @tpSubChapter Util tests
@@ -33,7 +33,7 @@ public class WildcardTypeTest {
         Type t = pt.getActualTypeArguments()[0];
         printTypes(t);
         Class<?> rawType = Types.getRawType(t);
-        Assert.assertEquals(String.class, rawType);
+        Assertions.assertEquals(String.class, rawType);
     }
 
     /**
@@ -48,7 +48,7 @@ public class WildcardTypeTest {
         Type t = pt.getActualTypeArguments()[0];
         printTypes(t);
         Class<?> rawType = Types.getRawType(t);
-        Assert.assertEquals(Object.class, rawType);
+        Assertions.assertEquals(Object.class, rawType);
     }
 
     /**
@@ -63,7 +63,7 @@ public class WildcardTypeTest {
         Type t = pt.getActualTypeArguments()[0];
         printTypes(t);
         Class<?> rawType = Types.getRawType(t);
-        Assert.assertEquals(Object.class, rawType);
+        Assertions.assertEquals(Object.class, rawType);
     }
 
     /**
@@ -78,7 +78,7 @@ public class WildcardTypeTest {
         Type t = pt.getActualTypeArguments()[0];
         printTypes(t);
         Class<?> rawType = Types.getRawType(t);
-        Assert.assertEquals(Object.class, rawType);
+        Assertions.assertEquals(Object.class, rawType);
     }
 
     void printTypes(Type t) {


### PR DESCRIPTION
This is the 3nd PR in migrating the testsuite to junit5.  This PR is
a branch of PR-4028.  testsuite/pom.xml is back to fully running all
submodules.