### PR TITLE
Updated code to cast to GenericEntity

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/ClientInvoker.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/ClientInvoker.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.client.SyncInvoker;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.container.DynamicFeature;
 import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.GenericEntity;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 
@@ -121,8 +122,17 @@ public class ClientInvoker implements MethodInvoker {
         Object e = request.getEntity();
         Object o = null;
         if (e != null) {
-            o = rxInvoker.method(getHttpMethod(),
-                    Entity.entity(e, request.getHeaders().getMediaType(), request.getEntityAnnotations()), gt);
+            if (e instanceof GenericEntity) {
+                o = rxInvoker.method(getHttpMethod(),
+                        Entity.entity(e,
+                                request.getHeaders().getMediaType(), request.getEntityAnnotations()),
+                        gt);
+            } else {
+                o = rxInvoker.method(getHttpMethod(),
+                        Entity.entity(new GenericEntity<Object>(e, request.getEntityGenericType()),
+                                request.getHeaders().getMediaType(), request.getEntityAnnotations()),
+                        gt);
+            }
         } else {
             o = rxInvoker.method(getHttpMethod(), gt);
         }


### PR DESCRIPTION
Sending multipart/form-data with MicorProfileRestClient asynchronous results in exception. The same Request works synchronous as expected. During analysis it was found that the data is not coming as a GenericEntity to the available MessageBodyWriters in async flow, thus resulting in an incorrect MBW being picked up, which results in an exception. Further analysis led to the ClientInvoker.invokeAsync() method where this data is set to entity. Here entity is set in raw format and thus going as a immutable list to the downstream. So a code fix is required to cast the data to GenericEntity if it's not originally. 