### PR TITLE
6.2.4.final  bootable jar

### DIFF
--- a/arquillian/RESTEASY-1056-jetty-bv11/pom.xml
+++ b/arquillian/RESTEASY-1056-jetty-bv11/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-misc-arquillian-tests</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>RESTEASY-1056-jetty-bv11</artifactId>

--- a/arquillian/RESTEASY-1630-jetty-resteasy-servlet-initializer/pom.xml
+++ b/arquillian/RESTEASY-1630-jetty-resteasy-servlet-initializer/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-misc-arquillian-tests</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>RESTEASY-1630-jetty-resteasy-servlet-initializer</artifactId>

--- a/arquillian/RESTEASY-736-jetty/pom.xml
+++ b/arquillian/RESTEASY-736-jetty/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-misc-arquillian-tests</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>RESTEASY-736-jetty</artifactId>

--- a/arquillian/pom.xml
+++ b/arquillian/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>RESTEasy Misc Arquillian-based tests</name>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
     </parent>
 
     <artifactId>resteasy-dist</artifactId>

--- a/distribution/src-distribution/pom.xml
+++ b/distribution/src-distribution/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-dist</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
     </parent>
 
     <artifactId>resteasy-src-dist</artifactId>

--- a/docbook/pom.xml
+++ b/docbook/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-reference-guide</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
     <packaging>jdocbook</packaging>
     <name>RESTEasy Reference Guide</name>
     <description/>

--- a/docbook/reference/en/en-US/master.xml
+++ b/docbook/reference/en/en-US/master.xml
@@ -71,7 +71,7 @@
    <bookinfo>
       <title>RESTEasy</title>
       <subtitle>Jakarta RESTFul Web Services</subtitle>
-      <releaseinfo>6.2.4.Final</releaseinfo>
+      <releaseinfo>6.2.4.Final--bootable-jar</releaseinfo>
    </bookinfo>
 
    <toc/>

--- a/docbook/reference/en/en-US/modules/Installation_Configuration.xml
+++ b/docbook/reference/en/en-US/modules/Installation_Configuration.xml
@@ -256,7 +256,7 @@
                 <programlisting><![CDATA[$ galleon.sh install wildfly:current]]></programlisting>
 
                 To install the RESTEasy upgrade on top of that you simply need to use the tool again with the Maven GAV:
-                <programlisting><![CDATA[$ galleon.sh install org.jboss.resteasy:galleon-feature-pack:6.2.4.Final]]></programlisting>
+                <programlisting><![CDATA[$ galleon.sh install org.jboss.resteasy:galleon-feature-pack:6.2.4.Final--bootable-jar]]></programlisting>
             </para>
             <para>
                 If you are using Maven to provision WildFly you can simply add the feature pack to your plugin configuration.
@@ -278,7 +278,7 @@
             <feature-pack>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>galleon-feature-pack</artifactId>
-                <version>6.2.4.Final</version>
+                <version>6.2.4.Final--bootable-jar</version>
             </feature-pack>
         </feature-packs>
     </configuration>
@@ -365,17 +365,17 @@ public class MyApplication extends Application
 <dependency>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-core</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
 </dependency>
 <dependency>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-client</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
 </dependency>
 <dependency>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxb-provider</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
 </dependency>
 ]]></programlisting>
         <para>
@@ -408,7 +408,7 @@ public class MyApplication extends Application
 <dependency>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-servlet-initializer</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
 </dependency>
 ]]></programlisting>
         </section>
@@ -1363,12 +1363,12 @@ String value = ConfigProvider.getConfig().getOptionalValue("prop_name", String.c
 <dependency>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-core</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
 </dependency>
 <dependency>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-client</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
 </dependency>
 ]]></programlisting>
 

--- a/docbook/reference/en/en-US/modules/Json-p.xml
+++ b/docbook/reference/en/en-US/modules/Json-p.xml
@@ -10,7 +10,7 @@
 <dependency>
    <groupId>org.jboss.resteasy</groupId>
    <artifactId>resteasy-json-p-provider</artifactId>
-   <version>6.2.4.Final</version>
+   <version>6.2.4.Final--bootable-jar</version>
 </dependency>
 ]]></programlisting>
 </chapter>

--- a/docbook/reference/en/en-US/modules/Links.xml
+++ b/docbook/reference/en/en-US/modules/Links.xml
@@ -53,7 +53,7 @@
 					<tr>
 						<td>org.jboss.resteasy</td>
 						<td>resteasy-links</td>
-						<td>6.2.4.Final</td>
+						<td>6.2.4.Final--bootable-jar</td>
 					</tr>
 				</tbody>
 			</table>

