### PR TITLE
[RESTEASY-3598] If the proxy builder implementation was not found on …

### DIFF
--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/jaxrs/ProxyBuilder.java
@@ -29,7 +29,19 @@ public abstract class ProxyBuilder<T> {
                 }
             }
 
-            Class clazz = loader.loadClass("org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl");
+            if (loader == null) {
+                loader = ProxyBuilder.class.getClassLoader();
+            }
+
+            Class clazz;
+            try {
+                clazz = loader.loadClass("org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl");
+            } catch (ClassNotFoundException ignore) {
+                // The class was not found on the default, potentially modular, class loader. Attempt to load this
+                // from this builders class loader.
+                clazz = ProxyBuilder.class.getClassLoader()
+                        .loadClass("org.jboss.resteasy.client.jaxrs.internal.proxy.ProxyBuilderImpl");
+            }
             Constructor c = clazz.getConstructor(Class.class, WebTarget.class);
             return (ProxyBuilder<T>) c.newInstance(iface, webTarget);
         } catch (Exception e) {


### PR DESCRIPTION
…the current threads context class loader, attempt to load the type from the builders class loader.

https://issues.redhat.com/browse/RESTEASY-3598

Upstream: #4601