### PR TITLE
[RESTEASY-3674] Fix SSLContext and HostnameVerifier usage in URLConnectionEngine + add optional system proxy support

### DIFF
--- a/resteasy-client-api/src/main/java/org/jboss/resteasy/client/jaxrs/ResteasyClientBuilder.java
+++ b/resteasy-client-api/src/main/java/org/jboss/resteasy/client/jaxrs/ResteasyClientBuilder.java
@@ -188,6 +188,8 @@ public abstract class ResteasyClientBuilder extends ClientBuilder {
 
     public abstract String getDefaultProxyScheme();
 
+    public abstract boolean isUseJvmProxySettings();
+
     /**
      * Specify a default proxy host and port. Default schema will be used.
      *
@@ -206,6 +208,15 @@ public abstract class ResteasyClientBuilder extends ClientBuilder {
      * @return an updated client builder instance
      */
     public abstract ResteasyClientBuilder defaultProxy(String hostname, int port, String scheme);
+
+    /**
+     * Specify if the JVM proxy settings should be used.
+     *
+     * @param useJvmProxySettings a boolean indicating whether the JVM's global proxy
+     *                            settings should be used for the client connections.
+     * @return an updated client builder instance
+     */
+    public abstract ResteasyClientBuilder useJvmProxySettings(boolean useJvmProxySettings);
 
     /**
      * Enable state (cookie) management.

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ClientHttpEngineBuilder43.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ClientHttpEngineBuilder43.java
@@ -230,6 +230,9 @@ public class ClientHttpEngineBuilder43 implements ClientHttpEngineBuilder {
         if (that.isDisableAutomaticRetries()) {
             httpClientBuilder.disableAutomaticRetries();
         }
+        if (that.isUseJvmProxySettings()) {
+            httpClientBuilder.useSystemProperties();
+        }
         httpClient = httpClientBuilder.build();
 
         ApacheHttpClient43Engine engine = new ApacheHttpClient43Engine(httpClient, true);

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/URLConnectionClientEngineBuilder.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/URLConnectionClientEngineBuilder.java
@@ -33,7 +33,16 @@ public class URLConnectionClientEngineBuilder implements ClientHttpEngineBuilder
             clientEngine.setProxyScheme(resteasyClientBuilder.getDefaultProxyScheme());
         }
 
+        if (resteasyClientBuilder.getHostnameVerifier() != null) {
+            clientEngine.setHostnameVerifier(resteasyClientBuilder.getHostnameVerifier());
+        }
+
+        if (resteasyClientBuilder.getSSLContext() != null) {
+            clientEngine.setSslContext(resteasyClientBuilder.getSSLContext());
+        }
+
         clientEngine.setFollowRedirects(resteasyClientBuilder.isFollowRedirects());
+        clientEngine.setUseJvmProxySettings(resteasyClientBuilder.isUseJvmProxySettings());
         return clientEngine;
     }
 }

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/URLConnectionEngine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/URLConnectionEngine.java
@@ -37,7 +37,7 @@ public class URLConnectionEngine implements ClientHttpEngine {
     protected HostnameVerifier hostnameVerifier;
     protected Integer readTimeout;
     protected Integer connectTimeout;
-    protected boolean useDefaultProxy;
+    protected boolean useJvmProxySettings;
     protected String proxyHost;
     protected Integer proxyPort;
     protected String proxyScheme;
@@ -151,7 +151,7 @@ public class URLConnectionEngine implements ClientHttpEngine {
         Proxy proxy = null;
         if (this.proxyHost != null && this.proxyPort != null) {
             proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(this.proxyHost, this.proxyPort));
-        } else if (!this.useDefaultProxy) {
+        } else if (!this.useJvmProxySettings) {
             proxy = Proxy.NO_PROXY;
         }
 
@@ -265,19 +265,12 @@ public class URLConnectionEngine implements ClientHttpEngine {
         this.readTimeout = readTimeout;
     }
 
-    /**
-     * Configures whether the default proxy settings should be enabled for the connection.
-     *
-     * @param useDefaultProxy a boolean flag indicating whether to enable the default parametric-driven proxy.
-     *                        If set to {@code true}, the default proxy settings will be enabled;
-     *                        otherwise, they will remain disabled.
-     */
-    public void setUseDefaultProxy(boolean useDefaultProxy) {
-        this.useDefaultProxy = useDefaultProxy;
+    public void setUseJvmProxySettings(boolean useJvmProxySettings) {
+        this.useJvmProxySettings = useJvmProxySettings;
     }
 
-    public boolean isUseDefaultProxy() {
-        return this.useDefaultProxy;
+    public boolean isUseJvmProxySettings() {
+        return this.useJvmProxySettings;
     }
 
     public void setProxyHost(String proxyHost) {

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/ResteasyClientBuilderImpl.java
@@ -68,6 +68,7 @@ public class ResteasyClientBuilderImpl extends ResteasyClientBuilder {
     protected int connectionCheckoutTimeoutMs = -1;
     protected HostnameVerifier verifier = null;
     private ProxyInfo defaultProxy;
+    private boolean useJvmProxySettings = false;
     protected int responseBufferSize;
     protected List<String> sniHostNames = new ArrayList<>();
     protected boolean trustSelfSignedCertificates = true;
@@ -330,6 +331,12 @@ public class ResteasyClientBuilderImpl extends ResteasyClientBuilder {
      */
     public ResteasyClientBuilderImpl defaultProxy(String hostname, int port, final String scheme) {
         this.defaultProxy = hostname != null ? new ProxyInfo(scheme, hostname, port) : null;
+        return this;
+    }
+
+    @Override
+    public ResteasyClientBuilder useJvmProxySettings(boolean useJvmProxySettings) {
+        this.useJvmProxySettings = useJvmProxySettings;
         return this;
     }
 
@@ -605,6 +612,11 @@ public class ResteasyClientBuilderImpl extends ResteasyClientBuilder {
     @Override
     public String getDefaultProxyScheme() {
         return defaultProxy != null ? defaultProxy.scheme() : null;
+    }
+
+    @Override
+    public boolean isUseJvmProxySettings() {
+        return useJvmProxySettings;
     }
 
     @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-3674

This PR fixes an issue where the provided SSLContext and HostnameVerifier were not actually being used when creating HttpURLConnection instances. As a result, custom SSL configurations were silently ignored.

Additionally, the code previously enforced NO_PROXY usage, bypassing the standard Java mechanisms for proxy configuration (e.g. -Djava.net.useSystemProxies, https.proxyHost, https.proxyPort, etc.).

To improve this, I introduced a switch that allows enabling the use of system proxy settings. This way, the proxy behavior aligns with the JVM’s standard configuration, while still preserving the old behavior by default.

On top of that, I also updated the following components:

- URLConnectionClientEngineBuilder and ResteasyClientBuilder: now properly propagate and respect the JVM proxy/SSL settings so that clients created through these builders behave consistently.
- Apache client implementation: extended with equivalent support for custom SSL configuration and system proxy handling, ensuring feature parity across the different client engines.

Key points:

- Correctly apply the provided SSLContext and HostnameVerifier to HttpsURLConnection.
- Replace the hardcoded NO_PROXY with an optional mechanism that respects JVM proxy settings.
- The new proxy handling is opt-in, so this change is not breaking existing behavior.
- Ensure builders (URLConnectionClientEngineBuilder, ResteasyClientBuilder) and the Apache implementation fully support these features.

Why this matters:

- Ensures that custom SSL/TLS settings (such as trust stores or custom hostname verification) are correctly honored.
- Restores compatibility with enterprise environments where proxies are configured via system properties.
- Provides consistent behavior across different client engine implementations.