### PR TITLE
[RESTEASY-3557] Add better support for configuring an SSLContext when…

### DIFF
--- a/docbook/src/main/asciidoc/Installation_Configuration.adoc
+++ b/docbook/src/main/asciidoc/Installation_Configuration.adoc
@@ -826,6 +826,12 @@ RESTEasy can receive the following configuration options from any ConfigSource's
 | The value of the `java.io.tmpdir` system property.
 | The temporary directory to use when the `dev.resteasy.entity.memory.threshold` was reached and the entity must be
 written to a file. Note that the directory must already exist.
+
+| `dev.resteasy.client.ssl.context.algorithm`
+| `TLS`
+| When a `ClientBuilder.keyStore()` or `ClientBuilder.trustStore()` is set and no `SSLContext` is set on a client builder
+  this value is used to set the `SSLContext` algorithm to use when invoking `SSLContext.getInstance()` for client
+  connections.
 |===
 
 NOTE: The resteasy.servlet.mapping.prefix context param variable must be set if the servlet-mapping for the RESTEasy

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/jaxrs/api/ClientBuilderConfiguration.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/jaxrs/api/ClientBuilderConfiguration.java
@@ -35,6 +35,7 @@ import jakarta.ws.rs.core.Configuration;
  * {@link org.jboss.resteasy.client.jaxrs.ClientHttpEngine}.
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ * @since 6.2.11
  */
 public interface ClientBuilderConfiguration {
 

--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/jaxrs/i18n/LogMessages.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/jaxrs/i18n/LogMessages.java
@@ -30,4 +30,9 @@ public interface LogMessages extends BasicLogger {
     @LogMessage(level = Level.WARN)
     @Message(id = Messages.BASE + 187, value = "Closing a %s instance for you. Please close clients yourself.")
     void closingForYou(Class<?> clazz);
+
+    @LogMessage(level = Level.WARN)
+    @Message(id = Messages.BASE + 300, value = "Could not determine the protocol from %s. Defaulting to %s.")
+    void invalidProtocol(Object found, String defaultValue);
+
 }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engine/ClientHttpEngineFactory.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engine/ClientHttpEngineFactory.java
@@ -32,6 +32,7 @@ import org.jboss.resteasy.client.jaxrs.engines.AsyncClientHttpEngine;
  * </p>
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ * @since 6.2.11
  */
 @FunctionalInterface
 public interface ClientHttpEngineFactory {

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/SslUtils.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/SslUtils.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.client.jaxrs.internal;
+
+import java.security.KeyStore;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509ExtendedKeyManager;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class SslUtils {
+
+    static X509ExtendedKeyManager getKeyManager(final KeyStore keyStore, final String password) throws Exception {
+        final KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore, password != null ? password.toCharArray() : new char[0]);
+        for (KeyManager current : keyManagerFactory.getKeyManagers()) {
+            if (current instanceof X509ExtendedKeyManager) {
+                return (X509ExtendedKeyManager) current;
+            }
+        }
+        throw new IllegalStateException("Unable to obtain X509ExtendedKeyManager.");
+    }
+
+    static KeyManager[] getKeyManagers(final KeyStore keyStore, final String password) throws Exception {
+        final KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore, password != null ? password.toCharArray() : new char[0]);
+        return keyManagerFactory.getKeyManagers();
+    }
+
+    static X509TrustManager getTrustManager(final KeyStore trustStore) throws Exception {
+        final TrustManagerFactory trustManagerFactory = TrustManagerFactory
+                .getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init(trustStore);
+        for (TrustManager current : trustManagerFactory.getTrustManagers()) {
+            if (current instanceof X509TrustManager) {
+                return (X509TrustManager) current;
+            }
+        }
+        throw new IllegalStateException("Unable to obtain X509TrustManager.");
+    }
+
+    static TrustManager[] getTrustManagers(final KeyStore trustStore) throws Exception {
+        final TrustManagerFactory trustManagerFactory = TrustManagerFactory
+                .getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init(trustStore);
+        return trustManagerFactory.getTrustManagers();
+    }
+}

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
@@ -901,4 +901,7 @@ public interface Messages {
 
     @Message(id = BASE + 2082, value = "The generic type for %s could not be determined based on %s.")
     IllegalArgumentException couldNotDetermineGenericType(String typeName, String implName);
+
+    @Message(id = BASE + 2085, value = "Failed to resolve the SSLContext for the client.")
+    RuntimeException failedToResolveSSLContext(@Cause Throwable cause);
 }

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/config/Options.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/config/Options.java
@@ -81,6 +81,20 @@ public class Options<T> {
             Functions.singleton(() -> Path.of(defaultTmpDir()).toAbsolutePath()));
 
     /**
+     * An option for defining the {@link javax.net.ssl.SSLContext#getInstance(String) SSLContext} algorithm for the
+     * {@linkplain jakarta.ws.rs.client.Client REST client}.
+     * <p>
+     * The default is TLS.
+     * </p>
+     *
+     * @since 6.2.12
+     */
+    public static final Options<String> CLIENT_SSL_CONTEXT_ALGORITHM = new Options<>(
+            "dev.resteasy.client.ssl.context.algorithm",
+            String.class,
+            () -> "TLS");
+
+    /**
      * An option which allows which HTTP status code should be sent when the {@link SseEventSink#close()} is invoked.
      * In some implementations 200 (OK) is the default. However, RESTEasy prefers 204 (No Content) as no content has
      * been sent the response.


### PR DESCRIPTION
… the trustStore() and/or keyStore() is set on the ClientBuilder.

https://issues.redhat.com/browse/RESTEASY-3557