### PR TITLE
[RESTEASY-3621] [6.2.x] Resource methods inherited from package-private class not registered

### DIFF
--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
@@ -758,8 +758,16 @@ public class ResourceBuilder {
             builder = createResourceClassBuilder(clazz);
         }
         for (Method method : clazz.getMethods()) {
-            if (!method.isSynthetic() && !method.getDeclaringClass().equals(Object.class))
-                processMethod(isLocator, builder, clazz, method);
+            if (!method.getDeclaringClass().equals(Object.class)) {
+                if (!method.isSynthetic()) {
+                    processMethod(isLocator, builder, clazz, method);
+                } else if (method.isBridge() && !hasNonSyntheticDeclaredMethodWithName(method)) {
+                    final Method bridgedMethod = findNonSyntheticSuperclassMethod(method);
+                    if (bridgedMethod != null) {
+                        processMethod(builder, clazz, method, bridgedMethod);
+                    }
+                }
+            }
 
         }
         if (!clazz.isInterface()) {
@@ -777,6 +785,35 @@ public class ResourceBuilder {
         else
             builder = buildRootResource(clazz, path.value());
         return builder;
+    }
+
+    private static Method findNonSyntheticSuperclassMethod(final Method bridgeMethod) {
+        for (Class<?> superClass = bridgeMethod.getDeclaringClass().getSuperclass(); superClass != null
+                && !superClass.equals(Object.class); superClass = superClass.getSuperclass()) {
+            try {
+                final Method m = superClass.getDeclaredMethod(bridgeMethod.getName(), bridgeMethod.getParameterTypes());
+                if (!m.isSynthetic()) {
+                    return m;
+                }
+            } catch (NoSuchMethodException e) {
+                // not in this superclass, keep walking up
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns true if the bridge method's declaring class has a non-synthetic declared method with the same name.
+     * This indicates a generic type-erasure bridge (which has a concrete counterpart with more specific types),
+     * as opposed to an accessibility bridge for a package-private superclass (which has no concrete counterpart).
+     */
+    private static boolean hasNonSyntheticDeclaredMethodWithName(final Method bridgeMethod) {
+        for (Method m : bridgeMethod.getDeclaringClass().getDeclaredMethods()) {
+            if (!m.isSynthetic() && m.getName().equals(bridgeMethod.getName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static Set<String> getHttpMethods(Method method) {
@@ -984,11 +1021,24 @@ public class ResourceBuilder {
 
     protected void processMethod(boolean isLocator, ResourceClassBuilder resourceClassBuilder, Class<?> root,
             Method implementation) {
-        Method method = getAnnotatedMethod(root, implementation);
+        processMethod(resourceClassBuilder, root, implementation, implementation);
+    }
+
+    /**
+     * Process the resource method to configure the builder.
+     *
+     * @param resourceClassBuilder the builder to configure
+     * @param root                 the root resource class
+     * @param implementation       the method to be invoked (may be a bridge method)
+     * @param annotatedMethod      the method containing Jakarta REST annotations (may be in a superclass)
+     */
+    private void processMethod(final ResourceClassBuilder resourceClassBuilder, final Class<?> root,
+            final Method implementation, final Method annotatedMethod) {
+        Method method = getAnnotatedMethod(root, annotatedMethod);
         if (method != null) {
             Set<String> httpMethods = getHttpMethods(method);
 
-            ResourceLocatorBuilder resourceLocatorBuilder;
+            ResourceLocatorBuilder<?> resourceLocatorBuilder;
 
             if (httpMethods == null) {
                 resourceLocatorBuilder = resourceClassBuilder.locator(implementation, method);

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/PackagePrivateInheritanceTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/PackagePrivateInheritanceTest.java
@@ -31,11 +31,11 @@ import org.wildfly.arquillian.junit.annotations.RequiresModule;
  * @tpTestCaseDetails Regression test for RESTEASY-3621: a public resource class that inherits a
  *                    JAX-RS resource method from a package-private superclass must be invocable
  *                    without throwing IllegalAccessException.
- * @tpSince RESTEasy 7.0.2
+ * @tpSince RESTEasy 6.2.17
  */
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
-@RequiresModule(value = "org.jboss.resteasy.resteasy-core-spi", minVersion = "6.2.16.Final")
+@RequiresModule(value = "org.jboss.resteasy.resteasy-core-spi", minVersion = "6.2.17.Final")
 public class PackagePrivateInheritanceTest {
 
     private static Client client;
@@ -64,7 +64,7 @@ public class PackagePrivateInheritanceTest {
     /**
      * @tpTestDetails Verify that a GET request to a resource method declared in a package-private
      *                superclass succeeds with HTTP 200 and the expected response body.
-     * @tpSince RESTEasy 7.0.2
+     * @tpSince RESTEasy 6.2.17
      */
     @Test
     public void inheritedMethodFromPackagePrivateClassIsInvocable() {

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/PackagePrivateInheritanceTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/PackagePrivateInheritanceTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.resource.basic;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.resteasy.spi.HttpResponseCodes;
+import org.jboss.resteasy.test.resource.basic.resource.PackagePrivateInheritanceResource;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.wildfly.arquillian.junit.annotations.RequiresModule;
+
+/**
+ * @tpSubChapter Resource
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Regression test for RESTEASY-3621: a public resource class that inherits a
+ *                    JAX-RS resource method from a package-private superclass must be invocable
+ *                    without throwing IllegalAccessException.
+ * @tpSince RESTEasy 7.0.2
+ */
+@ExtendWith(ArquillianExtension.class)
+@RunAsClient
+@RequiresModule(value = "org.jboss.resteasy.resteasy-core-spi", minVersion = "6.2.16.Final")
+public class PackagePrivateInheritanceTest {
+
+    private static Client client;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        WebArchive war = TestUtil.prepareArchive(PackagePrivateInheritanceTest.class.getSimpleName());
+        war.addClass(PackagePrivateInheritanceResource.class.getSuperclass());
+        return TestUtil.finishContainerPrepare(war, null, PackagePrivateInheritanceResource.class);
+    }
+
+    private String generateURL(String path) {
+        return PortProviderUtil.generateURL(path, PackagePrivateInheritanceTest.class.getSimpleName());
+    }
+
+    @BeforeAll
+    public static void beforeAll() {
+        client = ClientBuilder.newClient();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        client.close();
+    }
+
+    /**
+     * @tpTestDetails Verify that a GET request to a resource method declared in a package-private
+     *                superclass succeeds with HTTP 200 and the expected response body.
+     * @tpSince RESTEasy 7.0.2
+     */
+    @Test
+    public void inheritedMethodFromPackagePrivateClassIsInvocable() {
+        Response response = client.target(generateURL("/package-private-inheritance")).request().get();
+        Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        Assertions.assertEquals("hello", response.readEntity(String.class));
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/resource/PackagePrivateAbstractResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/resource/PackagePrivateAbstractResource.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.resource.basic.resource;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+
+/**
+ * Package-private abstract class with a JAX-RS resource method.
+ * Used to verify that methods inherited from package-private superclasses
+ * can be invoked via reflection (RESTEASY-3621).
+ */
+abstract class PackagePrivateAbstractResource {
+
+    @GET
+    @Produces("text/plain")
+    public String get() {
+        return "hello";
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/resource/PackagePrivateInheritanceResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/basic/resource/PackagePrivateInheritanceResource.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.resource.basic.resource;
+
+import jakarta.ws.rs.Path;
+
+/**
+ * Public resource class that inherits its resource method from a package-private superclass.
+ * Used to verify RESTEASY-3621: invoking inherited methods from package-private classes
+ * must not throw IllegalAccessException.
+ */
+@Path("/package-private-inheritance")
+public class PackagePrivateInheritanceResource extends PackagePrivateAbstractResource {
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/ResourceBuilderTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/ResourceBuilderTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.resource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
+import org.jboss.resteasy.spi.metadata.ResourceClass;
+import org.jboss.resteasy.test.resource.resource.TestInheritResourceMethod;
+import org.jboss.resteasy.test.resource.resource.TestInheritResourceMethodFromPrivateClass;
+import org.jboss.resteasy.test.resource.resource.TestRootResource;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @tpSubChapter Resource tests
+ * @tpChapter Unit tests
+ * @tpTestCaseDetails Tests building resource classes from annotations.
+ * @tpSince RESTEasy 7.0.0
+ */
+public class ResourceBuilderTest {
+
+    /**
+     * @tpTestDetails Test resource method declared in resource class.
+     * @tpSince RESTEasy 7.0.0
+     */
+    @Test
+    public void methodInResourceClass() {
+        ResourceClass resource = new ResourceBuilder()
+                .getRootResourceFromAnnotations(TestRootResource.class);
+        assertEquals(1, resource.getResourceMethods().length);
+    }
+
+    /**
+     * @tpTestDetails Test resource method declared in public parent class.
+     * @tpSince RESTEasy 7.0.0
+     */
+    @Test
+    public void inheritedMethod() {
+        ResourceClass resource = new ResourceBuilder()
+                .getRootResourceFromAnnotations(TestInheritResourceMethod.class);
+        assertEquals(1, resource.getResourceMethods().length);
+    }
+
+    /**
+     * @tpTestDetails Test resource method declared in package-private parent class.
+     * @tpSince RESTEasy 7.0.0
+     */
+    @Test
+    public void inheritedMethodFromPrivateClass() {
+        ResourceClass resource = new ResourceBuilder()
+                .getRootResourceFromAnnotations(TestInheritResourceMethodFromPrivateClass.class);
+        assertEquals(1, resource.getResourceMethods().length);
+    }
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/ResourceBuilderTest.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/ResourceBuilderTest.java
@@ -18,13 +18,13 @@ import org.junit.jupiter.api.Test;
  * @tpSubChapter Resource tests
  * @tpChapter Unit tests
  * @tpTestCaseDetails Tests building resource classes from annotations.
- * @tpSince RESTEasy 7.0.0
+ * @tpSince RESTEasy 6.2.17
  */
 public class ResourceBuilderTest {
 
     /**
      * @tpTestDetails Test resource method declared in resource class.
-     * @tpSince RESTEasy 7.0.0
+     * @tpSince RESTEasy 6.2.17
      */
     @Test
     public void methodInResourceClass() {
@@ -35,7 +35,7 @@ public class ResourceBuilderTest {
 
     /**
      * @tpTestDetails Test resource method declared in public parent class.
-     * @tpSince RESTEasy 7.0.0
+     * @tpSince RESTEasy 6.2.17
      */
     @Test
     public void inheritedMethod() {
@@ -46,7 +46,7 @@ public class ResourceBuilderTest {
 
     /**
      * @tpTestDetails Test resource method declared in package-private parent class.
-     * @tpSince RESTEasy 7.0.0
+     * @tpSince RESTEasy 6.2.17
      */
     @Test
     public void inheritedMethodFromPrivateClass() {

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/PrivateAbstractResourceClass.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/PrivateAbstractResourceClass.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.resource.resource;
+
+import jakarta.ws.rs.GET;
+
+/**
+ * @author <a href="mailto:tom@intevation.de">Tom Gottfried</a>
+ */
+abstract class PrivateAbstractResourceClass {
+    @GET
+    public String get() {
+        return "test";
+    }
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/PublicAbstractResourceClass.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/PublicAbstractResourceClass.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.resource.resource;
+
+import jakarta.ws.rs.GET;
+
+/**
+ * @author <a href="mailto:tom@intevation.de">Tom Gottfried</a>
+ */
+public abstract class PublicAbstractResourceClass {
+    @GET
+    public String get() {
+        return "test";
+    }
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/TestInheritResourceMethod.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/TestInheritResourceMethod.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.resource.resource;
+
+import jakarta.ws.rs.Path;
+
+/**
+ * @author <a href="mailto:tom@intevation.de">Tom Gottfried</a>
+ */
+@Path("root")
+public class TestInheritResourceMethod extends PublicAbstractResourceClass {
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/TestInheritResourceMethodFromPrivateClass.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/TestInheritResourceMethodFromPrivateClass.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.resource.resource;
+
+import jakarta.ws.rs.Path;
+
+/**
+ * @author <a href="mailto:tom@intevation.de">Tom Gottfried</a>
+ */
+@Path("root")
+public class TestInheritResourceMethodFromPrivateClass extends PrivateAbstractResourceClass {
+}

--- a/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/TestRootResource.java
+++ b/testsuite/unit-tests/src/test/java/org/jboss/resteasy/test/resource/resource/TestRootResource.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.resource.resource;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+/**
+ * @author <a href="mailto:tom@intevation.de">Tom Gottfried</a>
+ */
+@Path("root")
+public class TestRootResource {
+    @GET
+    public String get() {
+        return "test";
+    }
+}


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/RESTEASY-3621