### PR TITLE
[RESTEASY-3610] Upgrade Netty to 4.1.123.Final.

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -49,7 +49,7 @@
         <version.commons-io.commons-io>2.11.0</version.commons-io.commons-io>
         <version.commons-codec.commons-codec>1.15</version.commons-codec.commons-codec>
         <version.dev.resteasy.junit.extension>1.0.0.Beta1</version.dev.resteasy.junit.extension>
-        <version.io.netty.netty4>4.1.119.Final</version.io.netty.netty4>
+        <version.io.netty.netty4>4.1.123.Final</version.io.netty.netty4>
         <version.io.vertx>4.4.9</version.io.vertx>
         <version.io.undertow>2.3.18.Final</version.io.undertow>
         <version.jakarta.activation>2.1.3</version.jakarta.activation>


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-3610

Upstream #4612 