### PR TITLE
[RESTEASY-3555] Bump com.fasterxml.jackson:jackson-bom

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -38,8 +38,7 @@
 
     <properties>
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
-        <version.com.fasterxml.jackson>2.15.4</version.com.fasterxml.jackson>
-        <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson>2.18.1</version.com.fasterxml.jackson>
         <version.com.google.guava>31.0.1-jre</version.com.google.guava>
         <version.com.google.guava.failureaccess>1.0.2</version.com.google.guava.failureaccess>
         <version.com.io7m.xom>1.2.10</version.com.io7m.xom>


### PR DESCRIPTION
Bumps the fasterxml-dependencies group with 1 update in the / directory: [com.fasterxml.jackson:jackson-bom](https://github.com/FasterXML/jackson-bom).

Updates `com.fasterxml.jackson:jackson-bom` from 2.15.4 to 2.18.1
- [Commits](https://github.com/FasterXML/jackson-bom/compare/jackson-bom-2.15.4...jackson-bom-2.18.1)

---
updated-dependencies:
- dependency-name: com.fasterxml.jackson:jackson-bom dependency-type: direct:production update-type: version-update:semver-minor dependency-group: fasterxml-dependencies ...


Upstream: #4372