### PR TITLE
[RESTEASY-3721] Fix NonRepeatableRequestException when the request body exceeds FileUploadMemoryThreshold with non-preemptive authentication.

### DIFF
--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ClientEntityOutputStream.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ClientEntityOutputStream.java
@@ -65,25 +65,29 @@ class ClientEntityOutputStream extends EntityOutputStream {
         synchronized (lock) {
             final Path path = getFile();
             if (path != null) {
-                return new PathHttpEntity(path, contentInputStream(path));
+                return new PathHttpEntity(path);
             }
             return new ByteArrayEntity(getAndClearMemory());
         }
     }
 
-    private static class PathHttpEntity extends AbstractHttpEntity {
+    static class PathHttpEntity extends AbstractHttpEntity {
         private final Path file;
-        private final InputStream content;
 
-        private PathHttpEntity(final Path file, final InputStream content) {
+        private PathHttpEntity(final Path file) {
             this.file = file;
-            this.content = content;
+        }
+
+        Path getFile() {
+            return file;
         }
 
         @Override
         public boolean isRepeatable() {
-            // We delete the file once the getContent().close() happens
-            return false;
+            // The entity is backed by a temp file that can be re-read on auth retries.
+            // The file is deleted by the engine via cleanUpAfterExecute() once the
+            // full request/response cycle (including any retries) has completed.
+            return true;
         }
 
         @Override
@@ -99,7 +103,7 @@ class ClientEntityOutputStream extends EntityOutputStream {
 
         @Override
         public InputStream getContent() throws IOException, UnsupportedOperationException {
-            return content;
+            return Files.newInputStream(file);
         }
 
         @Override

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ClientEntityOutputStream.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ClientEntityOutputStream.java
@@ -65,25 +65,30 @@ class ClientEntityOutputStream extends EntityOutputStream {
         synchronized (lock) {
             final Path path = getFile();
             if (path != null) {
-                return new PathHttpEntity(path, contentInputStream(path));
+                return new PathHttpEntity(path);
             }
             return new ByteArrayEntity(getAndClearMemory());
         }
     }
 
-    private static class PathHttpEntity extends AbstractHttpEntity {
+    private static class PathHttpEntity extends AbstractHttpEntity implements AutoCloseable {
         private final Path file;
-        private final InputStream content;
 
-        private PathHttpEntity(final Path file, final InputStream content) {
+        private PathHttpEntity(final Path file) {
             this.file = file;
-            this.content = content;
+        }
+
+        @Override
+        public void close() throws IOException {
+            Files.deleteIfExists(file);
         }
 
         @Override
         public boolean isRepeatable() {
-            // We delete the file once the getContent().close() happens
-            return false;
+            // The entity is backed by a temp file that can be re-read on auth retries.
+            // The file is deleted via close() once the full request/response cycle
+            // (including any retries) has completed.
+            return true;
         }
 
         @Override
@@ -99,7 +104,7 @@ class ClientEntityOutputStream extends EntityOutputStream {
 
         @Override
         public InputStream getContent() throws IOException, UnsupportedOperationException {
-            return content;
+            return Files.newInputStream(file);
         }
 
         @Override

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43Engine.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.ref.Cleaner;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.Configurable;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -493,13 +495,23 @@ public class ManualClosingApacheHttpClient43Engine implements ApacheHttpClientEn
     }
 
     /**
-     * If passed httpMethod is of type HttpPost then obtain its entity. If the entity has an enclosing File then
-     * delete it by invoking this method after the request has completed. The entity will have an enclosing File
-     * only if it was too huge to fit into memory.
+     * Cleans up any temporary file backing the request entity after the
+     * request/response cycle (including auth retries) has completed.
      *
-     * @param httpMethod - the httpMethod to clean up.
+     * @param httpMethod the executed HTTP method to clean up
      */
     protected void cleanUpAfterExecute(final HttpRequestBase httpMethod) {
+        if (httpMethod instanceof HttpEntityEnclosingRequestBase) {
+            final HttpEntity entity = ((HttpEntityEnclosingRequestBase) httpMethod).getEntity();
+            if (entity instanceof ClientEntityOutputStream.PathHttpEntity) {
+                final Path file = ((ClientEntityOutputStream.PathHttpEntity) entity).getFile();
+                try {
+                    Files.deleteIfExists(file);
+                } catch (IOException e) {
+                    LogMessages.LOGGER.debugf(e, "Failed to delete temporary entity file %s", file);
+                }
+            }
+        }
     }
 
     /**

--- a/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43Engine.java
+++ b/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43Engine.java
@@ -29,6 +29,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.Configurable;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -493,13 +494,22 @@ public class ManualClosingApacheHttpClient43Engine implements ApacheHttpClientEn
     }
 
     /**
-     * If passed httpMethod is of type HttpPost then obtain its entity. If the entity has an enclosing File then
-     * delete it by invoking this method after the request has completed. The entity will have an enclosing File
-     * only if it was too huge to fit into memory.
+     * Cleans up any temporary file backing the request entity after the
+     * request/response cycle (including auth retries) has completed.
      *
-     * @param httpMethod - the httpMethod to clean up.
+     * @param httpMethod the executed HTTP method to clean up
      */
     protected void cleanUpAfterExecute(final HttpRequestBase httpMethod) {
+        if (httpMethod instanceof HttpEntityEnclosingRequestBase) {
+            final HttpEntity entity = ((HttpEntityEnclosingRequestBase) httpMethod).getEntity();
+            if (entity instanceof AutoCloseable) {
+                try {
+                    ((AutoCloseable) entity).close();
+                } catch (Exception e) {
+                    LogMessages.LOGGER.debugf(e, "Failed to clean up request entity %s", entity);
+                }
+            }
+        }
     }
 
     /**

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
@@ -2,10 +2,14 @@ package org.jboss.resteasy.test.security;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Hashtable;
+import java.util.stream.Stream;
 
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
 
 import org.apache.http.auth.AuthScope;
@@ -20,9 +24,12 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient43Engine;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClientEngine;
 import org.jboss.resteasy.setup.AbstractUsersRolesSecurityDomainSetup;
 import org.jboss.resteasy.spi.HttpResponseCodes;
+import org.jboss.resteasy.spi.config.SizeUnit;
+import org.jboss.resteasy.spi.config.Threshold;
 import org.jboss.resteasy.test.security.resource.BasicAuthBaseProxy;
 import org.jboss.resteasy.test.security.resource.BasicAuthBaseResource;
 import org.jboss.resteasy.test.security.resource.BasicAuthBaseResourceAnybody;
@@ -56,6 +63,7 @@ public class BasicAuthTest {
     private static final String ACCESS_FORBIDDEN_MESSAGE = "Access forbidden: role not allowed";
 
     private static ResteasyClient authorizedClient;
+    private static ResteasyClient authorizedClient2;
     private static ResteasyClient unauthorizedClient;
     private static ResteasyClient noAutorizationClient;
 
@@ -105,11 +113,22 @@ public class BasicAuthTest {
             unauthorizedClientUsingRequestFilterWithWrongPassword = (ResteasyClient) builder
                     .register(new BasicAuthRequestFilter("bill", "password2")).build();
         }
+
+        {
+            UsernamePasswordCredentials credentials = new UsernamePasswordCredentials("bill", "password1");
+            CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(new AuthScope(AuthScope.ANY), credentials);
+            CloseableHttpClient client = HttpClients.custom().setDefaultCredentialsProvider(credentialsProvider).build();
+            ApacheHttpClient43Engine engine = new ApacheHttpClient43Engine(client);
+            engine.setFileUploadMemoryThreshold(Threshold.of(1, SizeUnit.BYTE));
+            authorizedClient2 = ((ResteasyClientBuilder) ClientBuilder.newBuilder()).httpEngine(engine).build();
+        }
     }
 
     @AfterAll
     public static void after() throws Exception {
         authorizedClient.close();
+        authorizedClient2.close();
         unauthorizedClient.close();
         noAutorizationClient.close();
         authorizedClientUsingRequestFilter.close();
@@ -134,6 +153,86 @@ public class BasicAuthTest {
 
     private String generateURL(String path) {
         return PortProviderUtil.generateURL(path, BasicAuthTest.class.getSimpleName());
+    }
+
+    /**
+     * @tpTestDetails Test for RESTEASY-3721.
+     *                Verifies that a file-backed POST request with non-preemptive auth succeeds —
+     *                the entity is re-sent after the initial 401 challenge without throwing
+     *                NonRepeatableRequestException.
+     * @tpSince RESTEasy 7.0.3
+     */
+    @Test
+    public void testSecurity2() throws Exception {
+        Response response = authorizedClient2.target(generateURL("/secured")).request()
+                .build("POST", Entity.text("xxxxx")).invoke();
+        Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        response.close();
+    }
+
+    /**
+     * @tpTestDetails Test for RESTEASY-3721.
+     *                Verifies that a file-backed POST request with wrong credentials receives a 401
+     *                without throwing NonRepeatableRequestException, and that the temp file is
+     *                deleted by cleanUpAfterExecute() after the request cycle completes.
+     * @tpSince RESTEasy 7.0.3
+     */
+    @Test
+    public void testSecurity2WrongCredentialsTempFileDeleted() throws Exception {
+        UsernamePasswordCredentials wrongCredentials = new UsernamePasswordCredentials("bill", "wrongpassword");
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(new AuthScope(AuthScope.ANY), wrongCredentials);
+        CloseableHttpClient httpClient = HttpClients.custom().setDefaultCredentialsProvider(credentialsProvider).build();
+        ApacheHttpClient43Engine engine = new ApacheHttpClient43Engine(httpClient);
+        engine.setFileUploadMemoryThreshold(Threshold.of(1, SizeUnit.BYTE));
+
+        Path tmpDir = Path.of(System.getProperty("java.io.tmpdir"));
+        long tmpFilesBefore = countTmpFiles(tmpDir);
+
+        try (ResteasyClient client = ((ResteasyClientBuilder) ClientBuilder.newBuilder()).httpEngine(engine).build()) {
+            Response response = client.target(generateURL("/secured")).request()
+                    .build("POST", Entity.text("xxxxx")).invoke();
+            Assertions.assertEquals(HttpResponseCodes.SC_UNAUTHORIZED, response.getStatus());
+            response.close();
+        }
+
+        Assertions.assertEquals(tmpFilesBefore, countTmpFiles(tmpDir),
+                "Temp file was not deleted after failed auth request");
+    }
+
+    /**
+     * @tpTestDetails Test for RESTEASY-3721.
+     *                Verifies that a successful file-backed POST with non-preemptive auth (auth retry
+     *                after 401) correctly deletes the temp file after the full request cycle completes.
+     * @tpSince RESTEasy 7.0.3
+     */
+    @Test
+    public void testSecurity2TempFileDeletedAfterAuthRetry() throws Exception {
+        UsernamePasswordCredentials credentials = new UsernamePasswordCredentials("bill", "password1");
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(new AuthScope(AuthScope.ANY), credentials);
+        CloseableHttpClient httpClient = HttpClients.custom().setDefaultCredentialsProvider(credentialsProvider).build();
+        ApacheHttpClient43Engine engine = new ApacheHttpClient43Engine(httpClient);
+        engine.setFileUploadMemoryThreshold(Threshold.of(1, SizeUnit.BYTE));
+
+        Path tmpDir = Path.of(System.getProperty("java.io.tmpdir"));
+        long tmpFilesBefore = countTmpFiles(tmpDir);
+
+        try (ResteasyClient client = ((ResteasyClientBuilder) ClientBuilder.newBuilder()).httpEngine(engine).build()) {
+            Response response = client.target(generateURL("/secured")).request()
+                    .build("POST", Entity.text("xxxxx")).invoke();
+            Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+            response.close();
+        }
+
+        Assertions.assertEquals(tmpFilesBefore, countTmpFiles(tmpDir),
+                "Temp file was not deleted after successful auth retry");
+    }
+
+    private static long countTmpFiles(final Path dir) throws IOException {
+        try (Stream<Path> stream = Files.list(dir)) {
+            return stream.filter(p -> p.getFileName().toString().endsWith(".tmp")).count();
+        }
     }
 
     /**

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/BasicAuthTest.java
@@ -2,10 +2,16 @@ package org.jboss.resteasy.test.security;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Hashtable;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
 
 import org.apache.http.auth.AuthScope;
@@ -20,9 +26,12 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient43Engine;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClientEngine;
 import org.jboss.resteasy.setup.AbstractUsersRolesSecurityDomainSetup;
 import org.jboss.resteasy.spi.HttpResponseCodes;
+import org.jboss.resteasy.spi.config.SizeUnit;
+import org.jboss.resteasy.spi.config.Threshold;
 import org.jboss.resteasy.test.security.resource.BasicAuthBaseProxy;
 import org.jboss.resteasy.test.security.resource.BasicAuthBaseResource;
 import org.jboss.resteasy.test.security.resource.BasicAuthBaseResourceAnybody;
@@ -56,6 +65,7 @@ public class BasicAuthTest {
     private static final String ACCESS_FORBIDDEN_MESSAGE = "Access forbidden: role not allowed";
 
     private static ResteasyClient authorizedClient;
+    private static ResteasyClient authorizedClient2;
     private static ResteasyClient unauthorizedClient;
     private static ResteasyClient noAutorizationClient;
 
@@ -105,11 +115,22 @@ public class BasicAuthTest {
             unauthorizedClientUsingRequestFilterWithWrongPassword = (ResteasyClient) builder
                     .register(new BasicAuthRequestFilter("bill", "password2")).build();
         }
+
+        {
+            UsernamePasswordCredentials credentials = new UsernamePasswordCredentials("bill", "password1");
+            CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(new AuthScope(AuthScope.ANY), credentials);
+            CloseableHttpClient client = HttpClients.custom().setDefaultCredentialsProvider(credentialsProvider).build();
+            ApacheHttpClient43Engine engine = new ApacheHttpClient43Engine(client);
+            engine.setFileUploadMemoryThreshold(Threshold.of(1, SizeUnit.BYTE));
+            authorizedClient2 = ((ResteasyClientBuilder) ClientBuilder.newBuilder()).httpEngine(engine).build();
+        }
     }
 
     @AfterAll
     public static void after() throws Exception {
         authorizedClient.close();
+        authorizedClient2.close();
         unauthorizedClient.close();
         noAutorizationClient.close();
         authorizedClientUsingRequestFilter.close();
@@ -134,6 +155,89 @@ public class BasicAuthTest {
 
     private String generateURL(String path) {
         return PortProviderUtil.generateURL(path, BasicAuthTest.class.getSimpleName());
+    }
+
+    /**
+     * @tpTestDetails Test for RESTEASY-3721.
+     *                Verifies that a file-backed POST request with non-preemptive auth succeeds —
+     *                the entity is re-sent after the initial 401 challenge without throwing
+     *                NonRepeatableRequestException.
+     * @tpSince RESTEasy 7.0.3
+     */
+    @Test
+    public void testSecurity2() throws Exception {
+        try (Response response = authorizedClient2.target(generateURL("/secured")).request()
+                .build("POST", Entity.text("xxxxx")).invoke()) {
+            Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        }
+    }
+
+    /**
+     * @tpTestDetails Test for RESTEASY-3721.
+     *                Verifies that a file-backed POST request with wrong credentials receives a 401
+     *                without throwing NonRepeatableRequestException, and that the temp file is
+     *                deleted by cleanUpAfterExecute() after the request cycle completes.
+     * @tpSince RESTEasy 7.0.3
+     */
+    @Test
+    public void testSecurity2WrongCredentialsTempFileDeleted() throws Exception {
+        UsernamePasswordCredentials wrongCredentials = new UsernamePasswordCredentials("bill", "wrongpassword");
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(new AuthScope(AuthScope.ANY), wrongCredentials);
+        CloseableHttpClient httpClient = HttpClients.custom().setDefaultCredentialsProvider(credentialsProvider).build();
+        ApacheHttpClient43Engine engine = new ApacheHttpClient43Engine(httpClient);
+        engine.setFileUploadMemoryThreshold(Threshold.of(1, SizeUnit.BYTE));
+
+        Path tmpDir = Path.of(System.getProperty("java.io.tmpdir"));
+        Set<Path> tmpFilesBefore = listTmpFiles(tmpDir);
+
+        try (ResteasyClient client = ((ResteasyClientBuilder) ClientBuilder.newBuilder()).httpEngine(engine).build();
+                Response response = client.target(generateURL("/secured")).request()
+                        .build("POST", Entity.text("xxxxx")).invoke()) {
+            Assertions.assertEquals(HttpResponseCodes.SC_UNAUTHORIZED, response.getStatus());
+        }
+
+        Set<Path> newFiles = listTmpFiles(tmpDir);
+        newFiles.removeAll(tmpFilesBefore);
+        Assertions.assertTrue(newFiles.isEmpty(),
+                "Temp file(s) were not deleted after failed auth request: " + newFiles);
+    }
+
+    /**
+     * @tpTestDetails Test for RESTEASY-3721.
+     *                Verifies that a successful file-backed POST with non-preemptive auth (auth retry
+     *                after 401) correctly deletes the temp file after the full request cycle completes.
+     * @tpSince RESTEasy 7.0.3
+     */
+    @Test
+    public void testSecurity2TempFileDeletedAfterAuthRetry() throws Exception {
+        UsernamePasswordCredentials credentials = new UsernamePasswordCredentials("bill", "password1");
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(new AuthScope(AuthScope.ANY), credentials);
+        CloseableHttpClient httpClient = HttpClients.custom().setDefaultCredentialsProvider(credentialsProvider).build();
+        ApacheHttpClient43Engine engine = new ApacheHttpClient43Engine(httpClient);
+        engine.setFileUploadMemoryThreshold(Threshold.of(1, SizeUnit.BYTE));
+
+        Path tmpDir = Path.of(System.getProperty("java.io.tmpdir"));
+        Set<Path> tmpFilesBefore = listTmpFiles(tmpDir);
+
+        try (ResteasyClient client = ((ResteasyClientBuilder) ClientBuilder.newBuilder()).httpEngine(engine).build();
+                Response response = client.target(generateURL("/secured")).request()
+                        .build("POST", Entity.text("xxxxx")).invoke()) {
+            Assertions.assertEquals(HttpResponseCodes.SC_OK, response.getStatus());
+        }
+
+        Set<Path> newFiles = listTmpFiles(tmpDir);
+        newFiles.removeAll(tmpFilesBefore);
+        Assertions.assertTrue(newFiles.isEmpty(),
+                "Temp file(s) were not deleted after successful auth retry: " + newFiles);
+    }
+
+    private static Set<Path> listTmpFiles(final Path dir) throws IOException {
+        try (Stream<Path> stream = Files.list(dir)) {
+            return stream.filter(p -> p.getFileName().toString().endsWith(".tmp"))
+                    .collect(Collectors.toCollection(java.util.HashSet::new));
+        }
     }
 
     /**

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/resource/BasicAuthBaseResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/security/resource/BasicAuthBaseResource.java
@@ -5,6 +5,7 @@ import java.util.List;
 import jakarta.annotation.security.DenyAll;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
@@ -22,6 +23,12 @@ public class BasicAuthBaseResource {
     @RolesAllowed("admin")
     public List<String> getFailure() {
         return null;
+    }
+
+    @POST
+    @RolesAllowed("admin")
+    public String post(@Context SecurityContext ctx) {
+        return "hello";
     }
 
     @GET


### PR DESCRIPTION
### Fix

- `PathHttpEntity.isRepeatable()` now returns `true` — the entity is backed by a temp file on disk, which is inherently re-readable.
- `getContent()` opens a fresh `InputStream` via `Files.newInputStream(file)` on each call, ensuring retries read from the beginning.
- Removed the stored `InputStream` field from the constructor — only the `Path` is retained.
- `getContentLength()` returns the actual file size (allows `Content-Length` header instead of chunked encoding).
- `PathHttpEntity` is kept `private` and now implements `AutoCloseable` — `close()` deletes the temp file, so the entity owns its own cleanup.
- `cleanUpAfterExecute()` checks `instanceof AutoCloseable` and calls `close()` — decoupled from `PathHttpEntity` internals.

Issue Jira: https://issues.redhat.com/browse/RESTEASY-3721