### PR TITLE
[RESTEASY-3749] Upgrade the junit-resteasy-extension to 1.0.0.Beta5. …

### DIFF
--- a/providers/json-binding/src/test/java/org/jboss/resteasy/plugins/providers/jsonb/EntityTest.java
+++ b/providers/json-binding/src/test/java/org/jboss/resteasy/plugins/providers/jsonb/EntityTest.java
@@ -20,17 +20,14 @@
 package org.jboss.resteasy.plugins.providers.jsonb;
 
 import java.util.Objects;
-import java.util.Set;
 
 import jakarta.json.JsonValue;
-import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -44,7 +41,7 @@ import dev.resteasy.junit.extension.annotations.RestResource;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RestBootstrap(EntityTest.TestApplication.class)
+@RestBootstrap(EntityTest.TestResource.class)
 public class EntityTest {
 
     @RestResource
@@ -72,14 +69,6 @@ public class EntityTest {
                         .post(Entity.json(testEntity))) {
             Assertions.assertEquals(Response.Status.OK, response.getStatusInfo());
             Assertions.assertEquals(testEntity, response.readEntity(TestEntity.class));
-        }
-    }
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(TestResource.class);
         }
     }
 

--- a/providers/multipart/src/test/java/org/jboss/resteasy/plugins/providers/multipart/MultipartEntityPartProviderTest.java
+++ b/providers/multipart/src/test/java/org/jboss/resteasy/plugins/providers/multipart/MultipartEntityPartProviderTest.java
@@ -28,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -42,7 +41,6 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
-import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.POST;
@@ -50,7 +48,6 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.GenericEntity;
 import jakarta.ws.rs.core.GenericType;
@@ -70,7 +67,7 @@ import dev.resteasy.junit.extension.annotations.RestResource;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RestBootstrap(MultipartEntityPartProviderTest.TestApplication.class)
+@RestBootstrap(MultipartEntityPartProviderTest.TestResource.class)
 public class MultipartEntityPartProviderTest {
 
     @RestResource
@@ -781,14 +778,6 @@ public class MultipartEntityPartProviderTest {
             }
         }
         throw new RuntimeException("Could not find entity part named " + name + " - " + getMessage(parts));
-    }
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(TestResource.class);
-        }
     }
 
     @Path("/test")

--- a/resteasy-client-jetty/src/test/java/org/jboss/resteasy/test/client/jetty/MultipartTest.java
+++ b/resteasy-client-jetty/src/test/java/org/jboss/resteasy/test/client/jetty/MultipartTest.java
@@ -24,15 +24,12 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
-import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.POST;
@@ -42,7 +39,6 @@ import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation;
-import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.GenericEntity;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -61,7 +57,7 @@ import dev.resteasy.junit.extension.annotations.RestResource;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RestBootstrap(MultipartTest.TestApplication.class)
+@RestBootstrap(MultipartTest.TestResource.class)
 public class MultipartTest {
 
     @RestResource
@@ -118,15 +114,6 @@ public class MultipartTest {
         Assertions.assertNotNull(contentType, () -> String.format("Failed to find content-type in %s", headers));
         Assertions.assertTrue(contentType.toString().contains("boundary"),
                 () -> String.format("Failed to find boundary in %s", contentType));
-    }
-
-    @ApplicationPath("/")
-    @ApplicationScoped
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(TestResource.class);
-        }
     }
 
     @Path("/echo")

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -89,7 +89,7 @@
         <version.commons-io.commons-io>2.22.0</version.commons-io.commons-io>
         <version.commons-codec.commons-codec>1.15</version.commons-codec.commons-codec>
         <version.commons-logging.commons-logging>1.3.2</version.commons-logging.commons-logging>
-        <version.dev.resteasy.junit.extension>1.0.0.Beta4</version.dev.resteasy.junit.extension>
+        <version.dev.resteasy.junit.extension>1.0.0.Beta5</version.dev.resteasy.junit.extension>
         <version.io.netty.netty4>4.1.135.Final</version.io.netty.netty4>
         <version.io.vertx>4.4.9</version.io.vertx>
         <version.io.undertow>2.3.24.Final</version.io.undertow>

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestClassLinksProvider.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestClassLinksProvider.java
@@ -1,11 +1,8 @@
 package org.jboss.resteasy.links.test;
 
 import java.net.URI;
