### PR TITLE
[RESTEASY-3542] Allow the EntityOutputStream's temporary directory to…

### DIFF
--- a/docbook/src/main/asciidoc/Installation_Configuration.adoc
+++ b/docbook/src/main/asciidoc/Installation_Configuration.adoc
@@ -812,6 +812,20 @@ RESTEasy can receive the following configuration options from any ConfigSource's
 | false
 | Setting this value to true will disable RESTEasy creating a `com.fasterxml.jackson.databind.ObjectMapper` if the
   Jackson Provider is being used and there is no `jakarta.ws.rs.ext.ContextResolver` for an `ObjectMapper`.
+
+| `dev.resteasy.entity.memory.threshold`
+| 5MB
+| The threshold to use for the amount of data to store in memory for entities.
+
+| `dev.resteasy.entity.file.threshold`
+|50MB
+| The threshold to use for the amount of data that can be stored in a file for entities. If the threshold is reached an
+`IllegalStateException` will be thrown. A value of -1 means no limit.
+
+| `dev.resteasy.entity.tmpdir`
+| The value of the `java.io.tmpdir` system property.
+| The temporary directory to use when the `dev.resteasy.entity.memory.threshold` was reached and the entity must be
+written to a file. Note that the directory must already exist.
 |===
 
 NOTE: The resteasy.servlet.mapping.prefix context param variable must be set if the servlet-mapping for the RESTEasy

--- a/docbook/src/main/asciidoc/Multipart.adoc
+++ b/docbook/src/main/asciidoc/Multipart.adoc
@@ -702,8 +702,9 @@ The form-data format is the same as other multi-part formats, except that each i
 In {spec-name} 3.1 the `jakarta.ws.rs.core.EntityPart` API was introduced.
 This can be used to read and write `multipart/form-data` with a standardized API. 
 
-The content of the `EntityPart` has two definable size limits.
-These can be set as system properties, servlet context properties or a MicroProfile Config compatible value. 
+The content of the `EntityPart` has two definable size limits. It also allows you to override the temporary directory
+where files will be written to. These can be set as system properties, servlet context properties or a MicroProfile
+Config compatible value.
 
 [cols="1,1,1,1", options="header"]
 |===
@@ -711,7 +712,6 @@ These can be set as system properties, servlet context properties or a MicroProf
 | Description
 | Default Value
 | Example
-
 
 | `dev.resteasy.entity.memory.threshold`
 | The threshold to use for the amount of data to store in memory for entities.
@@ -723,6 +723,13 @@ These can be set as system properties, servlet context properties or a MicroProf
   `IllegalStateException` will be thrown. A value of -1 means no limit.
 |50MB
 |1GB is equivalent to 1 Gigabyte
+
+| `dev.resteasy.entity.tmpdir`
+| The temporary directory to use when the `dev.resteasy.entity.memory.threshold` was reached and the entity must be
+  written to a file. Note that the directory must already exist.
+`IllegalStateException` will be thrown. A value of -1 means no limit.
+| The value of the `java.io.tmpdir` system property.
+| `/tmp/entity`
 |===
 
 You can read, write and inject (with `@FormParam`) an `EntityPart` in the following forms; 

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/EntityOutputStream.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/EntityOutputStream.java
@@ -30,14 +30,12 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
-import org.jboss.resteasy.spi.config.ConfigurationFactory;
 import org.jboss.resteasy.spi.config.Options;
 import org.jboss.resteasy.spi.config.SizeUnit;
 import org.jboss.resteasy.spi.config.Threshold;
@@ -328,23 +326,7 @@ public class EntityOutputStream extends OutputStream {
     }
 
     private static Path getTempDir() {
-        return Path.of(getProperty("java.io.tmpdir", String.class, () -> System.getProperty("java.io.tmpdir")));
-    }
-
-    private static <T> Optional<T> getProperty(final String name, final Class<T> returnType) {
-        if (System.getSecurityManager() == null) {
-            return ConfigurationFactory.getInstance()
-                    .getConfiguration()
-                    .getOptionalValue(name, returnType);
-        }
-        return AccessController.doPrivileged((PrivilegedAction<Optional<T>>) () -> ConfigurationFactory.getInstance()
-                .getConfiguration()
-                .getOptionalValue(name, returnType));
-    }
-
-    @SuppressWarnings("SameParameterValue")
-    private static <T> T getProperty(final String name, final Class<T> returnType, final Supplier<T> dft) {
-        return getProperty(name, returnType).orElseGet(dft);
+        return getOptionValue(Options.ENTITY_TMP_DIR);
     }
 
     private static <T> T getOptionValue(final Options<T> option) {


### PR DESCRIPTION
… be overridden. This property is also used to override where multipart messages write their temporary files.

https://issues.redhat.com/browse/RESTEASY-3542

Upstream: #4390 

Related to: https://github.com/quarkusio/quarkus/issues/18113