### PR TITLE
Test BootableJar using Channel Manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <version.org.jacoco.plugin>0.8.12</version.org.jacoco.plugin>
         <version.org.wildfly.galleon-plugins>7.0.0.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.plugins.wildfly-maven-plugin>5.0.0.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
-        <version.org.wildfly.jar.plugin>11.0.0.Beta1</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>11.0.2.Final</version.org.wildfly.jar.plugin>
 
         <!-- Test options -->
         <additionalJvmArgs>-Djava.io.tmpdir=${project.build.directory}</additionalJvmArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <version.org.jacoco.plugin>0.8.12</version.org.jacoco.plugin>
         <version.org.wildfly.galleon-plugins>7.0.0.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.plugins.wildfly-maven-plugin>5.0.0.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
+        <version.org.wildfly.jar.plugin>11.0.0.Beta1</version.org.wildfly.jar.plugin>
 
         <!-- Test options -->
         <additionalJvmArgs>-Djava.io.tmpdir=${project.build.directory}</additionalJvmArgs>
@@ -383,6 +384,12 @@
                     <groupId>org.wildfly.plugins</groupId>
                     <artifactId>wildfly-maven-plugin</artifactId>
                     <version>${version.org.wildfly.plugins.wildfly-maven-plugin}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-jar-maven-plugin</artifactId>
