### PR TITLE
[6.2] Module org.bouncycastle has been removed

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/mediatype/BlacklistedMediaTypeTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/providers/mediatype/BlacklistedMediaTypeTest.java
@@ -44,7 +44,7 @@ import org.wildfly.arquillian.junit.annotations.RequiresModule;
  */
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
-@RequiresModule("org.bouncycastle")
+@RequiresModule("org.bouncycastle.bcprov")
 public class BlacklistedMediaTypeTest {
 
     private static final String APPLICATION_SIGNED_EXCHANGE = "application/signed-exchange";

--- a/testsuite/integration-tests/src/test/resources/jboss-deployment-structure-bouncycastle.xml
+++ b/testsuite/integration-tests/src/test/resources/jboss-deployment-structure-bouncycastle.xml
@@ -2,7 +2,9 @@
 <jboss-deployment-structure>
     <deployment>
         <dependencies>
-            <module name="org.bouncycastle" services="import" />
+            <module name="org.bouncycastle.bcpkix" export="true" services="export" />
+            <module name="org.bouncycastle.bcprov" export="true" services="export" />
+            <module name="org.bouncycastle.bcmail" export="true" services="export" />
         </dependencies>
     </deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
*** back-port of https://github.com/resteasy/resteasy/pull/4649 to 6.2 ***

Module org.bouncycastle has been removed (when provisioning with galleon even though WFLY-16576 has not been completed): we need to replace its references with individual modules where needed