### PR TITLE
[RESTEASY-3387] Use java.util.Locale to parse the languages from the Accept-Language …

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/util/LocaleHelper.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/util/LocaleHelper.java
@@ -11,14 +11,7 @@ public class LocaleHelper {
         int q = lang.indexOf(';');
         if (q > -1)
             lang = lang.substring(0, q);
-        String[] split = lang.trim().split("-");
-        if (split.length == 1)
-            return new Locale(split[0].toLowerCase());
-        else if (split.length == 2)
-            return new Locale(split[0].toLowerCase(), split[1].toLowerCase());
-        else if (split.length > 2)
-            return new Locale(split[0], split[1], split[2]);
-        return null; // unreachable
+        return Locale.forLanguageTag(lang);
     }
 
     /**
@@ -29,9 +22,6 @@ public class LocaleHelper {
      * @return converted language format string
      */
     public static String toLanguageString(Locale value) {
-        StringBuffer buf = new StringBuffer(value.getLanguage().toLowerCase());
-        if (value.getCountry() != null && !value.getCountry().equals(""))
-            buf.append("-").append(value.getCountry().toLowerCase());
-        return buf.toString();
+        return value.toLanguageTag();
     }
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/ContentLanguageHeaderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/ContentLanguageHeaderTest.java
@@ -77,7 +77,7 @@ public class ContentLanguageHeaderTest {
 
         Assertions.assertTrue(headers.keySet().contains("Content-Language"),
                 "Content-Language header is not present in response");
-        Assertions.assertEquals("en-us", headers.getFirst("Content-Language"),
+        Assertions.assertTrue("en-us".equalsIgnoreCase(headers.getFirst("Content-Language").toString()),
                 "Content-Language header does not have expected value");
     }
 
@@ -94,7 +94,7 @@ public class ContentLanguageHeaderTest {
 
         Assertions.assertTrue(headers.keySet().contains("Content-Language"),
                 "Content-Language header is not present in response");
-        Assertions.assertEquals("en-us", headers.getFirst("Content-Language"),
+        Assertions.assertTrue("en-us".equalsIgnoreCase(headers.getFirst("Content-Language").toString()),
                 "Content-Language header does not have expected value");
     }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/VariantsTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/VariantsTest.java
@@ -203,7 +203,7 @@ public class VariantsTest {
         Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
         Assertions.assertEquals("GET", response.readEntity(String.class));
         Assertions.assertEquals(MediaType.APPLICATION_XML_TYPE.withCharset("UTF-8"), response.getMediaType());
-        Assertions.assertEquals("en-us", new LocaleDelegate().toString(response.getLanguage()));
+        Assertions.assertTrue("en-us".equalsIgnoreCase(new LocaleDelegate().toString(response.getLanguage())));
         response.close();
     }
 
@@ -220,7 +220,7 @@ public class VariantsTest {
         Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
         Assertions.assertEquals("GET", response.readEntity(String.class));
         Assertions.assertEquals(MediaType.APPLICATION_XML_TYPE.withCharset("UTF-8"), response.getMediaType());
-        Assertions.assertEquals("en-us", new LocaleDelegate().toString(response.getLanguage()));
+        Assertions.assertTrue("en-us".equalsIgnoreCase(new LocaleDelegate().toString(response.getLanguage())));
         response.close();
     }
 
@@ -237,7 +237,7 @@ public class VariantsTest {
         Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
         Assertions.assertEquals("GET", response.readEntity(String.class));
         Assertions.assertEquals(MediaType.APPLICATION_XML_TYPE.withCharset("UTF-8"), response.getMediaType());
-        Assertions.assertEquals("en-us", new LocaleDelegate().toString(response.getLanguage()));
+        Assertions.assertTrue("en-us".equalsIgnoreCase(new LocaleDelegate().toString(response.getLanguage())));
         response.close();
     }
 


### PR DESCRIPTION
…header.

Updated the unit tests to check the header with case insensitivity.

This is a fix for https://issues.redhat.com/projects/RESTEASY/issues/RESTEASY-3387. Signed-off-by:Nathan Erwin <nathan.d.erwin@gmail.com>

Replaces #3808 with updates for the JUnit 5 migration.