+                    <version>${version.org.wildfly.jar.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/testsuite/arquillian-utils/pom.xml
+++ b/testsuite/arquillian-utils/pom.xml
@@ -137,7 +137,7 @@
         </dependency>
     </dependencies>
 
-    <profiles>
+    <!--<profiles>
         <profile>
             <id>bootablejar.profile</id>
             <activation>
@@ -152,7 +152,7 @@
                 </dependency>
             </dependencies>
         </profile>
-    </profiles>
+    </profiles>-->
 
     <build>
         <plugins>

--- a/testsuite/arquillian-utils/pom.xml
+++ b/testsuite/arquillian-utils/pom.xml
@@ -137,6 +137,23 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <!--

--- a/testsuite/arquillian-utils/pom.xml
+++ b/testsuite/arquillian-utils/pom.xml
@@ -137,23 +137,6 @@
         </dependency>
     </dependencies>
 
-    <!--<profiles>
-        <profile>
-            <id>bootablejar.profile</id>
-            <activation>
-                <property>
-                    <name>ts.bootable</name>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.wildfly.arquillian</groupId>
-                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>-->
-
     <build>
         <plugins>
             <!--

--- a/testsuite/config/configure-bootable-jar.cli
+++ b/testsuite/config/configure-bootable-jar.cli
@@ -1,0 +1,2 @@
+# Allow TRACE methods in Undertow
+/subsystem=undertow/server=default-server/http-listener=default:list-clear(name=disallowed-methods)

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -25,6 +25,11 @@
         <module.jar.path>${jboss.home}${file.separator}modules${file.separator}system${file.separator}layers${file.separator}base</module.jar.path>
 
         <version.org.jboss.shrinkwrap.resolver>3.3.0</version.org.jboss.shrinkwrap.resolver>
+
+        <!-- Channel Manifest for Bootable Jar -->
+        <channel-manifest.groupId>org.jboss.eap.channels</channel-manifest.groupId>
+        <channel-manifest.artifactId>eap-8.0-plus-eap-xp-5.0</channel-manifest.artifactId>
+        <channel-manifest.version>1.0.1.GA-redhat-20240229</channel-manifest.version>
     </properties>
 
     <artifactId>resteasy-integration-tests</artifactId>
@@ -171,6 +176,180 @@
                                         <!-- The CustomJackson2Provider doesn't work with this if the full project is not built. -->
                                         <exclude>**/CustomJackson2ProviderTest.java</exclude>
                                     </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>bootablejar.profile.channel</id>
+            <activation>
+                <property>
+                    <name>ts.bootable.channel</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.wildfly.plugins</groupId>
+                            <artifactId>wildfly-jar-maven-plugin</artifactId>
+                            <configuration>
+                                <channels>
+                                    <channel>
+                                        <manifest>
+                                            <groupId>${channel-manifest.groupId}</groupId>
+                                            <artifactId>${channel-manifest.artifactId}</artifactId>
+                                            <version>${channel-manifest.version}</version>
+                                        </manifest>
+                                    </channel>
+                                </channels>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Disable the standard copy-based provisioning -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>initialize-basedirs</id>
+                                <phase>none</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <executions>
+                            <!-- Package a jaxrs-server layer with a few other layers -->
+                            <execution>
+                                <id>bootable-jar-observability-packaging</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <output-file-name>jaxrs-server.jar</output-file-name>
+                                    <hollowJar>true</hollowJar>
+                                    <record-state>false</record-state>
+                                    <log-time>true</log-time>
+                                    <plugin-options>
+                                        <jboss-fork-embedded>true</jboss-fork-embedded>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.wildfly.galleon.pack.group.id}</groupId>
+                                            <artifactId>wildfly-galleon-pack</artifactId>
+                                            <version>${server.version}</version>
+                                            <!-- Required for rxjava -->
+                                            <includedPackages>
+                                                <package>org.jboss.resteasy.resteasy-rxjava2</package>
+                                            </includedPackages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <layers>
+                                        <layer>jaxrs-server</layer>
+                                        <layer>microprofile-config</layer>
+                                        <layer>datasources</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>undertow-https</layer>
+                                        <layer>ejb</layer>
+                                    </layers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <install.dir>${project.build.directory}/wildfly</install.dir>
+                                <bootable.jar>${project.build.directory}/jaxrs-server.jar</bootable.jar>
+                                <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
+                                <container.management.port.managed>${container.management.port.managed}</container.management.port.managed>
+                                <securityManagerArg>${securityManagerArg}</securityManagerArg>
+                                <additionalJvmArgs>${additionalJvmArgs}</additionalJvmArgs>
+                                <ipv6>false</ipv6>
+                                <ipv6ArquillianSettings></ipv6ArquillianSettings>
+                                <node>127.0.0.1</node>
+                                <project.version>${project.version}</project.version>
+                                <version.resteasy.testsuite>${version.resteasy.testsuite}</version.resteasy.testsuite>
+                                <security.provider>${security.provider}</security.provider>
+                                <modular.jdk.args>${modular.jdk.args}</modular.jdk.args>
+                                <container.base.dir.managed>${container.base.dir.managed}</container.base.dir.managed>
+                                <container.offset.managed>0</container.offset.managed>
+                                <container.qualifier.managed>${container.qualifier.managed}</container.qualifier.managed>
+                                <container.qualifier.managed.encoding>${container.qualifier.managed.encoding}</container.qualifier.managed.encoding>
+                                <container.offset.managed.encoding>${container.offset.managed.encoding}</container.offset.managed.encoding>
+                                <container.management.port.managed.encoding>${container.management.port.managed.encoding}</container.management.port.managed.encoding>
+                                <resteasy.microprofile.sseclient.buffersize>5</resteasy.microprofile.sseclient.buffersize>
+                            </systemPropertyVariables>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>disable-jsonb-client</id>
+                                <phase>none</phase>
+                            </execution>
+
+                            <execution>
+                                <id>default-test-bootable-jar</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes>
+                                        <!-- Tests requires excluding JsonBindingProvider-->
+                                        <exclude>**/JsonBindingAnnotationsJacksonTest.java</exclude>
+                                        <exclude>**/SseJsonEventTest</exclude>
+                                        <!-- Tests without proper arquillian container in arquillian-bootable.xml -->
+                                        <exclude>**/*Gzip*</exclude>
+                                        <exclude>**/SslServerWithCorrectCertificateTest.java</exclude>
+                                        <exclude>**/SslServerWithWildcardHostnameCertificateTest.java</exclude>
+                                        <exclude>**/SslServerWithWrongHostnameCertificateTest.java</exclude>
+                                        <exclude>**/SslSniHostNamesTest.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+
+                            <!-- execution with excluded JSON-B -->
+                            <execution>
+                                <id>disable-jsonb-client-bootable-jar</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <includes>
+                                        <!-- TODO JsonBindingAnnotationsJacksonTest may be included here as well with additional changes-->
+                                        <include>**/SseJsonEventTest.java</include>
+                                    </includes>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>org.jboss.resteasy:resteasy-json-binding-provider</classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
                                 </configuration>
                             </execution>
                         </executions>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -223,6 +223,14 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <!-- Do not provision WildFly for bootable JAR tests -->
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
@@ -269,6 +277,13 @@
                                             </manifest>
                                         </channel>
                                     </channels>
