### PR TITLE
Add a profile for ignoring @ManagedBean support for WildFly Preview. …

### DIFF
--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -121,6 +121,16 @@
                 <server.test.feature.pack.artifactId>wildfly-preview-feature-pack</server.test.feature.pack.artifactId>
                 <server.test.feature.pack.version>${version.org.wildfly}</server.test.feature.pack.version>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludedGroups>managed-bean-support-required</excludedGroups>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>provision-without-resteasy</id>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ManagedBeanValidationTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ManagedBeanValidationTest.java
@@ -20,6 +20,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
@@ -33,6 +34,7 @@ import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
 @ServerSetup(LoggingSetupTask.class)
+@Tag("managed-bean-support-required")
 public class ManagedBeanValidationTest {
 
     private static Client client;


### PR DESCRIPTION
…This support may get added back at some point and if not the test needs to be migrated to WildFly itself or simply deleted.