### PR TITLE
Fix DynamicFeatureTest (TestUtil had wrong log folder for bootable jar)

### DIFF
--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/TestUtil.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/utils/TestUtil.java
@@ -320,7 +320,13 @@ public class TestUtil {
             if (containerQualifier == null) {
                 return new File(getJbossHome(), "standalone").getAbsolutePath();
             } else {
-                return new File("target", containerQualifier).getAbsolutePath();
+                File containerQualifierDir = new File("target", containerQualifier);
+                File containerQualifierStandaloneDir = new File(containerQualifierDir, "standalone");
+                if (containerQualifierStandaloneDir.exists()) {
+                    return containerQualifierStandaloneDir.getAbsolutePath();
+                } else {
+                    return containerQualifierDir.getAbsolutePath();
+                }
             }
         } else {
             return System.getProperty("jboss.server.base.dir", "");

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -293,7 +293,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables combine.children="append">
-                                <install.dir>${project.build.directory}/wildfly</install.dir>
+                                <install.dir>${project.build.directory}/jbossas-managed</install.dir>
                                 <bootable.jar>${project.build.directory}/jaxrs-server.jar</bootable.jar>
                                 <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
                             </systemPropertyVariables>


### PR DESCRIPTION
When using bootable jar, the standalone directory is not identified correctly and test `DynamicFeatureTest` fails because it cannot find the server.log file