### PR TITLE
Test Jetty & Vertx engines with productized bits

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/other/JettyClientHttpEngineTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/other/JettyClientHttpEngineTest.java
@@ -40,7 +40,7 @@ public class JettyClientHttpEngineTest extends ClientHttpEngineTest {
     @Deployment
     public static WebArchive deployment() {
         final File[] libs = Maven.resolver()
-                .resolve("org.jboss.resteasy:resteasy-client-jetty:" + System.getProperty("version.resteasy.testsuite"))
+                .resolve("org.jboss.resteasy:resteasy-client-jetty:" + System.getProperty("project.version"))
                 .withTransitivity()
                 .asList(File.class)
                 .stream()

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/other/VertxClientHttpEngineTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/client/other/VertxClientHttpEngineTest.java
@@ -40,7 +40,7 @@ public class VertxClientHttpEngineTest extends ClientHttpEngineTest {
     @Deployment
     public static WebArchive deployment() {
         final File[] libs = Maven.resolver()
-                .resolve("org.jboss.resteasy:resteasy-client-vertx:" + System.getProperty("version.resteasy.testsuite"))
+                .resolve("org.jboss.resteasy:resteasy-client-vertx:" + System.getProperty("project.version"))
                 .withTransitivity()
                 .asList(File.class)
                 .stream()


### PR DESCRIPTION
When testing productized bits, we set `version.resteasy.testsuite` to productized bits version to test; since `resteasy-client-jetty` and `resteasy-client-vertx` are not productized, this leads to:
```
Caused by: org.eclipse.aether.resolution.DependencyResolutionException: The following artifacts could not be resolved: org.jboss.resteasy:resteasy-client-jetty:jar:6.2.11.Final-redhat-00001 (absent): Could not find artifact org.jboss.resteasy:resteasy-client-jetty:jar:6.2.11.Final-redhat-00001 in ...
```
and
```
Caused by: org.eclipse.aether.resolution.DependencyResolutionException: The following artifacts could not be resolved: org.jboss.resteasy:resteasy-client-vertx:jar:6.2.11.Final-redhat-00001 (absent): Could not find artifact org.jboss.resteasy:resteasy-client-vertx:jar:6.2.11.Final-redhat-00001 in ...
```
This MR is about retaining the possibility to run those tests with upstream bits and adding the option to test productized bits;