### PR TITLE
[RESTEASY-3623] Upgrade Netty to 4.1.126.Final.

### DIFF
--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -49,7 +49,7 @@
         <version.commons-io.commons-io>2.11.0</version.commons-io.commons-io>
         <version.commons-codec.commons-codec>1.15</version.commons-codec.commons-codec>
         <version.dev.resteasy.junit.extension>1.0.0.Beta1</version.dev.resteasy.junit.extension>
-        <version.io.netty.netty4>4.1.123.Final</version.io.netty.netty4>
+        <version.io.netty.netty4>4.1.126.Final</version.io.netty.netty4>
         <version.io.vertx>4.4.9</version.io.vertx>
         <version.io.undertow>2.3.18.Final</version.io.undertow>
         <version.jakarta.activation>2.1.3</version.jakarta.activation>

--- a/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/NettyTest.java
+++ b/server-adapters/resteasy-netty4/src/test/java/org/jboss/resteasy/test/NettyTest.java
@@ -255,7 +255,7 @@ public class NettyTest {
         Socket client = new Socket(getHost(), getPort());
         PrintWriter out = new PrintWriter(client.getOutputStream(), true);
         BufferedReader in = new BufferedReader(new InputStreamReader(client.getInputStream()));
-        out.printf(Locale.US, "GET %s HTTP/1.1\nHost: %s:%d\n\n", uri, getHost(), getPort());
+        out.printf(Locale.US, "GET %s HTTP/1.1\r\nHost: %s:%d\r\n\r\n", uri, getHost(), getPort());
         String statusLine = in.readLine();
         String response = in.readLine();
         while (!response.startsWith("uri")) {

--- a/server-adapters/resteasy-reactor-netty/src/test/java/org/jboss/resteasy/test/NettyTest.java
+++ b/server-adapters/resteasy-reactor-netty/src/test/java/org/jboss/resteasy/test/NettyTest.java
@@ -247,7 +247,7 @@ public class NettyTest {
         Socket client = new Socket(getHost(), getPort());
         PrintWriter out = new PrintWriter(client.getOutputStream(), true);
         BufferedReader in = new BufferedReader(new InputStreamReader(client.getInputStream()));
-        out.printf(Locale.US, "GET %s HTTP/1.1\nHost: %s:%d\n\n", uri, getHost(), getPort());
+        out.printf(Locale.US, "GET %s HTTP/1.1\r\nHost: %s:%d\r\n\r\n", uri, getHost(), getPort());
         String statusLine = in.readLine();
         String response = in.readLine();
 

--- a/server-adapters/resteasy-vertx/src/test/java/org/jboss/resteasy/test/VertxTest.java
+++ b/server-adapters/resteasy-vertx/src/test/java/org/jboss/resteasy/test/VertxTest.java
@@ -262,7 +262,7 @@ public class VertxTest {
         Socket client = new Socket(getHost(), getPort());
         PrintWriter out = new PrintWriter(client.getOutputStream(), true);
         BufferedReader in = new BufferedReader(new InputStreamReader(client.getInputStream()));
-        out.printf(Locale.US, "GET %s HTTP/1.1\nHost: %s:%d\n\n", uri, getHost(), getPort());
+        out.printf(Locale.US, "GET %s HTTP/1.1\r\nHost: %s:%d\r\n\r\n", uri, getHost(), getPort());
         String statusLine = in.readLine();
         String response = in.readLine();
         while (!response.startsWith("uri")) {


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-3623

Upstream: #4659 

Replaces #4657 