### PR TITLE
The Jetty and Vert.x clients need to be built for CI testing when tes…

### DIFF
--- a/.github/workflows/wildfly-build.yml
+++ b/.github/workflows/wildfly-build.yml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         java: ['17', '21']
         profile:
-          - '-am -Pprovision-without-resteasy,without-jackson -pl wildfly/resteasy-channel,/resteasy-dependencies-bom,testsuite/integration-tests'
+          - '-am -Pprovision-without-resteasy,without-jackson -pl resteasy-client-jetty,resteasy-client-vertx,wildfly/resteasy-channel,/resteasy-dependencies-bom,testsuite/integration-tests'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
…ting on upstream WildFly.