### PR TITLE
[RESTEASY-3562] Ensure headers are written for multipart requests eve…

### DIFF
--- a/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/AbstractMultipartWriter.java
+++ b/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/AbstractMultipartWriter.java
@@ -110,8 +110,11 @@ public class AbstractMultipartWriter {
                 // super.close();
             }
         };
+        final HeaderFlushedOutputStream headerFlushedOutputStream = new HeaderFlushedOutputStream(headers, partStream);
         writer.writeTo(entity, entityType, entityGenericType, annotations, part.getMediaType(), headers,
-                new HeaderFlushedOutputStream(headers, partStream));
+                headerFlushedOutputStream);
+        // Flush the headers for cases where the entity was empty
+        headerFlushedOutputStream.flushHeaders();
         entityStream.write(LINE_SEPARATOR_BYTES);
     }
 


### PR DESCRIPTION
…n if the entity is empty.

https://issues.redhat.com/browse/RESTEASY-3562

Upstream: #4443 