-import java.util.Set;
 
-import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.core.Application;
 
 import org.jboss.resteasy.links.RESTServiceDiscovery;
 import org.junit.jupiter.api.Assertions;
@@ -14,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import dev.resteasy.junit.extension.annotations.RestBootstrap;
 import dev.resteasy.junit.extension.annotations.RestResource;
 
-@RestBootstrap(TestClassLinksProvider.TestApplication.class)
+@RestBootstrap({ BookStore.class, ClassLinksProviderService.class })
 public class TestClassLinksProvider {
     @RestResource
     private Client client;
@@ -29,13 +26,5 @@ public class TestClassLinksProvider {
         Assertions.assertEquals(2, restServiceDiscovery.size());
         Assertions.assertTrue(restServiceDiscovery.contains(new RESTServiceDiscovery.AtomLink(baseUri + "books", "list")));
         Assertions.assertTrue(restServiceDiscovery.contains(new RESTServiceDiscovery.AtomLink(baseUri + "books", "add")));
-    }
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(BookStore.class, ClassLinksProviderService.class);
-        }
     }
 }

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestLinkIds.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestLinkIds.java
@@ -1,10 +1,5 @@
 package org.jboss.resteasy.links.test;
 
-import java.util.Set;
-
-import jakarta.ws.rs.ApplicationPath;
-import jakarta.ws.rs.core.Application;
-
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.jboss.resteasy.links.RESTServiceDiscovery;
 import org.jboss.resteasy.links.RESTServiceDiscovery.AtomLink;
@@ -15,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import dev.resteasy.junit.extension.annotations.RestBootstrap;
 import dev.resteasy.junit.extension.annotations.RestResource;
 
-@RestBootstrap(TestLinkIds.TestApplication.class)
+@RestBootstrap(IDServiceTestBean.class)
 public class TestLinkIds {
 
     private static IDServiceTest client;
@@ -74,13 +69,5 @@ public class TestLinkIds {
         AtomLink link = links.get(0);
         Assertions.assertEquals("self", link.getRel());
         Assertions.assertEquals(url + relativeUrl, link.getHref());
-    }
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(IDServiceTestBean.class);
-        }
     }
 }

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestLinks.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestLinks.java
@@ -1,20 +1,7 @@
 package org.jboss.resteasy.links.test;
 
-import java.util.Set;
-
-import jakarta.ws.rs.ApplicationPath;
-import jakarta.ws.rs.core.Application;
-
 import dev.resteasy.junit.extension.annotations.RestBootstrap;
 
-@RestBootstrap(TestLinks.TestApplication.class)
+@RestBootstrap({ ObjectMapperProvider.class, BookStore.class })
 public class TestLinks extends AbstractTestLinks {
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(ObjectMapperProvider.class, BookStore.class);
-        }
-    }
 }

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestMinimalLinks.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestMinimalLinks.java
@@ -5,21 +5,8 @@
 
 package org.jboss.resteasy.links.test;
 
-import java.util.Set;
-
-import jakarta.ws.rs.ApplicationPath;
-import jakarta.ws.rs.core.Application;
-
 import dev.resteasy.junit.extension.annotations.RestBootstrap;
 
-@RestBootstrap(TestMinimalLinks.TestApplication.class)
+@RestBootstrap({ ObjectMapperProvider.class, BookStoreMinimal.class })
 public class TestMinimalLinks extends AbstractTestLinks {
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(ObjectMapperProvider.class, BookStoreMinimal.class);
-        }
-    }
 }

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestMinimalSecureLinks.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestMinimalSecureLinks.java
@@ -5,21 +5,8 @@
 
 package org.jboss.resteasy.links.test;
 
-import java.util.Set;
-
-import jakarta.ws.rs.ApplicationPath;
-import jakarta.ws.rs.core.Application;
-
 import dev.resteasy.junit.extension.annotations.RestBootstrap;
 