+                                    <cli-sessions>
+                                        <cli-session>
+                                            <script-files>
+                                                <script>${basedir}/../config/configure-bootable-jar.cli</script>
+                                            </script-files>
+                                        </cli-session>
+                                    </cli-sessions>
                                 </configuration>
                             </execution>
                         </executions>
@@ -277,28 +292,12 @@
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <systemPropertyVariables>
+                            <systemPropertyVariables combine.children="append">
                                 <install.dir>${project.build.directory}/wildfly</install.dir>
                                 <bootable.jar>${project.build.directory}/jaxrs-server.jar</bootable.jar>
                                 <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
-                                <container.management.port.managed>${container.management.port.managed}</container.management.port.managed>
-                                <securityManagerArg>${securityManagerArg}</securityManagerArg>
-                                <additionalJvmArgs>${additionalJvmArgs}</additionalJvmArgs>
-                                <ipv6>false</ipv6>
-                                <ipv6ArquillianSettings></ipv6ArquillianSettings>
-                                <node>127.0.0.1</node>
-                                <project.version>${project.version}</project.version>
-                                <version.resteasy.testsuite>${version.resteasy.testsuite}</version.resteasy.testsuite>
-                                <security.provider>${security.provider}</security.provider>
-                                <modular.jdk.args>${modular.jdk.args}</modular.jdk.args>
-                                <container.base.dir.managed>${container.base.dir.managed}</container.base.dir.managed>
-                                <container.offset.managed>0</container.offset.managed>
-                                <container.qualifier.managed>${container.qualifier.managed}</container.qualifier.managed>
-                                <container.qualifier.managed.encoding>${container.qualifier.managed.encoding}</container.qualifier.managed.encoding>
-                                <container.offset.managed.encoding>${container.offset.managed.encoding}</container.offset.managed.encoding>
-                                <container.management.port.managed.encoding>${container.management.port.managed.encoding}</container.management.port.managed.encoding>
-                                <resteasy.microprofile.sseclient.buffersize>5</resteasy.microprofile.sseclient.buffersize>
                             </systemPropertyVariables>
+                            <excludedGroups>${additional.surefire.excluded.groups}</excludedGroups>
                         </configuration>
                         <executions>
                             <execution>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -27,9 +27,9 @@
         <version.org.jboss.shrinkwrap.resolver>3.3.0</version.org.jboss.shrinkwrap.resolver>
 
         <!-- Channel Manifest for Bootable Jar -->
-        <channel-manifest.groupId>org.jboss.eap.channels</channel-manifest.groupId>
-        <channel-manifest.artifactId>eap-8.0-plus-eap-xp-5.0</channel-manifest.artifactId>
-        <channel-manifest.version>1.0.1.GA-redhat-20240229</channel-manifest.version>
+        <channel-manifest.groupId/>
+        <channel-manifest.artifactId/>
+        <channel-manifest.version/>
     </properties>
 
     <artifactId>resteasy-integration-tests</artifactId>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -25,11 +25,6 @@
         <module.jar.path>${jboss.home}${file.separator}modules${file.separator}system${file.separator}layers${file.separator}base</module.jar.path>
 
         <version.org.jboss.shrinkwrap.resolver>3.3.0</version.org.jboss.shrinkwrap.resolver>
-
-        <!-- Channel Manifest for Bootable Jar -->
-        <channel-manifest.groupId/>
-        <channel-manifest.artifactId/>
-        <channel-manifest.version/>
     </properties>
 
     <artifactId>resteasy-integration-tests</artifactId>
@@ -227,8 +222,13 @@
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
+                                            <!--
                                             <groupId>${testsuite.wildfly.galleon.pack.group.id}</groupId>
                                             <artifactId>wildfly-galleon-pack</artifactId>
+                                            <version>${server.version}</version>
+                                            -->
+                                            <groupId>${server.test.feature.pack.groupId}</groupId>
+                                            <artifactId>${server.test.feature.pack.artifactId}</artifactId>
                                             <version>${server.version}</version>
                                             <!-- Required for rxjava -->
                                             <includedPackages>
