### PR TITLE
[RESTEASY-3516] Upgrade Weld to 6.0.0.Beta4 and the Weld API to 6.0.B…

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -90,8 +90,8 @@
         <version.org.mockito>5.12.0</version.org.mockito>
         <version.org.wildfly.common>1.7.0.Final</version.org.wildfly.common>
         <version.org.wildfly.security>2.5.0.Final</version.org.wildfly.security>
-        <version.weld.api>6.0.Beta4</version.weld.api>
-        <version.weld>6.0.0.Beta1</version.weld>
+        <version.weld.api>6.0.Beta5</version.weld.api>
+        <version.weld>6.0.0.Beta4</version.weld>
         <version.com.github.java-json-tools.btf>1.3</version.com.github.java-json-tools.btf>
         <version.com.github.java-json-tools.jackson-coreutils>2.0</version.com.github.java-json-tools.jackson-coreutils>
         <version.com.github.java-json-tools.json-patch>1.13</version.com.github.java-json-tools.json-patch>


### PR DESCRIPTION
…eta5.

https://issues.redhat.com/browse/RESTEASY-3516

Fixes a TCK issue running with WildFly 33.