-@RestBootstrap(value = TestMinimalSecureLinks.TestApplication.class, configFactory = TestMinimalSecureLinks.TestConfigurationProvider.class)
+@RestBootstrap(value = SecureBookStoreMinimal.class, configFactory = TestMinimalSecureLinks.TestConfigurationProvider.class)
 public class TestMinimalSecureLinks extends AbstractTestSecureLinks {
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(SecureBookStoreMinimal.class);
-        }
-    }
 }

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestSecureLinks.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/TestSecureLinks.java
@@ -1,20 +1,7 @@
 package org.jboss.resteasy.links.test;
 
-import java.util.Set;
-
-import jakarta.ws.rs.ApplicationPath;
-import jakarta.ws.rs.core.Application;
-
 import dev.resteasy.junit.extension.annotations.RestBootstrap;
 
-@RestBootstrap(value = TestSecureLinks.TestApplication.class, configFactory = TestSecureLinks.TestConfigurationProvider.class)
+@RestBootstrap(value = SecureBookStore.class, configFactory = TestSecureLinks.TestConfigurationProvider.class)
 public class TestSecureLinks extends AbstractTestSecureLinks {
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(SecureBookStore.class);
-        }
-    }
 }

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/el/TestLinksInvalidEL.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/el/TestLinksInvalidEL.java
@@ -1,10 +1,6 @@
 package org.jboss.resteasy.links.test.el;
 
-import java.util.Set;
-
-import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.InternalServerErrorException;
-import jakarta.ws.rs.core.Application;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
@@ -16,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import dev.resteasy.junit.extension.annotations.RestBootstrap;
 import dev.resteasy.junit.extension.annotations.RestResource;
 
-@RestBootstrap(TestLinksInvalidEL.TestApplication.class)
+@RestBootstrap(BookStoreInvalidEL.class)
 public class TestLinksInvalidEL {
 
     private static final Logger LOG = Logger.getLogger(TestLinksInvalidEL.class);
@@ -51,14 +47,6 @@ public class TestLinksInvalidEL {
             Assertions.assertEquals(500, x.getResponse().getStatus());
         } catch (Exception x) {
             Assertions.fail("Expected InternalServerErrorException");
-        }
-    }
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(BookStoreInvalidEL.class);
         }
     }
 }

--- a/resteasy-links/src/test/java/org/jboss/resteasy/links/test/el/TestLinksNoPackage.java
+++ b/resteasy-links/src/test/java/org/jboss/resteasy/links/test/el/TestLinksNoPackage.java
@@ -1,10 +1,5 @@
 package org.jboss.resteasy.links.test.el;
 
-import java.util.Set;
-
-import jakarta.ws.rs.ApplicationPath;
-import jakarta.ws.rs.core.Application;
-
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.jboss.resteasy.links.RESTServiceDiscovery;
 import org.jboss.resteasy.links.RESTServiceDiscovery.AtomLink;
@@ -17,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import dev.resteasy.junit.extension.annotations.RestBootstrap;
 import dev.resteasy.junit.extension.annotations.RestResource;
 
-@RestBootstrap(TestLinksNoPackage.TestApplication.class)
+@RestBootstrap(BookStoreNoPackage.class)
 public class TestLinksNoPackage {
 
     private static String url;
@@ -48,13 +43,5 @@ public class TestLinksNoPackage {
         AtomLink atomLink = links.getLinkForRel("self");
         Assertions.assertNotNull(atomLink);
         Assertions.assertEquals(url + "book/foo", atomLink.getHref());
-    }
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(BookStoreNoPackage.class);
-        }
     }
 }

--- a/resteasy-reactor/src/test/java/org/jboss/resteasy/reactor/ReactorTest.java
+++ b/resteasy-reactor/src/test/java/org/jboss/resteasy/reactor/ReactorTest.java
@@ -8,9 +8,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.logging.Logger;
@@ -27,7 +25,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.context.Context;
 
