### PR TITLE
[RESTEASY-3464] Deprecate the DerUtils.decodePrivateKey methods.

### DIFF
--- a/security/jose-jwt/src/main/java/org/jboss/resteasy/jose/jws/util/DerUtils.java
+++ b/security/jose-jwt/src/main/java/org/jboss/resteasy/jose/jws/util/DerUtils.java
@@ -21,6 +21,7 @@ public final class DerUtils {
     private DerUtils() {
     }
 
+    @Deprecated(forRemoval = true, since = "6.2")
     public static PrivateKey decodePrivateKey(InputStream is)
             throws Exception {
 

--- a/security/resteasy-crypto/src/main/java/org/jboss/resteasy/security/DerUtils.java
+++ b/security/resteasy-crypto/src/main/java/org/jboss/resteasy/security/DerUtils.java
@@ -25,6 +25,7 @@ public class DerUtils {
         BouncyIntegration.init();
     }
 
+    @Deprecated(forRemoval = true, since = "6.2")
     public static PrivateKey decodePrivateKey(InputStream is)
             throws Exception {
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-3464

Upstream #4064 