### PR TITLE
[RESTEASY-3519] Ensure if an Application for a SeBoostrap instance in…

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/se/ResteasySeInstance.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/se/ResteasySeInstance.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
+import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.SeBootstrap.Configuration;
 import jakarta.ws.rs.SeBootstrap.Instance;
 import jakarta.ws.rs.core.Application;
@@ -84,7 +85,12 @@ public class ResteasySeInstance implements Instance {
         final ExecutorService executor = ContextualExecutors.threadPool();
         return CompletableFuture.supplyAsync(() -> {
             try {
-                final Configuration config = ResteasySeConfiguration.from(configuration);
+                final Class<?> applicationClass = application.getClass();
+                String applicationPath = null;
+                if (applicationClass.isAnnotationPresent(ApplicationPath.class)) {
+                    applicationPath = applicationClass.getAnnotation(ApplicationPath.class).value();
+                }
+                final Configuration config = ResteasySeConfiguration.from(configuration, applicationPath);
                 final EmbeddedServer server = EmbeddedServers.findServer(config);
                 final ResteasyDeployment deployment = server.getDeployment();
                 deployment.setRegisterBuiltin(ConfigurationOption.REGISTER_BUILT_INS.getValue(config));
@@ -131,7 +137,11 @@ public class ResteasySeInstance implements Instance {
         final ExecutorService executor = ContextualExecutors.threadPool();
         return CompletableFuture.supplyAsync(() -> {
             try {
-                final Configuration config = ResteasySeConfiguration.from(configuration);
+                String applicationPath = null;
+                if (applicationClass.isAnnotationPresent(ApplicationPath.class)) {
+                    applicationPath = applicationClass.getAnnotation(ApplicationPath.class).value();
+                }
+                final Configuration config = ResteasySeConfiguration.from(configuration, applicationPath);
                 final EmbeddedServer server = EmbeddedServers.findServer(config);
                 final ResteasyDeployment deployment = server.getDeployment();
                 deployment.setRegisterBuiltin(ConfigurationOption.REGISTER_BUILT_INS.getValue(config));

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/embedded/EmbeddedJaxrsServer.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/embedded/EmbeddedJaxrsServer.java
@@ -16,7 +16,9 @@ public interface EmbeddedJaxrsServer<T extends EmbeddedServer> extends EmbeddedS
         final Configuration config = ResteasySeConfiguration.from(configuration);
         setHostname(config.host());
         setPort(config.port());
-        setRootResourcePath(config.rootPath());
+        if (config.hasProperty(Configuration.ROOT_PATH)) {
+            setRootResourcePath(config.rootPath());
+        }
         start();
     }
 

--- a/resteasy-core/src/test/java/org/jboss/resteasy/core/se/ConfigurationTest.java
+++ b/resteasy-core/src/test/java/org/jboss/resteasy/core/se/ConfigurationTest.java
@@ -99,6 +99,19 @@ public class ConfigurationTest {
                 () -> "Expected test.from.config to not be defined");
     }
 
+    @Test
+    public void rootPathNotSet() {
+        final Configuration.Builder builder = Configuration.builder();
+        Assertions.assertEquals("/", builder.build().rootPath());
+    }
+
+    @Test
+    public void rootPathSet() {
+        final Configuration.Builder builder = Configuration.builder()
+                .rootPath("root-path");
+        Assertions.assertEquals("root-path", builder.build().rootPath());
+    }
+
     private static class TestConfiguration implements Configuration {
         private final Map<String, Object> properties = new HashMap<>();
 

--- a/resteasy-core/src/test/java/org/jboss/resteasy/core/se/SeBootstrapTest.java
+++ b/resteasy-core/src/test/java/org/jboss/resteasy/core/se/SeBootstrapTest.java
@@ -1,0 +1,176 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.core.se;
+
+import java.util.concurrent.ExecutionException;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.core.Application;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class SeBootstrapTest {
+
+    @Test
+    public void checkAnnotatedApplicationClass() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(AnnotatedApplication.class);
+        Assertions.assertEquals("/annotated", configuration.rootPath());
+    }
+
+    @Test
+    public void checkAnnotatedApplicationUriClass() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(AnnotatedApplication.class);
+        Assertions.assertEquals("http://localhost:8081/annotated", configuration.baseUri().toString());
+    }
+
+    @Test
+    public void checkNonAnnotatedApplicationClass() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(NonAnnotatedApplication.class);
+        Assertions.assertEquals("/", configuration.rootPath());
+    }
+
+    @Test
+    public void checkNonAnnotatedApplicationUriClass() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(NonAnnotatedApplication.class);
+        Assertions.assertEquals("http://localhost:8081/", configuration.baseUri().toString());
+    }
+
+    @Test
+    public void checkAnnotatedApplicationClassOverridden() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(AnnotatedApplication.class, SeBootstrap.Configuration.builder()
+                .rootPath("override").build());
+        Assertions.assertEquals("override", configuration.rootPath());
+    }
+
+    @Test
+    public void checkAnnotatedApplicationUriClassOverridden() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(AnnotatedApplication.class, SeBootstrap.Configuration.builder()
+                .rootPath("override").build());
+        Assertions.assertEquals("http://localhost:8081/override", configuration.baseUri().toString());
+    }
+
+    @Test
+    public void checkNonAnnotatedApplicationClassOverridden() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(NonAnnotatedApplication.class, SeBootstrap.Configuration.builder()
+                .rootPath("override").build());
+        Assertions.assertEquals("override", configuration.rootPath());
+    }
+
+    @Test
+    public void checkNonAnnotatedApplicationUriClassOverridden() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(NonAnnotatedApplication.class, SeBootstrap.Configuration.builder()
+                .rootPath("override").build());
+        Assertions.assertEquals("http://localhost:8081/override", configuration.baseUri().toString());
+    }
+
+    @Test
+    public void checkAnnotatedApplicationInstance() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(new AnnotatedApplication());
+        Assertions.assertEquals("/annotated", configuration.rootPath());
+    }
+
+    @Test
+    public void checkAnnotatedApplicationUriInstance() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(new AnnotatedApplication());
+        Assertions.assertEquals("http://localhost:8081/annotated", configuration.baseUri().toString());
+    }
+
+    @Test
+    public void checkNonAnnotatedApplicationInstance() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(new NonAnnotatedApplication());
+        Assertions.assertEquals("/", configuration.rootPath());
+    }
+
+    @Test
+    public void checkNonAnnotatedApplicationUriInstance() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(new NonAnnotatedApplication());
+        Assertions.assertEquals("http://localhost:8081/", configuration.baseUri().toString());
+    }
+
+    @Test
+    public void checkAnnotatedApplicationInstanceOverridden() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(new AnnotatedApplication(), SeBootstrap.Configuration.builder()
+                .rootPath("override").build());
+        Assertions.assertEquals("override", configuration.rootPath());
+    }
+
+    @Test
+    public void checkAnnotatedApplicationUriInstanceOverridden() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(new AnnotatedApplication(), SeBootstrap.Configuration.builder()
+                .rootPath("override").build());
+        Assertions.assertEquals("http://localhost:8081/override", configuration.baseUri().toString());
+    }
+
+    @Test
+    public void checkNonAnnotatedApplicationInstanceOverridden() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(new NonAnnotatedApplication(), SeBootstrap.Configuration.builder()
+                .rootPath("override").build());
+        Assertions.assertEquals("override", configuration.rootPath());
+    }
+
+    @Test
+    public void checkNonAnnotatedApplicationUriInstanceOverridden() throws Exception {
+        final SeBootstrap.Configuration configuration = boot(new NonAnnotatedApplication(), SeBootstrap.Configuration.builder()
+                .rootPath("override").build());
+        Assertions.assertEquals("http://localhost:8081/override", configuration.baseUri().toString());
+    }
+
+    private SeBootstrap.Configuration boot(final Class<? extends Application> clazz)
+            throws ExecutionException, InterruptedException {
+        final SeBootstrap.Instance instance = SeBootstrap.start(clazz)
+                .toCompletableFuture().get();
+        return instance.configuration();
+    }
+
+    private SeBootstrap.Configuration boot(final Class<? extends Application> clazz,
+            final SeBootstrap.Configuration configuration)
+            throws ExecutionException, InterruptedException {
+        final SeBootstrap.Instance instance = SeBootstrap.start(clazz, configuration)
+                .toCompletableFuture().get();
+        return instance.configuration();
+    }
+
+    private SeBootstrap.Configuration boot(final Application application) throws ExecutionException, InterruptedException {
+        final SeBootstrap.Instance instance = SeBootstrap.start(application)
+                .toCompletableFuture().get();
+        return instance.configuration();
+    }
+
+    private SeBootstrap.Configuration boot(final Application application, SeBootstrap.Configuration configuration)
+            throws ExecutionException, InterruptedException {
+        final SeBootstrap.Instance instance = SeBootstrap.start(application, configuration)
+                .toCompletableFuture().get();
+        return instance.configuration();
+    }
+
+    @ApplicationPath("/annotated")
+    public static class AnnotatedApplication extends Application {
+
+    }
+
+    public static class NonAnnotatedApplication extends Application {
+
+    }
+}