-@RestBootstrap(value = ReactorTest.TestApplication.class)
+@RestBootstrap({ ReactorResource.class, ReactorInjector.class })
 public class ReactorTest {
 
     private static CountDownLatch latch;
@@ -103,14 +101,6 @@ public class ReactorTest {
 
         data = client.target(generateURL("/injection-async")).request().get(Integer.class);
         Assertions.assertEquals((Integer) 42, data);
-    }
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(ReactorResource.class, ReactorInjector.class);
-        }
     }
 
     private static String generateURL(final String path) {

--- a/resteasy-reactor/src/test/java/org/jboss/resteasy/reactor/proxyframework/MonoWithProxyFrameworkApiTest.java
+++ b/resteasy-reactor/src/test/java/org/jboss/resteasy/reactor/proxyframework/MonoWithProxyFrameworkApiTest.java
@@ -3,12 +3,9 @@ package org.jboss.resteasy.reactor.proxyframework;
 import static org.jboss.resteasy.reactor.proxyframework.CustomResource.THE_CUSTOM_RESOURCE;
 
 import java.net.URI;
-import java.util.Set;
 
-import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.core.Application;
 
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.junit.jupiter.api.Assertions;
@@ -18,7 +15,7 @@ import dev.resteasy.junit.extension.annotations.RestBootstrap;
 import dev.resteasy.junit.extension.annotations.RestResource;
 import reactor.core.publisher.Mono;
 
-@RestBootstrap(MonoWithProxyFrameworkApiTest.TestApplication.class)
+@RestBootstrap(CustomResource.class)
 public class MonoWithProxyFrameworkApiTest {
 
     @Path("api/v1")
@@ -27,14 +24,6 @@ public class MonoWithProxyFrameworkApiTest {
         @GET
         @Path("resource/custom")
         Mono<String> getCustomResource();
-    }
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(CustomResource.class);
-        }
     }
 
     @RestResource

--- a/resteasy-rxjava2/src/test/java/org/jboss/resteasy/rxjava2/RxTest.java
+++ b/resteasy-rxjava2/src/test/java/org/jboss/resteasy/rxjava2/RxTest.java
@@ -7,11 +7,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Invocation;
-import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.logging.Logger;
@@ -26,7 +24,7 @@ import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 
-@RestBootstrap(RxTest.TestApplication.class)
+@RestBootstrap({ RxResource.class, RxInjector.class })
 public class RxTest {
 
     private static CountDownLatch latch;
@@ -140,13 +138,5 @@ public class RxTest {
 
         data = client.target(injectionAsyncUri).request().get(Integer.class);
         Assertions.assertEquals((Integer) 42, data);
-    }
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(RxResource.class, RxInjector.class);
-        }
     }
 }

--- a/resteasy-wadl/src/test/java/org/jboss/resteasy/test/nextgen/wadl/WADLNettyContainerTest.java
+++ b/resteasy-wadl/src/test/java/org/jboss/resteasy/test/nextgen/wadl/WADLNettyContainerTest.java
@@ -1,10 +1,6 @@
 package org.jboss.resteasy.test.nextgen.wadl;
 
-import java.util.Set;
-
-import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.core.Application;
 
 import org.jboss.resteasy.test.nextgen.wadl.resources.BasicResource;
 import org.jboss.resteasy.test.nextgen.wadl.resources.issues.RESTEASY1246;
@@ -16,7 +12,7 @@ import dev.resteasy.junit.extension.annotations.RestResource;
 /**
  * @author <a href="mailto:l.weinan@gmail.com">Weinan Li</a>
  */
-@RestBootstrap(WADLNettyContainerTest.TestApplication.class)
+@RestBootstrap({ BasicResource.class, RESTEASY1246.class, MyWadlResource.class })
 public class WADLNettyContainerTest {
     @RestResource
     private static Client client;
@@ -27,13 +23,5 @@ public class WADLNettyContainerTest {
         basicTest.setClient(client);
         basicTest.testBasicSet();
         basicTest.testResteasy1246();
-    }
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(BasicResource.class, RESTEASY1246.class, MyWadlResource.class);
-        }
     }
 }

--- a/security/resteasy-crypto/src/test/java/org/jboss/resteasy/test/security/doseta/SigningDnsTest.java
+++ b/security/resteasy-crypto/src/test/java/org/jboss/resteasy/test/security/doseta/SigningDnsTest.java
@@ -3,9 +3,7 @@ package org.jboss.resteasy.test.security.doseta;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
-import java.util.Set;
 
