### PR TITLE
[RESTEASY-3494] Upgrade BouncyCastle to 1.78.1.

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -65,7 +65,7 @@
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.james.apache-mime4j>0.8.11</version.org.apache.james.apache-mime4j>
         <version.org.apache.maven>3.3.9</version.org.apache.maven> <!-- Used to download aether-provider -->
-        <version.org.bouncycastle>1.75</version.org.bouncycastle>
+        <version.org.bouncycastle>1.78.1</version.org.bouncycastle>
         <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
         <version.org.eclipse.angus.angus-activation>1.0.0</version.org.eclipse.angus.angus-activation>
         <version.org.eclipse.angus.angus-mail>1.0.0</version.org.eclipse.angus.angus-mail>


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-3494

Upstream #4148