--- a/resteasy-core/src/test/java/org/jboss/resteasy/core/se/TestEmbeddedServer.java
+++ b/resteasy-core/src/test/java/org/jboss/resteasy/core/se/TestEmbeddedServer.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.core.se;
+
+import jakarta.ws.rs.SeBootstrap.Configuration;
+
+import org.jboss.resteasy.core.ResteasyDeploymentImpl;
+import org.jboss.resteasy.plugins.server.embedded.EmbeddedServer;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class TestEmbeddedServer implements EmbeddedServer {
+    private final ResteasyDeployment deployment;
+
+    public TestEmbeddedServer() {
+        deployment = new ResteasyDeploymentImpl();
+
+    }
+
+    @Override
+    public void start(final Configuration configuration) {
+    }
+
+    @Override
+    public void stop() {
+    }
+
+    @Override
+    public ResteasyDeployment getDeployment() {
+        return deployment;
+    }
+}

--- a/resteasy-core/src/test/resources/META-INF/services/org.jboss.resteasy.plugins.server.embedded.EmbeddedServer
+++ b/resteasy-core/src/test/resources/META-INF/services/org.jboss.resteasy.plugins.server.embedded.EmbeddedServer
@@ -1,0 +1,1 @@
+org.jboss.resteasy.core.se.TestEmbeddedServer

