### PR TITLE
[RESTEASY-3515] Use the SSLContext.getDefault() instead of attempting…

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ClientHttpEngineBuilder43.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ClientHttpEngineBuilder43.java
@@ -153,8 +153,7 @@ public class ClientHttpEngineBuilder43 implements ClientHttpEngineBuilder {
                     }
                 };
             } else {
-                final SSLContext tlsContext = SSLContext.getInstance(SSLConnectionSocketFactory.TLS);
-                tlsContext.init(null, null, null);
+                final SSLContext tlsContext = SSLContext.getDefault();
                 sslsf = new SSLConnectionSocketFactory(tlsContext, verifier);
             }
 


### PR DESCRIPTION
… to get an instance. This is important when running in containers when the default might be configured in the container.

https://issues.redhat.com/browse/RESTEASY-3515

Upstream #4289 