### PR TITLE
Avoid uncaught exception for invalid URIs for unmatched requests

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/registry/SegmentNode.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/registry/SegmentNode.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.core.registry;
 
 import java.lang.reflect.Method;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -138,7 +139,14 @@ public class SegmentNode {
             }
         }
         if (matches.size() == 0) {
-            throw new NotFoundException(Messages.MESSAGES.couldNotFindResourceForFullPath(request.getUri().getRequestUri()));
+            URI uri = null;
+            try  {
+                uri = uriInfo.getRequestUri();
+            }
+            catch (Exception e) {
+                logger.log("Invalid URI", e);
+            }
+            throw new NotFoundException(Messages.MESSAGES.couldNotFindResourceForFullPath(uri));
         }
         MatchCache match = match(matches, request.getHttpMethod(), request);
         if (match.match != null) {


### PR DESCRIPTION
We've found when a user makes a request to an unknown path with a query parameter whose value is `"` an uncaught exception is thrown (see stack).

The fix in this PR is what I believe to be the least intrusive but as I'm not familiar with the code a more comprehensive fix might be appropriate.

```
java.lang.IllegalArgumentException: Illegal character in query at index ##: https://somehost/foo?x="
	at java.base/java.net.URI.create(URI.java:932)
	at org.jboss.resteasy.specimpl.ResteasyUriInfo.getRequestUri(ResteasyUriInfo.java:317)
	at org.jboss.resteasy.core.registry.SegmentNode.match(SegmentNode.java:141)
	at org.jboss.resteasy.core.registry.RootNode.match(RootNode.java:62)
	at org.jboss.resteasy.core.registry.RootClassNode.match(RootClassNode.java:42)
	at org.jboss.resteasy.core.ResourceMethodRegistry.getResourceInvoker(ResourceMethodRegistry.java:417)
	at org.jboss.resteasy.core.SynchronousDispatcher.getInvoker(SynchronousDispatcher.java:293)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$invoke$4(SynchronousDispatcher.java:233)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$preprocess$0(SynchronousDispatcher.java:154)
	at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:333)
	at org.jboss.resteasy.core.SynchronousDispatcher.preprocess(SynchronousDispatcher.java:157)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:229)
	at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:222)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:55)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51)
```