### PR TITLE
Fixed issue where OutputStream was never closed

### DIFF
--- a/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/Jackson2JsonpInterceptor.java
+++ b/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/Jackson2JsonpInterceptor.java
@@ -187,6 +187,7 @@ public class Jackson2JsonpInterceptor implements AsyncWriterInterceptor {
                 writer.flush();
             } finally {
                 context.setOutputStream(old);
+                old.close();
             }
         } else {
             context.proceed();


### PR DESCRIPTION
The original OutputStream was wrapped with DoNotCloseDelegateOutputStream, which overrode the close() method. As a result, the OutputStream was never closed, potentially leading to memory leaks.