--- a/server-adapters/resteasy-undertow-cdi/src/main/java/dev/resteasy/embedded/server/UndertowCdiEmbeddedServer.java
+++ b/server-adapters/resteasy-undertow-cdi/src/main/java/dev/resteasy/embedded/server/UndertowCdiEmbeddedServer.java
@@ -138,7 +138,12 @@ public class UndertowCdiEmbeddedServer implements EmbeddedServer {
         EmbeddedServers.validateDeployment(deployment);
 
         // Determine the servlet mapping name
-        String mapping = EmbeddedServers.checkContextPath(deployment);
+        String mapping;
+        if (configuration.hasProperty(Configuration.ROOT_PATH)) {
+            mapping = configuration.rootPath();
+        } else {
+            mapping = EmbeddedServers.checkContextPath(deployment);
+        }
         if (!mapping.endsWith("/")) {
             mapping += "/";
         }
@@ -175,8 +180,6 @@ public class UndertowCdiEmbeddedServer implements EmbeddedServer {
         }
         // Ensure the Undertow Weld Container is always the one chosen.
         deploymentInfo.addInitParameter(Container.CONTEXT_PARAM_CONTAINER_CLASS, UndertowContainer.class.getName());
-        // Determine the context path
-        final String contextPath = EmbeddedServers.checkContextPath(configuration.rootPath());
 
         if (deploymentInfo.getDefaultMultipartConfig() == null) {
             final Application application = deployment.getApplication();
@@ -188,8 +191,8 @@ public class UndertowCdiEmbeddedServer implements EmbeddedServer {
         return deploymentInfo
                 // Set up deployment specific info
                 .setClassLoader(deployment.getApplication().getClass().getClassLoader())
-                .setContextPath(contextPath)
-                .setDeploymentName("RESTEasy-" + contextPath)
+                .setContextPath("/")
+                .setDeploymentName("RESTEasy-SeBootstrap")
                 // Set up the RESTEasy Servlet
                 .addServletContextAttribute(ResteasyDeployment.class.getName(), deployment)
                 .addServlet(resteasyServlet)

--- a/server-adapters/resteasy-undertow-cdi/src/test/java/dev/resteasy/embedded/server/InjectionTest.java
+++ b/server-adapters/resteasy-undertow-cdi/src/test/java/dev/resteasy/embedded/server/InjectionTest.java
@@ -61,7 +61,7 @@ public class InjectionTest {
     }
 
     @Test
-    public void application(@RequestPath("inject/greet/app") final WebTarget target) {
+    public void application(@RequestPath("greet/app") final WebTarget target) {
         try (Response response = target.request().get()) {
             Assertions.assertEquals(Response.Status.OK, response.getStatusInfo());
             Assertions.assertEquals("Hello App", response.readEntity(String.class));
@@ -69,7 +69,7 @@ public class InjectionTest {
     }
 
     @Test
-    public void resource(@RequestPath("inject/greet/Violet") final WebTarget target) {
+    public void resource(@RequestPath("greet/Violet") final WebTarget target) {
         try (Response response = target.request().get()) {
             Assertions.assertEquals(Response.Status.OK, response.getStatusInfo());
             Assertions.assertEquals("Hello Violet", response.readEntity(String.class));

--- a/server-adapters/resteasy-undertow/src/main/java/org/jboss/resteasy/plugins/server/undertow/UndertowJaxrsServer.java
+++ b/server-adapters/resteasy-undertow/src/main/java/org/jboss/resteasy/plugins/server/undertow/UndertowJaxrsServer.java
@@ -59,7 +59,7 @@ public class UndertowJaxrsServer implements EmbeddedJaxrsServer<UndertowJaxrsSer
     @Override
     public UndertowJaxrsServer deploy() {
         serverHelper.checkDeployment(deployment);
-        return deploy(deployment, serverHelper.checkContextPath(rootResourcePath),
+        return deploy(deployment, "/",
                 deployment.getClass().getClassLoader());
     }
 
@@ -231,7 +231,13 @@ public class UndertowJaxrsServer implements EmbeddedJaxrsServer<UndertowJaxrsSer
     }
 
     public DeploymentInfo undertowDeployment(ResteasyDeployment resteasyDeployment) {
-        return undertowDeployment(resteasyDeployment, serverHelper.checkAppDeployment(resteasyDeployment));
+        String mapping;
+        if (rootResourcePath != null) {
+            mapping = serverHelper.checkContextPath(rootResourcePath);
+        } else {
+            mapping = serverHelper.checkAppDeployment(resteasyDeployment);
+        }
+        return undertowDeployment(resteasyDeployment, mapping);
     }
 
     public DeploymentInfo undertowDeployment(Class<? extends Application> application) {

--- a/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxJaxrsServer.java
+++ b/server-adapters/resteasy-vertx/src/main/java/org/jboss/resteasy/plugins/server/vertx/VertxJaxrsServer.java
@@ -41,7 +41,7 @@ public class VertxJaxrsServer implements EmbeddedJaxrsServer<VertxJaxrsServer> {
     protected Vertx vertx;
     protected HttpServerOptions serverOptions = new HttpServerOptions();
     protected VertxResteasyDeployment deployment;
-    protected String root = "";
+    protected String root;
     protected SecurityDomain domain;
     private String deploymentID;
     private EmbeddedServerHelper serverHelper = new EmbeddedServerHelper();
@@ -67,9 +67,14 @@ public class VertxJaxrsServer implements EmbeddedJaxrsServer<VertxJaxrsServer> {
             deployment.start();
         }
 
-        String aPath = serverHelper.checkAppDeployment(deployment);
-        if (aPath == null) {
+        String aPath;
+        if (root != null) {
             aPath = root;
+        } else {
+            aPath = serverHelper.checkAppDeployment(deployment);
+        }
+        if (aPath == null) {
+            aPath = "";
         }
         setRootResourcePath(serverHelper.checkContextPath(aPath));
 


### PR DESCRIPTION
…cludes an @ApplicationPath annotation, the value is used as the root path. If the configuration overrides the root path for the application, honor that.

https://issues.redhat.com/browse/RESTEASY-3519

Upstream #4378 