### PR TITLE
[RESTEASY-3520] If the generic type cannot be resolved for a ContextR…

### DIFF
--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
@@ -898,4 +898,7 @@ public interface Messages {
     @Message(id = BASE + 2081, value = "File limit of %s has been reached. The entity cannot be processed. Increase the " +
             "size with the configuration property %s.")
     IllegalStateException fileLimitReached(Threshold limit, String propertyName);
+
+    @Message(id = BASE + 2082, value = "The generic type for %s could not be determined based on %s.")
+    IllegalArgumentException couldNotDetermineGenericType(String typeName, String implName);
 }

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/context/InjectedProviderClientTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/context/InjectedProviderClientTest.java
@@ -1,0 +1,105 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.test.cdi.context;
+
+import java.net.URI;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ContextResolver;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.resteasy.test.cdi.context.resources.EchoResource;
+import org.jboss.resteasy.test.cdi.context.resources.EnumHeaderDelegate;
+import org.jboss.resteasy.test.cdi.context.resources.JsonToString;
+import org.jboss.resteasy.test.cdi.context.resources.JsonToStringContextResolver;
+import org.jboss.resteasy.utils.TestApplication;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.wildfly.arquillian.junit.annotations.RequiresModule;
+
+/**
+ * This is a test for <a href="https://issues.redhat.com/browse/RESTEASY-3520">RESTEASY-3520</a>. It injects a
+ * {@link ContextResolver} implementation and registers it with a client. The injected resolver is likely a CDI client
+ * proxy given the {@link ApplicationScoped @ApplicationScoped} CDI scope for
+ * {@linkplain jakarta.ws.rs.ext.Provider providers}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ExtendWith(ArquillianExtension.class)
+@ApplicationScoped
+@RequiresModule(value = "org.jboss.resteasy.resteasy-core", minVersion = "7.0.0.Alpha3")
+public class InjectedProviderClientTest {
+
+    @Inject
+    private JsonToStringContextResolver resolver;
+
+    @Inject
+    private EnumHeaderDelegate headerDelegate;
+
+    @Inject
+    private Client client;
+
+    @ArquillianResource
+    private URI uri;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addClasses(JsonToString.class,
+                        JsonToStringContextResolver.class,
+                        EchoResource.class,
+                        EnumHeaderDelegate.class,
+                        EchoResource.ResponseType.class,
+                        TestUtil.class,
+                        TestApplication.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void contextResolverInjected() throws Exception {
+        Assertions.assertNotNull(resolver);
+        Assertions.assertNotNull(headerDelegate);
+        final String entityJson = "{\"test\":\"value\"}";
+        try (
+                Response response = client
+                        .register(resolver)
+                        .register(headerDelegate)
+                        .target(TestUtil.generateUri(uri, "/echo")).request()
+                        .post(Entity.json(entityJson))) {
+            Assertions.assertEquals(200, response.getStatus());
+            final var json = response.readEntity(JsonObject.class);
+            Assertions.assertEquals(entityJson, json.getString("entity"));
+            Assertions.assertEquals(EchoResource.ResponseType.TEST,
+                    headerDelegate.fromString(response.getHeaderString(EchoResource.RESPONSE_TYPE_HEADER)));
+        }
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/context/resources/EchoResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/context/resources/EchoResource.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.test.cdi.context.resources;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Providers;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@Path("/echo")
+@RequestScoped
+public class EchoResource {
+
+    public static final String RESPONSE_TYPE_HEADER = "response-type";
+    @Inject
+    private HttpHeaders headers;
+
+    @Inject
+    private Providers providers;
+
+    public enum ResponseType {
+        TEST
+    }
+
+    @POST
+    public Response echo(final JsonObject json) {
+
+        final var builder = Json.createObjectBuilder();
+        final var headerArray = Json.createArrayBuilder();
+        headers.getRequestHeaders().forEach((key, value) -> {
+            final var headerBuilder = Json.createObjectBuilder();
+            headerBuilder.add(key, Json.createArrayBuilder(value));
+            headerArray.add(headerBuilder);
+        });
+        builder.add("headers", headerArray);
+        final var resolver = providers.getContextResolver(JsonToString.class, MediaType.APPLICATION_JSON_TYPE);
+        if (resolver != null) {
+            builder.add("entity", resolver.getContext(JsonToString.class)
+                    .objectToString(json));
+        } else {
+            throw new BadRequestException("Failed to find the JsonToString provider for the request");
+        }
+
+        return Response.ok(builder.build())
+                .header(RESPONSE_TYPE_HEADER, ResponseType.TEST)
+                .build();
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/context/resources/EnumHeaderDelegate.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/context/resources/EnumHeaderDelegate.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.test.cdi.context.resources;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("unchecked")
+@Provider
+public class EnumHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Enum<?>> {
+    @Override
+    public Enum<?> fromString(final String value) {
+        // Find the last index of the dot which separates the class name and the enum name
+        final int nameIndex = value.lastIndexOf('.');
+        final String className = value.substring(0, nameIndex);
+        final String enumName = value.substring(nameIndex + 1);
+        // Attempt to create the enum class
+        final Class<? extends Enum<?>> enumClass;
+        try {
+            enumClass = (Class<? extends Enum<?>>) Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new WebApplicationException(e);
+        }
+        return resolveEnumValue(enumClass, enumName);
+    }
+
+    @Override
+    public String toString(final Enum<?> value) {
+        return String.format("%s.%s", value.getClass().getName(), value.name());
+    }
+
+    private static <T extends Enum<T>> T resolveEnumValue(final Class<?> enumType, final String name) {
+        return Enum.valueOf((Class<T>) enumType, name);
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/context/resources/JsonToString.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/context/resources/JsonToString.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.test.cdi.context.resources;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class JsonToString {
+
+    public String objectToString(Object entity) {
+        return String.valueOf(entity);
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/context/resources/JsonToStringContextResolver.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/context/resources/JsonToStringContextResolver.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.test.cdi.context.resources;
+
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+public class JsonToStringContextResolver implements ContextResolver<JsonToString> {
+    @Override
+    public JsonToString getContext(final Class<?> type) {
+        if (JsonToString.class.isAssignableFrom(type)) {
+            return new JsonToString();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
…esolver, check the super type for resolution. This is for cases when the ContextResolver implementation might be a CDI client proxy.

https://issues.redhat.com/browse/RESTEASY-3520