### PR TITLE
Bootable jar tests

### DIFF
--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -326,6 +326,8 @@
                                         <exclude>**/SslServerWithWildcardHostnameCertificateTest.java</exclude>
                                         <exclude>**/SslServerWithWrongHostnameCertificateTest.java</exclude>
                                         <exclude>**/SslSniHostNamesTest.java</exclude>
+                                        <exclude>**/JettyClientHttpEngineTest.java</exclude>
+                                        <exclude>**/VertxClientHttpEngineTest.java</exclude>
                                     </excludes>
                                 </configuration>
                             </execution>

--- a/testsuite/integration-tests/src/test/resources/jboss-deployment-structure-bouncycastle.xml
+++ b/testsuite/integration-tests/src/test/resources/jboss-deployment-structure-bouncycastle.xml
@@ -2,7 +2,9 @@
 <jboss-deployment-structure>
     <deployment>
         <dependencies>
-            <module name="org.bouncycastle" services="import" />
+            <module name="org.bouncycastle.bcpkix" export="true" services="export"/>
+            <module name="org.bouncycastle.bcprov" export="true" services="export"/>
+            <module name="org.bouncycastle.bcmail" export="true" services="export"/>
         </dependencies>
     </deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
These tests are already excluded in the regular testing pipeline; this way we can avoid messing with the surefire.excludes parameter