### PR TITLE
Add parameter name inference for Jakarta REST binding annotations for rest-issue-579

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/ProcessorFactory.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/internal/proxy/processors/ProcessorFactory.java
@@ -93,41 +93,46 @@ public class ProcessorFactory {
                 Encoded.class) != null;
 
         if ((query = FindAnnotation.findAnnotation(annotations, QueryParam.class)) != null) {
-            processor = new QueryParamProcessor(query.value(), genericType, annotations, configuration);
+            processor = new QueryParamProcessor(getParamName(defaultParameterName, query.value()), genericType, annotations,
+                    configuration);
         } else if ((queryParam2 = FindAnnotation.findAnnotation(annotations,
                 org.jboss.resteasy.annotations.jaxrs.QueryParam.class)) != null) {
             processor = new QueryParamProcessor(getParamName(defaultParameterName, queryParam2.value()), genericType,
                     annotations, configuration);
         } else if ((header = FindAnnotation.findAnnotation(annotations,
                 HeaderParam.class)) != null) {
-            processor = new HeaderParamProcessor(header.value(), genericType, annotations, configuration);
+            processor = new HeaderParamProcessor(getParamName(defaultParameterName, header.value()), genericType, annotations,
+                    configuration);
         } else if ((header2 = FindAnnotation.findAnnotation(annotations,
                 org.jboss.resteasy.annotations.jaxrs.HeaderParam.class)) != null) {
             processor = new HeaderParamProcessor(getParamName(defaultParameterName, header2.value()), genericType, annotations,
                     configuration);
         } else if ((cookie = FindAnnotation.findAnnotation(annotations,
                 CookieParam.class)) != null) {
-            processor = new CookieParamProcessor(cookie.value(), genericType, annotations);
+            processor = new CookieParamProcessor(getParamName(defaultParameterName, cookie.value()), genericType, annotations);
         } else if ((cookie2 = FindAnnotation.findAnnotation(annotations,
                 org.jboss.resteasy.annotations.jaxrs.CookieParam.class)) != null) {
             processor = new CookieParamProcessor(getParamName(defaultParameterName, cookie2.value()), genericType, annotations);
         } else if ((uriParam = FindAnnotation.findAnnotation(annotations,
                 PathParam.class)) != null) {
-            processor = new PathParamProcessor(uriParam.value(), isEncoded, genericType, annotations, configuration);
+            processor = new PathParamProcessor(getParamName(defaultParameterName, uriParam.value()), isEncoded, genericType,
+                    annotations, configuration);
         } else if ((uriParam2 = FindAnnotation.findAnnotation(annotations,
                 org.jboss.resteasy.annotations.jaxrs.PathParam.class)) != null) {
             processor = new PathParamProcessor(getParamName(defaultParameterName, uriParam2.value()), isEncoded, genericType,
                     annotations, configuration);
         } else if ((matrix = FindAnnotation.findAnnotation(annotations,
                 MatrixParam.class)) != null) {
-            processor = new MatrixParamProcessor(matrix.value(), genericType, annotations, configuration);
+            processor = new MatrixParamProcessor(getParamName(defaultParameterName, matrix.value()), genericType, annotations,
+                    configuration);
         } else if ((matrix2 = FindAnnotation.findAnnotation(annotations,
                 org.jboss.resteasy.annotations.jaxrs.MatrixParam.class)) != null) {
             processor = new MatrixParamProcessor(getParamName(defaultParameterName, matrix2.value()), genericType, annotations,
                     configuration);
         } else if ((formParam = FindAnnotation.findAnnotation(annotations,
                 FormParam.class)) != null) {
-            processor = new FormParamProcessor(formParam.value(), genericType, annotations, configuration);
+            processor = new FormParamProcessor(getParamName(defaultParameterName, formParam.value()), genericType, annotations,
+                    configuration);
         } else if ((formParam2 = FindAnnotation.findAnnotation(annotations,
                 org.jboss.resteasy.annotations.jaxrs.FormParam.class)) != null) {
             processor = new FormParamProcessor(getParamName(defaultParameterName, formParam2.value()), genericType, annotations,

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/metadata/ResourceBuilder.java
@@ -252,7 +252,9 @@ public class ResourceBuilder {
 
             if ((queryParam = findAnnotation(annotations, QueryParam.class)) != null) {
                 parameter.paramType = Parameter.ParamType.QUERY_PARAM;
-                parameter.paramName = queryParam.value();
+                if (queryParam.value() != null && queryParam.value().length() > 0) {
+                    parameter.paramName = queryParam.value();
+                }
             } else if ((queryParam2 = findAnnotation(annotations,
                     org.jboss.resteasy.annotations.jaxrs.QueryParam.class)) != null) {
                 parameter.paramType = Parameter.ParamType.QUERY_PARAM;
@@ -264,7 +266,9 @@ public class ResourceBuilder {
                 parameter.paramName = ""; // TODO query.prefix();
             } else if ((header = findAnnotation(annotations, HeaderParam.class)) != null) {
                 parameter.paramType = Parameter.ParamType.HEADER_PARAM;
-                parameter.paramName = header.value();
+                if (header.value() != null && header.value().length() > 0) {
+                    parameter.paramName = header.value();
+                }
             } else if ((header2 = findAnnotation(annotations,
                     org.jboss.resteasy.annotations.jaxrs.HeaderParam.class)) != null) {
                 parameter.paramType = Parameter.ParamType.HEADER_PARAM;
@@ -273,7 +277,9 @@ public class ResourceBuilder {
                 }
             } else if ((formParam = findAnnotation(annotations, FormParam.class)) != null) {
                 parameter.paramType = Parameter.ParamType.FORM_PARAM;
-                parameter.paramName = formParam.value();
+                if (formParam.value() != null && formParam.value().length() > 0) {
+                    parameter.paramName = formParam.value();
+                }
             } else if ((formParam2 = findAnnotation(annotations,
                     org.jboss.resteasy.annotations.jaxrs.FormParam.class)) != null) {
                 parameter.paramType = Parameter.ParamType.FORM_PARAM;
@@ -282,7 +288,9 @@ public class ResourceBuilder {
                 }
             } else if ((cookie = findAnnotation(annotations, CookieParam.class)) != null) {
                 parameter.paramType = Parameter.ParamType.COOKIE_PARAM;
-                parameter.paramName = cookie.value();
+                if (cookie.value() != null && cookie.value().length() > 0) {
+                    parameter.paramName = cookie.value();
+                }
             } else if ((cookie2 = findAnnotation(annotations,
                     org.jboss.resteasy.annotations.jaxrs.CookieParam.class)) != null) {
                 parameter.paramType = Parameter.ParamType.COOKIE_PARAM;
@@ -291,7 +299,9 @@ public class ResourceBuilder {
                 }
             } else if ((uriParam = findAnnotation(annotations, PathParam.class)) != null) {
                 parameter.paramType = Parameter.ParamType.PATH_PARAM;
-                parameter.paramName = uriParam.value();
+                if (uriParam.value() != null && uriParam.value().length() > 0) {
+                    parameter.paramName = uriParam.value();
+                }
             } else if ((uriParam2 = findAnnotation(annotations,
                     org.jboss.resteasy.annotations.jaxrs.PathParam.class)) != null) {
                 parameter.paramType = Parameter.ParamType.PATH_PARAM;
@@ -305,7 +315,9 @@ public class ResourceBuilder {
                 parameter.paramType = Parameter.ParamType.BEAN_PARAM;
             } else if ((matrix = findAnnotation(annotations, MatrixParam.class)) != null) {
                 parameter.paramType = Parameter.ParamType.MATRIX_PARAM;
-                parameter.paramName = matrix.value();
+                if (matrix.value() != null && matrix.value().length() > 0) {
+                    parameter.paramName = matrix.value();
+                }
             } else if ((matrix2 = findAnnotation(annotations,
                     org.jboss.resteasy.annotations.jaxrs.MatrixParam.class)) != null) {
                 parameter.paramType = Parameter.ParamType.MATRIX_PARAM;

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/path/OptionalParamNameTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/path/OptionalParamNameTest.java
@@ -1,0 +1,173 @@
+package org.jboss.resteasy.test.resource.path;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.spi.HttpResponseCodes;
+import org.jboss.resteasy.test.resource.path.resource.OptionalParamNameResource;
+import org.jboss.resteasy.utils.PortProviderUtil;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test for optional parameter names feature (GitHub issue #579)
+ * Tests that @PathParam, @QueryParam, @MatrixParam, @FormParam, @HeaderParam, and @CookieParam
+ * can infer parameter names from method parameter names when annotation value is not specified.
+ *
+ * @tpSubChapter Resource
+ * @tpChapter Integration tests
+ * @tpTestCaseDetails Test optional parameter name inference for Jakarta REST parameter annotations
+ * @tpSince RESTEasy 7.0.0
+ */
+@ExtendWith(ArquillianExtension.class)
+@RunAsClient
+public class OptionalParamNameTest {
+
+    private static ResteasyClient client;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        WebArchive war = TestUtil.prepareArchive(OptionalParamNameTest.class.getSimpleName());
+        return TestUtil.finishContainerPrepare(war, null, OptionalParamNameResource.class);
+    }
+
+    @BeforeAll
+    public static void setup() {
+        client = (ResteasyClient) ClientBuilder.newClient();
+    }
+
+    @AfterAll
+    public static void cleanup() {
+        client.close();
+    }
+
+    private String generateURL(String path) {
+        return PortProviderUtil.generateURL(path, OptionalParamNameTest.class.getSimpleName());
+    }
+
+    /**
+     * Test @PathParam with inferred parameter name
+     */
+    @Test
+    public void testPathParamInferred() {
+        Response response = client.target(generateURL("/path/John/Doe"))
+                .request()
+                .get();
+        Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        Assertions.assertEquals("Hello, John Doe", response.readEntity(String.class));
+        response.close();
+    }
+
+    /**
+     * Test @PathParam with explicit parameter name (backward compatibility)
+     */
+    @Test
+    public void testPathParamExplicit() {
+        Response response = client.target(generateURL("/path-explicit/Jane/Smith"))
+                .request()
+                .get();
+        Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        Assertions.assertEquals("Hello, Jane Smith", response.readEntity(String.class));
+        response.close();
+    }
+
+    /**
+     * Test @QueryParam with inferred parameter name
+     */
+    @Test
+    public void testQueryParamInferred() {
+        Response response = client.target(generateURL("/query"))
+                .queryParam("search", "test")
+                .queryParam("page", "1")
+                .request()
+                .get();
+        Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        Assertions.assertEquals("search=test, page=1", response.readEntity(String.class));
+        response.close();
+    }
+
+    /**
+     * Test @HeaderParam with inferred parameter name
+     */
+    @Test
+    public void testHeaderParamInferred() {
+        Response response = client.target(generateURL("/header"))
+                .request()
+                .header("authorization", "Bearer token123")
+                .get();
+        Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        Assertions.assertEquals("Auth: Bearer token123", response.readEntity(String.class));
+        response.close();
+    }
+
+    /**
+     * Test @MatrixParam with inferred parameter name
+     */
+    @Test
+    public void testMatrixParamInferred() {
+        Response response = client.target(generateURL("/matrix/segment;color=red;size=large"))
+                .request()
+                .get();
+        Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        Assertions.assertEquals("segment, color=red, size=large", response.readEntity(String.class));
+        response.close();
+    }
+
+    /**
+     * Test @CookieParam with inferred parameter name
+     */
+    @Test
+    public void testCookieParamInferred() {
+        Response response = client.target(generateURL("/cookie"))
+                .request()
+                .cookie("sessionId", "abc123")
+                .get();
+        Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        Assertions.assertEquals("Session: abc123", response.readEntity(String.class));
+        response.close();
+    }
+
+    /**
+     * Test @FormParam with inferred parameter name
+     */
+    @Test
+    public void testFormParamInferred() {
+        Response response = client.target(generateURL("/form"))
+                .request()
+                .post(jakarta.ws.rs.client.Entity.form(
+                        new jakarta.ws.rs.core.Form()
+                                .param("username", "testuser")
+                                .param("password", "testpass")));
+        Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        Assertions.assertEquals("User: testuser", response.readEntity(String.class));
+        response.close();
+    }
+
+    /**
+     * Test mixed usage - some explicit, some inferred
+     */
+    @Test
+    public void testMixedUsage() {
+        Response response = client.target(generateURL("/mixed/user123/item456"))
+                .queryParam("sort", "name")
+                .queryParam("order", "asc")
+                .request()
+                .get();
+        Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        Assertions.assertEquals("userId=user123, itemId=item456, sort=name, order=asc",
+                response.readEntity(String.class));
+        response.close();
+    }
+}
+
+// Made with Bob

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/path/resource/OptionalParamNameResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/resource/path/resource/OptionalParamNameResource.java
@@ -1,0 +1,132 @@
+package org.jboss.resteasy.test.resource.path.resource;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * Resource class for testing optional parameter name inference.
+ * Demonstrates the new feature where parameter annotations can infer
+ * parameter names from method parameter names when not explicitly specified.
+ *
+ * IMPORTANT: This class must be compiled with -parameters flag to preserve
+ * parameter names in bytecode for method parameters.
+ */
+@Path("/")
+public class OptionalParamNameResource {
+
+    /**
+     * Test @PathParam with inferred parameter names
+     */
+    @GET
+    @Path("path/{name}/{surname}")
+    public String pathParamInferred(
+            @PathParam String name,
+            @PathParam String surname) {
+        return "Hello, " + name + " " + surname;
+    }
+
+    /**
+     * Test @PathParam with explicit parameter names (backward compatibility)
+     */
+    @GET
+    @Path("path-explicit/{firstName}/{lastName}")
+    public String pathParamExplicit(
+            @PathParam("firstName") String name,
+            @PathParam("lastName") String surname) {
+        return "Hello, " + name + " " + surname;
+    }
+
+    /**
+     * Test @QueryParam with inferred parameter names
+     */
+    @GET
+    @Path("query")
+    public String queryParamInferred(
+            @QueryParam String search,
+            @QueryParam int page) {
+        return "search=" + search + ", page=" + page;
+    }
+
+    /**
+     * Test @HeaderParam with inferred parameter name
+     */
+    @GET
+    @Path("header")
+    public String headerParamInferred(
+            @HeaderParam String authorization) {
+        return "Auth: " + authorization;
+    }
+
+    /**
+     * Test @MatrixParam with inferred parameter names
+     */
+    @GET
+    @Path("matrix/{segment}")
+    public String matrixParamInferred(
+            @PathParam String segment,
+            @MatrixParam String color,
+            @MatrixParam String size) {
+        return segment + ", color=" + color + ", size=" + size;
+    }
+
+    /**
+     * Test @CookieParam with inferred parameter name
+     */
+    @GET
+    @Path("cookie")
+    public String cookieParamInferred(
+            @CookieParam String sessionId) {
+        return "Session: " + sessionId;
+    }
+
+    /**
+     * Test @FormParam with inferred parameter names
+     */
+    @POST
+    @Path("form")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public String formParamInferred(
+            @FormParam String username,
+            @FormParam String password) {
+        return "User: " + username;
+    }
+
+    /**
+     * Test mixed usage - some explicit, some inferred
+     */
+    @GET
+    @Path("mixed/{userId}/{itemId}")
+    public String mixedUsage(
+            @PathParam String userId, // Inferred
+            @PathParam("itemId") String item, // Explicit
+            @QueryParam String sort, // Inferred
+            @QueryParam("order") String direction) { // Explicit
+        return "userId=" + userId + ", itemId=" + item + ", sort=" + sort + ", order=" + direction;
+    }
+
+    /**
+     * Field injection - always works without -parameters flag
+     */
+    @PathParam
+    private String id;
+
+    @QueryParam
+    private String filter;
+
+    @GET
+    @Path("field/{id}")
+    public String fieldInjection() {
+        return "ID: " + id + ", Filter: " + filter;
+    }
+}
+
+// Made with Bob


### PR DESCRIPTION
- Updated client-side (ProcessorFactory.java) to use getParamName() fallback for Jakarta annotations
- Updated server-side (ResourceBuilder.java) to handle empty annotation values
- Follows the same pattern already used for RESTEasy's own annotations