### PR TITLE
[RESTEASY-3529] Upgrade JBoss Logging Tools to 3.0.1.Final

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -75,7 +75,7 @@
         <version.jakarta.persistence.persistence-api>3.0.0</version.jakarta.persistence.persistence-api>
         <version.org.jacoco>0.8.12</version.org.jacoco>
         <version.org.jboss.logging.jboss-logging>3.5.3.Final</version.org.jboss.logging.jboss-logging>
-        <version.org.jboss.logging.jboss-logging-annotations>2.2.1.Final</version.org.jboss.logging.jboss-logging-annotations>
+        <version.org.jboss.logging.jboss-logging-annotations>3.0.1.Final</version.org.jboss.logging.jboss-logging-annotations>
         <version.org.jboss.logmanager>3.0.6.Final</version.org.jboss.logmanager>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>
         <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-3529

Replaces #4227 