### PR TITLE
[RESTEASY-3631] Upgrade Undertow to 2.3.19.Final.

### DIFF
--- a/providers/json-binding/pom.xml
+++ b/providers/json-binding/pom.xml
@@ -79,6 +79,15 @@
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Transitively io.undertow:undertow-core -> org.jboss.threads:jboss-threads with a newer version.
+                     Excluding here resolves issues with the lower version winning.
+                 -->
+                <exclusion>
+                    <groupId>io.smallrye.common</groupId>
+                    <artifactId>smallrye-common-constraint</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/providers/multipart/pom.xml
+++ b/providers/multipart/pom.xml
@@ -72,6 +72,15 @@
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Transitively io.undertow:undertow-core -> org.jboss.threads:jboss-threads with a newer version.
+                     Excluding here resolves issues with the lower version winning.
+                 -->
+                <exclusion>
+                    <groupId>io.smallrye.common</groupId>
+                    <artifactId>smallrye-common-constraint</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -51,7 +51,7 @@
         <version.dev.resteasy.junit.extension>1.0.0.Beta1</version.dev.resteasy.junit.extension>
         <version.io.netty.netty4>4.1.127.Final</version.io.netty.netty4>
         <version.io.vertx>4.4.9</version.io.vertx>
-        <version.io.undertow>2.3.18.Final</version.io.undertow>
+        <version.io.undertow>2.3.19.Final</version.io.undertow>
         <version.jakarta.activation>2.1.4</version.jakarta.activation>
         <version.jakarta.enterprise.cdi-api>4.0.1</version.jakarta.enterprise.cdi-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>

--- a/server-adapters/resteasy-undertow-cdi/pom.xml
+++ b/server-adapters/resteasy-undertow-cdi/pom.xml
@@ -118,6 +118,21 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- We need to define this here to override the exclusions -->
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <!-- Transitively io.undertow:undertow-core -> org.jboss.threads:jboss-threads with a newer version.
+                     Excluding here resolves issues with the lower version winning.
+                 -->
+                <exclusion>
+                    <groupId>io.smallrye.common</groupId>
+                    <artifactId>smallrye-common-constraint</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
     </dependencies>
 

--- a/server-adapters/resteasy-undertow/pom.xml
+++ b/server-adapters/resteasy-undertow/pom.xml
@@ -55,6 +55,21 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- We need to define this here to override the exclusions -->
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <!-- Transitively io.undertow:undertow-core -> org.jboss.threads:jboss-threads with a newer version.
+                     Excluding here resolves issues with the lower version winning.
+                 -->
+                <exclusion>
+                    <groupId>io.smallrye.common</groupId>
+                    <artifactId>smallrye-common-constraint</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
https://issues.redhat.com/browse/RESTEASY-3631

Upstream #4680 

Replaces #4667