--- a/docbook/reference/en/en-US/modules/RESTEasy_Embedded_Container.xml
+++ b/docbook/reference/en/en-US/modules/RESTEasy_Embedded_Container.xml
@@ -147,7 +147,7 @@ public class UndertowTest
   <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jdk-http</artifactId>
-      <version>6.2.4.Final</version>
+      <version>6.2.4.Final--bootable-jar</version>
   </dependency>
 ]]></programlisting>
 
@@ -176,7 +176,7 @@ public class UndertowTest
   <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-netty4</artifactId>
-      <version>6.2.4.Final</version>
+      <version>6.2.4.Final--bootable-jar</version>
   </dependency>
 ]]></programlisting>
 
@@ -209,7 +209,7 @@ public class UndertowTest
   <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-reactor-netty</artifactId>
-      <version>6.2.4.Final</version>
+      <version>6.2.4.Final--bootable-jar</version>
   </dependency>
 ]]></programlisting>
 
@@ -236,7 +236,7 @@ public class UndertowTest
   <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-vertx</artifactId>
-      <version>6.2.4.Final</version>
+      <version>6.2.4.Final--bootable-jar</version>
   </dependency>
     ]]></programlisting>
 

--- a/docbook/reference/en/en-US/modules/signature.xml
+++ b/docbook/reference/en/en-US/modules/signature.xml
@@ -172,7 +172,7 @@
     <para><programlisting>        &lt;dependency&gt;
             &lt;groupId&gt;org.jboss.resteasy&lt;/groupId&gt;
             &lt;artifactId&gt;resteasy-crypto&lt;/artifactId&gt;
-            &lt;version&gt;6.2.4.Final&lt;/version&gt;
+            &lt;version&gt;6.2.4.Final--bootable-jar&lt;/version&gt;
         &lt;/dependency&gt;
 
 </programlisting></para>

--- a/docbook/reference/en/en-US/modules/smime.xml
+++ b/docbook/reference/en/en-US/modules/smime.xml
@@ -19,7 +19,7 @@
         &lt;dependency&gt;
             &lt;groupId&gt;org.jboss.resteasy&lt;/groupId&gt;
             &lt;artifactId&gt;resteasy-crypto&lt;/artifactId&gt;
-            &lt;version&gt;6.2.4.Final&lt;/version&gt;
+            &lt;version&gt;6.2.4.Final--bootable-jar&lt;/version&gt;
         &lt;/dependency&gt;
 
 </programlisting></para>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Dependency versions -->
-        <dep.arquillian-bom.version>1.7.0.Alpha14</dep.arquillian-bom.version>
+        <dep.arquillian-bom.version>1.7.2.Final</dep.arquillian-bom.version>
         <version.org.jboss.arquillian.container.arquillian-weld-embedded>3.0.2.Final</version.org.jboss.arquillian.container.arquillian-weld-embedded>
         <version.org.jboss.resteasy.checkstyle>1.0.0.Final</version.org.jboss.resteasy.checkstyle>
         <server.version>28.0.0.Final</server.version>
         <version.org.wildfly>${server.version}</version.org.wildfly>
-        <version.org.wildfly.arquillian.wildfly-arquillian>5.0.0.Alpha6</version.org.wildfly.arquillian.wildfly-arquillian>
+        <version.org.wildfly.arquillian.wildfly-arquillian>5.0.1.Final</version.org.wildfly.arquillian.wildfly-arquillian>
 
         <jboss.home/>
         <!-- print logs to file by default -->
@@ -51,8 +51,9 @@
         <version.javadoc.plugin>3.3.1</version.javadoc.plugin>
         <version.org.jacoco.plugin>0.8.10</version.org.jacoco.plugin>
         <version.org.jboss.galleon>5.1.0.Final</version.org.jboss.galleon>
-        <version.org.wildfly.galleon-plugins>6.4.2.Final</version.org.wildfly.galleon-plugins>
-        <version.org.wildfly.plugins.wildfly-maven-plugin>4.0.0.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
+        <version.org.wildfly.galleon-plugins>7.0.0.Beta3</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.plugins.wildfly-maven-plugin>5.0.0.Beta3</version.org.wildfly.plugins.wildfly-maven-plugin>
+        <version.org.wildfly.jar.plugin>11.0.0.Beta1</version.org.wildfly.jar.plugin>
 
         <!-- Test options -->
         <additionalJvmArgs>-Djava.io.tmpdir=${project.build.directory}</additionalJvmArgs>
