### PR TITLE
[RESTEASY-3554] Avoid an NPE in the Vertx client. Also enable HTTP/2 …

### DIFF
--- a/resteasy-client-vertx/src/main/java/org/jboss/resteasy/client/jaxrs/engines/vertx/VertxClientHttpEngineFactory.java
+++ b/resteasy-client-vertx/src/main/java/org/jboss/resteasy/client/jaxrs/engines/vertx/VertxClientHttpEngineFactory.java
@@ -40,9 +40,6 @@ public class VertxClientHttpEngineFactory implements ClientHttpEngineFactory {
 
         final HttpClientOptions options = new HttpClientOptions();
 
-        configuration.executorService();
-        configuration.configuration();
-
         final long connectionTimeout = configuration.connectionTimeout(TimeUnit.MILLISECONDS);
         if (connectionTimeout > 0L) {
             options.setConnectTimeout(Math.toIntExact(connectionTimeout));
@@ -67,6 +64,6 @@ public class VertxClientHttpEngineFactory implements ClientHttpEngineFactory {
             options.setReadIdleTimeout(Math.toIntExact(readTimeout));
         }
 
-        return new VertxClientHttpEngine(vertx, options);
+        return new VertxClientHttpEngine(vertx, options, configuration);
     }
 }


### PR DESCRIPTION
…by default.

https://issues.redhat.com/browse/RESTEASY-3554

Upstream #4394 