@@ -247,9 +247,21 @@
                                     <channels>
                                         <channel>
                                             <manifest>
-                                                <groupId>${channel-manifest.groupId}</groupId>
+                                                <groupId>${wildfly.channel.manifest.groupId}</groupId>
+                                                <artifactId>${wildfly.channel.manifest.artifactId}</artifactId>
+                                                <version>${wildfly.channel.manifest.version}</version>
+                                            </manifest>
+                                            <!--<manifest>
+                                                <groupId>${wildfly.channel.manifest.groupId}</groupId>
                                                 <artifactId>${channel-manifest.artifactId}</artifactId>
                                                 <version>${channel-manifest.version}</version>
+                                            </manifest>-->
+                                        </channel>
+                                        <channel>
+                                            <manifest>
+                                                <groupId>${resteasy.channel.manifest.groupId}</groupId>
+                                                <artifactId>${resteasy.channel.manifest.artifactId}</artifactId>
+                                                <version>${resteasy.channel.manifest.version}</version>
                                             </manifest>
                                         </channel>
                                     </channels>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -179,12 +179,34 @@
             </build>
         </profile>
         <profile>
+            <id>default</id>
+            <activation>
+                <property>
+                    <name>!ts.bootable</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-managed</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>bootablejar.profile</id>
             <activation>
                 <property>
                     <name>ts.bootable</name>
                 </property>
             </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <!-- Disable the standard copy-based provisioning -->
@@ -222,11 +244,6 @@
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
-                                            <!--
-                                            <groupId>${testsuite.wildfly.galleon.pack.group.id}</groupId>
-                                            <artifactId>wildfly-galleon-pack</artifactId>
-                                            <version>${server.version}</version>
-                                            -->
                                             <groupId>${server.test.feature.pack.groupId}</groupId>
                                             <artifactId>${server.test.feature.pack.artifactId}</artifactId>
                                             <version>${server.version}</version>
@@ -238,7 +255,6 @@
                                     </feature-packs>
                                     <layers>
                                         <layer>jaxrs-server</layer>
-                                        <layer>microprofile-config</layer>
                                         <layer>datasources</layer>
                                         <layer>h2-default-datasource</layer>
                                         <layer>undertow-https</layer>
@@ -250,18 +266,6 @@
                                                 <groupId>${wildfly.channel.manifest.groupId}</groupId>
                                                 <artifactId>${wildfly.channel.manifest.artifactId}</artifactId>
                                                 <version>${wildfly.channel.manifest.version}</version>
-                                            </manifest>
-                                            <!--<manifest>
-                                                <groupId>${wildfly.channel.manifest.groupId}</groupId>
-                                                <artifactId>${channel-manifest.artifactId}</artifactId>
-                                                <version>${channel-manifest.version}</version>
-                                            </manifest>-->
-                                        </channel>
-                                        <channel>
-                                            <manifest>
-                                                <groupId>${resteasy.channel.manifest.groupId}</groupId>
-                                                <artifactId>${resteasy.channel.manifest.artifactId}</artifactId>
-                                                <version>${resteasy.channel.manifest.version}</version>
                                             </manifest>
                                         </channel>
                                     </channels>
@@ -704,11 +708,6 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
-            <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-junit-api</artifactId>
             <scope>test</scope>
         </dependency>
@@ -726,12 +725,14 @@
                 <filtering>true</filtering>
                 <includes>
                     <include>arquillian.xml</include>
+                    <include>arquillian-bootable.xml</include>
                 </includes>
             </testResource>
             <testResource>
                 <directory>src/test/resources</directory>
                 <excludes>
                     <exclude>arquillian.xml</exclude>
+                    <exclude>arquillian-bootable.xml</exclude>
                 </excludes>
             </testResource>
         </testResources>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -184,35 +184,6 @@
             </build>
         </profile>
         <profile>