-import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
@@ -16,7 +14,6 @@ import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation.Builder;
 import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.resteasy.annotations.security.doseta.Signed;
@@ -40,7 +37,7 @@ import se.unlogic.eagledns.EagleDNS;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-@RestBootstrap(SigningDnsTest.TestApplication.class)
+@RestBootstrap(SigningDnsTest.SignedResource.class)
 public class SigningDnsTest {
     public static DosetaKeyRepository clientRepository;
     public static DosetaKeyRepository serverRepository;
@@ -117,14 +114,6 @@ public class SigningDnsTest {
             //         System.out.println(signature);
         }
 
-    }
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(SignedResource.class);
-        }
     }
 
     @Test

--- a/security/resteasy-crypto/src/test/java/org/jboss/resteasy/test/security/doseta/SigningTest.java
+++ b/security/resteasy-crypto/src/test/java/org/jboss/resteasy/test/security/doseta/SigningTest.java
@@ -8,9 +8,7 @@ import java.security.PublicKey;
 import java.security.SignatureException;
 import java.util.Base64;
 import java.util.HashMap;
-import java.util.Set;
 
-import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -24,7 +22,6 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.ResponseProcessingException;
 import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -58,7 +55,7 @@ import dev.resteasy.junit.extension.annotations.RestResource;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-@RestBootstrap(SigningTest.TestApplication.class)
+@RestBootstrap(SigningTest.SignedResource.class)
 public class SigningTest {
     private static final Logger LOG = Logger.getLogger(SigningTest.class);
     public static KeyPair keys;
@@ -283,14 +280,6 @@ public class SigningTest {
         @Path("expires-year")
         public String getExpiresYear() {
             return "hello world";
-        }
-    }
-
-    @ApplicationPath("/")
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(SignedResource.class);
         }
     }
 

