### PR TITLE
[RESTEASY-3510] Allow options to be looked up via a custom ResteasyCo…

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyDeploymentImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ResteasyDeploymentImpl.java
@@ -39,6 +39,7 @@ import org.jboss.resteasy.spi.ResteasyConfiguration;
 import org.jboss.resteasy.spi.ResteasyDeployment;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.spi.config.ConfigurationFactory;
+import org.jboss.resteasy.spi.config.Options;
 import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.util.GetRestful;
 
@@ -287,17 +288,21 @@ public class ResteasyDeploymentImpl implements ResteasyDeployment {
     }
 
     protected void initializeFactory() {
+        // Get the ResteasyConfiguration if it exists
+        Object context = getDefaultContextObjects() == null ? null
+                : getDefaultContextObjects().get(ResteasyConfiguration.class);
+        // Check if the efault exception manager is enabled
+        final boolean defaultExceptionManagerEnabled = getOptionValue(Options.ENABLE_DEFAULT_EXCEPTION_MAPPER,
+                (ResteasyConfiguration) context);
         // it is very important that each deployment create their own provider factory
         // this allows each WAR to have their own set of providers
         if (providerFactory == null)
-            providerFactory = new ResteasyProviderFactoryImpl();
+            providerFactory = new ResteasyProviderFactoryImpl(defaultExceptionManagerEnabled);
         providerFactory.setRegisterBuiltins(registerBuiltin);
         providerFactory.getStatisticsController().setEnabled(statisticsEnabled);
 
         Object tracingText;
         Object thresholdText;
-        Object context = getDefaultContextObjects() == null ? null
-                : getDefaultContextObjects().get(ResteasyConfiguration.class);
 
         org.jboss.resteasy.spi.config.Configuration config = ConfigurationFactory.getInstance()
                 .getConfiguration((ResteasyConfiguration) context);
@@ -338,7 +343,8 @@ public class ResteasyDeploymentImpl implements ResteasyDeployment {
                 if (ResteasyProviderFactory.peekInstance() == null
                         || !(ResteasyProviderFactory.peekInstance() instanceof ThreadLocalResteasyProviderFactory)) {
 
-                    threadLocalProviderFactory = new ThreadLocalResteasyProviderFactory(providerFactory);
+                    threadLocalProviderFactory = new ThreadLocalResteasyProviderFactory(providerFactory,
+                            defaultExceptionManagerEnabled);
                     ResteasyProviderFactory.setInstance(threadLocalProviderFactory);
                 } else {
                     ThreadLocalResteasyProviderFactory.push(providerFactory);
@@ -1032,5 +1038,13 @@ public class ResteasyDeploymentImpl implements ResteasyDeployment {
             return (Boolean) value;
         }
         return !String.valueOf(value).equalsIgnoreCase("false");
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static <T> T getOptionValue(final Options<T> option, final ResteasyConfiguration config) {
+        if (System.getSecurityManager() == null) {
+            return option.getValue(config);
+        }
+        return AccessController.doPrivileged((PrivilegedAction<T>) option::getValue);
     }
 }

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
@@ -59,6 +59,18 @@ public final class ThreadLocalResteasyProviderFactory extends ResteasyProviderFa
         this.defaultFactory = defaultFactory;
     }
 
+    /**
+     * Creates a new thread local provider.
+     *
+     * @param defaultFactory                 the delegate provider
+     * @param defaultExceptionManagerEnabled {@code true} if the default exception manager should be enabled
+     */
+    public ThreadLocalResteasyProviderFactory(final ResteasyProviderFactory defaultFactory,
+            final boolean defaultExceptionManagerEnabled) {
+        super(defaultExceptionManagerEnabled);
+        this.defaultFactory = defaultFactory;
+    }
+
     public ResteasyProviderFactory getDelegate() {
         ResteasyProviderFactory factory = delegate.get();
         if (factory == null)

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ResteasyProviderFactoryImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ResteasyProviderFactoryImpl.java
@@ -147,12 +147,22 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory
     protected boolean lockSnapshots;
     protected StatisticsControllerImpl statisticsController = new StatisticsControllerImpl();
 
-    private final boolean defaultExceptionManagerEnabled = getOptionValue(Options.ENABLE_DEFAULT_EXCEPTION_MAPPER);
+    private final boolean defaultExceptionManagerEnabled;
 
     public ResteasyProviderFactoryImpl() {
+        this(getOptionValue(Options.ENABLE_DEFAULT_EXCEPTION_MAPPER));
+    }
+
+    /**
+     * Creates a new factory.
+     *
+     * @param defaultExceptionManagerEnabled {@code true} if the default exception manager should be enabled
+     */
+    public ResteasyProviderFactoryImpl(final boolean defaultExceptionManagerEnabled) {
         // NOTE!!! It is important to put all initialization into initialize() as ThreadLocalResteasyProviderFactory
         // subclasses and delegates to this class.
         initialize();
+        this.defaultExceptionManagerEnabled = defaultExceptionManagerEnabled;
     }
 
     /**
@@ -168,6 +178,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory
         initializeCommon(null, true, false);
         // don't know when client will be made shareable so just do it here
         lockSnapshots();
+        this.defaultExceptionManagerEnabled = getOptionValue(Options.ENABLE_DEFAULT_EXCEPTION_MAPPER);
     }
 
     /**
@@ -195,6 +206,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory
             serverHelper = new ServerHelper(this, parentImpl.serverHelper);
             initializeCommon(parentImpl, false, true);
         }
+        this.defaultExceptionManagerEnabled = getOptionValue(Options.ENABLE_DEFAULT_EXCEPTION_MAPPER);
     }
 
     protected void registerBuiltin() {
@@ -1014,6 +1026,7 @@ public class ResteasyProviderFactoryImpl extends ResteasyProviderFactory
         Class exceptionType = type;
         SortedKey<ExceptionMapper> mapper = null;
         Map<Class<?>, SortedKey<ExceptionMapper>> mappers = getSortedExceptionMappers();
+        final boolean defaultExceptionManagerEnabled = isDefaultExceptionManagerEnabled();
         if (mappers == null && defaultExceptionManagerEnabled) {
             return (ExceptionMapper<T>) DefaultExceptionMapper.INSTANCE;
         }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/DisabledDefaultExceptionMapperTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/DisabledDefaultExceptionMapperTest.java
@@ -30,8 +30,6 @@ import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Providers;
 
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.resteasy.setup.DisableDefaultExceptionMapperSetupTask;
 import org.jboss.resteasy.test.core.basic.resource.ExceptionResource;
 import org.jboss.resteasy.utils.TestUtil;
 import org.junit.jupiter.api.Assertions;
@@ -42,7 +40,6 @@ import org.junit.jupiter.api.Test;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@ServerSetup(DisableDefaultExceptionMapperSetupTask.class)
 public abstract class DisabledDefaultExceptionMapperTest {
 
     @Inject

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/DisabledDefaultExceptionNoThrowableMapperWebXmlTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/core/basic/DisabledDefaultExceptionNoThrowableMapperWebXmlTest.java
@@ -1,0 +1,106 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.test.core.basic;
+
+import java.lang.reflect.ReflectPermission;
+import java.util.Map;
+import java.util.PropertyPermission;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.resteasy.spi.config.Options;
+import org.jboss.resteasy.test.core.basic.resource.ExceptionResource;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.wildfly.arquillian.junit.annotations.RequiresModule;
+import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
+
+/**
+ * Tests that the default {@link ExceptionMapper} is disabled by setting the {@code dev.resteasy.exception.mapper}
+ * system property to false.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ExtendWith(ArquillianExtension.class)
+@RequestScoped
+@RequiresModule(value = "org.jboss.resteasy.resteasy-core", minVersion = "6.2.10.Final")
+public class DisabledDefaultExceptionNoThrowableMapperWebXmlTest extends DisabledDefaultExceptionMapperTest {
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap
+                .create(WebArchive.class, DisabledDefaultExceptionNoThrowableMapperWebXmlTest.class.getSimpleName() + ".war")
+                .addClasses(
+                        DisabledDefaultExceptionMapperTest.class,
+                        ExceptionResource.class,
+                        TestUtil.class)
+                .addAsWebInfResource(
+                        TestUtil.createWebXml(null, null, Map.of(Options.ENABLE_DEFAULT_EXCEPTION_MAPPER.name(), "false")),
+                        "web.xml")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                // These can be removed if WFARQ-118 is resolved
+                .addAsManifestResource(DeploymentDescriptors.createPermissionsXmlAsset(
+                        // Required for Arquillian
+                        new ReflectPermission("suppressAccessChecks"),
+                        new PropertyPermission("arquillian.*", "read"),
+                        new RuntimePermission("accessClassInPackage.sun.reflect.annotation"),
+                        // Required for JUnit
+                        new RuntimePermission("accessDeclaredMembers")),
+                        "permissions.xml");
+    }
+
+    /**
+     * Tests that the default exception mapper does not exist.
+     */
+    @Test
+    public void defaultExceptionMapper() {
+        Assertions.assertNull(providers.getExceptionMapper(Throwable.class),
+                "Expected not to have a default exception mapper");
+    }
+
+    /**
+     * Test that the exception falls through and an UnhandledException is thrown.
+     *
+     * @throws Exception if an exception occurs
+     */
+    @Test
+    public void noDefaultExceptionMapper() throws Exception {
+        final Response response = client.target(TestUtil.generateUri(url, "exception"))
+                .request()
+                .get();
+        Assertions.assertEquals(Response.Status.INTERNAL_SERVER_ERROR, response.getStatusInfo());
+        // We should end up with a stack trace in the response by default. There should be an UnhandledException and the
+        // exception thrown.
+        final String value = response.readEntity(String.class);
+        Assertions.assertTrue(value.contains(ExceptionResource.EXCEPTION_MESSAGE),
+                String.format("Expected %s to be in the result: %s", ExceptionResource.EXCEPTION_MESSAGE, value));
+        Assertions.assertTrue(value.contains("UnhandledException"),
+                String.format("Expected UnhandledException to be in the result: %s", value));
+    }
+}


### PR DESCRIPTION
…nfiguration. Use a known ResteasyConfiguration to look up the dev.resteasy.exception.mapper configuration parameter.

https://issues.redhat.com/browse/RESTEASY-3510

Upstream PR: #4213