### PR TITLE
[RESTEASY-3577] Do not require a parameter type of EntityPart to ensu…

### DIFF
--- a/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/EntityPartFilter.java
+++ b/providers/multipart/src/main/java/org/jboss/resteasy/plugins/providers/multipart/EntityPartFilter.java
@@ -42,7 +42,6 @@ import org.jboss.resteasy.core.ResteasyContext;
 import org.jboss.resteasy.plugins.server.Cleanables;
 import org.jboss.resteasy.spi.EntityOutputStream;
 import org.jboss.resteasy.spi.multipart.MultipartContent;
-import org.jboss.resteasy.spi.util.Types;
 
 /**
  * Checks the method found to see if it as a {@link FormParam} or {@link org.jboss.resteasy.annotations.jaxrs.FormParam}
@@ -98,12 +97,7 @@ public class EntityPartFilter implements ContainerRequestFilter {
         for (Parameter parameter : parameters) {
             if (parameter.isAnnotationPresent(FormParam.class)
                     || parameter.isAnnotationPresent(org.jboss.resteasy.annotations.jaxrs.FormParam.class)) {
-                if (parameter.getType().isAssignableFrom(EntityPart.class)) {
-                    return true;
-                } else if (parameter.getType().isAssignableFrom(List.class)
-                        && Types.isGenericTypeInstanceOf(EntityPart.class, parameter.getParameterizedType())) {
-                    return true;
-                }
+                return true;
             }
         }
         return false;

--- a/providers/multipart/src/test/java/org/jboss/resteasy/plugins/providers/multipart/MultipartEntityPartProviderTest.java
+++ b/providers/multipart/src/test/java/org/jboss/resteasy/plugins/providers/multipart/MultipartEntityPartProviderTest.java
@@ -335,6 +335,50 @@ public class MultipartEntityPartProviderTest {
     }
 
     /**
+     * Tests sending {@code multipart/form-data} content as a {@link EntityPart List<EntityPart>}. Two parts are sent
+     * and injected as {@link FormParam @FormParam} method parameters. Each part send is different and injected as a
+     * specific type.
+     * <p>
+     * The result from the REST endpoint is {@code multipart/form-data} content with a new name and the content for the
+     * injected field.
+     * </p>
+     *
+     * @throws Exception if an error occurs in the test
+     */
+    @Test
+    public void multiInjectionNoEntityPart(@RequestPath("test/multi-injected-no-entity-part") final WebTarget target)
+            throws Exception {
+        final List<EntityPart> multipart = List.of(
+                EntityPart.withName("string-part")
+                        .content("test string")
+                        .mediaType(MediaType.TEXT_PLAIN_TYPE)
+                        .build(),
+                EntityPart.withName("input-stream-part")
+                        .content("test input stream".getBytes(StandardCharsets.UTF_8))
+                        .mediaType(MediaType.APPLICATION_OCTET_STREAM_TYPE)
+                        .build());
+        try (
+                Response response = target
+                        .request(MediaType.MULTIPART_FORM_DATA_TYPE)
+                        .post(Entity.entity(new GenericEntity<>(multipart) {
+                        }, MediaType.MULTIPART_FORM_DATA))) {
+            Assertions.assertEquals(Response.Status.OK, response.getStatusInfo());
+            final List<EntityPart> entityParts = response.readEntity(new GenericType<>() {
+            });
+            if (entityParts.size() != 2) {
+                final String msg = "Expected 2 entries got " +
+                        entityParts.size() +
+                        '.' +
+                        System.lineSeparator() +
+                        getMessage(entityParts);
+                Assertions.fail(msg);
+            }
+            checkEntity(entityParts, "received-string", "test string");
+            checkEntity(entityParts, "received-input-stream", "test input stream");
+        }
+    }
+
+    /**
      * Tests sending {@code multipart/form-data} content as a {@link EntityPart List<EntityPart>}. Three parts are sent
      * and injected as {@link FormParam @FormParam} method parameters. Each part send is different and injected as a
      * specific type.
@@ -702,6 +746,25 @@ public class MultipartEntityPartProviderTest {
                             .mediaType(entityPart.getMediaType())
                             .fileName(entityPart.getFileName().orElse(null))
                             .build(),
+                    EntityPart.withName("received-input-stream")
+                            .content(MultipartEntityPartProviderTest.toString(in).getBytes(StandardCharsets.UTF_8))
+                            .mediaType(MediaType.APPLICATION_OCTET_STREAM_TYPE)
+                            .build(),
+                    EntityPart.withName("received-string")
+                            .content(string)
+                            .mediaType(MediaType.TEXT_PLAIN_TYPE)
+                            .build());
+            return Response.ok(new GenericEntity<>(multipart) {
+            }, MediaType.MULTIPART_FORM_DATA).build();
+        }
+
+        @POST
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        @Produces(MediaType.MULTIPART_FORM_DATA)
+        @Path("/multi-injected-no-entity-part")
+        public Response multipleInjectableNoEntityPart(@FormParam("string-part") final String string,
+                @FormParam("input-stream-part") final InputStream in) throws IOException {
+            final List<EntityPart> multipart = List.of(
                     EntityPart.withName("received-input-stream")
                             .content(MultipartEntityPartProviderTest.toString(in).getBytes(StandardCharsets.UTF_8))
                             .mediaType(MediaType.APPLICATION_OCTET_STREAM_TYPE)

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/EntityPartFormParamTestCase.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/param/EntityPartFormParamTestCase.java
@@ -171,6 +171,52 @@ public class EntityPartFormParamTestCase {
         }
     }
 
+    /**
+     * Tests sending {@code multipart/form-data} content as a {@link EntityPart List<EntityPart>}. Two parts are sent
+     * and injected as {@link FormParam @FormParam} method parameters. Each part send is different and injected as a
+     * specific type.
+     * <p>
+     * The result from the REST endpoint is {@code multipart/form-data} content with a new name and the content for the
+     * injected field.
+     * </p>
+     *
+     * @throws Exception if an error occurs in the test
+     */
+    @RequiresModule(value = "org.jboss.resteasy.resteasy-multipart-provider", minVersion = "6.2.12.Final")
+    @Test
+    public void multiInjectionNoEntityPart() throws Exception {
+        try (Client client = ClientBuilder.newClient()) {
+            final List<EntityPart> multipart = List.of(
+                    EntityPart.withName("string-part")
+                            .content("test string")
+                            .mediaType(MediaType.TEXT_PLAIN_TYPE)
+                            .build(),
+                    EntityPart.withName("input-stream-part")
+                            .content("test input stream".getBytes(StandardCharsets.UTF_8))
+                            .mediaType(MediaType.APPLICATION_OCTET_STREAM_TYPE)
+                            .build());
+            try (
+                    Response response = client.target(TestUtil.generateUri(uri, "test/multi-injected-no-entity-part"))
+                            .request(MediaType.MULTIPART_FORM_DATA_TYPE)
+                            .post(Entity.entity(new GenericEntity<>(multipart) {
+                            }, MediaType.MULTIPART_FORM_DATA))) {
+                Assertions.assertEquals(Response.Status.OK, response.getStatusInfo());
+                final List<EntityPart> entityParts = response.readEntity(new GenericType<>() {
+                });
+                if (entityParts.size() != 2) {
+                    final String msg = "Expected 2 entries got " +
+                            entityParts.size() +
+                            '.' +
+                            System.lineSeparator() +
+                            getMessage(entityParts);
+                    Assertions.fail(msg);
+                }
+                checkEntity(entityParts, "received-string", "test string");
+                checkEntity(entityParts, "received-input-stream", "test input stream");
+            }
+        }
+    }
+
     private static void checkEntity(final List<EntityPart> entityParts, final String name, final String expectedText)
             throws IOException {
         final EntityPart part = find(entityParts, name);
@@ -274,6 +320,26 @@ public class EntityPartFormParamTestCase {
                             .mediaType(entityPart.getMediaType())
                             .fileName(entityPart.getFileName().orElse(null))
                             .build(),
+                    EntityPart.withName("received-input-stream")
+                            //.content(content.getContent(byte[].class))
+                            .content(EntityPartFormParamTestCase.toString(in).getBytes(StandardCharsets.UTF_8))
+                            .mediaType(MediaType.APPLICATION_OCTET_STREAM_TYPE)
+                            .build(),
+                    EntityPart.withName("received-string")
+                            .content(string)
+                            .mediaType(MediaType.TEXT_PLAIN_TYPE)
+                            .build());
+            return Response.ok(new GenericEntity<>(multipart) {
+            }, MediaType.MULTIPART_FORM_DATA).build();
+        }
+
+        @POST
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        @Produces(MediaType.MULTIPART_FORM_DATA)
+        @Path("/multi-injected-no-entity-part")
+        public Response multipleInjectableNoEntityPart(@FormParam("string-part") final String string,
+                @FormParam("input-stream-part") final InputStream in) throws IOException {
+            final List<EntityPart> multipart = List.of(
                     EntityPart.withName("received-input-stream")
                             //.content(content.getContent(byte[].class))
                             .content(EntityPartFormParamTestCase.toString(in).getBytes(StandardCharsets.UTF_8))


### PR DESCRIPTION
…re other valid type parameters can be injected.

https://issues.redhat.com/browse/RESTEASY-3577

Upstream #4478 