--- a/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/core/basic/ApplicationExplicitATest.java
+++ b/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/core/basic/ApplicationExplicitATest.java
@@ -28,7 +28,7 @@ import dev.resteasy.junit.extension.annotations.RestResource;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RestBootstrap(value = ApplicationExplicitATest.ApplicationTestAExplicitApplication.class)
+@RestBootstrap(application = ApplicationExplicitATest.ApplicationTestAExplicitApplication.class)
 public class ApplicationExplicitATest {
 
     @RestResource

--- a/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/core/basic/ApplicationExplicitBTest.java
+++ b/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/core/basic/ApplicationExplicitBTest.java
@@ -28,7 +28,7 @@ import dev.resteasy.junit.extension.annotations.RestResource;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RestBootstrap(value = ApplicationExplicitBTest.ApplicationTestBExplicitApplication.class)
+@RestBootstrap(application = ApplicationExplicitBTest.ApplicationTestBExplicitApplication.class)
 public class ApplicationExplicitBTest {
 
     private static final String CONTENT_ERROR_MESSAGE = "Wrong content of response";

--- a/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/core/basic/ApplicationMappedTest.java
+++ b/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/core/basic/ApplicationMappedTest.java
@@ -32,7 +32,7 @@ import dev.resteasy.junit.extension.api.ConfigurationProvider;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RestBootstrap(value = ApplicationMappedTest.ApplicationTestMappedApplication.class, configFactory = ApplicationMappedTest.TestConfigurationProvider.class)
+@RestBootstrap(application = ApplicationMappedTest.ApplicationTestMappedApplication.class, configFactory = ApplicationMappedTest.TestConfigurationProvider.class)
 public class ApplicationMappedTest {
 
     private static final String CONTENT_ERROR_MESSAGE = "Wrong content of response";

--- a/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/core/basic/ApplicationScannedTest.java
+++ b/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/core/basic/ApplicationScannedTest.java
@@ -34,7 +34,7 @@ import dev.resteasy.junit.extension.api.ConfigurationProvider;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RestBootstrap(value = ApplicationScannedTest.ApplicationTestScannedApplication.class, configFactory = ApplicationScannedTest.TestConfigurationProvider.class)
+@RestBootstrap(application = ApplicationScannedTest.ApplicationTestScannedApplication.class, configFactory = ApplicationScannedTest.TestConfigurationProvider.class)
 public class ApplicationScannedTest {
 
     private static final String CONTENT_ERROR_MESSAGE = "Wrong content of response";

--- a/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/core/interceptors/ReaderContextTest.java
+++ b/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/core/interceptors/ReaderContextTest.java
@@ -36,7 +36,7 @@ import dev.resteasy.junit.extension.annotations.RestResource;
  * @tpTestCaseDetails Basic test for reated context
  * @tpSince RESTEasy 4.1.0
  */
-@RestBootstrap(ReaderContextTest.TestApplication.class)
+@RestBootstrap(application = ReaderContextTest.TestApplication.class)
 public class ReaderContextTest {
 
     @RestResource

--- a/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/core/validate/NonCDIValidatorFactoryTest.java
+++ b/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/core/validate/NonCDIValidatorFactoryTest.java
@@ -5,15 +5,12 @@
 
 package org.jboss.resteasy.embedded.test.core.validate;
 
-import java.util.Set;
-
 import jakarta.validation.constraints.Size;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.resteasy.api.validation.Validation;
@@ -32,15 +29,8 @@ import dev.resteasy.junit.extension.annotations.RestResource;
  * @tpTestCaseDetails Regression test for RESTEASY-2549
  * @tpSince RESTEasy 3.14.0
  */
-@RestBootstrap(NonCDIValidatorFactoryTest.TestApp.class)
+@RestBootstrap(NonCDIValidatorFactoryTest.TestResource.class)
 public class NonCDIValidatorFactoryTest {
-
-    public static class TestApp extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(TestResource.class);
-        }
-    }
 
     @Path("test")
     public static class TestResource {

--- a/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/interceptor/ClientRequestFilterRegistrationTest.java
+++ b/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/interceptor/ClientRequestFilterRegistrationTest.java
@@ -6,11 +6,9 @@
 package org.jboss.resteasy.embedded.test.interceptor;
 
 import java.net.URI;
-import java.util.Set;
 
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.resteasy.embedded.test.interceptor.resource.ClientRequestFilterImpl;
@@ -28,7 +26,7 @@ import dev.resteasy.junit.extension.annotations.RestResource;
  * @tpTestCaseDetails Tests @Provider annotation on ClientRequestFilter
  * @tpSince RESTEasy 4.1.0
  */
-@RestBootstrap(ClientRequestFilterRegistrationTest.TestApplication.class)
+@RestBootstrap({ ClientResource.class, ClientRequestFilterImpl.class })
 public class ClientRequestFilterRegistrationTest {
 
     @RestResource
@@ -39,13 +37,6 @@ public class ClientRequestFilterRegistrationTest {
         WebTarget base = client.target(uri);
         Response response = base.request().get();
         Assertions.assertEquals(456, response.getStatus());
-    }
-
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(ClientResource.class, ClientRequestFilterImpl.class);
-        }
     }
 
 }

--- a/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/interceptor/PriorityExecutionTest.java
+++ b/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/interceptor/PriorityExecutionTest.java
@@ -50,7 +50,7 @@ import dev.resteasy.junit.extension.annotations.RestResource;
  * @tpSince RESTEasy 4.1.0
  * @tpTestCaseDetails Regression test for RESTEASY-1294
  */
-@RestBootstrap(PriorityExecutionTest.PriorityApplication.class)
+@RestBootstrap(application = PriorityExecutionTest.PriorityApplication.class)
 public class PriorityExecutionTest {
     public static volatile Queue<String> interceptors = new ConcurrentLinkedQueue<>();
     public static Logger logger = Logger.getLogger(PriorityExecutionTest.class);

--- a/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/providers/custom/WriterNotBuiltinTest.java
+++ b/server-adapters/embedded-server-tests/src/main/java/org/jboss/resteasy/embedded/test/providers/custom/WriterNotBuiltinTest.java
@@ -6,11 +6,9 @@
 package org.jboss.resteasy.embedded.test.providers.custom;
 
 import java.net.URI;
-import java.util.Set;
 
 import jakarta.ws.rs.SeBootstrap;
 import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.resteasy.core.se.ConfigurationOption;
@@ -32,7 +30,8 @@ import dev.resteasy.junit.extension.api.ConfigurationProvider;
  * @tpTestCaseDetails Demonstrate MessageBodyWriter, MessageBodyReader
  * @tpSince RESTEasy 4.1.0
  */
-@RestBootstrap(value = WriterNotBuiltinTest.TestApplication.class, configFactory = WriterNotBuiltinTest.TestConfiguration.class)
+@RestBootstrap(value = { ReaderWriterResource.class,
+        WriterNotBuiltinTestWriter.class }, configFactory = WriterNotBuiltinTest.TestConfiguration.class)
 public class WriterNotBuiltinTest {
 
     @RestResource
@@ -52,13 +51,6 @@ public class WriterNotBuiltinTest {
         Assertions.assertEquals("text/plain;charset=UTF-8", response.getStringHeaders().getFirst("content-type"));
         Assertions.assertEquals("hello world", response.readEntity(String.class), "Response contains wrong content");
         Assertions.assertTrue(WriterNotBuiltinTestWriter.used, "Wrong MessageBodyWriter was used");
-    }
-
-    public static class TestApplication extends Application {
-        @Override
-        public Set<Class<?>> getClasses() {
-            return Set.of(ReaderWriterResource.class, WriterNotBuiltinTestWriter.class);
-        }
     }
 
     public static class TestConfiguration implements ConfigurationProvider {

--- a/server-adapters/resteasy-undertow-cdi/src/test/java/dev/resteasy/embedded/server/ContextInjectionTest.java
+++ b/server-adapters/resteasy-undertow-cdi/src/test/java/dev/resteasy/embedded/server/ContextInjectionTest.java
@@ -77,7 +77,7 @@ import dev.resteasy.junit.extension.api.ConfigurationProvider;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RestBootstrap(value = ContextInjectionTest.RootApplication.class, configFactory = ContextInjectionTest.InjectionConfiguration.class)
+@RestBootstrap(application = ContextInjectionTest.RootApplication.class, configFactory = ContextInjectionTest.InjectionConfiguration.class)
 public class ContextInjectionTest {
     public static class InjectionConfiguration implements ConfigurationProvider {
         @Override

--- a/server-adapters/resteasy-undertow-cdi/src/test/java/dev/resteasy/embedded/server/InjectionTest.java
+++ b/server-adapters/resteasy-undertow-cdi/src/test/java/dev/resteasy/embedded/server/InjectionTest.java
@@ -48,7 +48,7 @@ import dev.resteasy.junit.extension.api.ConfigurationProvider;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RestBootstrap(value = InjectionTest.RootApplication.class, configFactory = InjectionTest.InjectionConfiguration.class)
+@RestBootstrap(application = InjectionTest.RootApplication.class, configFactory = InjectionTest.InjectionConfiguration.class)
 public class InjectionTest {
     public static class InjectionConfiguration implements ConfigurationProvider {
         @Override

--- a/server-adapters/resteasy-undertow-cdi/src/test/java/dev/resteasy/embedded/server/ServletTest.java
+++ b/server-adapters/resteasy-undertow-cdi/src/test/java/dev/resteasy/embedded/server/ServletTest.java
@@ -56,7 +56,7 @@ import io.undertow.servlet.api.DeploymentInfo;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RestBootstrap(value = ServletTest.RootApplication.class, configFactory = ServletTest.InjectionConfiguration.class)
+@RestBootstrap(application = ServletTest.RootApplication.class, configFactory = ServletTest.InjectionConfiguration.class)
 public class ServletTest {
     public static class InjectionConfiguration implements ConfigurationProvider {
         @Override


### PR DESCRIPTION
…Did some minor refactoring of removing unneeded Application test classes when we could simply use the new @RestBootstrap(value = {}) with the resources only.

https://redhat.atlassian.net/browse/RESTEASY-3749

Upstream #4918 4918