### PR TITLE
[RESTEASY-3583] Add a ServiceLoader dev.resteasy.embedded.server.UndertowBuilderConfigurer to update the Undertow.Builder

### DIFF
--- a/server-adapters/resteasy-undertow-cdi/src/main/java/dev/resteasy/embedded/server/UndertowBuilderConfigurator.java
+++ b/server-adapters/resteasy-undertow-cdi/src/main/java/dev/resteasy/embedded/server/UndertowBuilderConfigurator.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2025 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.resteasy.embedded.server;
+
+import io.undertow.Undertow;
+
+/**
+ * This interface is discovered as a {@link org.jboss.resteasy.spi.PriorityServiceLoader} for configuring the
+ * {@link Undertow.Builder} before it builds the {@link Undertow} and starts it.
+ */
+public interface UndertowBuilderConfigurator {
+    void configure(Undertow.Builder builder);
+}

--- a/server-adapters/resteasy-undertow-cdi/src/main/java/dev/resteasy/embedded/server/UndertowCdiEmbeddedServer.java
+++ b/server-adapters/resteasy-undertow-cdi/src/main/java/dev/resteasy/embedded/server/UndertowCdiEmbeddedServer.java
@@ -12,6 +12,7 @@ import jakarta.ws.rs.core.Application;
 import org.jboss.resteasy.plugins.server.embedded.EmbeddedServer;
 import org.jboss.resteasy.plugins.server.embedded.EmbeddedServers;
 import org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher;
+import org.jboss.resteasy.spi.PriorityServiceLoader;
 import org.jboss.resteasy.spi.ResteasyDeployment;
 import org.jboss.weld.environment.ContainerInstance;
 import org.jboss.weld.environment.servlet.Container;
@@ -68,6 +69,11 @@ public class UndertowCdiEmbeddedServer implements EmbeddedServer {
             case MANDATORY:
                 builder.setSocketOption(Options.SSL_CLIENT_AUTH_MODE, SslClientAuthMode.REQUIRED);
                 break;
+        }
+        PriorityServiceLoader<UndertowBuilderConfigurator> undertowBuilderConfigurators = PriorityServiceLoader.load(
+                UndertowBuilderConfigurator.class);
+        for (UndertowBuilderConfigurator undertowBuilderConfigurator : undertowBuilderConfigurators) {
+            undertowBuilderConfigurator.configure(builder);
         }
         final Undertow server = builder.build();
         server.start();


### PR DESCRIPTION
This implements a simple ServiceLoader interface, which can be used by applications, which need to update the Undertow.Builder before it is built/started (such as, to add http2 support to a non-TLS server).