### PR TITLE
[RESTEASY-3617] avoiding blocking call in reactive flow

### DIFF
--- a/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/ResteasyJackson2Provider.java
+++ b/providers/jackson2/src/main/java/org/jboss/resteasy/plugins/providers/jackson/ResteasyJackson2Provider.java
@@ -48,6 +48,7 @@ import com.fasterxml.jackson.jakarta.rs.json.JsonEndpointConfig;
 public class ResteasyJackson2Provider extends JacksonJsonProvider implements AsyncBufferedMessageBodyWriter<Object> {
 
     DecoratorMatcher decoratorMatcher = new DecoratorMatcher();
+    ObjectMapper objectMapperDefault = new ObjectMapper().findAndRegisterModules();
 
     @Override
     public boolean isReadable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
@@ -303,7 +304,7 @@ public class ResteasyJackson2Provider extends JacksonJsonProvider implements Asy
     protected ObjectMapper _locateMapperViaProvider(final Class<?> type, final MediaType mediaType) {
         final ObjectMapper mapper = super._locateMapperViaProvider(type, mediaType);
         if (mapper == null && useDefaultObjectMapper()) {
-            return new ObjectMapper().findAndRegisterModules();
+            return objectMapperDefault.copy();
         }
         return mapper;
     }


### PR DESCRIPTION
ResteasyJackson2Provider initializes the default ObjectMapper from [this](https://github.com/resteasy/resteasy/pull/4325) change, which is initialized using `ObjectMapper.findAndRegisterModules()` this internally trying to load the classes using service loader, which is a blocking call. This is a blocking call in reactive flow which is flagged by Blockhound. 

This fix would make the initialization only once and reused without affecting the reactive flow.  