### PR TITLE
Module org.bouncycastle has been removed in WFLY-16576

### DIFF
--- a/testsuite/integration-tests/src/test/resources/jboss-deployment-structure-bouncycastle.xml
+++ b/testsuite/integration-tests/src/test/resources/jboss-deployment-structure-bouncycastle.xml
@@ -2,7 +2,9 @@
 <jboss-deployment-structure>
     <deployment>
         <dependencies>
-            <module name="org.bouncycastle" services="import" />
+            <module name="org.bouncycastle.bcpkix" export="true" services="export"/>
+            <module name="org.bouncycastle.bcprov" export="true" services="export"/>
+            <module name="org.bouncycastle.bcmail" export="true" services="export"/>
         </dependencies>
     </deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
Module org.bouncycastle has been removed in WFLY-16576: we need to replace its references with individual modules where needed