### PR TITLE
[RESTEASY-3722] Update the documentation to use the new feature pack …

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -138,7 +138,7 @@ jobs:
           cache: 'maven'
       - name: Test with Java 11 on WildFly 34 - ${{ matrix.os }}
         run:  |
-          mvn clean install -U -B -fae '-Dserver.version=34.0.0.Final' '-Dgithub.actions' '-Djvm=${{env.JAVA_HOME_11_X64}}/bin/java'
+          mvn clean install -U -B -fae '-Dserver.version=34.0.0.Final' '-Dgithub.actions' '-Djvm=${{env.JAVA_HOME_11_X64}}/bin/java' '-Plegacy-wildfly-channels'
       - uses: actions/upload-artifact@v7
         if: failure()
         with:

--- a/.github/workflows/resteasy-tck.yml
+++ b/.github/workflows/resteasy-tck.yml
@@ -158,7 +158,7 @@ jobs:
           echo JAVA_HOME="${JAVA_HOME}"
           export JAVA_HOME
           mvn -version
-          mvn clean install -U -B -fae -Dtck.debug.log=true -Dversion.org.jboss.resteasy="${{ steps.resteasy-build.outputs.RESTEASY_VERSION }}" -Dversion.org.wildfly=34.0.0.Final
+          mvn clean install -U -B -fae -Dtck.debug.log=true -Dversion.org.jboss.resteasy="${{ steps.resteasy-build.outputs.RESTEASY_VERSION }}" -Dversion.org.wildfly=34.0.1.Final -Plegacy-wildfly-channels
       - uses: actions/upload-artifact@v7
         if: failure()
         with:

--- a/docbook/src/main/asciidoc/Installation_Configuration.adoc
+++ b/docbook/src/main/asciidoc/Installation_Configuration.adoc
@@ -140,14 +140,14 @@ Using Maven to provision WildFly you can simply use the RESTEasy Channel Manifes
                 <feature-packs>
                     <feature-pack>
                         <groupId>org.wildfly</groupId>
-                        <artifactId>wildfly-ee-galleon-pack</artifactId>
+                        <artifactId>wildfly-ee-10-feature-pack</artifactId>
                     </feature-pack>
                 </feature-packs>
                 <channels>
                     <channel>
                         <manifest>
                             <groupId>org.wildfly.channels</groupId>
-                            <artifactId>wildfly-ee</artifactId>
+                            <artifactId>wildfly-ee-10</artifactId>
                         </manifest>
                     </channel>
                     <channel>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -358,9 +358,20 @@
                 </plugins>
             </build>
         </profile>
+        <!-- WildFly 34 and below support Java 11 and require different feature-packs and channels-->
+        <profile>
+            <id>legacy-wildfly-channels</id>
+            <properties>
+                <server.test.feature.pack.artifactId>wildfly-ee-galleon-pack</server.test.feature.pack.artifactId>
+                <wildfly.channel.manifest.artifactId>wildfly-ee</wildfly.channel.manifest.artifactId>
+            </properties>
+        </profile>
         <!-- The WildFly Channel is only available on WildFly 32+ -->
         <profile>
             <id>legacy-wildfly</id>
+            <properties>
+                <server.test.feature.pack.artifactId>wildfly-ee-galleon-pack</server.test.feature.pack.artifactId>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -549,7 +560,7 @@
             <artifactId>resteasy-wadl</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-wadl-undertow-connector</artifactId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -30,10 +30,10 @@
         <!-- Provisioning properties -->
         <server.version />
         <server.test.feature.pack.groupId>org.wildfly</server.test.feature.pack.groupId>
-        <server.test.feature.pack.artifactId>wildfly-ee-galleon-pack</server.test.feature.pack.artifactId>
+        <server.test.feature.pack.artifactId>wildfly-ee-10-feature-pack</server.test.feature.pack.artifactId>
 
         <wildfly.channel.manifest.groupId>org.wildfly.channels</wildfly.channel.manifest.groupId>
-        <wildfly.channel.manifest.artifactId>wildfly-ee</wildfly.channel.manifest.artifactId>
+        <wildfly.channel.manifest.artifactId>wildfly-ee-10</wildfly.channel.manifest.artifactId>
         <wildfly.channel.manifest.version>${server.version}</wildfly.channel.manifest.version>
 
         <resteasy.channel.manifest.groupId>org.jboss.resteasy.channels</resteasy.channel.manifest.groupId>


### PR DESCRIPTION
…and channel names for EE 10. Added a new test profile to provision with the old feature pack and channel names. Default to use the new EE 10 variant names.

https://redhat.atlassian.net/browse/RESTEASY-3722