### PR TITLE
[RESTEASY-3490] Client proxy: invoke default methods rather than failing with RESTEASY004530

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/ClientProxy.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/ClientProxy.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.client.jaxrs.internal.proxy;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.Map;
@@ -52,6 +53,11 @@ public class ClientProxy implements InvocationHandler {
                 return this.toString();
             } else if (method.getName().equals("as") && args.length == 1 && args[0] instanceof Class) {
                 return ProxyBuilder.proxy((Class<?>) args[0], target, config);
+            } else if (method.isDefault()) {
+                return MethodHandles.privateLookupIn(clazz, MethodHandles.lookup())
+                        .unreflectSpecial(method, clazz)
+                        .bindTo(o)
+                        .invokeWithArguments(args);
             }
         }
 

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/ClientProxyDefaultMethodTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/proxy/ClientProxyDefaultMethodTest.java
@@ -1,0 +1,48 @@
+package org.jboss.resteasy.test.client.proxy;
+
+import jakarta.ws.rs.client.ClientBuilder;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.test.client.proxy.resource.ClientSmokeResource;
+import org.jboss.resteasy.test.core.smoke.resource.ResourceWithInterfaceSimpleClient;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * @tpSubChapter Smoke tests for jaxrs
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Client proxy supports interface default methods
+ */
+@ExtendWith(ArquillianExtension.class)
+@RunAsClient
+public class ClientProxyDefaultMethodTest {
+
+    @Deployment
+    public static Archive<?> deploySimpleResource() {
+        WebArchive war = TestUtil.prepareArchive(ClientProxyDefaultMethodTest.class.getSimpleName());
+        return TestUtil.finishContainerPrepare(war, null, ClientSmokeResource.class);
+    }
+
+    /**
+     * @tpTestDetails Check proxy supports interface default method
+     */
+    @Test
+    public void testNoDefaultsResource() throws Exception {
+        ResteasyClient client = (ResteasyClient) ClientBuilder.newClient();
+        ResourceWithInterfaceSimpleClient proxy = client.target(
+                PortProviderUtil.generateBaseUrl(ClientProxyDefaultMethodTest.class.getSimpleName()))
+                .proxyBuilder(ResourceWithInterfaceSimpleClient.class).build();
+
+        Assertions.assertEquals("basic", proxy.getBasicThroughDefaultMethod(), "Wrong client answer.");
+        client.close();
+    }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/smoke/resource/ResourceWithInterfaceSimpleClient.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/smoke/resource/ResourceWithInterfaceSimpleClient.java
@@ -35,4 +35,8 @@ public interface ResourceWithInterfaceSimpleClient {
     @Path("uriParam/{param}")
     @Produces("text/plain")
     int getUriParam(@PathParam("param") int param);
+
+    default String getBasicThroughDefaultMethod() {
+        return getBasic();
+    }
 }


### PR DESCRIPTION
Hi RESTEasy devs,

We use the client proxy. When calling a default method, we get an error RESTEASY004530 that the method isn't recognized.

Is it possible to extend the proxy implementation to respect default methods?