@@ -360,6 +361,11 @@
                     <groupId>org.wildfly.plugins</groupId>
                     <artifactId>wildfly-maven-plugin</artifactId>
                     <version>${version.org.wildfly.plugins.wildfly-maven-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-jar-maven-plugin</artifactId>
+                    <version>${version.org.wildfly.jar.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/profiling-tests/pom.xml
+++ b/profiling-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-profiling-tests</artifactId>

--- a/providers/fastinfoset/pom.xml
+++ b/providers/fastinfoset/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
 	    <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-fastinfoset-provider</artifactId>

--- a/providers/jackson2/pom.xml
+++ b/providers/jackson2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
 	    <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-jackson2-provider</artifactId>

--- a/providers/jaxb/pom.xml
+++ b/providers/jaxb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
 	    <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-jaxb-provider</artifactId>

--- a/providers/json-binding/pom.xml
+++ b/providers/json-binding/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-json-binding-provider</artifactId>

--- a/providers/json-p-ee7/pom.xml
+++ b/providers/json-p-ee7/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-json-p-provider</artifactId>

--- a/providers/multipart/pom.xml
+++ b/providers/multipart/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-multipart-provider</artifactId>

--- a/providers/pom.xml
+++ b/providers/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>RESTEasy Providers</name>

--- a/providers/resteasy-atom/pom.xml
+++ b/providers/resteasy-atom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-atom-provider</artifactId>

--- a/providers/resteasy-html/pom.xml
+++ b/providers/resteasy-html/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-html</artifactId>

--- a/providers/resteasy-validator-provider/pom.xml
+++ b/providers/resteasy-validator-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>providers-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>resteasy-validator-provider</artifactId>

--- a/resteasy-bom/pom.xml
+++ b/resteasy-bom/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-bom</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
     <packaging>pom</packaging>
 
     <name>RESTEasy Maven Import (BOM)</name>

--- a/resteasy-cdi/pom.xml
+++ b/resteasy-cdi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
     </parent>
     <artifactId>resteasy-cdi</artifactId>
     <name>RESTEasy CDI integration module</name>

--- a/resteasy-client-api/pom.xml
+++ b/resteasy-client-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resteasy-client-jetty/pom.xml
+++ b/resteasy-client-jetty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resteasy-client-reactor-netty/pom.xml
+++ b/resteasy-client-reactor-netty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/resteasy-client-utils/pom.xml
+++ b/resteasy-client-utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/resteasy-client-vertx/pom.xml
+++ b/resteasy-client-vertx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resteasy-client/pom.xml
+++ b/resteasy-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resteasy-core-spi/pom.xml
+++ b/resteasy-core-spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-core-spi</artifactId>

--- a/resteasy-core/pom.xml
+++ b/resteasy-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-core</artifactId>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-dependencies</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
     <packaging>pom</packaging>
     <name>RESTEasy dependencies BOM</name>
     <description>RESTEasy dependencies BOM</description>

--- a/resteasy-feature-pack/common/pom.xml
+++ b/resteasy-feature-pack/common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-feature-pack</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/resteasy-feature-pack/galleon-feature-pack/pom.xml
+++ b/resteasy-feature-pack/galleon-feature-pack/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-feature-pack</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/resteasy-feature-pack/galleon-preview-feature-pack/pom.xml
+++ b/resteasy-feature-pack/galleon-preview-feature-pack/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-feature-pack</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/resteasy-feature-pack/pom.xml
+++ b/resteasy-feature-pack/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/resteasy-jsapi/pom.xml
+++ b/resteasy-jsapi/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
     </parent>
 
     <artifactId>resteasy-jsapi</artifactId>

--- a/resteasy-links/pom.xml
+++ b/resteasy-links/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>resteasy-jaxrs-all</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
     </parent>
 
     <artifactId>resteasy-links</artifactId>

--- a/resteasy-reactor/pom.xml
+++ b/resteasy-reactor/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
   </parent>
   <artifactId>resteasy-reactor</artifactId>
   <name>RESTEasy Reactor integration</name>

--- a/resteasy-rxjava2/pom.xml
+++ b/resteasy-rxjava2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-jaxrs-all</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
   </parent>
   <artifactId>resteasy-rxjava2</artifactId>
   <name>RESTEasy RxJava 2 integration</name>

--- a/resteasy-servlet-initializer/pom.xml
+++ b/resteasy-servlet-initializer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-servlet-initializer</artifactId>

--- a/resteasy-stats/pom.xml
+++ b/resteasy-stats/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-stats</artifactId>

--- a/resteasy-upgrade-guide/pom.xml
+++ b/resteasy-upgrade-guide/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jboss.resteasy</groupId>
     <artifactId>resteasy-upgrade-guide-${translation}</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
     <packaging>jdocbook</packaging>
     <name>RESTEasy Upgrade Guide (${translation})</name>
     <description/>

--- a/resteasy-wadl-undertow-connector/pom.xml
+++ b/resteasy-wadl-undertow-connector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/resteasy-wadl/pom.xml
+++ b/resteasy-wadl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/security/jose-jwt/pom.xml
+++ b/security/jose-jwt/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>security-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>RESTEasy Security</name>

--- a/security/resteasy-crypto/pom.xml
+++ b/security/resteasy-crypto/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>security-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-adapters/pom.xml
+++ b/server-adapters/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
     </parent>
     <name>RESTEasy Http Adapter Plugins</name>
     <description/>

--- a/server-adapters/resteasy-jdk-http/pom.xml
+++ b/server-adapters/resteasy-jdk-http/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-http-adapter-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-adapters/resteasy-netty4-cdi/pom.xml
+++ b/server-adapters/resteasy-netty4-cdi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-http-adapter-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-adapters/resteasy-netty4/pom.xml
+++ b/server-adapters/resteasy-netty4/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-http-adapter-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-adapters/resteasy-reactor-netty/pom.xml
+++ b/server-adapters/resteasy-reactor-netty/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-http-adapter-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-adapters/resteasy-undertow-cdi/pom.xml
+++ b/server-adapters/resteasy-undertow-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-http-adapter-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/server-adapters/resteasy-undertow/pom.xml
+++ b/server-adapters/resteasy-undertow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-http-adapter-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-adapters/resteasy-vertx/pom.xml
+++ b/server-adapters/resteasy-vertx/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-http-adapter-pom</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-adapters/server-adapter-test-base/pom.xml
+++ b/server-adapters/server-adapter-test-base/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>resteasy-http-adapter-pom</artifactId>
         <groupId>org.jboss.resteasy</groupId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/arquillian-utils/pom.xml
+++ b/testsuite/arquillian-utils/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-testsuite</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
     </parent>
 
     <artifactId>arquillian-utils</artifactId>
-    <version>6.2.4.Final</version>
+    <version>6.2.4.Final--bootable-jar</version>
     <name>RESTEasy Main testsuite: Arquillian utils</name>
     <packaging>jar</packaging>
     <properties>

--- a/testsuite/arquillian-utils/pom.xml
+++ b/testsuite/arquillian-utils/pom.xml
@@ -33,6 +33,20 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <dependencyManagement>

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/category/NotForBootableJar.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/category/NotForBootableJar.java
@@ -1,0 +1,7 @@
+package org.jboss.resteasy.category;
+
+/**
+ * Marker interface for tests which are expected to fail with bootable jar.
+ */
+public interface NotForBootableJar {
+}

--- a/testsuite/integration-tests-embedded/pom.xml
+++ b/testsuite/integration-tests-embedded/pom.xml
@@ -6,7 +6,7 @@
    <parent>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-testsuite</artifactId>
-      <version>6.2.4.Final</version>
+      <version>6.2.4.Final--bootable-jar</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-testsuite</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -56,6 +56,11 @@
         <server.test.feature.pack.groupId>org.wildfly</server.test.feature.pack.groupId>
         <server.test.feature.pack.artifactId>wildfly-ee-galleon-pack</server.test.feature.pack.artifactId>
         <server.test.feature.pack.version>${version.org.wildfly}</server.test.feature.pack.version>
+
+        <!-- Channel Manifest for Bootable Jar -->
+        <channel-manifest.groupId>org.jboss.eap.channels</channel-manifest.groupId>
+        <channel-manifest.artifactId>eap-8.0-plus-eap-xp-5.0</channel-manifest.artifactId>
+        <channel-manifest.version>1.0.1.GA-redhat-20240229</channel-manifest.version>
     </properties>
 
     <artifactId>resteasy-integration-tests</artifactId>
@@ -121,6 +126,180 @@
             <properties>
                 <additional.surefire.exclude.tracing.tests>,org.jboss.resteasy.category.TracingRequired</additional.surefire.exclude.tracing.tests>
             </properties>
+        </profile>
+        <profile>
+            <id>bootablejar.profile.channel</id>
+            <activation>
+                <property>
+                    <name>ts.bootable.channel</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.wildfly.plugins</groupId>
+                            <artifactId>wildfly-jar-maven-plugin</artifactId>
+                            <configuration>
+                                <channels>
+                                    <channel>
+                                        <manifest>
+                                            <groupId>${channel-manifest.groupId}</groupId>
+                                            <artifactId>${channel-manifest.artifactId}</artifactId>
+                                            <version>${channel-manifest.version}</version>
+                                        </manifest>
+                                    </channel>
+                                </channels>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Disable the standard copy-based provisioning -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>initialize-basedirs</id>
+                                <phase>none</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <executions>
+                            <!-- Package a jaxrs-server layer with a few other layers -->
+                            <execution>
+                                <id>bootable-jar-observability-packaging</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <output-file-name>jaxrs-server.jar</output-file-name>
+                                    <hollowJar>true</hollowJar>
+                                    <record-state>false</record-state>
+                                    <log-time>true</log-time>
+                                    <plugin-options>
+                                        <jboss-fork-embedded>true</jboss-fork-embedded>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.wildfly.galleon.pack.group.id}</groupId>
+                                            <artifactId>wildfly-galleon-pack</artifactId>
+                                            <version>${server.version}</version>
+                                            <!-- Required for rxjava -->
+                                            <includedPackages>
+                                                <package>org.jboss.resteasy.resteasy-rxjava2</package>
+                                            </includedPackages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <layers>
+                                        <layer>jaxrs-server</layer>
+                                        <layer>microprofile-config</layer>
+                                        <layer>datasources</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>undertow-https</layer>
+                                        <layer>ejb</layer>
+                                    </layers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <install.dir>${project.build.directory}/wildfly</install.dir>
+                                <bootable.jar>${project.build.directory}/jaxrs-server.jar</bootable.jar>
+                                <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
+                                <container.management.port.managed>${container.management.port.managed}</container.management.port.managed>
+                                <securityManagerArg>${securityManagerArg}</securityManagerArg>
+                                <additionalJvmArgs>${additionalJvmArgs}</additionalJvmArgs>
+                                <ipv6>false</ipv6>
+                                <ipv6ArquillianSettings></ipv6ArquillianSettings>
+                                <node>127.0.0.1</node>
+                                <project.version>${project.version}</project.version>
+                                <version.resteasy.testsuite>${version.resteasy.testsuite}</version.resteasy.testsuite>
+                                <security.provider>${security.provider}</security.provider>
+                                <modular.jdk.args>${modular.jdk.args}</modular.jdk.args>
+                                <container.base.dir.managed>${container.base.dir.managed}</container.base.dir.managed>
+                                <container.offset.managed>0</container.offset.managed>
+                                <container.qualifier.managed>${container.qualifier.managed}</container.qualifier.managed>
+                                <container.qualifier.managed.encoding>${container.qualifier.managed.encoding}</container.qualifier.managed.encoding>
+                                <container.offset.managed.encoding>${container.offset.managed.encoding}</container.offset.managed.encoding>
+                                <container.management.port.managed.encoding>${container.management.port.managed.encoding}</container.management.port.managed.encoding>
+                                <resteasy.microprofile.sseclient.buffersize>5</resteasy.microprofile.sseclient.buffersize>
+                            </systemPropertyVariables>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>disable-jsonb-client</id>
+                                <phase>none</phase>
+                            </execution>
+
+                            <execution>
+                                <id>default-test-bootable-jar</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes>
+                                        <!-- Tests requires excluding JsonBindingProvider-->
+                                        <exclude>**/JsonBindingAnnotationsJacksonTest.java</exclude>
+                                        <exclude>**/SseJsonEventTest</exclude>
+                                        <!-- Tests without proper arquillian container in arquillian-bootable.xml -->
+                                        <exclude>**/*Gzip*</exclude>
+                                        <exclude>**/SslServerWithCorrectCertificateTest.java</exclude>
+                                        <exclude>**/SslServerWithWildcardHostnameCertificateTest.java</exclude>
+                                        <exclude>**/SslServerWithWrongHostnameCertificateTest.java</exclude>
+                                        <exclude>**/SslSniHostNamesTest.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+
+                            <!-- execution with excluded JSON-B -->
+                            <execution>
+                                <id>disable-jsonb-client-bootable-jar</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <includes>
+                                        <!-- TODO JsonBindingAnnotationsJacksonTest may be included here as well with additional changes-->
+                                        <include>**/SseJsonEventTest.java</include>
+                                    </includes>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>org.jboss.resteasy:resteasy-json-binding-provider</classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 
@@ -458,7 +637,7 @@
                         <id>prepare-tracing-configuration</id>
                         <phase>process-test-classes</phase>
                         <configuration>
-                            <target>
+                            <target unless="${ts.bootable}">
                                 <!-- Prepare configuration with more verbose logging for tracing tests -->
                                 <copy file="${container.base.dir.manual.tracing}/configuration/standalone.xml"
                                       tofile="${container.base.dir.manual.tracing}/configuration/standalone-tracing.xml"/>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/CDIResourceTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/CDIResourceTest.java
@@ -16,6 +16,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.spi.HttpResponseCodes;
 import org.jboss.resteasy.test.ContainerConstants;
 import org.jboss.resteasy.test.cdi.basic.resource.resteasy1082.FooResource;
@@ -31,6 +32,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -44,6 +46,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class) // based on re-deploying WAR file
 public class CDIResourceTest {
 
     protected static final Logger logger = Logger.getLogger(CDIResourceTest.class.getName());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionTest.java
@@ -23,6 +23,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.spi.HttpResponseCodes;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBook;
@@ -55,6 +56,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -68,6 +70,7 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(JmsTestQueueSetupTask.class)
+@Category(NotForBootableJar.class)
 public class InjectionTest {
     protected static final Logger log = Logger.getLogger(InjectionTest.class.getName());
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/MDBInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/MDBInjectionTest.java
@@ -17,6 +17,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.spi.HttpResponseCodes;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBook;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBookBag;
@@ -49,6 +50,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -61,6 +63,7 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(JmsTestQueueSetupTask.class)
+@Category(NotForBootableJar.class)
 public class MDBInjectionTest {
     protected static final Logger log = Logger.getLogger(MDBInjectionTest.class.getName());
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/ReverseInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/ReverseInjectionTest.java
@@ -37,6 +37,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.spi.HttpResponseCodes;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBook;
 import org.jboss.resteasy.test.cdi.injection.resource.CDIInjectionBookBag;
@@ -81,6 +82,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -98,6 +100,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(JmsTestQueueSetupTask.class)
+@Category(NotForBootableJar.class)
 public class ReverseInjectionTest {
     private static Logger log = Logger.getLogger(ReverseInjectionTest.class);
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
@@ -15,12 +15,14 @@ import jakarta.ws.rs.core.FeatureContext;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.utils.PermissionUtil;
 import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -29,6 +31,7 @@ import org.junit.runner.RunWith;
  * @tpSince RESTEasy 3.0.17
  */
 @RunWith(Arquillian.class)
+@Category(NotForBootableJar.class)
 public class ClientBuilderTest {
 
     @SuppressWarnings(value = "unchecked")

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/DuplicateDeploymentTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/DuplicateDeploymentTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.test.core.basic.resource.DuplicateDeploymentReader;
 import org.jboss.resteasy.test.core.basic.resource.DuplicateDeploymentResource;
 import org.jboss.resteasy.utils.TestUtil;
@@ -16,6 +17,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -26,6 +28,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class)
 public class DuplicateDeploymentTest {
     private static int initWarningCount = 0;
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/logging/DebugLoggingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/logging/DebugLoggingTest.java
@@ -14,6 +14,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.spi.HttpResponseCodes;
 import org.jboss.resteasy.test.core.logging.resource.DebugLoggingCustomReaderAndWriter;
@@ -31,6 +32,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 
@@ -43,6 +45,7 @@ import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class)
 public class DebugLoggingTest {
 
     static ResteasyClient client;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/ResourceClassProcessorErrorTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/ResourceClassProcessorErrorTest.java
@@ -10,6 +10,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.test.core.spi.resource.ResourceClassProcessorErrorImplementation;
 import org.jboss.resteasy.test.core.spi.resource.ResourceClassProcessorPureEndPoint;
 import org.jboss.resteasy.utils.LogCounter;
@@ -19,6 +20,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -29,6 +31,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class) // no log check support for bootable-jar in RESTEasy TS so far
 public class ResourceClassProcessorErrorTest {
 
     private static final String DEPLOYMENT_NAME = "deployment_name";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/crypto/CryptoTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/crypto/CryptoTest.java
@@ -25,6 +25,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.security.KeyTools;
 import org.jboss.resteasy.security.smime.EnvelopedInput;
@@ -49,6 +50,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -60,6 +62,7 @@ import org.junit.runner.RunWith;
 @SuppressWarnings(value = "unchecked")
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class)
 public class CryptoTest {
     private static final String ERROR_CONTENT_MSG = "Wrong content of response";
     private static final String ERROR_CORE_MSG = "Wrong BouncyCastleProvider and RESTEasy integration";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/crypto/VerifyDecryptTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/crypto/VerifyDecryptTest.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartOutput;
@@ -29,6 +30,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -39,6 +41,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class) // module org.eclipse.angus.mail is now private
 public class VerifyDecryptTest {
     private static final String RESPONSE_ERROR_MSG = "Response contains wrong content";
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/DuplicateProviderRegistrationTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/DuplicateProviderRegistrationTest.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.ext.ReaderInterceptor;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.test.ContainerConstants;
 import org.jboss.resteasy.test.providers.custom.resource.DuplicateProviderRegistrationFeature;
 import org.jboss.resteasy.test.providers.custom.resource.DuplicateProviderRegistrationFilter;
@@ -26,6 +27,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -35,6 +37,7 @@ import org.junit.runner.RunWith;
  * @tpSince RESTEasy 3.0.17
  */
 @RunWith(Arquillian.class)
+@Category(NotForBootableJar.class)
 public class DuplicateProviderRegistrationTest {
 
     private static final String RESTEASY_002155_ERR_MSG = "Wrong count of RESTEASY002155 warning message";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/MissingProducerTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/MissingProducerTest.java
@@ -5,11 +5,13 @@ import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALI
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -20,6 +22,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class)
 public class MissingProducerTest {
     private static final String ERR_MSG = "Warning was not logged";
     private static int initLogMsg1Count = parseLog1();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jsonb/basic/JsonBindingDebugLoggingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jsonb/basic/JsonBindingDebugLoggingTest.java
@@ -23,6 +23,7 @@ import org.hamcrest.MatcherAssert;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.test.ContainerConstants;
 import org.jboss.resteasy.test.providers.jsonb.basic.resource.DebugLoggingServerSetup;
@@ -40,6 +41,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -51,6 +53,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup({ DebugLoggingServerSetup.class }) // TBD: remove debug logging activation?
+@Category(NotForBootableJar.class)
 public class JsonBindingDebugLoggingTest {
 
     static ResteasyClient client;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/mediatype/BlacklistedMediaTypeTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/mediatype/BlacklistedMediaTypeTest.java
@@ -21,6 +21,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.security.KeyTools;
 import org.jboss.resteasy.security.smime.EnvelopedInput;
 import org.jboss.resteasy.test.crypto.resource.CryptoCertResource;
@@ -34,6 +35,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -43,6 +45,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class) // org.bouncycastle is now private
 public class BlacklistedMediaTypeTest {
 
     private static final String APPLICATION_SIGNED_EXCHANGE = "application/signed-exchange";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/EncodingMimeMultipartFormProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/EncodingMimeMultipartFormProviderTest.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 import org.jboss.resteasy.spi.HttpResponseCodes;
@@ -20,6 +21,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -29,6 +31,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class)
 public class EncodingMimeMultipartFormProviderTest {
 
     private static final String TEST_URI = generateURL("/encoding-mime");

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/MimeMultipartProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/MimeMultipartProviderTest.java
@@ -26,6 +26,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ProxyBuilder;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartOutput;
@@ -43,6 +44,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -52,6 +54,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class)
 public class MimeMultipartProviderTest {
 
     private static Logger logger = Logger.getLogger(MimeMultipartProviderTest.class);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/DuplicitePathTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/DuplicitePathTest.java
@@ -13,6 +13,7 @@ import org.hamcrest.MatcherAssert;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.spi.HttpResponseCodes;
 import org.jboss.resteasy.test.response.resource.DuplicitePathDupliciteApplicationOne;
@@ -30,6 +31,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -40,6 +42,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class)
 public class DuplicitePathTest {
     static ResteasyClient client;
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
@@ -19,6 +19,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.category.ExpectedFailingOnWildFly18;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClientEngine;
@@ -50,7 +51,7 @@ import org.junit.runner.RunWith;
 @ServerSetup({ BasicAuthTest.SecurityDomainSetup.class })
 @RunWith(Arquillian.class)
 @RunAsClient
-@Category({ ExpectedFailingOnWildFly18.class }) //WFLY-12655
+@Category({ ExpectedFailingOnWildFly18.class, NotForBootableJar.class }) //WFLY-12655
 public class BasicAuthTest {
 
     private static final String WRONG_RESPONSE = "Wrong response content.";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SecurityContextTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SecurityContextTest.java
@@ -11,6 +11,7 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.internal.BasicAuthentication;
 import org.jboss.resteasy.setup.AbstractUsersRolesSecurityDomainSetup;
 import org.jboss.resteasy.spi.HttpResponseCodes;
@@ -24,6 +25,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.CommandFailedException;
 
@@ -36,6 +38,7 @@ import org.wildfly.extras.creaper.core.CommandFailedException;
 @ServerSetup({ SecurityContextTest.SecurityDomainSetup.class })
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class)
 public class SecurityContextTest {
 
     private static final String USERNAME = "bill";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/TwoSecurityDomainsTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/TwoSecurityDomainsTest.java
@@ -18,6 +18,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.category.ExpectedFailingOnWildFly18;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClientEngine;
@@ -44,7 +45,7 @@ import org.junit.runner.RunWith;
 @ServerSetup(TwoSecurityDomainsTest.SecurityDomainSetup.class)
 @RunWith(Arquillian.class)
 @RunAsClient
-@Category({ ExpectedFailingOnWildFly18.class }) //WFLY-12655
+@Category({ ExpectedFailingOnWildFly18.class, NotForBootableJar.class }) //WFLY-12655
 public class TwoSecurityDomainsTest {
 
     private static ResteasyClient authorizedClient;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/warning/SubResourceWarningTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/warning/SubResourceWarningTest.java
@@ -5,6 +5,7 @@ import static org.jboss.resteasy.test.ContainerConstants.DEFAULT_CONTAINER_QUALI
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.resteasy.category.NotForBootableJar;
 import org.jboss.resteasy.test.core.interceptors.resource.TestResource1;
 import org.jboss.resteasy.test.core.interceptors.resource.TestResource2;
 import org.jboss.resteasy.test.core.interceptors.resource.TestSubResource;
@@ -16,6 +17,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 
@@ -27,6 +29,7 @@ import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Category(NotForBootableJar.class)
 public class SubResourceWarningTest {
 
     // check server.log msg count before app is deployed.  Deploying causes messages to be logged.

--- a/testsuite/integration-tests/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration-tests/src/test/resources/arquillian-bootable.xml
@@ -1,0 +1,46 @@
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://jboss.org/schema/arquillian
+        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+    <defaultProtocol type="Servlet 5.0" />
+    <group qualifier="integration-tests" default="true">
+        <container qualifier="${container.qualifier.managed}" default="true">
+            <configuration>
+                <property name="installDir">${install.dir}</property>
+                <property name="jarFile">${bootable.jar}</property>
+
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} -Djboss.socket.binding.port-offset=${container.offset.managed}</property>
+                <property name="jbossArguments">${securityManagerArg}</property>
+                <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
+                                     In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node}</property>
+                <property name="managementPort">${container.management.port.managed}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">8787 ${container.management.port.managed}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+        <container qualifier="${container.qualifier.managed.encoding}">
+            <configuration>
+                <property name="installDir">${install.dir}-encoding</property>
+                <property name="jarFile">${bootable.jar}</property>
+
+                <!-- Forcing file.encoding=us-ascii in order to test RESTEASY-2171 -->
+                <property name="javaVmArguments">-Dorg.jboss.resteasy.port=15080 -Dfile.encoding=us-ascii -server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} -Djboss.socket.binding.port-offset=7000
+                </property>
+                <property name="jbossArguments">${securityManagerArg}</property>
+                <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
+                                     In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node}</property>
+                <property name="managementPort">${container.management.port.managed.encoding}</property>
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">8787 ${container.management.port.managed.encoding}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+    </group>
+
+</arquillian>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -17,6 +17,7 @@
         <version.resteasy.testsuite>${project.version}</version.resteasy.testsuite>
         <additional.surefire.excluded.groups/>
         <additional.surefire.exclude.tracing.tests/>
+        <additional.surefire.excluded.bootable.tests/>
         <!-- default value required for cmd-line -->
         <securityManagerArg>-DSECMGR="false"</securityManagerArg>
         <jacoco.agent/>
@@ -96,7 +97,7 @@
                         <version.resteasy.testsuite>${version.resteasy.testsuite}</version.resteasy.testsuite>
                         <jboss.server.config.file.name>${jboss.server.config.file.name}</jboss.server.config.file.name>
                     </systemPropertyVariables>
-                    <excludedGroups>org.jboss.resteasy.category.ExpectedFailing${additional.surefire.excluded.groups}${additional.surefire.exclude.tracing.tests}</excludedGroups>
+                    <excludedGroups>org.jboss.resteasy.category.ExpectedFailing${additional.surefire.excluded.groups}${additional.surefire.exclude.tracing.tests}${additional.surefire.excluded.bootable.tests}</excludedGroups>
                 </configuration>
             </plugin>
             <plugin>
@@ -449,6 +450,23 @@
                 <galleon.skip>true</galleon.skip>
                 <wildfly.skip>true</wildfly.skip>
             </properties>
+        </profile>
+
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <properties>
+                <additional.surefire.excluded.bootable.tests>,org.jboss.resteasy.category.NotForBootableJar</additional.surefire.excluded.bootable.tests>
+                <testsuite.wildfly.galleon.pack.group.id>org.wildfly</testsuite.wildfly.galleon.pack.group.id>
+            </properties>
+            <modules>
+                <module>arquillian-utils</module>
+                <module>integration-tests</module>
+            </modules>
         </profile>
     </profiles>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs-all</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>RESTEasy Main testsuite</name>

--- a/testsuite/unit-tests/pom.xml
+++ b/testsuite/unit-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-testsuite</artifactId>
-        <version>6.2.4.Final</version>
+        <version>6.2.4.Final--bootable-jar</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This PR is to be changed because it has to against some branch derived from the 6.2.4.Final tag (e.g. 6.2.4.SPx)

This PR:
-  reintroduces bootable jar tests
- adds option to run bootable jar tests with a channel manifest