-            <id>bootablejar.profile.channel</id>
-            <activation>
-                <property>
-                    <name>ts.bootable.channel</name>
-                </property>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.wildfly.plugins</groupId>
-                            <artifactId>wildfly-jar-maven-plugin</artifactId>
-                            <configuration>
-                                <channels>
-                                    <channel>
-                                        <manifest>
-                                            <groupId>${channel-manifest.groupId}</groupId>
-                                            <artifactId>${channel-manifest.artifactId}</artifactId>
-                                            <version>${channel-manifest.version}</version>
-                                        </manifest>
-                                    </channel>
-                                </channels>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
             <id>bootablejar.profile</id>
             <activation>
                 <property>
@@ -273,6 +244,15 @@
                                         <layer>undertow-https</layer>
                                         <layer>ejb</layer>
                                     </layers>
+                                    <channels>
+                                        <channel>
+                                            <manifest>
+                                                <groupId>${channel-manifest.groupId}</groupId>
+                                                <artifactId>${channel-manifest.artifactId}</artifactId>
+                                                <version>${channel-manifest.version}</version>
+                                            </manifest>
+                                        </channel>
+                                    </channels>
                                 </configuration>
                             </execution>
                         </executions>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/CDIResourceTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/basic/CDIResourceTest.java
@@ -29,6 +29,7 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
@@ -44,6 +45,7 @@ import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
 
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
+@Tag("NotForBootableJar")
 public class CDIResourceTest {
 
     protected static final Logger logger = Logger.getLogger(CDIResourceTest.class.getName());

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/InjectionTest.java
@@ -53,6 +53,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
@@ -68,6 +69,7 @@ import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
 @ServerSetup(JmsTestQueueSetupTask.class)
+@Tag("NotForBootableJar")
 public class InjectionTest {
     protected static final Logger log = Logger.getLogger(InjectionTest.class.getName());
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/MDBInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/MDBInjectionTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
@@ -61,6 +62,7 @@ import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
 @ServerSetup(JmsTestQueueSetupTask.class)
+@Tag("NotForBootableJar")
 public class MDBInjectionTest {
     protected static final Logger log = Logger.getLogger(MDBInjectionTest.class.getName());
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/ReverseInjectionTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/injection/ReverseInjectionTest.java
@@ -79,6 +79,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
@@ -98,6 +99,7 @@ import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
  */
 @ExtendWith(ArquillianExtension.class)
 @ServerSetup(JmsTestQueueSetupTask.class)
+@Tag("NotForBootableJar")
 public class ReverseInjectionTest {
     private static Logger log = Logger.getLogger(ReverseInjectionTest.class);
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/ClientBuilderTest.java
@@ -19,6 +19,7 @@ import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
@@ -29,6 +30,7 @@ import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
  * @tpSince RESTEasy 3.0.17
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("NotForBootableJar")
 public class ClientBuilderTest {
 
     @SuppressWarnings(value = "unchecked")

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/DuplicateDeploymentTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/DuplicateDeploymentTest.java
@@ -15,6 +15,7 @@ import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
+@Tag("NotForBootableJar")
 public class DuplicateDeploymentTest {
     private static int initWarningCount = 0;
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/logging/DebugLoggingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/logging/DebugLoggingTest.java
@@ -30,6 +30,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -43,6 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
 @ServerSetup(DebugLoggingTest.DebugLoggingSetupTask.class)
+@Tag("NotForBootableJar")
 public class DebugLoggingTest {
 
     public static class DebugLoggingSetupTask extends LoggingSetupTask {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/ResourceClassProcessorErrorTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/spi/ResourceClassProcessorErrorTest.java
@@ -16,6 +16,7 @@ import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
+@Tag("NotForBootableJar")
 public class ResourceClassProcessorErrorTest {
 
     private static final String DEPLOYMENT_NAME = "deployment_name";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/crypto/CryptoTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/crypto/CryptoTest.java
@@ -47,6 +47,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
@@ -60,6 +61,7 @@ import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
 @SuppressWarnings(value = "unchecked")
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
+@Tag("NotForBootableJar")
 public class CryptoTest {
     private static final String ERROR_CONTENT_MSG = "Wrong content of response";
     private static final String ERROR_CORE_MSG = "Wrong BouncyCastleProvider and RESTEasy integration";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/crypto/VerifyDecryptTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/crypto/VerifyDecryptTest.java
@@ -28,6 +28,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
@@ -40,6 +41,7 @@ import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
  */
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
+@Tag("NotForBootableJar")
 public class VerifyDecryptTest {
     private static final String RESPONSE_ERROR_MSG = "Response contains wrong content";
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/DynamicFeatureTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/interceptor/DynamicFeatureTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -77,6 +78,7 @@ public class DynamicFeatureTest {
      */
     @Test
     @Order(1)
+    @Tag("NotForBootableJar")
     public void testDynamicFeatureProcessing() {
         int counter = logCounter.count();
         Assertions.assertNotEquals(0, counter,

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/DuplicateProviderRegistrationTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/DuplicateProviderRegistrationTest.java
@@ -24,6 +24,7 @@ import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
@@ -35,6 +36,7 @@ import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
  * @tpSince RESTEasy 3.0.17
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("NotForBootableJar")
 public class DuplicateProviderRegistrationTest {
 
     private static final String RESTEASY_002155_ERR_MSG = "Wrong count of RESTEASY002155 warning message";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/MissingProducerTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/custom/MissingProducerTest.java
@@ -9,6 +9,7 @@ import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
+@Tag("NotForBootableJar")
 public class MissingProducerTest {
     private static final String ERR_MSG = "Warning was not logged";
     private static int initLogMsg1Count = parseLog1();

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jsonb/basic/JsonBindingDebugLoggingTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/jsonb/basic/JsonBindingDebugLoggingTest.java
@@ -31,6 +31,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
@@ -44,6 +45,7 @@ import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
  */
 @ExtendWith(ArquillianExtension.class)
 @ServerSetup({ LoggingSetupTask.class }) // TBD: remove debug logging activation?
+@Tag("NotForBootableJar")
 public class JsonBindingDebugLoggingTest {
 
     static ResteasyClient client;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/mediatype/BlacklistedMediaTypeTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/mediatype/BlacklistedMediaTypeTest.java
@@ -33,9 +33,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.wildfly.arquillian.junit.annotations.RequiresModule;
 
 /**
  * @tpSubChapter Blacklisted media types - RESTEASY-2198
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
-@Tag("NotForBootableJar")
+@RequiresModule("org.bouncycastle")
 public class BlacklistedMediaTypeTest {
 
     private static final String APPLICATION_SIGNED_EXCHANGE = "application/signed-exchange";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/mediatype/BlacklistedMediaTypeTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/mediatype/BlacklistedMediaTypeTest.java
@@ -33,6 +33,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -43,6 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
+@Tag("NotForBootableJar")
 public class BlacklistedMediaTypeTest {
 
     private static final String APPLICATION_SIGNED_EXCHANGE = "application/signed-exchange";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/EncodingMimeMultipartFormProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/EncodingMimeMultipartFormProviderTest.java
@@ -19,6 +19,7 @@ import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
+@Tag("NotForBootableJar")
 public class EncodingMimeMultipartFormProviderTest {
 
     private static final String TEST_URI = generateURL("/encoding-mime");

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/MimeMultipartProviderTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/multipart/MimeMultipartProviderTest.java
@@ -41,6 +41,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
@@ -52,6 +53,7 @@ import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
  */
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
+@Tag("NotForBootableJar")
 public class MimeMultipartProviderTest {
 
     private static Logger logger = Logger.getLogger(MimeMultipartProviderTest.class);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/DuplicitePathTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/response/DuplicitePathTest.java
@@ -26,6 +26,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
+@Tag("NotForBootableJar")
 public class DuplicitePathTest {
     static ResteasyClient client;
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
@@ -35,6 +35,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.wildfly.arquillian.junit.annotations.RequiresModule;
@@ -48,6 +49,7 @@ import org.wildfly.arquillian.junit.annotations.RequiresModule;
 @ServerSetup({ BasicAuthTest.SecurityDomainSetup.class })
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
+@Tag("NotForBootableJar")
 public class BasicAuthTest {
 
     private static final String WRONG_RESPONSE = "Wrong response content.";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SecurityContextTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/SecurityContextTest.java
@@ -21,6 +21,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ServerSetup({ SecurityContextTest.SecurityDomainSetup.class })
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
+@Tag("NotForBootableJar")
 public class SecurityContextTest {
 
     private static final String USERNAME = "bill";

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/TwoSecurityDomainsTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/TwoSecurityDomainsTest.java
@@ -30,6 +30,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ServerSetup(TwoSecurityDomainsTest.SecurityDomainSetup.class)
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
+@Tag("NotForBootableJar")
 public class TwoSecurityDomainsTest {
 
     private static ResteasyClient authorizedClient;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/warning/SubResourceWarningTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/warning/SubResourceWarningTest.java
@@ -18,6 +18,7 @@ import org.jboss.resteasy.utils.TestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
 @ServerSetup(SubResourceWarningTest.WarnLoggingSetupTask.class)
+@Tag("NotForBootableJar")
 public class SubResourceWarningTest {
 
     public static class WarnLoggingSetupTask extends LoggingSetupTask {

--- a/testsuite/integration-tests/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration-tests/src/test/resources/arquillian-bootable.xml
@@ -1,0 +1,46 @@
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://jboss.org/schema/arquillian
+        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+    <defaultProtocol type="Servlet 5.0" />
+    <group qualifier="integration-tests" default="true">
+        <container qualifier="${container.qualifier.managed}" default="true">
+            <configuration>
+                <property name="installDir">${install.dir}</property>
+                <property name="jarFile">${bootable.jar}</property>
+
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} -Djboss.socket.binding.port-offset=${container.offset.managed}</property>
+                <property name="jbossArguments">${securityManagerArg}</property>
+                <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
+                                     In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node}</property>
+                <property name="managementPort">${container.management.port.managed}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">8787 ${container.management.port.managed}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+        <container qualifier="${container.qualifier.managed.encoding}">
+            <configuration>
+                <property name="installDir">${install.dir}-encoding</property>
+                <property name="jarFile">${bootable.jar}</property>
+
+                <!-- Forcing file.encoding=us-ascii in order to test RESTEASY-2171 -->
+                <property name="javaVmArguments">-Dorg.jboss.resteasy.port=15080 -Dfile.encoding=us-ascii -server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} -Djboss.socket.binding.port-offset=7000
+                </property>
+                <property name="jbossArguments">${securityManagerArg}</property>
+                <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
+                                     In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node}</property>
+                <property name="managementPort">${container.management.port.managed.encoding}</property>
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">8787 ${container.management.port.managed.encoding}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+    </group>
+
+</arquillian>

--- a/testsuite/integration-tests/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration-tests/src/test/resources/arquillian-bootable.xml
@@ -14,7 +14,7 @@
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.managed}</property>
                 <!-- AS7-4070 -->
-                <property name="waitForPorts">8787 ${container.management.port.managed}</property>
+                <property name="waitForPorts">${container.management.port.managed}</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
@@ -30,7 +30,7 @@
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.managed.encoding}</property>
                 <!-- AS7-4070 -->
-                <property name="waitForPorts">8787 ${container.management.port.managed.encoding}</property>
+                <property name="waitForPorts">${container.management.port.managed.encoding}</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>

--- a/testsuite/integration-tests/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration-tests/src/test/resources/arquillian-bootable.xml
@@ -8,7 +8,7 @@
             <configuration>
                 <property name="installDir">${install.dir}</property>
                 <property name="jarFile">${bootable.jar}</property>
-                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} -Djboss.socket.binding.port-offset=${container.offset.managed}</property>
+                <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} -Djboss.socket.binding.port-offset=${container.offset.managed}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node}</property>
@@ -23,7 +23,7 @@
                 <property name="installDir">${install.dir}-encoding</property>
                 <property name="jarFile">${bootable.jar}</property>
                 <!-- Forcing file.encoding=us-ascii in order to test RESTEASY-2171 -->
-                <property name="javaVmArguments">-Dorg.jboss.resteasy.port=15080 -Dfile.encoding=us-ascii -server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} -Djboss.socket.binding.port-offset=7000
+                <property name="javaVmArguments">-Dorg.jboss.resteasy.port=15080 -Dfile.encoding=us-ascii -server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} -Djboss.socket.binding.port-offset=7000
                 </property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration-tests/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration-tests/src/test/resources/arquillian-bootable.xml
@@ -8,15 +8,11 @@
             <configuration>
                 <property name="installDir">${install.dir}</property>
                 <property name="jarFile">${bootable.jar}</property>
-
                 <property name="javaVmArguments">-server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} -Djboss.socket.binding.port-offset=${container.offset.managed}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
-                <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
-                                     In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.managed}</property>
-
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">8787 ${container.management.port.managed}</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
@@ -26,13 +22,10 @@
             <configuration>
                 <property name="installDir">${install.dir}-encoding</property>
                 <property name="jarFile">${bootable.jar}</property>
-
                 <!-- Forcing file.encoding=us-ascii in order to test RESTEASY-2171 -->
                 <property name="javaVmArguments">-Dorg.jboss.resteasy.port=15080 -Dfile.encoding=us-ascii -server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${modular.jdk.args} ${ipv6ArquillianSettings} -Djboss.socket.binding.port-offset=7000
                 </property>
                 <property name="jbossArguments">${securityManagerArg}</property>
-                <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
-                                     In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.managed.encoding}</property>
@@ -42,5 +35,4 @@
             </configuration>
         </container>
     </group>
-
 </arquillian>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -480,6 +480,22 @@
                 <wildfly.skip>true</wildfly.skip>
             </properties>
         </profile>
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <properties>
+                <additional.surefire.excluded.groups>NotForBootableJar</additional.surefire.excluded.groups>
+                <testsuite.wildfly.galleon.pack.group.id>org.wildfly</testsuite.wildfly.galleon.pack.group.id>
+            </properties>
+            <modules>
+                <module>arquillian-utils</module>
+                <module>integration-tests</module>
+            </modules>
+        </profile>
     </profiles>
 
 </project>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -118,6 +118,11 @@
                         <groupId>javax.inject</groupId>
                         <artifactId>javax.inject</artifactId>
                     </exclusion>
+                    <!-- caused  [CIRCULAR REFERENCE: java.lang.RuntimeException: Could not create new instance of class org.jboss.arquillian.test.impl.EventTestRunnerAdaptor] -->
+                    <exclusion>
+                        <groupId>org.jboss.arquillian.junit</groupId>
+                        <artifactId>arquillian-junit-container</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -36,6 +36,7 @@
 
         <wildfly.channel.manifest.groupId>org.wildfly.channels</wildfly.channel.manifest.groupId>
         <wildfly.channel.manifest.artifactId>wildfly-ee</wildfly.channel.manifest.artifactId>
+        <wildfly.channel.manifest.version>${server.version}</wildfly.channel.manifest.version>
 
         <resteasy.channel.manifest.groupId>dev.resteasy.channels</resteasy.channel.manifest.groupId>
         <resteasy.channel.manifest.artifactId>resteasy-${channel.stream.version}</resteasy.channel.manifest.artifactId>
@@ -494,7 +495,7 @@
             </activation>
             <properties>
                 <additional.surefire.excluded.groups>NotForBootableJar</additional.surefire.excluded.groups>
-                <testsuite.wildfly.galleon.pack.group.id>org.wildfly</testsuite.wildfly.galleon.pack.group.id>
+                <!--<testsuite.wildfly.galleon.pack.group.id>org.wildfly</testsuite.wildfly.galleon.pack.group.id>-->
             </properties>
             <modules>
                 <module>arquillian-utils</module>


### PR DESCRIPTION
This MR is for retaining the capability to test RESTEASY using WildFly Bootable Jar;

This MR is specifically targeted at testing RESTEASY using WildFly Bootable Jar obtained from branch `32.x` of the git@github.com:wildfly/wildfly.git repository;

Optionally, it's possible to provision the Bootable Jar through channels;

Run Bootable Jar tests like:

```bash
mvn -f testsuite/pom.xml \
    clean verify \
    -Dts.bootable=true \
    -Ddefault=false \
    -Ddisable.microprofile.tests \
    -Dserver.version=32.0.1.Final \
    -Dversion.org.wildfly.jar.plugin=11.0.2.Final \
    --batch-mode \
    --fail-at-end \
    -Denforcer.skip \
    -Dserver.home=/tmp/wildfly-32.0.1.Final \
    -Dversion.resteasy.testsuite=6.2.9.Final \
    -Dmaven.test.failure.ignore=true \
    -Dchannel-manifest.groupId=org.wildfly.channels \
    -Dchannel-manifest.artifactId=wildfly-ee \
    -Dchannel-manifest.version=32.0.1.Final
```

Upstream: #4059