### PR TITLE
RESTEASY-3339: Add test cases

### DIFF
--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/validation/ValidateOnceWithCDITest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/validation/ValidateOnceWithCDITest.java
@@ -1,0 +1,75 @@
+package org.jboss.resteasy.test.cdi.validation;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.resteasy.spi.HttpResponseCodes;
+import org.jboss.resteasy.test.cdi.validation.resource.TestApplication;
+import org.jboss.resteasy.test.validation.resource.ValidationCounter;
+import org.jboss.resteasy.test.validation.resource.ValidationCounterConstraint;
+import org.jboss.resteasy.test.validation.resource.ValidationCounterResource;
+import org.jboss.resteasy.test.validation.resource.ValidationCounterValidator;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * @tpSubChapter CDI
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails RESTEASY-3339: Assert that parameter validation is executed only once
+ * @tpSince RESTEasy 7.0.2
+ */
+@ExtendWith(ArquillianExtension.class)
+@RunAsClient
+public class ValidateOnceWithCDITest {
+
+    Client client;
+
+    @BeforeEach
+    public void init() {
+        client = ClientBuilder.newClient();
+    }
+
+    @AfterEach
+    public void after() throws Exception {
+        client.close();
+    }
+
+    @Deployment(testable = false)
+    public static Archive<?> basicDeploymentTestResourceWithOtherGroups() {
+        WebArchive war = TestUtil.prepareArchive(ValidateOnceWithCDITest.class.getSimpleName());
+        war.addClasses(TestApplication.class)
+                .addClasses(ValidationCounterResource.class, ValidationCounter.class,
+                        ValidationCounterConstraint.class, ValidationCounterValidator.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsWebInfResource(ValidateOnceWithCDITest.class.getPackage(), "web.xml", "/web.xml");
+        return TestUtil.finishContainerPrepare(war, null);
+    }
+
+    /**
+     * @tpTestDetails Assert that parameter validation is executed only once
+     * @tpSince RESTEasy 7.0.2
+     */
+    // TODO: Fails, because parameter validation is executed twice
+    @Test
+    public void testParameters() throws Exception {
+        Response response = client
+                .target(PortProviderUtil.generateURL("/count", ValidateOnceWithCDITest.class.getSimpleName()))
+                .request().post(Entity.entity(new ValidationCounter(), MediaType.APPLICATION_JSON));
+        Assertions.assertEquals(HttpResponseCodes.SC_NO_CONTENT, response.getStatus());
+        response.close();
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ValidateOnceTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/ValidateOnceTest.java
@@ -1,0 +1,69 @@
+package org.jboss.resteasy.test.validation;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.resteasy.spi.HttpResponseCodes;
+import org.jboss.resteasy.test.validation.resource.ValidationCounter;
+import org.jboss.resteasy.test.validation.resource.ValidationCounterConstraint;
+import org.jboss.resteasy.test.validation.resource.ValidationCounterResource;
+import org.jboss.resteasy.test.validation.resource.ValidationCounterValidator;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * @tpSubChapter Validator provider
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails RESTEASY-3339: Assert that parameter validation is executed only once
+ * @tpSince RESTEasy 7.0.2
+ */
+@ExtendWith(ArquillianExtension.class)
+@RunAsClient
+public class ValidateOnceTest {
+
+    Client client;
+
+    @BeforeEach
+    public void init() {
+        client = ClientBuilder.newClient();
+    }
+
+    @AfterEach
+    public void after() throws Exception {
+        client.close();
+    }
+
+    @Deployment(testable = false)
+    public static Archive<?> basicDeploymentTestResourceWithOtherGroups() {
+        WebArchive war = TestUtil.prepareArchive(ValidateOnceTest.class.getSimpleName());
+        war.addClasses(ValidationCounterResource.class, ValidationCounter.class,
+                ValidationCounterConstraint.class, ValidationCounterValidator.class);
+        return TestUtil.finishContainerPrepare(war, null);
+    }
+
+    /**
+     * @tpTestDetails Assert that parameter validation is executed only once
+     * @tpSince RESTEasy 7.0.2
+     */
+    @Test
+    public void testParameters() throws Exception {
+        Response response = client
+                .target(PortProviderUtil.generateURL("/count", ValidateOnceTest.class.getSimpleName()))
+                .request().post(Entity.entity(new ValidationCounter(), MediaType.APPLICATION_JSON));
+        Assertions.assertEquals(HttpResponseCodes.SC_NO_CONTENT, response.getStatus());
+        response.close();
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/resource/ValidationCounter.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/resource/ValidationCounter.java
@@ -1,0 +1,9 @@
+package org.jboss.resteasy.test.validation.resource;
+
+import java.io.Serializable;
+
+@ValidationCounterConstraint
+public class ValidationCounter implements Serializable {
+    public static final long serialVersionUID = -1068336400309384949L;
+    public int count = 0;
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/resource/ValidationCounterConstraint.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/resource/ValidationCounterConstraint.java
@@ -1,0 +1,25 @@
+package org.jboss.resteasy.test.validation.resource;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = ValidationCounterValidator.class)
+@Target({ TYPE, PARAMETER, METHOD })
+@Retention(RUNTIME)
+public @interface ValidationCounterConstraint {
+    String message() default "Validation executed more than once";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/resource/ValidationCounterResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/resource/ValidationCounterResource.java
@@ -1,0 +1,13 @@
+package org.jboss.resteasy.test.validation.resource;
+
+import jakarta.validation.Valid;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+@Path("/")
+public class ValidationCounterResource {
+    @POST
+    @Path("/count")
+    public void postNative(@Valid ValidationCounter foo) {
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/resource/ValidationCounterValidator.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/validation/resource/ValidationCounterValidator.java
@@ -1,0 +1,18 @@
+package org.jboss.resteasy.test.validation.resource;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import org.jboss.logging.Logger;
+
+public class ValidationCounterValidator
+        implements ConstraintValidator<ValidationCounterConstraint, ValidationCounter> {
+
+    private static Logger logger = Logger.getLogger(ValidationCounterValidator.class);
+
+    @Override
+    public boolean isValid(ValidationCounter value, ConstraintValidatorContext context) {
+        logger.infof("Validation executed %d time(s) so far", value.count);
+        return value.count++ == 0;
+    }
+}


### PR DESCRIPTION
Background:
Parameter validation is executed a first time by RESTEasy itself: https://github.com/resteasy/resteasy/blob/5f3f9328682cbdf7b2fedf5d324ede0774fed6ec/resteasy-core/src/main/java/org/jboss/resteasy/core/MethodInjectorImpl.java#L135
Validation is executed a second time when invoking the method: https://github.com/resteasy/resteasy/blob/5f3f9328682cbdf7b2fedf5d324ede0774fed6ec/resteasy-core/src/main/java/org/jboss/resteasy/core/MethodInjectorImpl.java#L154
The latter is due to the fact that the Validation Service Provider executes [method validation for CDI beans by default](https://docs.hibernate.org/validator/8.0/reference/en-US/html_single/#_method_validation)