### PR TITLE
[RESTEASY-3754] & [RESTEASY-3755] Update CDI support

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -95,6 +95,7 @@ jobs:
       matrix:
         profile:
           - '-Dsecurity.manager'
+          - '-Denhanced.cdi.enabled'
 
     steps:
       - uses: actions/checkout@v7

--- a/docbook/src/main/asciidoc/CDI.adoc
+++ b/docbook/src/main/asciidoc/CDI.adoc
@@ -92,6 +92,166 @@ Resources can use `public`, `protected`, or package-private no-arg constructors.
 Using `protected` or package-private constructors follows CDI best practices by hiding implementation details.
 ====
 
+=== Parameter Injection with CDI Qualifiers
+
+{spec-name} parameter annotations (`@PathParam`, `@QueryParam`, `@HeaderParam`, `@MatrixParam`, `@CookieParam`,
+`@FormParam`, and `@BeanParam`) are registered as CDI qualifiers by RESTEasy. This allows parameter values to be
+injected directly via CDI without requiring a no-arg constructor at all.
+
+==== Constructor Parameter Injection
+
+Resource classes can receive {spec-name} parameter values directly in an `@Inject` constructor:
+
+[source,java]
+----
+@Path("/items/{id}")
+@RequestScoped
+public class ItemResource {
+
+    private final String id;
+    private final ItemService service;
+
+    @Inject
+    public ItemResource(@PathParam("id") String id, ItemService service) {
+        this.id = id;
+        this.service = service;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Item getItem() {
+        return service.findById(id);
+    }
+}
+----
+
+No no-arg constructor is needed. CDI resolves the `@PathParam` qualifier through a RESTEasy-provided producer that
+extracts the value from the current request context. Standard CDI beans (like `ItemService`) and {spec-name} parameter
+values can be mixed freely in the same constructor.
+
+==== Field Injection
+
+Fields annotated with `@Inject` and a {spec-name} parameter annotation receive parameter values from the current request:
+
+[source,java]
+----
+@Path("/items/{id}")
+@RequestScoped
+public class ItemResource {
+
+    @Inject
+    @PathParam("id")
+    private String id;
+
+    @Inject
+    @QueryParam("expand")
+    private boolean expand;
+
+    @Inject
+    @HeaderParam("Accept-Language")
+    private String language;
+
+    @Inject
+    @DefaultValue("10")
+    @QueryParam("limit")
+    private int limit;
+}
+----
+
+==== Setter Method Injection
+
+Setter methods annotated with `@Inject` can receive parameter values. The parameter annotation may be placed on either
+the method or the method parameter:
+
+[source,java]
+----
+@Path("/items/{id}")
+@RequestScoped
+public class ItemResource {
+
+    private String id;
+    private String filter;
+
+    // Annotation on parameter
+    @Inject
+    public void setId(@PathParam("id") String id) {
+        this.id = id;
+    }
+
+    // Annotation on method
+    @Inject
+    @QueryParam("filter")
+    public void setFilter(String filter) {
+        this.filter = filter;
+    }
+}
+----
+
+When the annotation is placed on the method, the parameter name is derived from the method name using JavaBean
+conventions (e.g. `setUserId` resolves to `userId`). When the annotation is placed on the parameter, the parameter
+name is taken from the annotation value.
+
+==== Bean Parameter Injection
+
+The `@BeanParam` annotation aggregates multiple parameters into a single object:
+
+[source,java]
+----
+public class SearchParams {
+    @Inject
+    @QueryParam("q")
+    private String query;
+
+    @Inject
+    @QueryParam("limit")
+    @DefaultValue("10")
+    private int limit;
+
+    @Inject
+    @HeaderParam("Accept-Language")
+    private String language;
+}
+
+@Path("/search")
+@RequestScoped
+public class SearchResource {
+
+    @Inject
+    @BeanParam
+    private SearchParams params;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Item> search() {
+        return searchItems(params);
+    }
+}
+----
+
+==== Type Conversion
+
+Parameter values are converted from their string representation to the target Java type using the same conversion rules
+as standard {spec-name} parameter handling (see the {spec-name} specification for details on `ParamConverterProvider`,
+`valueOf`, and `fromString` resolution).
+
+==== Disabling Enhanced CDI Support
+
+The enhanced CDI support, which includes `@Context` injection and parameter qualifier injection, can be disabled by
+setting the `dev.resteasy.cdi.enhanced.enabled` configuration property to `false`. This is useful when upgrading from
+an older version of RESTEasy and you want to opt out of the new behavior.
+
+The property can be set via a system property:
+
+[source]
+----
+-Ddev.resteasy.cdi.enhanced.enabled=false
+----
+
+Or via MicroProfile Config if available.
+
+When disabled, `@Context` and `@*Param` annotations are not treated as CDI qualifiers, and resource classes must use
+traditional {spec-name} injection or provide a public no-arg constructor.
+
 === Configuration within WildFly
 
 CDI integration is provided with no additional configuration with WildFly. 

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@
 
         <!-- Test options -->
         <additionalJvmArgs>-Djava.io.tmpdir=${project.build.directory}</additionalJvmArgs>
+        <wildfly.system.properties/>
 
         <!-- maven-release-plugin configuration -->
         <autoVersionSubmodules>true</autoVersionSubmodules>

--- a/resteasy-cdi/src/main/java/module-info.java
+++ b/resteasy-cdi/src/main/java/module-info.java
@@ -23,8 +23,6 @@ module org.jboss.resteasy.cdi {
     requires org.jboss.jandex;
     requires org.jboss.logging;
     requires static org.jboss.logging.annotations;
-    // Used if Weld is available, but may not be required in some instances
-    requires static weld.core.impl;
 
     // RESTEasy modules
     requires org.jboss.resteasy.core;
@@ -33,10 +31,13 @@ module org.jboss.resteasy.cdi {
     exports org.jboss.resteasy.cdi;
 
     // Opens
-    opens org.jboss.resteasy.cdi to weld.core.impl;
+    opens org.jboss.resteasy.cdi;
 
     // Service providers
     // CDI extension discovery
     provides jakarta.enterprise.inject.spi.Extension
-            with org.jboss.resteasy.cdi.ResteasyCdiExtension;
+            with org.jboss.resteasy.cdi.ResteasyCdiExtension,
+                    org.jboss.resteasy.cdi.ResteasyParamCdiExtension;
+    provides jakarta.ws.rs.core.Feature
+            with org.jboss.resteasy.cdi.CdiFeature;
 }

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiFeature.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiFeature.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.cdi;
+
+import jakarta.ws.rs.core.Feature;
+import jakarta.ws.rs.core.FeatureContext;
+
+/**
+ * A Jakarta REST {@link Feature} that registers CDI integration providers. This feature is loaded automatically via
+ * {@link java.util.ServiceLoader} when {@code jakarta.ws.rs.loadServices} is not set to {@code false}.
+ * <p>
+ * Currently registers:
+ * </p>
+ * <ul>
+ * <li>{@link CdiProxyUnwrapFilter} &mdash; unwraps CDI proxies from response entities before serialization</li>
+ * </ul>
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+public class CdiFeature implements Feature {
+    @Override
+    public boolean configure(final FeatureContext context) {
+        context.register(new CdiProxyUnwrapFilter());
+        return true;
+    }
+}

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiOptions.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiOptions.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.cdi;
+
+import java.util.function.Supplier;
+
+import org.jboss.resteasy.spi.config.Options;
+
+/**
+ * Configuration options for the RESTEasy CDI integration. These options extend the {@link Options} framework and
+ * can be configured via system properties, environment variables, or MicroProfile Config.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+public class CdiOptions<T> extends Options<T> {
+
+    /**
+     * An option for enabling or disabling the enhanced CDI support. When enabled, Jakarta REST annotations such as
+     * {@link jakarta.ws.rs.core.Context @Context}, {@link jakarta.ws.rs.QueryParam @QueryParam},
+     * {@link jakarta.ws.rs.PathParam @PathParam}, {@link jakarta.ws.rs.HeaderParam @HeaderParam},
+     * {@link jakarta.ws.rs.MatrixParam @MatrixParam}, {@link jakarta.ws.rs.CookieParam @CookieParam},
+     * {@link jakarta.ws.rs.FormParam @FormParam}, and {@link jakarta.ws.rs.BeanParam @BeanParam} are treated as CDI
+     * qualifiers, allowing parameter values to be injected via CDI.
+     * <p>
+     * The default is {@code false}.
+     * </p>
+     */
+    public static final CdiOptions<Boolean> ENHANCED_CDI_SUPPORT = new CdiOptions<>("dev.resteasy.cdi.enhanced.enabled",
+            Boolean.class, () -> false);
+
+    private CdiOptions(final String key, final Class<T> name, final Supplier<T> dftValue) {
+        super(key, name, dftValue);
+    }
+}

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiPropertyInjector.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiPropertyInjector.java
@@ -1,10 +1,5 @@
 package org.jboss.resteasy.cdi;
 
-import java.lang.invoke.CallSite;
-import java.lang.invoke.ConstantCallSite;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
@@ -12,7 +7,6 @@ import java.util.concurrent.CompletionStage;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.ws.rs.WebApplicationException;
 
-import org.jboss.resteasy.cdi.i18n.LogMessages;
 import org.jboss.resteasy.spi.ApplicationException;
 import org.jboss.resteasy.spi.Failure;
 import org.jboss.resteasy.spi.HttpRequest;
@@ -28,33 +22,7 @@ import org.jboss.resteasy.spi.PropertyInjector;
  * @author <a href="mailto:jharting@redhat.com">Jozef Hartinger</a>
  */
 public class CdiPropertyInjector implements PropertyInjector {
-    private static final Class<?> WELD_PROXY_CLASS;
-    private static final CallSite META_DATA_GETTER;
-    private static final CallSite CONTEXTUAL_INSTANCE_GETTER;
 
-    static {
-        Class<?> weldProxyClass = null;
-        MethodHandle metaDataGetter = null;
-        MethodHandle contextualInstanceGetter = null;
-        try {
-            final MethodHandles.Lookup lookup = MethodHandles.publicLookup();
-            weldProxyClass = Class.forName("org.jboss.weld.proxy.WeldClientProxy");
-            final Class<?> metaData = Class.forName("org.jboss.weld.proxy.WeldClientProxy$Metadata");
-            metaDataGetter = lookup.findVirtual(weldProxyClass, "getMetadata", MethodType.methodType(metaData));
-            contextualInstanceGetter = lookup.findVirtual(metaData, "getContextualInstance",
-                    MethodType.methodType(Object.class));
-        } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException ignore) {
-        }
-        if (weldProxyClass == null || metaDataGetter == null || contextualInstanceGetter == null) {
-            WELD_PROXY_CLASS = null;
-            META_DATA_GETTER = null;
-            CONTEXTUAL_INSTANCE_GETTER = null;
-        } else {
-            WELD_PROXY_CLASS = weldProxyClass;
-            META_DATA_GETTER = new ConstantCallSite(metaDataGetter);
-            CONTEXTUAL_INSTANCE_GETTER = new ConstantCallSite(contextualInstanceGetter);
-        }
-    }
     private final PropertyInjector delegate;
     private final Class<?> clazz;
     private boolean injectorEnabled = true;
@@ -84,7 +52,7 @@ public class CdiPropertyInjector implements PropertyInjector {
     public CompletionStage<Void> inject(HttpRequest request, HttpResponse response, Object target, boolean unwrapAsync)
             throws Failure, WebApplicationException, ApplicationException {
         if (injectorEnabled) {
-            return delegate.inject(request, response, unwrapIfRequired(target), unwrapAsync);
+            return delegate.inject(request, response, CdiProxyUnwrapper.unwrapIfRequired(target), unwrapAsync);
         }
         return null;
     }
@@ -92,17 +60,5 @@ public class CdiPropertyInjector implements PropertyInjector {
     @Override
     public String toString() {
         return "CdiPropertyInjector (enabled: " + injectorEnabled + ") for " + clazz;
-    }
-
-    private static Object unwrapIfRequired(final Object target) {
-        try {
-            if (WELD_PROXY_CLASS != null && WELD_PROXY_CLASS.isInstance(target)) {
-                final var metaData = META_DATA_GETTER.dynamicInvoker().invoke(target);
-                return CONTEXTUAL_INSTANCE_GETTER.dynamicInvoker().invoke(metaData);
-            }
-        } catch (Throwable e) {
-            LogMessages.LOGGER.debugf(e, "Failed to handle unwrapping of %s", target);
-        }
-        return target;
     }
 }

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiProxyUnwrapFilter.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiProxyUnwrapFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.cdi;
+
+import java.io.IOException;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+
+/**
+ * A {@link ContainerResponseFilter} that unwraps CDI proxies from response entities before serialization. Normal-scoped
+ * CDI beans (e.g. {@link jakarta.enterprise.context.RequestScoped @RequestScoped}) are returned as proxy instances whose
+ * fields contain default values. Serialization frameworks such as Jackson that use field access or introspect the proxy
+ * class directly may serialize proxy-internal properties (e.g. Weld's {@code getMetadata()}) or produce incorrect
+ * values. This filter replaces the proxy with the underlying contextual instance so that serialization sees the real
+ * object.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ * @see CdiProxyUnwrapper
+ */
+@Priority(Priorities.HEADER_DECORATOR)
+public class CdiProxyUnwrapFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(final ContainerRequestContext requestContext, final ContainerResponseContext responseContext)
+            throws IOException {
+        final Object entity = responseContext.getEntity();
+        if (entity != null) {
+            final Object unwrapped = CdiProxyUnwrapper.unwrapIfRequired(entity);
+            if (unwrapped != entity) {
+                responseContext.setEntity(unwrapped);
+            }
+        }
+    }
+}

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiProxyUnwrapper.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiProxyUnwrapper.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.cdi;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+import org.jboss.resteasy.cdi.i18n.LogMessages;
+
+/**
+ * Utility for unwrapping CDI client proxies to their underlying contextual instances. Supports both Weld
+ * ({@code WeldClientProxy}) and OpenWebBeans ({@code OwbNormalScopeProxy}) via reflective method handles that are
+ * resolved once at class-load time. If neither implementation is on the classpath, {@link #unwrapIfRequired(Object)}
+ * returns the target unchanged.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ * @see CdiProxyUnwrapFilter
+ */
+class CdiProxyUnwrapper {
+
+    // Weld Handles
+    private static final Class<?> WELD_PROXY_CLASS;
+    private static final MethodHandle WELD_METADATA_GETTER;
+    private static final MethodHandle WELD_CONTEXTUAL_INSTANCE_GETTER;
+
+    // OpenWebBeans Handles
+    private static final Class<?> OWB_PROXY_CLASS;
+    private static final MethodHandle OWB_INSTANCE_GETTER;
+
+    static {
+        final ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        final MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+
+        // 1. Initialize Weld
+        Class<?> weldProxyClass = null;
+        MethodHandle weldMetaGetter = null;
+        MethodHandle weldInstGetter = null;
+        try {
+            weldProxyClass = Class.forName("org.jboss.weld.proxy.WeldClientProxy", false, tccl);
+            final Class<?> metaDataClass = Class.forName("org.jboss.weld.proxy.WeldClientProxy$Metadata", false, tccl);
+            weldMetaGetter = lookup.findVirtual(weldProxyClass, "getMetadata", MethodType.methodType(metaDataClass));
+            weldInstGetter = lookup.findVirtual(metaDataClass, "getContextualInstance", MethodType.methodType(Object.class));
+        } catch (Throwable e) {
+            // Weld is not on the classpath
+            LogMessages.LOGGER.trace(
+                    "Unable to find Weld proxy class. Weld may not be on the class path. Weld proxies will not be unwrapped.",
+                    e);
+        }
+        if (weldProxyClass != null && (weldMetaGetter == null || weldInstGetter == null)) {
+            weldProxyClass = null;
+            weldMetaGetter = null;
+            weldInstGetter = null;
+        }
+        WELD_PROXY_CLASS = weldProxyClass;
+        WELD_METADATA_GETTER = weldMetaGetter;
+        WELD_CONTEXTUAL_INSTANCE_GETTER = weldInstGetter;
+
+        // 2. Initialize OpenWebBeans
+        Class<?> owbProxyClass = null;
+        MethodHandle owbInstGetter = null;
+        try {
+            owbProxyClass = Class.forName("org.apache.webbeans.proxy.OwbNormalScopeProxy", false, tccl);
+            owbInstGetter = lookup.findVirtual(owbProxyClass, "Owb_getSystemInstance", MethodType.methodType(Object.class));
+        } catch (Throwable e) {
+            // OpenWebBeans is not on the classpath
+            LogMessages.LOGGER.trace(
+                    "Unable to find OpenWebBeans proxy class. OpenWebBeans may not be on the class path. OpenWebBeans proxies will not be unwrapped.",
+                    e);
+        }
+        if (owbProxyClass != null && owbInstGetter == null) {
+            owbProxyClass = null;
+        }
+        OWB_PROXY_CLASS = owbProxyClass;
+        OWB_INSTANCE_GETTER = owbInstGetter;
+    }
+
+    private CdiProxyUnwrapper() {
+    }
+
+    /**
+     * Unwraps a CDI proxy to its underlying contextual instance. If the object is not a proxy, it is returned as-is.
+     *
+     * @param target the instance
+     */
+    static Object unwrapIfRequired(final Object target) {
+        if (target == null) {
+            return null;
+        }
+
+        try {
+            // Check Weld
+            if (WELD_PROXY_CLASS != null && WELD_PROXY_CLASS.isInstance(target)) {
+                Object metaData = WELD_METADATA_GETTER.invoke(target);
+                return WELD_CONTEXTUAL_INSTANCE_GETTER.invoke(metaData);
+            }
+
+            // Check OpenWebBeans
+            if (OWB_PROXY_CLASS != null && OWB_PROXY_CLASS.isInstance(target)) {
+                return OWB_INSTANCE_GETTER.invoke(target);
+            }
+        } catch (Throwable e) {
+            LogMessages.LOGGER.debugf(e, "Failed to unwrap potential CDI proxy: %s", target);
+        }
+
+        // Return original object if it's not a known proxy or unwrapping failed
+        return target;
+    }
+}

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/ContextProducers.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/ContextProducers.java
@@ -23,7 +23,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
-import jakarta.inject.Singleton;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.container.ResourceInfo;
 import jakarta.ws.rs.core.Configuration;
@@ -43,7 +42,7 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@Singleton
+@ApplicationScoped
 public class ContextProducers {
 
     @Dependent

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/JaxrsInjectionTarget.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/JaxrsInjectionTarget.java
@@ -25,19 +25,32 @@ import org.jboss.resteasy.spi.validation.GeneralValidatorCDI;
 import org.jboss.resteasy.util.GetRestful;
 
 /**
- * This implementation of InjectionTarget is a wrapper that allows JAX-RS
- * property injection to be performed just after CDI injection.
+ * An {@link InjectionTarget} wrapper for Jakarta REST components that performs property injection and validation after
+ * CDI injection.
+ * <p>
+ * For components not managed by CDI (e.g. EJB session beans), property injection via {@link PropertyInjectorImpl} is
+ * used to populate {@code @Context} and {@code @*Param}-annotated fields. For CDI-managed components (those registered
+ * in the {@link ResteasyCdiExtension ResteasyCdiExtension.beanContainer}), property injection is skipped since CDI handles
+ * field injection directly through producers.
+ * </p>
+ * <p>
+ * Validation is performed for all root resource classes after injection, using a {@link GeneralValidatorCDI} resolved
+ * from a {@link ContextResolver}. If the class has a {@code @PostConstruct} method, validation is deferred to the
+ * {@link #postConstruct(Object)} phase.
+ * </p>
  *
  * @author Jozef Hartinger
- *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ * @deprecated this should not be used outside of this module and may be removed in a future release
  */
+@Deprecated(forRemoval = true, since = "7.0.3")
 public class JaxrsInjectionTarget<T> implements InjectionTarget<T> {
 
     private final InjectionTarget<T> delegate;
     private final Class<T> clazz;
-    private PropertyInjector propertyInjector;
-
     private final boolean hasPostConstruct;
+    private final boolean usePropertyInjector;
+    private volatile PropertyInjector propertyInjector;
 
     private static final Function<Method, Boolean> validatePostConstructParameters = (Method m) -> {
         if (m.getParameterCount() == 0)
@@ -48,29 +61,50 @@ public class JaxrsInjectionTarget<T> implements InjectionTarget<T> {
                     && m.getAnnotation(AroundInvoke.class) != null;
     };
 
+    /**
+     * @deprecated this should not be used outside of this module
+     */
+    @Deprecated(forRemoval = true, since = "7.0.3")
     public JaxrsInjectionTarget(final InjectionTarget<T> delegate, final Class<T> clazz) {
+        this(delegate, clazz, true);
+    }
+
+    /**
+     * Creates a new wrapped {@link InjectionTarget} for custom RESTEasy bean validation and optional property inject.
+     * <p>
+     * If the {@code usePropertyInjector} is set to {@code true}, a new {@link PropertyInjector} is used to inject
+     * Jakarta REST resources. These could be {@link jakarta.ws.rs.core.Context @Context} injection points or the
+     * {@link @*Param} injection points. For full CDI managed beans, this should typically be {@code false}.
+     * </p>
+     *
+     * @param delegate            the delegate injection target
+     * @param clazz               the type of the bean
+     * @param usePropertyInjector {@code true} if a {@link PropertyInjector} should be used and this is not a fully
+     *                            managed CDI bean, otherwise {@link false}
+     */
+    protected JaxrsInjectionTarget(final InjectionTarget<T> delegate, final Class<T> clazz, final boolean usePropertyInjector) {
         this.delegate = delegate;
         this.clazz = clazz;
         hasPostConstruct = Types.hasPostConstruct(clazz, validatePostConstructParameters);
+        this.usePropertyInjector = usePropertyInjector;
     }
 
     @Override
     public void inject(T instance, CreationalContext<T> ctx) {
         delegate.inject(instance, ctx);
 
-        // We need to load PropertyInjector lazily since RESTEasy starts
-        // after the CDI lifecycle events are executed
-        if (propertyInjector == null) {
-            propertyInjector = getPropertyInjector();
-        }
+        // We use a property injector for non-CDI managed resoruces
+        final PropertyInjector propertyInjector = getPropertyInjector();
 
         HttpRequest request = ResteasyContext.getContextData(HttpRequest.class);
         HttpResponse response = ResteasyContext.getContextData(HttpResponse.class);
 
-        if ((request != null) && (response != null)) {
-            propertyInjector.inject(request, response, instance, false);
-        } else {
-            propertyInjector.inject(instance, false);
+        if (propertyInjector != null) {
+            if ((request != null) && (response != null)) {
+                propertyInjector.inject(request, response, instance, false);
+            } else {
+                propertyInjector.inject(instance, false);
+            }
         }
 
         if (request != null && !hasPostConstruct) {
@@ -114,7 +148,17 @@ public class JaxrsInjectionTarget<T> implements InjectionTarget<T> {
     }
 
     private PropertyInjector getPropertyInjector() {
-        return new PropertyInjectorImpl(clazz, ResteasyProviderFactory.getInstance());
+        if (usePropertyInjector) {
+            if (propertyInjector == null) {
+                synchronized (this) {
+                    if (propertyInjector == null) {
+                        propertyInjector = new PropertyInjectorImpl(clazz, ResteasyProviderFactory.getInstance());
+                    }
+                }
+            }
+            return propertyInjector;
+        }
+        return null;
     }
 
     private void validate(HttpRequest request, T instance) {

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/ResteasyCdiExtension.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/ResteasyCdiExtension.java
@@ -6,9 +6,6 @@
 package org.jboss.resteasy.cdi;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Member;
-import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.security.AccessController;
@@ -25,6 +22,7 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.literal.InjectLiteral;
 import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
 import jakarta.enterprise.inject.spi.AfterTypeDiscovery;
 import jakarta.enterprise.inject.spi.AnnotatedType;
@@ -44,6 +42,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.cdi.i18n.LogMessages;
@@ -51,14 +50,20 @@ import org.jboss.resteasy.cdi.i18n.Messages;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 
 /**
- * This Extension handles default scopes for discovered JAX-RS components. It
- * also observes ProcessInjectionTarget event and wraps InjectionTargets
- * representing JAX-RS components within JaxrsInjectionTarget. Furthermore, it
- * builds the sessionBeanInterface map which maps Session Bean classes to a
- * local interface. This map is used in CdiInjectorFactory during lookup of
- * Sesion Bean JAX-RS components.
+ * A CDI {@link Extension} that integrates Jakarta REST components with CDI. This extension:
+ * <ul>
+ * <li>Assigns default scopes to discovered Jakarta REST resources ({@link RequestScoped}), providers
+ * ({@link ApplicationScoped}), and {@link Application} subclasses ({@link ApplicationScoped})</li>
+ * <li>Adds {@link jakarta.inject.Inject @Inject} to {@link jakarta.ws.rs.core.Context @Context}-annotated fields,
+ * setter methods, and constructors so that CDI can inject context values via {@link ContextProducers}</li>
+ * <li>Wraps {@link InjectionTarget} instances for Jakarta REST components within {@link JaxrsInjectionTarget}
+ * to handle property injection and validation</li>
+ * <li>Builds the session bean interface map used by {@link CdiInjectorFactory} for EJB lookup</li>
+ * <li>Tracks CDI-managed Jakarta REST components in the {@link ResteasyBeanContainer}</li>
+ * </ul>
  *
  * @author Jozef Hartinger
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
  */
 public class ResteasyCdiExtension implements Extension {
     private static boolean active;
@@ -80,9 +85,14 @@ public class ResteasyCdiExtension implements Extension {
 
     private final Map<Class<?>, Type> sessionBeanInterface = new HashMap<>();
     private final Set<Class<?>> beanContainer = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final boolean enhancedCdiSupportEnabled;
     private boolean generateClientBean = true;
     private boolean addContextProducers = true;
     private boolean noApplicationFound = true;
+
+    public ResteasyCdiExtension() {
+        enhancedCdiSupportEnabled = CdiOptions.ENHANCED_CDI_SUPPORT.getValue();
+    }
 
     /**
      * Obtain BeanManager reference for future use.
@@ -110,11 +120,11 @@ public class ResteasyCdiExtension implements Extension {
     }
 
     /**
-     * Registers a producer and disable for a {@link Client REST client}.
+     * Registers producers for required injections types and for a {@link Client REST client}.
      *
      * @param event the after bean discovery event
      */
-    public void registerClientProducer(@Observes final AfterBeanDiscovery event) {
+    public void registerBeans(@Observes final AfterBeanDiscovery event) {
         if (generateClientBean) {
             event.addBean().addTransitiveTypeClosure(Client.class)
                     .scope(ApplicationScoped.class)
@@ -123,6 +133,7 @@ public class ResteasyCdiExtension implements Extension {
                     .disposeWith((client, instance) -> client.close());
         }
         final Set<Class<?>> resources = Set.copyOf(beanContainer);
+        beanContainer.clear();
         final ResteasyBeanContainer instance = resources::contains;
         event.addBean().addType(ResteasyBeanContainer.class)
                 .scope(ApplicationScoped.class)
@@ -168,6 +179,13 @@ public class ResteasyCdiExtension implements Extension {
             BeanManager beanManager) {
         AnnotatedType<T> annotatedType = event.getAnnotatedType();
 
+        // If we're not an interface or decorator, add @Inject to any @Context injection points
+        if (enhancedCdiSupportEnabled && !annotatedType.getJavaClass().isInterface()
+                && !annotatedType.isAnnotationPresent(Decorator.class)
+                && !Utils.isUnproxyableClass(annotatedType.getJavaClass())) {
+            addInject(event);
+        }
+
         // Check if this is a stateful bean and consider it not managed by the CDI container. This means we will not add
         // it to the bean container.
         final boolean isStatefulBean = isStatefulBean(annotatedType);
@@ -179,10 +197,11 @@ public class ResteasyCdiExtension implements Extension {
                 LogMessages.LOGGER.debug(Messages.MESSAGES.discoveredCDIBeanJaxRsResource(annotatedType.getJavaClass()
                         .getCanonicalName()));
                 event.configureAnnotatedType().add(requestScopedLiteral);
-                if (!isStatefulBean) {
+                if (!isStatefulBean && !Utils.isUnproxyableClass(annotatedType.getJavaClass())) {
                     beanContainer.add(annotatedType.getJavaClass());
                 }
-            } else if (!isStatefulBean && Utils.isNormalScope(annotatedType, beanManager)) {
+            } else if (!isStatefulBean && Utils.isNormalScope(annotatedType, beanManager)
+                    && !Utils.isUnproxyableClass(annotatedType.getJavaClass())) {
                 beanContainer.add(annotatedType.getJavaClass());
             }
         }
@@ -199,13 +218,20 @@ public class ResteasyCdiExtension implements Extension {
             BeanManager beanManager) {
         AnnotatedType<T> annotatedType = event.getAnnotatedType();
 
+        // If we're not an interface or decorator, add @Inject to any @Context injection points
+        if (enhancedCdiSupportEnabled && !annotatedType.getJavaClass().isInterface()
+                && !annotatedType.isAnnotationPresent(Decorator.class)
+                && !Utils.isUnproxyableClass(annotatedType.getJavaClass())) {
+            addInject(event);
+        }
+
         // Check if this is a stateful bean and consider it not managed by the CDI container. This means we will not add
         // it to the bean container.
         final boolean isStatefulBean = isStatefulBean(annotatedType);
 
         if (!annotatedType.getJavaClass().isInterface()
                 && !isSessionBean(annotatedType)
-                && !isUnproxyableClass(annotatedType.getJavaClass())) {
+                && !Utils.isUnproxyableClass(annotatedType.getJavaClass())) {
             if (!Utils.isScopeDefined(annotatedType, beanManager)) {
                 LogMessages.LOGGER.debug(Messages.MESSAGES.discoveredCDIBeanJaxRsProvider(annotatedType.getJavaClass()
                         .getCanonicalName()));
@@ -229,19 +255,27 @@ public class ResteasyCdiExtension implements Extension {
     public <T extends Application> void observeApplications(@Observes ProcessAnnotatedType<T> event,
             BeanManager beanManager) {
         final Class<T> applicationClass = event.getAnnotatedType().getJavaClass();
+        final AnnotatedType<T> annotatedType = event.getAnnotatedType();
 
         // Check if this is a stateful bean and consider it not managed by the CDI container. This means we will not add
         // it to the bean container.
-        final boolean isStatefulBean = isStatefulBean(event.getAnnotatedType());
+        final boolean isStatefulBean = isStatefulBean(annotatedType);
 
         if (!Modifier.isAbstract(applicationClass.getModifiers())) {
             noApplicationFound = false;
-            if (!Utils.isScopeDefined(event.getAnnotatedType(), beanManager)) {
+            // If we're not an interface or decorator, add @Inject to any @Context injection points
+            if (enhancedCdiSupportEnabled && !annotatedType.getJavaClass().isInterface()
+                    && !annotatedType.isAnnotationPresent(Decorator.class)
+                    && !Utils.isUnproxyableClass(annotatedType.getJavaClass())) {
+                addInject(event);
+            }
+            if (!Utils.isScopeDefined(annotatedType, beanManager)) {
                 event.configureAnnotatedType().add(applicationScopedLiteral);
-                if (!isStatefulBean) {
+                if (!isStatefulBean && !Utils.isUnproxyableClass(applicationClass)) {
                     beanContainer.add(applicationClass);
                 }
-            } else if (!isStatefulBean && Utils.isNormalScope(event.getAnnotatedType(), beanManager)) {
+            } else if (!isStatefulBean && Utils.isNormalScope(annotatedType, beanManager)
+                    && !Utils.isUnproxyableClass(applicationClass)) {
                 beanContainer.add(applicationClass);
             }
         }
@@ -260,8 +294,11 @@ public class ResteasyCdiExtension implements Extension {
         }
     }
 
+    @SuppressWarnings("removal")
     protected <T> InjectionTarget<T> wrapInjectionTarget(ProcessInjectionTarget<T> event) {
-        return new JaxrsInjectionTarget<>(event.getInjectionTarget(), event.getAnnotatedType().getJavaClass());
+        final Class<T> injectionType = event.getAnnotatedType().getJavaClass();
+        return new JaxrsInjectionTarget<>(event.getInjectionTarget(), injectionType,
+                !enhancedCdiSupportEnabled || !beanContainer.contains(injectionType));
     }
 
     /**
@@ -323,66 +360,31 @@ public class ResteasyCdiExtension implements Extension {
     }
 
     /**
-     * Check for select case of unproxyable bean type.
-     * (see CDI 2.0 spec, section 3.11)
+     * Adds {@link Inject @Inject} to {@link Context @Context}-annotated injection points so that CDI can inject
+     * context values via {@link ContextProducers}. This covers:
+     * <ul>
+     * <li>Fields annotated with {@code @Context}</li>
+     * <li>Setter methods annotated with {@code @Context}</li>
+     * <li>Constructors with any parameter annotated with {@code @Context} (unless the constructor is already
+     * annotated with {@code @Inject})</li>
+     * </ul>
      *
-     * @param clazz
-     *
-     * @return
+     * @param pat the annotated type being processed
      */
-    private boolean isUnproxyableClass(Class<?> clazz) {
-        // Unproxyable bean type: classes which are declared final,
-        // or expose final methods,
-        // or have no non-private no-args constructor
-        return isFinal(clazz) ||
-                hasNonPrivateNonStaticFinalMethod(clazz) ||
-                !hasValidConstructor(clazz);
-    }
-
-    private boolean isFinal(Class<?> clazz) {
-        return Modifier.isFinal(clazz.getModifiers());
-    }
-
-    // Adapted from weld-core-impl:3.0.5.Final's Reflections.getNonPrivateNonStaticFinalMethod()
-    private boolean hasNonPrivateNonStaticFinalMethod(Class<?> type) {
-        for (Class<?> clazz = type; clazz != null && clazz != Object.class; clazz = clazz.getSuperclass()) {
-            for (Method method : clazz.getDeclaredMethods()) {
-                if (isFinal(method) && !isPrivate(method) && !isStatic(method)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private boolean hasValidConstructor(final Class<?> clazz) {
-        // Check if there is a constructor with @Inject or a no-arg constructor
-        for (Constructor<?> c : clazz.getDeclaredConstructors()) {
-            if (c.isAnnotationPresent(Inject.class)) {
-                return true;
-            }
-        }
-        // For a bean to be considered proxyable, the bean must have a non-private constructor with no parameters. If
-        // a method matching those requirements does not exist, we'll not register this component as a CDI bean.
-        Constructor<?> constructor;
-        try {
-            constructor = clazz.getDeclaredConstructor();
-        } catch (NoSuchMethodException e) {
-            return false;
-        }
-        return !isPrivate(constructor);
-    }
-
-    private boolean isFinal(Member member) {
-        return Modifier.isFinal(member.getModifiers());
-    }
-
-    private boolean isPrivate(Member member) {
-        return Modifier.isPrivate(member.getModifiers());
-    }
-
-    private boolean isStatic(Member member) {
-        return Modifier.isStatic(member.getModifiers());
+    private void addInject(final ProcessAnnotatedType<?> pat) {
+        // Add @Inject to fields
+        pat.configureAnnotatedType()
+                .filterFields(f -> !f.isAnnotationPresent(Inject.class) && f.isAnnotationPresent(Context.class))
+                .forEach(f -> f.add(InjectLiteral.INSTANCE));
+        // Add @Inject to methods
+        pat.configureAnnotatedType()
+                .filterMethods(m -> !m.isAnnotationPresent(Inject.class) && m.isAnnotationPresent(Context.class))
+                .forEach(m -> m.add(InjectLiteral.INSTANCE));
+        // Add @Inject to constructors
+        pat.configureAnnotatedType()
+                .filterConstructors(c -> !c.isAnnotationPresent(Inject.class)
+                        && c.getParameters().stream().anyMatch(p -> p.isAnnotationPresent(Context.class)))
+                .forEach(c -> c.add(InjectLiteral.INSTANCE));
     }
 
     private static ClassLoader getClassLoader() {

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/ResteasyParamCdiExtension.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/ResteasyParamCdiExtension.java
@@ -1,0 +1,643 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.cdi;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.decorator.Decorator;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.UnsatisfiedResolutionException;
+import jakarta.enterprise.inject.literal.InjectLiteral;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.Annotated;
+import jakarta.enterprise.inject.spi.AnnotatedConstructor;
+import jakarta.enterprise.inject.spi.AnnotatedField;
+import jakarta.enterprise.inject.spi.AnnotatedMethod;
+import jakarta.enterprise.inject.spi.AnnotatedParameter;
+import jakarta.enterprise.inject.spi.AnnotatedType;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
+import jakarta.enterprise.inject.spi.ProcessInjectionPoint;
+import jakarta.enterprise.inject.spi.WithAnnotations;
+import jakarta.enterprise.inject.spi.configurator.AnnotatedConstructorConfigurator;
+import jakarta.enterprise.inject.spi.configurator.AnnotatedFieldConfigurator;
+import jakarta.enterprise.inject.spi.configurator.AnnotatedMethodConfigurator;
+import jakarta.enterprise.inject.spi.configurator.AnnotatedParameterConfigurator;
+import jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.Nonbinding;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.Encoded;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+import org.jboss.resteasy.cdi.i18n.Messages;
+import org.jboss.resteasy.core.FormInjector;
+import org.jboss.resteasy.core.extractors.ParameterExtractors;
+import org.jboss.resteasy.core.extractors.RequestParameterExtractor;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.util.Types;
+
+/**
+ * A CDI {@link Extension} that enables Jakarta REST parameter annotations ({@code @CookieParam}, {@code @FormParam},
+ * {@code @HeaderParam}, {@code @MatrixParam}, {@code @PathParam}, {@code @QueryParam}, and {@code @BeanParam}) to
+ * function as CDI qualifiers. This allows Jakarta REST resource classes to receive parameter values via CDI
+ * constructor injection rather than requiring a public no-arg constructor.
+ * <p>
+ * The extension operates in four CDI lifecycle phases:
+ * </p>
+ * <ol>
+ * <li>{@link BeforeBeanDiscovery} &mdash; registers each {@code @*Param} annotation as a CDI qualifier</li>
+ * <li>{@link ProcessAnnotatedType} &mdash; adds {@link Inject @Inject} to {@code @*Param}-annotated fields,
+ * setter methods, and constructors so that CDI resolves parameter values automatically. RESTEasy-specific
+ * annotations ({@code org.jboss.resteasy.annotations.jaxrs.*Param}) are also handled by adding the corresponding
+ * Jakarta REST annotation alongside {@code @Inject}.</li>
+ * <li>{@link ProcessInjectionPoint} &mdash; collects the types of all {@code @*Param}-annotated injection points</li>
+ * <li>{@link AfterBeanDiscovery} &mdash; registers synthetic beans that produce parameter values at request time
+ * by delegating to {@link ParameterExtractors}</li>
+ * </ol>
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+public class ResteasyParamCdiExtension implements Extension {
+
+    private final Set<Type> paramTypes = ConcurrentHashMap.newKeySet();
+    private final Map<CacheKey, RequestParameterExtractor> extractorCache = new ConcurrentHashMap<>();
+    private final Map<Class<?>, FormInjector> formInjectorCache = new ConcurrentHashMap<>();
+
+    private final Set<Class<? extends Annotation>> paramAnnotations = Set.of(
+            BeanParam.class,
+            CookieParam.class,
+            FormParam.class,
+            HeaderParam.class,
+            MatrixParam.class,
+            PathParam.class,
+            QueryParam.class);
+    private final boolean enhancedCdiSupportEnabled;
+
+    public ResteasyParamCdiExtension() {
+        enhancedCdiSupportEnabled = CdiOptions.ENHANCED_CDI_SUPPORT.getValue();
+    }
+
+    /**
+     * Registers each {@code @*Param} annotation as a CDI qualifier, marking all annotation members as
+     * {@link Nonbinding} so that qualifier resolution matches on presence alone rather than on member values.
+     *
+     * @param event the before bean discovery event
+     */
+    public void registerQualifiers(@Observes final BeforeBeanDiscovery event) {
+        if (enhancedCdiSupportEnabled) {
+            // Register the @*Param annotations as qualifiers
+            for (Class<? extends Annotation> param : paramAnnotations) {
+                event.configureQualifier(param)
+                        .methods()
+                        .forEach(method -> method.add(Nonbinding.Literal.INSTANCE));
+            }
+        }
+    }
+
+    /**
+     * Observes Jakarta REST resource types and adds {@link Inject @Inject} to fields, setter methods, and constructors
+     * annotated with {@code @*Param} annotations so that CDI can resolve parameter values via the synthetic beans
+     * registered by this extension. This covers both Jakarta REST annotations ({@code jakarta.ws.rs.*Param}) and
+     * RESTEasy-specific annotations ({@code org.jboss.resteasy.annotations.jaxrs.*Param}).
+     *
+     * @param event the annotated type being processed
+     * @param <T>   the type being processed
+     */
+    public <T> void observeParamResources(@WithAnnotations({ Path.class }) @Observes ProcessAnnotatedType<T> event) {
+        if (enhancedCdiSupportEnabled) {
+            final AnnotatedType<T> annotatedType = event.getAnnotatedType();
+            if (!annotatedType.getJavaClass().isInterface()
+                    && !annotatedType.isAnnotationPresent(Decorator.class)
+                    && !Utils.isUnproxyableClass(annotatedType.getJavaClass())) {
+                addInject(event);
+            }
+        }
+    }
+
+    /**
+     * Adds {@link Inject @Inject} to {@code @*Param}-annotated injection points so that CDI can inject parameter
+     * values via the synthetic producer beans registered by this extension.
+     * <p>
+     * For Jakarta REST annotations ({@code jakarta.ws.rs.*Param}), only {@code @Inject} is added since these
+     * annotations are already registered as CDI qualifiers. For RESTEasy-specific annotations
+     * ({@code org.jboss.resteasy.annotations.jaxrs.*Param}), the corresponding Jakarta REST annotation is also
+     * added so that the existing CDI qualifier and producer infrastructure handles them.
+     * </p>
+     */
+    private void addInject(final ProcessAnnotatedType<?> pat) {
+        final AnnotatedTypeConfigurator<?> configurator = pat.configureAnnotatedType();
+
+        // Fields
+        for (AnnotatedFieldConfigurator<?> fieldConfig : configurator.fields()) {
+            final AnnotatedField<?> field = fieldConfig.getAnnotated();
+            if (field.isAnnotationPresent(Inject.class)) {
+                continue;
+            }
+            if (paramAnnotations.stream().anyMatch(field::isAnnotationPresent)) {
+                fieldConfig.add(InjectLiteral.INSTANCE);
+            } else {
+                final Annotation jakartaEquiv = toJakartaParam(field);
+                if (jakartaEquiv != null) {
+                    fieldConfig.add(InjectLiteral.INSTANCE);
+                    fieldConfig.add(jakartaEquiv);
+                }
+            }
+        }
+
+        // Setter methods
+        for (AnnotatedMethodConfigurator<?> methodConfig : configurator.methods()) {
+            final AnnotatedMethod<?> method = methodConfig.getAnnotated();
+            if (method.isAnnotationPresent(Inject.class)) {
+                continue;
+            }
+            if (paramAnnotations.stream().anyMatch(method::isAnnotationPresent)) {
+                methodConfig.add(InjectLiteral.INSTANCE);
+            } else {
+                final Annotation jakartaEquiv = toJakartaParam(method);
+                if (jakartaEquiv != null) {
+                    methodConfig.add(InjectLiteral.INSTANCE);
+                    methodConfig.add(jakartaEquiv);
+                }
+            }
+        }
+
+        // Constructors
+        for (AnnotatedConstructorConfigurator<?> ctorConfig : configurator.constructors()) {
+            final AnnotatedConstructor<?> ctor = ctorConfig.getAnnotated();
+            if (ctor.isAnnotationPresent(Inject.class)) {
+                continue;
+            }
+            final boolean hasParamAnnotation = ctor.getParameters().stream()
+                    .anyMatch(p -> paramAnnotations.stream().anyMatch(p::isAnnotationPresent)
+                            || toJakartaParam(p) != null);
+            if (hasParamAnnotation) {
+                ctorConfig.add(InjectLiteral.INSTANCE);
+                for (AnnotatedParameterConfigurator<?> paramConfig : ctorConfig.params()) {
+                    final Annotation jakartaEquiv = toJakartaParam(paramConfig.getAnnotated());
+                    if (jakartaEquiv != null) {
+                        paramConfig.add(jakartaEquiv);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * If the annotated element has a RESTEasy-specific {@code @*Param} annotation, returns the corresponding
+     * Jakarta REST annotation literal with the same value. Returns {@code null} if no RESTEasy annotation is present.
+     */
+    private static Annotation toJakartaParam(final Annotated annotated) {
+        final var cookie = annotated.getAnnotation(org.jboss.resteasy.annotations.jaxrs.CookieParam.class);
+        if (cookie != null) {
+            return new CookieParamLiteral(cookie.value());
+        }
+        final var form = annotated.getAnnotation(org.jboss.resteasy.annotations.jaxrs.FormParam.class);
+        if (form != null) {
+            return new FormParamLiteral(form.value());
+        }
+        final var header = annotated.getAnnotation(org.jboss.resteasy.annotations.jaxrs.HeaderParam.class);
+        if (header != null) {
+            return new HeaderParamLiteral(header.value());
+        }
+        final var matrix = annotated.getAnnotation(org.jboss.resteasy.annotations.jaxrs.MatrixParam.class);
+        if (matrix != null) {
+            return new MatrixParamLiteral(matrix.value());
+        }
+        final var path = annotated.getAnnotation(org.jboss.resteasy.annotations.jaxrs.PathParam.class);
+        if (path != null) {
+            return new PathParamLiteral(path.value());
+        }
+        final var query = annotated.getAnnotation(org.jboss.resteasy.annotations.jaxrs.QueryParam.class);
+        if (query != null) {
+            return new QueryParamLiteral(query.value());
+        }
+        return null;
+    }
+
+    /**
+     * Registers the {@code @*Param} annotations as CDI qualifiers with producers.
+     *
+     * @param afd the after bean discovery event
+     */
+    public void registerParamQualifiers(@Observes final AfterBeanDiscovery afd) {
+        // Register synthetic beans for the @*Param annotated injection points
+        for (Type type : paramTypes) {
+            // Register the bean with the BeanParam qualifier
+            afd.addBean()
+                    .addType(type)
+                    .scope(Dependent.class)
+                    .addQualifier(BeanParamLiteral.DEFAULT)
+                    .produceWith(instance -> {
+                        final InjectionPoint ip = instance.select(InjectionPoint.class).get();
+                        final Type beanParamType = ip.getType();
+                        if (!(beanParamType instanceof Class<?>)) {
+                            return null;
+                        }
+                        final Class<?> beanParamClass = (Class<?>) beanParamType;
+                        // If the type is a CDI-managed bean, let CDI create and inject it
+                        try {
+                            return instance.select(beanParamClass).get();
+                        } catch (UnsatisfiedResolutionException e) {
+                            // Fall back to FormInjector for non-CDI-managed types
+                            final ResteasyProviderFactory rpf = ResteasyProviderFactory.getInstance();
+                            final HttpRequest request = rpf.getContextData(HttpRequest.class);
+                            if (request == null) {
+                                return null;
+                            }
+                            final FormInjector formInjector = formInjectorCache.computeIfAbsent(beanParamClass,
+                                    (ignored) -> new FormInjector(beanParamClass, rpf));
+                            return formInjector.inject(request, null, false);
+                        }
+                    });
+            // Register the bean with the CookieParam qualifier
+            afd.addBean()
+                    .addType(type)
+                    .scope(Dependent.class)
+                    .addQualifier(CookieParamLiteral.DEFAULT)
+                    .produceWith(instance -> {
+                        // Get the injection point on where to
+                        final InjectionPoint ip = instance.select(InjectionPoint.class).get();
+                        final CookieParam param = findAnnotation(ip, CookieParam.class);
+                        final String name = resolveName(ip.getAnnotated(), param.value(), CookieParam.class);
+                        return extractParam(ip, CookieParam.class, name);
+                    });
+            // Register the bean with the FormParam qualifier
+            afd.addBean()
+                    .addType(type)
+                    .scope(Dependent.class)
+                    .addQualifier(FormParamLiteral.DEFAULT)
+                    .produceWith(instance -> {
+                        // Get the injection point on where to
+                        final InjectionPoint ip = instance.select(InjectionPoint.class).get();
+                        final FormParam param = findAnnotation(ip, FormParam.class);
+                        final String name = resolveName(ip.getAnnotated(), param.value(), FormParam.class);
+                        return extractParam(ip, FormParam.class, name);
+                    });
+            // Register the bean with the HeaderParam qualifier
+            afd.addBean()
+                    .addType(type)
+                    .scope(Dependent.class)
+                    .addQualifier(HeaderParamLiteral.DEFAULT)
+                    .produceWith(instance -> {
+                        // Get the injection point on where to
+                        final InjectionPoint ip = instance.select(InjectionPoint.class).get();
+                        final HeaderParam param = findAnnotation(ip, HeaderParam.class);
+                        final String name = resolveName(ip.getAnnotated(), param.value(), HeaderParam.class);
+                        return extractParam(ip, HeaderParam.class, name);
+                    });
+            // Register the bean with the MatrixParam qualifier
+            afd.addBean()
+                    .addType(type)
+                    .scope(Dependent.class)
+                    .addQualifier(MatrixParamLiteral.DEFAULT)
+                    .produceWith(instance -> {
+                        // Get the injection point on where to
+                        final InjectionPoint ip = instance.select(InjectionPoint.class).get();
+                        final MatrixParam param = findAnnotation(ip, MatrixParam.class);
+                        final String name = resolveName(ip.getAnnotated(), param.value(), MatrixParam.class);
+                        return extractParam(ip, MatrixParam.class, name);
+                    });
+            // Register the bean with the PathParam qualifier
+            afd.addBean()
+                    .addType(type)
+                    .scope(Dependent.class)
+                    .addQualifier(PathParamLiteral.DEFAULT)
+                    .produceWith(instance -> {
+                        // Get the injection point on where to
+                        final InjectionPoint ip = instance.select(InjectionPoint.class).get();
+                        final PathParam param = findAnnotation(ip, PathParam.class);
+                        final String name = resolveName(ip.getAnnotated(), param.value(), PathParam.class);
+                        return extractParam(ip, PathParam.class, name);
+                    });
+            // Register the bean with the Query qualifier
+            afd.addBean()
+                    .addType(type)
+                    .scope(Dependent.class)
+                    .addQualifier(QueryParamLiteral.DEFAULT)
+                    .produceWith(instance -> {
+                        // Get the injection point on where to
+                        final InjectionPoint ip = instance.select(InjectionPoint.class).get();
+                        final QueryParam param = findAnnotation(ip, QueryParam.class);
+                        final String name = resolveName(ip.getAnnotated(), param.value(), QueryParam.class);
+                        return extractParam(ip, QueryParam.class, name);
+                    });
+        }
+        // We no longer need the paramTypes
+        paramTypes.clear();
+    }
+
+    /**
+     * Observes each injection point during bean discovery and records the types of any injection points annotated
+     * with a {@code @*Param} qualifier. These types are later used to register synthetic producer beans.
+     *
+     * @param pip the process injection point event
+     * @param <T> the bean class of the bean that declares the injection point
+     * @param <X> the declared type of the injection point
+     */
+    public <T, X> void processInjectionPoint(@Observes final ProcessInjectionPoint<T, X> pip) {
+        if (enhancedCdiSupportEnabled) {
+            final InjectionPoint ip = pip.getInjectionPoint();
+            final Annotated annotated = ip.getAnnotated();
+            for (Class<? extends Annotation> type : paramAnnotations) {
+                if (annotated.isAnnotationPresent(type)) {
+                    paramTypes.add(Types.boxPrimitives(ip.getType()));
+                    return;
+                }
+            }
+            // Check if this is a setter parameter whose method has the annotation
+            if (annotated instanceof AnnotatedParameter<?>) {
+                final AnnotatedParameter<?> param = (AnnotatedParameter<?>) annotated;
+                final Annotated method = param.getDeclaringCallable();
+                for (Class<? extends Annotation> type : paramAnnotations) {
+                    final Annotation ann = method.getAnnotation(type);
+                    if (ann != null) {
+                        pip.configureInjectionPoint().addQualifier(ann);
+                        paramTypes.add(Types.boxPrimitives(ip.getType()));
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Extracts a parameter value from the current HTTP request for the given injection point. The
+     * {@link RequestParameterExtractor} is resolved once and cached for subsequent requests.
+     *
+     * @param injectionPoint the CDI injection point requesting the value
+     * @param annotationType the parameter annotation type (e.g. {@code QueryParam.class})
+     * @param paramName      the resolved parameter name
+     *
+     * @return the extracted and converted parameter value, or {@code null} if the request or type is unavailable
+     */
+    private Object extractParam(final InjectionPoint injectionPoint, final Class<? extends Annotation> annotationType,
+            final String paramName) {
+        final Type genericType = injectionPoint.getType();
+        final ResteasyProviderFactory rpf = ResteasyProviderFactory.getInstance();
+        final HttpRequest request = rpf.getContextData(HttpRequest.class);
+        if (request == null) {
+            return null;
+        }
+        final Class<?> rawType = Types.getRawTypeNoException(genericType);
+        if (rawType == null) {
+            return null;
+        }
+        final Bean<?> bean = injectionPoint.getBean();
+        final boolean encode = injectionPoint.getAnnotated().isAnnotationPresent(Encoded.class) ||
+                (bean != null && bean.getBeanClass().isAnnotationPresent(Encoded.class));
+        final String defaultValue = findDefaultValue(injectionPoint.getAnnotated());
+        final Set<Annotation> annotations = injectionPoint.getQualifiers();
+        final CacheKey key = new CacheKey(annotationType, paramName, genericType, encode, defaultValue, annotations);
+        final RequestParameterExtractor extractor = extractorCache.computeIfAbsent(key,
+                (current) -> ParameterExtractors.of(rawType, genericType, annotations, encode,
+                        paramName, defaultValue, annotationType, rpf));
+        return extractor.extract(request);
+    }
+
+    private static String findDefaultValue(final Annotated annotated) {
+        if (annotated instanceof AnnotatedParameter<?>) {
+            final AnnotatedParameter<?> annotatedParameter = (AnnotatedParameter<?>) annotated;
+            final Parameter parameter = annotatedParameter.getJavaParameter();
+            DefaultValue defaultValue = parameter.getAnnotation(DefaultValue.class);
+            if (defaultValue != null) {
+                return defaultValue.value();
+            }
+            // Let's see if this parent member is a method, if so check for the annotation on there
+            if (annotatedParameter.getDeclaringCallable() instanceof AnnotatedMethod<?>) {
+                final AnnotatedMethod<?> annotatedMethod = (AnnotatedMethod<?>) annotatedParameter.getDeclaringCallable();
+                defaultValue = annotatedMethod.getAnnotation(DefaultValue.class);
+                if (defaultValue != null) {
+                    return defaultValue.value();
+                }
+            }
+        } else if (annotated instanceof AnnotatedField<?>) {
+            final AnnotatedField<?> annotatedField = (AnnotatedField<?>) annotated;
+            final DefaultValue defaultValue = annotatedField.getAnnotation(DefaultValue.class);
+            if (defaultValue != null) {
+                return defaultValue.value();
+            }
+        }
+        return null;
+    }
+
+    private static String resolveName(final Annotated annotated, final String definedName,
+            final Class<? extends Annotation> annotationType) {
+        // If the name is not defined on the annotation, attempt to resolve the name from the parameter or field
+        if (definedName.isBlank()) {
+            if (annotated instanceof AnnotatedParameter<?>) {
+                final AnnotatedParameter<?> annotatedParameter = (AnnotatedParameter<?>) annotated;
+                final Parameter parameter = annotatedParameter.getJavaParameter();
+                // Check if the annotation is on the parent
+                if (annotatedParameter.isAnnotationPresent(annotationType)) {
+                    if (parameter.isNamePresent()) {
+                        return parameter.getName();
+                    }
+                } else {
+                    // Let's see if this parent member is a method, if so check for the annotation on there
+                    if (annotatedParameter.getDeclaringCallable() instanceof AnnotatedMethod<?>) {
+                        final AnnotatedMethod<?> annotatedMethod = (AnnotatedMethod<?>) annotatedParameter
+                                .getDeclaringCallable();
+                        final String methodName = annotatedMethod.getJavaMember().getName();
+                        final int len = methodName.length();
+                        if (len > 3 && methodName.startsWith("set")) {
+                            if (len == 4) {
+                                return String.valueOf(Character.toLowerCase(methodName.charAt(3)));
+                            }
+                            final char first = methodName.charAt(3);
+                            if (Character.isUpperCase(first) && Character.isUpperCase(methodName.charAt(4))) {
+                                return methodName.substring(3);
+                            }
+                            return Character.toLowerCase(first) + methodName.substring(4);
+                        }
+                    }
+                }
+            } else if (annotated instanceof AnnotatedField<?>) {
+                final AnnotatedField<?> annotatedField = (AnnotatedField<?>) annotated;
+                return annotatedField.getJavaMember().getName();
+            }
+            throw Messages.MESSAGES.cannotResolveParamName(annotationType.getName(), definedName);
+        }
+        return definedName;
+    }
+
+    private static <T extends Annotation> T findAnnotation(final InjectionPoint ip, final Class<T> annotationType) {
+        for (Annotation annotation : ip.getQualifiers()) {
+            if (annotation.annotationType() == annotationType) {
+                return annotationType.cast(annotation);
+            }
+        }
+        throw Messages.MESSAGES.failedToFindAnnotation(annotationType.getName(), ip.getAnnotated().toString());
+    }
+
+    @SuppressWarnings("ClassExplicitlyAnnotation")
+    private static class BeanParamLiteral extends AnnotationLiteral<BeanParam> implements BeanParam {
+        static final BeanParam DEFAULT = new BeanParamLiteral();
+
+        private BeanParamLiteral() {
+        }
+    }
+
+    @SuppressWarnings("ClassExplicitlyAnnotation")
+    private static class CookieParamLiteral extends AnnotationLiteral<CookieParam> implements CookieParam {
+        static final CookieParam DEFAULT = new CookieParamLiteral("");
+        private final String value;
+
+        private CookieParamLiteral(final String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+    }
+
+    @SuppressWarnings("ClassExplicitlyAnnotation")
+    private static class FormParamLiteral extends AnnotationLiteral<FormParam> implements FormParam {
+        static final FormParam DEFAULT = new FormParamLiteral("");
+        private final String value;
+
+        private FormParamLiteral(final String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+    }
+
+    @SuppressWarnings("ClassExplicitlyAnnotation")
+    private static class HeaderParamLiteral extends AnnotationLiteral<HeaderParam> implements HeaderParam {
+        static final HeaderParam DEFAULT = new HeaderParamLiteral("");
+        private final String value;
+
+        private HeaderParamLiteral(final String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+    }
+
+    @SuppressWarnings("ClassExplicitlyAnnotation")
+    private static class MatrixParamLiteral extends AnnotationLiteral<MatrixParam> implements MatrixParam {
+        static final MatrixParam DEFAULT = new MatrixParamLiteral("");
+        private final String value;
+
+        private MatrixParamLiteral(final String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+    }
+
+    @SuppressWarnings("ClassExplicitlyAnnotation")
+    private static class PathParamLiteral extends AnnotationLiteral<PathParam> implements PathParam {
+        static final PathParam DEFAULT = new PathParamLiteral("");
+        private final String value;
+
+        private PathParamLiteral(final String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+    }
+
+    @SuppressWarnings("ClassExplicitlyAnnotation")
+    private static class QueryParamLiteral extends AnnotationLiteral<QueryParam> implements QueryParam {
+        static final QueryParam DEFAULT = new QueryParamLiteral("");
+        private final String value;
+
+        private QueryParamLiteral(final String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+    }
+
+    private static class CacheKey {
+        final Class<? extends Annotation> annotationType;
+        final String paramName;
+        final Type type;
+        final boolean encode;
+        final String defaultValue;
+        final Set<Annotation> annotations;
+
+        private CacheKey(final Class<? extends Annotation> annotationType, final String paramName, final Type type,
+                final boolean encode, final String defaultValue, final Set<Annotation> annotations) {
+            this.annotationType = annotationType;
+            this.paramName = paramName;
+            this.type = type;
+            this.encode = encode;
+            this.defaultValue = defaultValue;
+            this.annotations = annotations;
+        }
+
+        @Override
+        public final boolean equals(final Object o) {
+            if (o == this) {
+                return true;
+            }
+            if (!(o instanceof CacheKey)) {
+                return false;
+            }
+
+            final CacheKey other = (CacheKey) o;
+            return encode == other.encode && Objects.equals(annotationType, other.annotationType)
+                    && Objects.equals(paramName, other.paramName) && Objects.equals(type, other.type)
+                    && Objects.equals(defaultValue, other.defaultValue)
+                    && Objects.equals(annotations, other.annotations);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(annotationType, paramName, type, encode, defaultValue, annotations);
+        }
+
+        @Override
+        public String toString() {
+            return "CacheKey{" + "annotationType=" + annotationType +
+                    ", paramName='" + paramName + '\'' +
+                    ", type=" + type +
+                    ", encode=" + encode +
+                    ", defaultValue='" + defaultValue + '\'' +
+                    ", annotations='" + annotations + '\'' +
+                    '}';
+        }
+    }
+}

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/Utils.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/Utils.java
@@ -7,6 +7,7 @@ package org.jboss.resteasy.cdi;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.List;
 
 import jakarta.enterprise.inject.spi.AnnotatedType;
@@ -162,6 +163,44 @@ public class Utils {
             }
         }
         return false;
+    }
+
+    /**
+     * Check for select case of unproxyable bean type.
+     * (see CDI 2.0 spec, section 3.11)
+     *
+     * @param clazz the type to check
+     *
+     * @return {@code true} if this type cannot be a CDI proxy, otherwise {@code false}
+     */
+    static boolean isUnproxyableClass(final Class<?> clazz) {
+        // Unproxyable bean type: classes which are declared final,
+        // or expose final methods,
+        // or have no non-private no-args constructor
+        return Modifier.isFinal(clazz.getModifiers()) ||
+                hasNonPrivateNonStaticFinalMethod(clazz) ||
+                !hasValidConstructor(clazz);
+    }
+
+    // Adapted from weld-core-impl:3.0.5.Final's Reflections.getNonPrivateNonStaticFinalMethod()
+    private static boolean hasNonPrivateNonStaticFinalMethod(Class<?> type) {
+        for (Class<?> clazz = type; clazz != null && clazz != Object.class; clazz = clazz.getSuperclass()) {
+            for (Method method : clazz.getDeclaredMethods()) {
+                if (Modifier.isFinal(method.getModifiers()) && !Modifier.isPrivate(method.getModifiers())
+                        && !Modifier.isStatic(method.getModifiers())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasValidConstructor(final Class<?> clazz) {
+        try {
+            return !Modifier.isPrivate(clazz.getDeclaredConstructor().getModifiers());
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
     }
 
     /**

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/i18n/Messages.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/i18n/Messages.java
@@ -104,4 +104,10 @@ public interface Messages {
 
     @Message(id = 10635, value = "Unable to resolve CDI bean for resource class %s.")
     IllegalStateException unableToResolveBean(String classname);
+
+    @Message(id = 10640, value = "Cannot resolve parameter name from annotation @%s(\"%s\"). Ensure -parameters was passed when compiling.")
+    IllegalStateException cannotResolveParamName(String annotationName, String value);
+
+    @Message(id = 10645, value = "Cannot resolve annotation @%s on %s")
+    IllegalStateException failedToFindAnnotation(String annotationName, String typeDescription);
 }

--- a/resteasy-cdi/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/resteasy-cdi/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,1 +1,2 @@
 org.jboss.resteasy.cdi.ResteasyCdiExtension
+org.jboss.resteasy.cdi.ResteasyParamCdiExtension

--- a/resteasy-cdi/src/main/resources/META-INF/services/jakarta.ws.rs.core.Feature
+++ b/resteasy-cdi/src/main/resources/META-INF/services/jakarta.ws.rs.core.Feature
@@ -1,0 +1,6 @@
+#
+# Copyright The RESTEasy Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+
+org.jboss.resteasy.cdi.CdiFeature

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/resteasy_jaxrs/i18n/Messages.java
@@ -643,6 +643,9 @@ public interface Messages {
     @Message(id = 3875, value = "Unable to find a constructor that takes a String param or a valueOf() or fromString() method for {0} on {1} for basetype: {2}", format = Format.MESSAGE_FORMAT)
     String unableToFindConstructor(String paramSignature, AccessibleObject target, String className);
 
+    @Message(id = 3876, value = "Unable to find a constructor that takes a String param or a valueOf() or fromString() method for %s with a base type of %s")
+    RuntimeException unableToFindStringConstructor(String paramSignature, String className);
+
     @Message(id = 3880, value = "Unable to find contextual data of type: %s")
     String unableToFindContextualData(String className);
 
@@ -889,4 +892,7 @@ public interface Messages {
 
     @Message(id = 5097, value = "Deployment has either not been started or stopped. There are no executor services available.")
     IllegalStateException executorNotAvailable();
+
+    @Message(id = 5110, value = "The annotation @%s is not supported for parameter extraction.")
+    IllegalArgumentException unsupportedAnnotation(String annotationName);
 }

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/PriorityServiceLoader.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/PriorityServiceLoader.java
@@ -30,6 +30,7 @@ import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.NoSuchElementException;
@@ -83,7 +84,6 @@ public class PriorityServiceLoader<S> implements Iterable<S> {
 
     private static final String PREFIX = "META-INF/services/";
 
-    private final Object lock = new Object();
     private final Supplier<String> toString;
     // Guarded by lock
     private final Holder<S>[] holders;
@@ -186,9 +186,7 @@ public class PriorityServiceLoader<S> implements Iterable<S> {
      */
     public Optional<S> first() {
         if (size > 0) {
-            synchronized (lock) {
-                return Optional.of(holders[0].getInstance());
-            }
+            return Optional.of(holders[0].getInstance());
         }
         return Optional.empty();
     }
@@ -203,9 +201,7 @@ public class PriorityServiceLoader<S> implements Iterable<S> {
      */
     public Optional<S> last() {
         if (size > 0) {
-            synchronized (lock) {
-                return Optional.of(holders[size - 1].getInstance());
-            }
+            return Optional.of(holders[size - 1].getInstance());
         }
         return Optional.empty();
     }
@@ -219,12 +215,7 @@ public class PriorityServiceLoader<S> implements Iterable<S> {
      * @return the types found for this service
      */
     public Set<Class<S>> getTypes() {
-        final Holder<S>[] holders;
-        synchronized (lock) {
-            holders = this.holders.clone();
-        }
-        final int len = holders.length;
-        final Set<Class<S>> result = new LinkedHashSet<>(len);
+        final Set<Class<S>> result = new LinkedHashSet<>(size);
         for (Holder<S> holder : holders) {
             result.add(holder.type);
         }
@@ -239,10 +230,6 @@ public class PriorityServiceLoader<S> implements Iterable<S> {
      */
     @Override
     public Iterator<S> iterator() {
-        final Holder<S>[] holders;
-        synchronized (lock) {
-            holders = this.holders.clone();
-        }
         return new Iterator<>() {
             final AtomicInteger current = new AtomicInteger();
 
@@ -271,6 +258,8 @@ public class PriorityServiceLoader<S> implements Iterable<S> {
     @SuppressWarnings("unchecked")
     private static <S> Holder<S>[] findClasses(final Class<S> type, final ClassLoader cl,
             final Function<Class<? extends S>, S> constructor) throws IOException {
+        int sequence = 0;
+        final Set<Class<S>> seen = new HashSet<>();
         final Set<Holder<S>> holders = new TreeSet<>();
         final Enumeration<URL> resources = cl.getResources(PREFIX + type.getName());
         while (resources.hasMoreElements()) {
@@ -283,16 +272,19 @@ public class PriorityServiceLoader<S> implements Iterable<S> {
                         line = line.substring(0, commentIdx);
                     }
                     line = line.trim();
-                    if (line.equals(""))
+                    if (line.isEmpty())
                         continue;
                     try {
                         final Class<S> found = (Class<S>) cl.loadClass(line);
+                        if (!seen.add(found)) {
+                            continue;
+                        }
                         final Priority priority = found.getAnnotation(Priority.class);
                         int p = Integer.MAX_VALUE;
                         if (priority != null) {
                             p = priority.value();
                         }
-                        holders.add(new Holder<>(found, p, constructor));
+                        holders.add(new Holder<>(sequence++, found, p, constructor));
                     } catch (ClassNotFoundException e) {
                         LogMessages.LOGGER.failedToLoad(e, line);
                     }
@@ -316,13 +308,16 @@ public class PriorityServiceLoader<S> implements Iterable<S> {
     }
 
     private static class Holder<S> implements Comparable<Holder<S>> {
+        final int sequence;
         final Class<S> type;
         final int priority;
         final Function<Class<? extends S>, S> constructor;
         final AccessControlContext acc;
         volatile S instance;
 
-        private Holder(final Class<S> type, final int priority, final Function<Class<? extends S>, S> constructor) {
+        private Holder(final int sequence, final Class<S> type, final int priority,
+                final Function<Class<? extends S>, S> constructor) {
+            this.sequence = sequence;
             this.type = type;
             this.priority = priority;
             this.constructor = constructor;
@@ -347,27 +342,33 @@ public class PriorityServiceLoader<S> implements Iterable<S> {
         }
 
         @Override
-        public int compareTo(final Holder o) {
-            return Integer.compare(priority, o.priority);
+        public int compareTo(final Holder<S> o) {
+            int result = Integer.compare(priority, o.priority);
+            return result != 0 ? result : Integer.compare(sequence, o.sequence);
         }
 
         @Override
         public String toString() {
-            return "Holder[type=" + type + ", priority=" + priority + ", currentInstance=" + instance + "]";
+            return "Holder[sequence=" + sequence + ", type=" + type + ", priority=" + priority + ", currentInstance=" + instance
+                    + "]";
         }
 
         S getInstance() {
             if (instance == null) {
                 synchronized (this) {
-                    try {
-                        if (acc == null) {
-                            instance = createInstance();
-                        } else {
-                            instance = AccessController.doPrivileged((PrivilegedExceptionAction<S>) this::createInstance, acc);
+                    if (instance == null) {
+                        try {
+                            if (acc == null) {
+                                instance = createInstance();
+                            } else {
+                                instance = AccessController.doPrivileged((PrivilegedExceptionAction<S>) this::createInstance,
+                                        acc);
+                            }
+                        } catch (NoSuchMethodException | InvocationTargetException | InstantiationException
+                                | IllegalAccessException
+                                | PrivilegedActionException e) {
+                            throw Messages.MESSAGES.failedToConstructClass(e, type);
                         }
-                    } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException
-                            | PrivilegedActionException e) {
-                        throw Messages.MESSAGES.failedToConstructClass(e, type);
                     }
                 }
             }

--- a/resteasy-core-spi/src/test/java/org/jboss/resteasy/spi/PriorityServiceLoaderTestCase.java
+++ b/resteasy-core-spi/src/test/java/org/jboss/resteasy/spi/PriorityServiceLoaderTestCase.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.jboss.resteasy.spi.resources.AbstractResolver;
 import org.jboss.resteasy.spi.resources.NoEntriesInterface;
 import org.jboss.resteasy.spi.resources.TestImpl;
+import org.jboss.resteasy.spi.resources.TestImplDuplicateNoPriority;
 import org.jboss.resteasy.spi.resources.TestImplFirst;
 import org.jboss.resteasy.spi.resources.TestImplLast;
 import org.jboss.resteasy.spi.resources.TestImplNoPriority;
@@ -43,7 +44,7 @@ public class PriorityServiceLoaderTestCase {
     public void firstAndLast() {
         final PriorityServiceLoader<TestInterface> loader1 = PriorityServiceLoader.load(TestInterface.class);
         check(true, TestImplFirst.class, loader1);
-        check(false, TestImplNoPriority.class, loader1);
+        check(false, TestImplDuplicateNoPriority.class, loader1);
 
         final PriorityServiceLoader<TestInterface.InnerInterface> loader2 = PriorityServiceLoader
                 .load(TestInterface.InnerInterface.class);
@@ -58,11 +59,12 @@ public class PriorityServiceLoaderTestCase {
     @Test
     public void iteratorOrder() {
         final Iterator<TestInterface> iterator = PriorityServiceLoader.load(TestInterface.class).iterator();
-        // We should have 4 total
+        // We should have 5 total
         checkNext(TestImplFirst.class, 1, iterator);
         checkNext(TestImpl.class, 2, iterator);
         checkNext(TestImplLast.class, 3, iterator);
         checkNext(TestImplNoPriority.class, 4, iterator);
+        checkNext(TestImplDuplicateNoPriority.class, 5, iterator);
         checkNoMore(iterator);
     }
 
@@ -84,13 +86,14 @@ public class PriorityServiceLoaderTestCase {
         final PriorityServiceLoader<TestInterface> loader = PriorityServiceLoader.load(TestInterface.class);
         final Set<Class<TestInterface>> found = loader.getTypes();
         // Should have 4 implementations
-        Assertions.assertEquals(4, found.size(), () -> "Expected 4 implementations found " + found.size());
+        Assertions.assertEquals(5, found.size(), () -> "Expected 5 implementations found " + found.size());
         final Iterator<Class<TestInterface>> iterator = found.iterator();
         // These should be in a specific order
         Assertions.assertEquals(TestImplFirst.class, iterator.next());
         Assertions.assertEquals(TestImpl.class, iterator.next());
         Assertions.assertEquals(TestImplLast.class, iterator.next());
         Assertions.assertEquals(TestImplNoPriority.class, iterator.next());
+        Assertions.assertEquals(TestImplDuplicateNoPriority.class, iterator.next());
     }
 
     @Test

--- a/resteasy-core-spi/src/test/java/org/jboss/resteasy/spi/resources/TestImplDuplicateNoPriority.java
+++ b/resteasy-core-spi/src/test/java/org/jboss/resteasy/spi/resources/TestImplDuplicateNoPriority.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.spi.resources;
+
+/**
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+public class TestImplDuplicateNoPriority implements TestInterface {
+}

--- a/resteasy-core-spi/src/test/resources/META-INF/services/org.jboss.resteasy.spi.resources.TestInterface
+++ b/resteasy-core-spi/src/test/resources/META-INF/services/org.jboss.resteasy.spi.resources.TestInterface
@@ -20,4 +20,7 @@
 org.jboss.resteasy.spi.resources.TestImpl
 org.jboss.resteasy.spi.resources.TestImplLast
 org.jboss.resteasy.spi.resources.TestImplNoPriority
+org.jboss.resteasy.spi.resources.TestImplDuplicateNoPriority
+# Add the same implementation twice to ensure it gets ignored
+org.jboss.resteasy.spi.resources.TestImplDuplicateNoPriority
 org.jboss.resteasy.spi.resources.TestImplFirst

--- a/resteasy-core/src/main/java/module-info.java
+++ b/resteasy-core/src/main/java/module-info.java
@@ -51,6 +51,7 @@ module org.jboss.resteasy.core {
     exports org.jboss.resteasy.statistics;
     exports org.jboss.resteasy.tracing;
     exports org.jboss.resteasy.util;
+    exports org.jboss.resteasy.core.extractors;
 
     // Service consumers
     // Note: Registry and EntityPart.Builder use PriorityServiceLoader with custom constructors,

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/CookieParamInjector.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/CookieParamInjector.java
@@ -3,12 +3,12 @@ package org.jboss.resteasy.core;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Set;
 
-import jakarta.ws.rs.CookieParam;
 import jakarta.ws.rs.core.Cookie;
 
+import org.jboss.resteasy.core.extractors.ParameterExtractors;
+import org.jboss.resteasy.core.extractors.RequestParameterExtractor;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
@@ -19,32 +19,23 @@ import org.jboss.resteasy.spi.ValueInjector;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class CookieParamInjector extends StringParameterInjector implements ValueInjector {
+public class CookieParamInjector implements ValueInjector {
+    private final RequestParameterExtractor extractor;
 
     public CookieParamInjector(final Class type, final Type genericType, final AccessibleObject target, final String cookieName,
             final String defaultValue, final Annotation[] annotations, final ResteasyProviderFactory factory) {
         if (type.equals(Cookie.class)) {
-            this.type = type;
-            this.paramName = cookieName;
-            this.paramType = CookieParam.class;
-            this.defaultValue = defaultValue;
+            extractor = ParameterExtractors.forCookieParam(type, null, Set.of(), cookieName, defaultValue, factory);
 
         } else {
-            initialize(type, genericType, cookieName, CookieParam.class, defaultValue, target, annotations, factory);
+            extractor = ParameterExtractors.forCookieParam(type, genericType, Set.of(annotations), cookieName, defaultValue,
+                    factory);
         }
     }
 
     @Override
     public Object inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
-        Cookie cookie = request.getHttpHeaders().getCookies().get(paramName);
-        if (type.equals(Cookie.class))
-            return cookie;
-
-        if (cookie == null)
-            return extractValues(null);
-        List<String> values = new ArrayList<String>();
-        values.add(cookie.getValue());
-        return extractValues(values);
+        return extractor.extract(request);
     }
 
     @Override

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/FormParamInjector.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/FormParamInjector.java
@@ -1,74 +1,36 @@
 package org.jboss.resteasy.core;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.Set;
 
-import jakarta.ws.rs.FormParam;
-import jakarta.ws.rs.core.EntityPart;
-import jakarta.ws.rs.core.MediaType;
-
+import org.jboss.resteasy.core.extractors.ParameterExtractors;
+import org.jboss.resteasy.core.extractors.RequestParameterExtractor;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.spi.ValueInjector;
-import org.jboss.resteasy.spi.util.Types;
-import org.jboss.resteasy.util.Encode;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class FormParamInjector extends StringParameterInjector implements ValueInjector {
-    private boolean encode;
+public class FormParamInjector implements ValueInjector {
+    private final RequestParameterExtractor extractor;
 
     public FormParamInjector(final Class type, final Type genericType, final AccessibleObject target, final String header,
             final String defaultValue, final boolean encode, final Annotation[] annotations,
             final ResteasyProviderFactory factory) {
-        super(type, genericType, header, FormParam.class, defaultValue, target, annotations, factory,
-                Map.of(FormParam.class, List.of(InputStream.class, EntityPart.class)));
-        this.encode = encode;
+        this.extractor = ParameterExtractors.forFormParam(type, genericType, Set.of(annotations), encode, header,
+                defaultValue,
+                factory);
     }
 
     @Override
     public Object inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
-        // A @FormParam for multipart/form-data can be a String, InputStream or EntityPart. This type is handled specially.
-        if (EntityPart.class.isAssignableFrom(type)) {
-            return request.getFormEntityPart(paramName).orElse(null);
-        } else if (List.class.isAssignableFrom(type) && Types.isGenericTypeInstanceOf(EntityPart.class, baseGenericType)) {
-            return request.getFormEntityParts();
-        } else if (InputStream.class.isAssignableFrom(type)) {
-            final Optional<EntityPart> part = request.getFormEntityPart(paramName);
-            return part.map(EntityPart::getContent).orElse(null);
-        } else if (String.class.isAssignableFrom(type) &&
-        // request.getHttpHeaders().getMediaType() may return null, but the isCompatible handles this check
-                MediaType.MULTIPART_FORM_DATA_TYPE.isCompatible(request.getHttpHeaders().getMediaType())) {
-            final Optional<EntityPart> part = request.getFormEntityPart(paramName);
-            return part.map(p -> {
-                try {
-                    return p.getContent(String.class);
-                } catch (IOException e) {
-                    throw new UncheckedIOException(Messages.MESSAGES.unableToExtractParameter(paramName, null), e);
-                }
-            }).orElse(null);
-        }
-        List<String> list = request.getDecodedFormParameters().get(paramName);
-        if (list != null && encode) {
-            List<String> encodedList = new ArrayList<String>();
-            for (String s : list) {
-                encodedList.add(Encode.encodeString(s));
-            }
-            list = encodedList;
-        }
-        return extractValues(list);
+        return extractor.extract(request);
     }
 
     @Override

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/HeaderParamInjector.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/HeaderParamInjector.java
@@ -3,10 +3,10 @@ package org.jboss.resteasy.core;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
-import java.util.List;
+import java.util.Set;
 
-import jakarta.ws.rs.HeaderParam;
-
+import org.jboss.resteasy.core.extractors.ParameterExtractors;
+import org.jboss.resteasy.core.extractors.RequestParameterExtractor;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
@@ -17,17 +17,19 @@ import org.jboss.resteasy.spi.ValueInjector;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class HeaderParamInjector extends StringParameterInjector implements ValueInjector {
+public class HeaderParamInjector implements ValueInjector {
+    private final RequestParameterExtractor extractor;
 
     public HeaderParamInjector(final Class type, final Type genericType, final AccessibleObject target, final String header,
             final String defaultValue, final Annotation[] annotations, final ResteasyProviderFactory factory) {
-        super(type, genericType, header, HeaderParam.class, defaultValue, target, annotations, factory);
+        this.extractor = ParameterExtractors.forHeaderParam(type, genericType, Set.of(annotations), header,
+                defaultValue,
+                factory);
     }
 
     @Override
     public Object inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
-        List<String> list = request.getHttpHeaders().getRequestHeaders().get(paramName);
-        return extractValues(list);
+        return extractor.extract(request);
     }
 
     @Override

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/MatrixParamInjector.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/MatrixParamInjector.java
@@ -3,13 +3,10 @@ package org.jboss.resteasy.core;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Set;
 
-import jakarta.ws.rs.MatrixParam;
-import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.core.PathSegment;
-
+import org.jboss.resteasy.core.extractors.ParameterExtractors;
+import org.jboss.resteasy.core.extractors.RequestParameterExtractor;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
@@ -20,42 +17,20 @@ import org.jboss.resteasy.spi.ValueInjector;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class MatrixParamInjector extends StringParameterInjector implements ValueInjector {
-    private boolean encode;
+public class MatrixParamInjector implements ValueInjector {
+    private final RequestParameterExtractor extractor;
 
     public MatrixParamInjector(final Class type, final Type genericType, final AccessibleObject target, final String paramName,
             final String defaultValue, final boolean encode, final Annotation[] annotations,
             final ResteasyProviderFactory factory) {
-        super(type, genericType, paramName, MatrixParam.class, defaultValue, target, annotations, factory);
-        this.encode = encode;
+        this.extractor = ParameterExtractors.forMatrixParam(type, genericType, Set.of(annotations), encode, paramName,
+                defaultValue,
+                factory);
     }
 
     @Override
     public Object inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
-        ArrayList<String> values = new ArrayList<String>();
-        if (encode) {
-            for (PathSegment segment : request.getUri().getPathSegments(false)) {
-                List<String> list = segment.getMatrixParameters().get(paramName);
-                if (list != null)
-                    values.addAll(list);
-            }
-        } else {
-            for (PathSegment segment : request.getUri().getPathSegments()) {
-                List<String> list = segment.getMatrixParameters().get(paramName);
-                if (list != null)
-                    values.addAll(list);
-            }
-        }
-        if (values.size() == 0)
-            return extractValues(null);
-        else
-            return extractValues(values);
-    }
-
-    @Override
-    protected void throwProcessingException(String message, Throwable cause) {
-        throw new NotFoundException(message, cause);
-
+        return extractor.extract(request);
     }
 
     @Override

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/PathParamInjector.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/PathParamInjector.java
@@ -3,21 +3,15 @@ package org.jboss.resteasy.core;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Set;
 
-import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.core.PathSegment;
-
+import org.jboss.resteasy.core.extractors.ParameterExtractors;
+import org.jboss.resteasy.core.extractors.RequestParameterExtractor;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
-import org.jboss.resteasy.specimpl.ResteasyUriInfo;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
-import org.jboss.resteasy.spi.InternalServerErrorException;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.spi.ValueInjector;
-import org.jboss.resteasy.spi.util.Types;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -25,98 +19,23 @@ import org.jboss.resteasy.spi.util.Types;
  */
 @SuppressWarnings("rawtypes")
 public class PathParamInjector implements ValueInjector {
-    private StringParameterInjector extractor;
-    private String paramName;
-    private boolean encode;
-    //   private boolean pathSegment = false;
-    private boolean pathSegmentArray = false;
-    private boolean pathSegmentList = false;
+    private final RequestParameterExtractor extractor;
 
     public PathParamInjector(final Class type, final Type genericType, final AccessibleObject target, final String paramName,
             final String defaultValue, final boolean encode, final Annotation[] annotations,
             final ResteasyProviderFactory factory) {
-        if (isPathSegmentArray(type)) {
-            pathSegmentArray = true;
-        } else if (isPathSegmentList(type, genericType)) {
-            pathSegmentList = true;
-        } else if (type.equals(PathSegment.class)) {
-            //         pathSegment = true;
-        } else {
-            extractor = new StringParameterInjector(type, genericType, paramName, PathParam.class, defaultValue, target,
-                    annotations, factory) {
-                @Override
-                protected void throwProcessingException(String message, Throwable cause) {
-                    throw new NotFoundException(message, cause);
-                }
-            };
-        }
-        this.paramName = paramName;
-        this.encode = encode;
-    }
-
-    private boolean isPathSegmentArray(Class type) {
-        return type.isArray() && type.getComponentType().equals(PathSegment.class);
-    }
-
-    private boolean isPathSegmentList(Class type, Type genericType) {
-        Class collectionBaseType = Types.getCollectionBaseType(type, genericType);
-        return (List.class.equals(type) || ArrayList.class.equals(type)) && collectionBaseType != null
-                && collectionBaseType.equals(PathSegment.class);
+        this.extractor = ParameterExtractors.forPathParam(type, genericType, Set.of(annotations), encode, paramName,
+                defaultValue,
+                factory);
     }
 
     @Override
     public Object inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
-        if (extractor == null) // we are a PathSegment
-        {
-            ResteasyUriInfo uriInfo = (ResteasyUriInfo) request.getUri();
-            List<PathSegment[]> list = null;
-            if (encode) {
-                list = uriInfo.getEncodedPathParameterPathSegments().get(paramName);
-            } else {
-                list = uriInfo.getPathParameterPathSegments().get(paramName);
-            }
-            if (list == null) {
-                throw new InternalServerErrorException(Messages.MESSAGES.unknownPathParam(paramName, uriInfo.getPath()));
-            }
-            List<PathSegment> segmentList = flattenToList(list);
-            if (pathSegmentArray) {
-                PathSegment[] segments = new PathSegment[segmentList.size()];
-                segments = segmentList.toArray(segments);
-                return segments;
-            } else if (pathSegmentList) {
-                return segmentList;
-            } else {
-                return segmentList.get(segmentList.size() - 1);
-            }
-        } else {
-            List<String> list = request.getUri().getPathParameters(!encode).get(paramName);
-            if (list == null) {
-                if (extractor.isCollectionOrArray()) {
-                    return extractor.extractValues(null);
-                } else {
-                    return extractor.extractValue(null);
-                }
-            }
-            if (extractor.isCollectionOrArray()) {
-                return extractor.extractValues(list);
-            } else {
-                return extractor.extractValue(list.get(list.size() - 1));
-            }
-        }
+        return extractor.extract(request);
     }
 
     @Override
     public Object inject(boolean unwrapAsync) {
         throw new RuntimeException(Messages.MESSAGES.illegalToInjectPathParam());
-    }
-
-    private List<PathSegment> flattenToList(List<PathSegment[]> list) {
-        ArrayList<PathSegment> psl = new ArrayList<PathSegment>();
-        for (PathSegment[] psa : list) {
-            for (PathSegment ps : psa) {
-                psl.add(ps);
-            }
-        }
-        return psl;
     }
 }

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/PropertyInjectorImpl.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/PropertyInjectorImpl.java
@@ -18,6 +18,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.jboss.resteasy.annotations.Body;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.spi.ApplicationException;
 import org.jboss.resteasy.spi.Failure;
 import org.jboss.resteasy.spi.HttpRequest;
@@ -61,6 +62,15 @@ public class PropertyInjectorImpl implements PropertyInjector {
             Annotation[] annotations = field.getAnnotations();
             if (annotations == null || annotations.length == 0)
                 continue;
+            // Skip any setters with @Inject as those will be handled by CDI
+            // For now, check the string. However, we could just add a dependency to Jakarta Inject
+            if (FindAnnotation.findAnnotation(annotations, "jakarta.inject.Inject") != null) {
+                if (LogMessages.LOGGER.isDebugEnabled()) {
+                    LogMessages.LOGGER.debugf("Ignoring field %s for RESTEasy property injection in favor of CDI injection.",
+                            field);
+                }
+                continue;
+            }
             Class<?> type = field.getType();
             Type genericType = field.getGenericType();
 
@@ -78,6 +88,15 @@ public class PropertyInjectorImpl implements PropertyInjector {
                 continue;
             if (method.getParameterCount() != 1)
                 continue;
+            // Skip any setters with @Inject as those will be handled by CDI
+            // For now, check the string. However, we could just add a dependency to Jakarta Inject
+            if (FindAnnotation.findAnnotation(method.getAnnotations(), "jakarta.inject.Inject") != null) {
+                if (LogMessages.LOGGER.isDebugEnabled()) {
+                    LogMessages.LOGGER.debugf("Ignoring method %s for RESTEasy property injection in favor of CDI injection.",
+                            method);
+                }
+                continue;
+            }
 
             Annotation[] annotations = method.getAnnotations();
             if (annotations == null || annotations.length == 0)

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/QueryParamInjector.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/QueryParamInjector.java
@@ -1,17 +1,12 @@
 package org.jboss.resteasy.core;
 
-import java.io.UnsupportedEncodingException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Type;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
+import java.util.Set;
 
-import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.QueryParam;
-
+import org.jboss.resteasy.core.extractors.ParameterExtractors;
+import org.jboss.resteasy.core.extractors.RequestParameterExtractor;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
@@ -22,37 +17,20 @@ import org.jboss.resteasy.spi.ValueInjector;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class QueryParamInjector extends StringParameterInjector implements ValueInjector {
-    private boolean encode;
-    private String encodedName;
+public class QueryParamInjector implements ValueInjector {
+    private final RequestParameterExtractor extractor;
 
     public QueryParamInjector(final Class<?> type, final Type genericType, final AccessibleObject target,
             final String paramName, final String defaultValue, final boolean encode, final Annotation[] annotations,
             final ResteasyProviderFactory factory) {
-        super(type, genericType, paramName, QueryParam.class, defaultValue, target, annotations, factory);
-        this.encode = encode;
-        try {
-            this.encodedName = URLDecoder.decode(paramName, StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            throw new BadRequestException(Messages.MESSAGES.unableToDecodeQueryString());
-        }
-    }
-
-    @Override
-    protected void throwProcessingException(String message, Throwable cause) {
-        throw new NotFoundException(message, cause);
+        this.extractor = ParameterExtractors.forQueryParam(type, genericType, Set.of(annotations), encode, paramName,
+                defaultValue,
+                factory);
     }
 
     @Override
     public Object inject(HttpRequest request, HttpResponse response, boolean unwrapAsync) {
-        if (encode) {
-            List<String> list = request.getUri().getQueryParameters(false).get(encodedName);
-            return extractValues(list);
-        } else {
-            List<String> list = request.getUri().getQueryParameters().get(paramName);
-            return extractValues(list);
-
-        }
+        return extractor.extract(request);
     }
 
     @Override

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/extractors/ParameterExtractors.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/extractors/ParameterExtractors.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.core.extractors;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.EntityPart;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.PathSegment;
+
+import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
+import org.jboss.resteasy.specimpl.ResteasyUriInfo;
+import org.jboss.resteasy.spi.InternalServerErrorException;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.util.Types;
+import org.jboss.resteasy.util.Encode;
+
+/**
+ * Factory for {@link RequestParameterExtractor} instances. Provides a unified {@linkplain #of entry point} that dispatches
+ * by annotation type, as well as individual factory methods for each Jakarta REST parameter annotation
+ * ({@code @CookieParam}, {@code @FormParam}, {@code @HeaderParam}, {@code @MatrixParam}, {@code @PathParam},
+ * {@code @QueryParam}).
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+public class ParameterExtractors {
+
+    /**
+     * Creates a {@link RequestParameterExtractor} for the given annotation type by dispatching to the appropriate
+     * {@code forXxxParam} method.
+     *
+     * @param injectionType  the target type to convert to
+     * @param genericType    the generic type of the injection point
+     * @param annotations    all annotations on the injection point
+     * @param encode         {@code true} if the parameter value should be URL-encoded
+     * @param paramName      the parameter name as declared in the annotation, or derived from the injection point
+     * @param defaultValue   the default value when the parameter is absent, or {@code null}
+     * @param annotationType the parameter annotation type (e.g. {@code PathParam.class})
+     * @param factory        the provider factory for converter lookups
+     *
+     * @return the extractor for the given parameter
+     *
+     * @throws IllegalArgumentException if the annotation type is not supported
+     */
+    public static RequestParameterExtractor of(final Class<?> injectionType, final Type genericType,
+            final Set<Annotation> annotations, final boolean encode, final String paramName, final String defaultValue,
+            final Class<? extends Annotation> annotationType,
+            final ResteasyProviderFactory factory) {
+        if (CookieParam.class.equals(annotationType)) {
+            return forCookieParam(injectionType, genericType, annotations, paramName, defaultValue, factory);
+        }
+        if (FormParam.class.equals(annotationType)) {
+            return forFormParam(injectionType, genericType, annotations, encode, paramName, defaultValue, factory);
+        }
+        if (HeaderParam.class.equals(annotationType)) {
+            return forHeaderParam(injectionType, genericType, annotations, paramName, defaultValue, factory);
+        }
+        if (MatrixParam.class.equals(annotationType)) {
+            return forMatrixParam(injectionType, genericType, annotations, encode, paramName, defaultValue, factory);
+        }
+        if (PathParam.class.equals(annotationType)) {
+            return forPathParam(injectionType, genericType, annotations, encode, paramName, defaultValue, factory);
+        }
+        if (QueryParam.class.equals(annotationType)) {
+            return forQueryParam(injectionType, genericType, annotations, encode, paramName, defaultValue, factory);
+        }
+
+        throw Messages.MESSAGES.unsupportedAnnotation(annotationType.getName());
+    }
+
+    /**
+     * Creates an extractor for {@code @CookieParam}.
+     *
+     * @param injectionType the target type to convert to
+     * @param genericType   the generic type of the injection point
+     * @param annotations   all annotations on the injection point
+     * @param paramName     the cookie name
+     * @param defaultValue  the default value when the cookie is absent, or {@code null}
+     * @param factory       the provider factory for converter lookups
+     *
+     * @return the cookie parameter extractor
+     */
+    public static RequestParameterExtractor forCookieParam(final Class<?> injectionType, final Type genericType,
+            final Set<Annotation> annotations, final String paramName, final String defaultValue,
+            final ResteasyProviderFactory factory) {
+        if (injectionType.equals(Cookie.class)) {
+            return request -> request.getHttpHeaders().getCookies().get(paramName);
+        }
+        final StringParameterConverter extractor = StringParameterConverter.of(injectionType, genericType,
+                findCookieParam(annotations), paramName, defaultValue, annotations, factory);
+        return request -> {
+            final Cookie cookie = request.getHttpHeaders().getCookies().get(paramName);
+            if (cookie == null)
+                return extractor.extractValues(null);
+            final List<String> values = new ArrayList<>();
+            values.add(cookie.getValue());
+            return extractor.extractValues(values);
+        };
+    }
+
+    /**
+     * Creates an extractor for {@code @FormParam}.
+     *
+     * @param injectionType the target type to convert to
+     * @param genericType   the generic type of the injection point
+     * @param annotations   all annotations on the injection point
+     * @param encode        {@code true} if the parameter value should be URL-encoded
+     * @param paramName     the form parameter name
+     * @param defaultValue  the default value when the parameter is absent, or {@code null}
+     * @param factory       the provider factory for converter lookups
+     *
+     * @return the form parameter extractor
+     */
+    public static RequestParameterExtractor forFormParam(final Class<?> injectionType, final Type genericType,
+            final Set<Annotation> annotations, final boolean encode, final String paramName, final String defaultValue,
+            final ResteasyProviderFactory factory) {
+        final Class<? extends Annotation> annotationType = findFormParam(annotations);
+
+        final StringParameterConverter extractor;
+        if (EntityPart.class.isAssignableFrom(injectionType) ||
+                (List.class.isAssignableFrom(injectionType)
+                        && Types.isGenericTypeInstanceOf(EntityPart.class, genericType))
+                ||
+                InputStream.class.isAssignableFrom(injectionType)) {
+            extractor = null;
+        } else {
+            extractor = StringParameterConverter.of(injectionType, genericType,
+                    annotationType,
+                    paramName, defaultValue, annotations,
+                    factory);
+        }
+        return request -> {
+            // A @FormParam for multipart/form-data can be a String, InputStream or EntityPart. This type is handled specially.
+            if (EntityPart.class.isAssignableFrom(injectionType)) {
+                return request.getFormEntityPart(paramName).orElse(null);
+            } else if (List.class.isAssignableFrom(injectionType)
+                    && Types.isGenericTypeInstanceOf(EntityPart.class, genericType)) {
+                return request.getFormEntityParts();
+            } else if (InputStream.class.isAssignableFrom(injectionType)) {
+                final Optional<EntityPart> part = request.getFormEntityPart(paramName);
+                return part.map(EntityPart::getContent).orElse(null);
+            } else if (String.class.isAssignableFrom(injectionType) &&
+            // request.getHttpHeaders().getMediaType() may return null, but the isCompatible handles this check
+                    MediaType.MULTIPART_FORM_DATA_TYPE.isCompatible(request.getHttpHeaders().getMediaType())) {
+                final Optional<EntityPart> part = request.getFormEntityPart(paramName);
+                return part.map(p -> {
+                    try {
+                        return p.getContent(String.class);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(Messages.MESSAGES.unableToExtractParameter(paramName, null), e);
+                    }
+                }).orElse(null);
+            }
+            List<String> list = request.getDecodedFormParameters().get(paramName);
+            if (list != null && encode) {
+                final List<String> encodedList = new ArrayList<>();
+                for (String s : list) {
+                    encodedList.add(Encode.encodeString(s));
+                }
+                list = encodedList;
+            }
+            // This will not be null at this stage. The checks above are used to ensure the extractor is only used
+            // if it was previously initialized to a non-null value. We use the assertion to make IDE's happy
+            assert extractor != null;
+            return extractor.extractValues(list);
+        };
+    }
+
+    /**
+     * Creates an extractor for {@code @HeaderParam}. Extracts the named header values from the request and converts
+     * them to the target type.
+     *
+     * @param injectionType the target type to convert to
+     * @param genericType   the generic type of the injection point
+     * @param annotations   all annotations on the injection point
+     * @param paramName     the header name
+     * @param defaultValue  the default value when the header is absent, or {@code null}
+     * @param factory       the provider factory for converter lookups
+     *
+     * @return the header parameter extractor
+     */
+    public static RequestParameterExtractor forHeaderParam(final Class<?> injectionType, final Type genericType,
+            final Set<Annotation> annotations, final String paramName, final String defaultValue,
+            final ResteasyProviderFactory factory) {
+        final Class<? extends Annotation> annotationType = findHeaderParam(annotations);
+
+        final StringParameterConverter extractor = StringParameterConverter.of(injectionType, genericType,
+                annotationType,
+                paramName,
+                defaultValue, annotations,
+                factory);
+        return request -> {
+            final List<String> list = request.getHttpHeaders().getRequestHeaders().get(paramName);
+            return extractor.extractValues(list);
+        };
+    }
+
+    /**
+     * Creates an extractor for {@code @MatrixParam}. Collects the named matrix parameter values from all path
+     * segments and converts them to the target type.
+     *
+     * @param injectionType the target type to convert to
+     * @param genericType   the generic type of the injection point
+     * @param annotations   all annotations on the injection point
+     * @param encode        {@code true} if the parameter value should be URL-encoded
+     * @param paramName     the matrix parameter name
+     * @param defaultValue  the default value when the parameter is absent, or {@code null}
+     * @param factory       the provider factory for converter lookups
+     *
+     * @return the matrix parameter extractor
+     */
+    public static RequestParameterExtractor forMatrixParam(final Class<?> injectionType, final Type genericType,
+            final Set<Annotation> annotations, final boolean encode, final String paramName, final String defaultValue,
+            final ResteasyProviderFactory factory) {
+        final Class<? extends Annotation> annotationType = findMatrixParam(annotations);
+
+        final StringParameterConverter extractor = StringParameterConverter.of(injectionType, genericType,
+                annotationType,
+                paramName, defaultValue, annotations,
+                factory, NotFoundException::new);
+        return request -> {
+            final ArrayList<String> values = new ArrayList<>();
+            for (PathSegment segment : request.getUri().getPathSegments(!encode)) {
+                final List<String> matrixParams = segment.getMatrixParameters().get(paramName);
+                if (matrixParams != null)
+                    values.addAll(matrixParams);
+            }
+            if (values.isEmpty())
+                return extractor.extractValues(null);
+            else
+                return extractor.extractValues(values);
+        };
+    }
+
+    /**
+     * Creates an extractor for {@code @PathParam}.
+     *
+     * @param injectionType the target type to convert to
+     * @param genericType   the generic type of the injection point
+     * @param annotations   all annotations on the injection point
+     * @param encode        {@code true} if the parameter value should be URL-encoded
+     * @param paramName     the path parameter name as declared in the {@code @Path} template
+     * @param defaultValue  the default value when the parameter is absent, or {@code null}
+     * @param factory       the provider factory for converter lookups
+     *
+     * @return the path parameter extractor
+     */
+    public static RequestParameterExtractor forPathParam(final Class<?> injectionType, final Type genericType,
+            final Set<Annotation> annotations, final boolean encode, final String paramName, final String defaultValue,
+            final ResteasyProviderFactory factory) {
+        final Class<? extends Annotation> annotationType = findPathParam(annotations);
+        final boolean pathSegmentArray = injectionType.isArray() && injectionType.getComponentType()
+                .equals(PathSegment.class);
+        final boolean pathSegmentList = isPathSegmentList(injectionType, genericType);
+
+        final StringParameterConverter extractor;
+        if (pathSegmentArray || pathSegmentList || injectionType.equals(PathSegment.class)) {
+            extractor = null;
+        } else {
+            extractor = StringParameterConverter.of(injectionType, genericType, annotationType,
+                    paramName, defaultValue, annotations,
+                    factory, NotFoundException::new);
+        }
+
+        return request -> {
+            final ResteasyUriInfo uriInfo = (ResteasyUriInfo) request.getUri();
+
+            if (extractor == null) {
+                List<PathSegment[]> pathSegments;
+                if (encode) {
+                    pathSegments = uriInfo.getEncodedPathParameterPathSegments().get(paramName);
+                } else {
+                    pathSegments = uriInfo.getPathParameterPathSegments().get(paramName);
+                }
+                if (pathSegments == null) {
+                    throw new InternalServerErrorException(Messages.MESSAGES.unknownPathParam(paramName, uriInfo.getPath()));
+                }
+                final Deque<PathSegment> segmentList = new ArrayDeque<>();
+                for (PathSegment[] array : pathSegments) {
+                    segmentList.addAll(List.of(array));
+                }
+                if (pathSegmentArray) {
+                    return segmentList.toArray(new PathSegment[0]);
+                } else if (pathSegmentList) {
+                    return new ArrayList<>(segmentList);
+                } else {
+                    return segmentList.getLast();
+                }
+            }
+            final List<String> pathParameters = request.getUri().getPathParameters(!encode).get(paramName);
+            if (pathParameters == null) {
+                if (extractor.isCollectionOrArray()) {
+                    return extractor.extractValues(null);
+                } else {
+                    return extractor.extractValue(null);
+                }
+            }
+            if (extractor.isCollectionOrArray()) {
+                return extractor.extractValues(pathParameters);
+            }
+            return extractor.extractValue(pathParameters.get(pathParameters.size() - 1));
+        };
+    }
+
+    /**
+     * Creates an extractor for {@code @QueryParam}. Extracts the named query parameter values from the request URI
+     * and converts them to the target type.
+     *
+     * @param injectionType the target type to convert to
+     * @param genericType   the generic type of the injection point
+     * @param annotations   all annotations on the injection point
+     * @param encode        {@code true} if the parameter value should be URL-encoded
+     * @param paramName     the query parameter name
+     * @param defaultValue  the default value when the parameter is absent, or {@code null}
+     * @param factory       the provider factory for converter lookups
+     *
+     * @return the query parameter extractor
+     */
+    public static RequestParameterExtractor forQueryParam(final Class<?> injectionType, final Type genericType,
+            final Set<Annotation> annotations, final boolean encode, final String paramName, final String defaultValue,
+            final ResteasyProviderFactory factory) {
+        final Class<? extends Annotation> annotationType = findQueryParam(annotations);
+        final String encodedName = URLDecoder.decode(paramName, StandardCharsets.UTF_8);
+
+        final StringParameterConverter extractor = StringParameterConverter.of(injectionType, genericType,
+                annotationType,
+                paramName, defaultValue, annotations,
+                factory, NotFoundException::new);
+        return request -> {
+            final List<String> queryParameters;
+            if (encode) {
+                queryParameters = request.getUri().getQueryParameters(false).get(encodedName);
+            } else {
+                queryParameters = request.getUri().getQueryParameters().get(paramName);
+
+            }
+            return extractor.extractValues(queryParameters);
+        };
+    }
+
+    private static boolean isPathSegmentList(final Class<?> type, final Type genericType) {
+        Class<?> collectionBaseType = Types.getCollectionBaseType(type, genericType);
+        return (List.class.equals(type) || ArrayList.class.equals(type)) && collectionBaseType != null
+                && collectionBaseType.equals(PathSegment.class);
+    }
+
+    private static Class<? extends Annotation> findCookieParam(final Set<Annotation> annotations) {
+        return findParamAnnotationType(annotations, CookieParam.class, org.jboss.resteasy.annotations.jaxrs.CookieParam.class);
+    }
+
+    private static Class<? extends Annotation> findHeaderParam(final Set<Annotation> annotations) {
+        return findParamAnnotationType(annotations, HeaderParam.class, org.jboss.resteasy.annotations.jaxrs.HeaderParam.class);
+    }
+
+    private static Class<? extends Annotation> findFormParam(final Set<Annotation> annotations) {
+        return findParamAnnotationType(annotations, FormParam.class, org.jboss.resteasy.annotations.jaxrs.FormParam.class);
+    }
+
+    private static Class<? extends Annotation> findMatrixParam(final Set<Annotation> annotations) {
+        return findParamAnnotationType(annotations, MatrixParam.class, org.jboss.resteasy.annotations.jaxrs.MatrixParam.class);
+    }
+
+    private static Class<? extends Annotation> findPathParam(final Set<Annotation> annotations) {
+        return findParamAnnotationType(annotations, PathParam.class, org.jboss.resteasy.annotations.jaxrs.PathParam.class);
+    }
+
+    private static Class<? extends Annotation> findQueryParam(final Set<Annotation> annotations) {
+        return findParamAnnotationType(annotations, QueryParam.class, org.jboss.resteasy.annotations.jaxrs.QueryParam.class);
+    }
+
+    private static Class<? extends Annotation> findParamAnnotationType(final Set<Annotation> annotations,
+            final Class<? extends Annotation> specAnnotation,
+            final Class<? extends Annotation> resteasyAnnotation) {
+        for (Annotation annotation : annotations) {
+            if (annotation.annotationType() == specAnnotation
+                    || annotation.annotationType() == resteasyAnnotation) {
+                return annotation.annotationType();
+            }
+        }
+        return null;
+    }
+}

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/extractors/RequestParameterExtractor.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/extractors/RequestParameterExtractor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.core.extractors;
+
+import org.jboss.resteasy.spi.HttpRequest;
+
+/**
+ * Extracts a parameter value from an {@link HttpRequest}. Each implementation is bound to a specific parameter
+ * annotation (e.g. {@code @PathParam}, {@code @QueryParam}) and knows how to locate and convert the raw request
+ * value into the target Java type.
+ * <p>
+ * Instances are typically created by {@link ParameterExtractors} and invoked once per request.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@FunctionalInterface
+public interface RequestParameterExtractor {
+
+    /**
+     * Extracts and converts a parameter value from the given request.
+     *
+     * @param request the current HTTP request
+     *
+     * @return the extracted value, or {@code null} if the parameter is absent and no default is configured
+     */
+    Object extract(HttpRequest request);
+}

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/extractors/StringParameterConverter.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/extractors/StringParameterConverter.java
@@ -1,0 +1,513 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.core.extractors;
+
+import java.lang.annotation.Annotation;
+import java.lang.invoke.CallSite;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+
+import org.jboss.resteasy.annotations.StringParameterUnmarshallerBinder;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.StringParameterUnmarshaller;
+import org.jboss.resteasy.spi.util.Types;
+import org.jboss.resteasy.util.StringToPrimitive;
+
+/**
+ * Converts string parameter values from an HTTP request into their target Java types.
+ * <p>
+ * Handles single values, arrays, and collections ({@link List}, {@link Set}, {@link SortedSet} and their common
+ * concrete subtypes). Conversion is resolved once at construction time via a priority chain:
+ * </p>
+ * <ol>
+ * <li>{@link ParamConverter} registered with the {@link ResteasyProviderFactory}</li>
+ * <li>{@link org.jboss.resteasy.spi.StringParameterUnmarshaller StringParameterUnmarshaller}</li>
+ * <li>{@link StringParameterUnmarshallerBinder} meta-annotation</li>
+ * <li>{@link RuntimeDelegate.HeaderDelegate} (for {@code @HeaderParam} only)</li>
+ * <li>Public single-{@code String} constructor</li>
+ * <li>Static {@code fromString} / {@code valueOf} method</li>
+ * <li>Primitive type conversion</li>
+ * </ol>
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+class StringParameterConverter {
+
+    private static final ParamConverter<Character> CHARACTER_PARAM_CONVERTER = new ParamConverter<>() {
+        @Override
+        public Character fromString(final String value) {
+            return (value != null && value.length() == 1) ? value.charAt(0) : null;
+        }
+
+        @Override
+        public String toString(final Character value) {
+            return null;
+        }
+    };
+
+    private final Class<?> baseType;
+    private final String signature;
+    private final String defaultValue;
+    private final boolean isArray;
+    private final CollectionHandler collectionHandler;
+    private final StringConverter converter;
+    private final BiFunction<String, Throwable, WebApplicationException> exceptionMapper;
+
+    private StringParameterConverter(final Class<?> baseType, final String paramName, final Class<?> paramAnnotation,
+            final String defaultValue, final boolean isArray, final CollectionHandler collectionHandler,
+            final StringConverter converter,
+            final BiFunction<String, Throwable, WebApplicationException> exceptionMapper) {
+        this.baseType = baseType;
+        this.signature = (paramAnnotation != null ? paramAnnotation.getName() : "") + "(\"" + paramName + "\")";
+        this.defaultValue = defaultValue;
+        this.isArray = isArray;
+        this.collectionHandler = collectionHandler;
+        this.converter = converter;
+        this.exceptionMapper = exceptionMapper != null ? exceptionMapper : BadRequestException::new;
+    }
+
+    /**
+     * Creates a converter for the given injection type and annotations.
+     *
+     * @param injectionType   the target type to convert to (may be a collection, array, or scalar)
+     * @param genericType     the generic type of the injection point, used to resolve collection element types
+     * @param paramAnnotation the parameter annotation type (e.g. {@code @PathParam}, {@code @QueryParam}), or {@code null}
+     * @param paramName       the parameter name, used in error messages
+     * @param defaultValue    the default value to use when no request value is present, or {@code null}
+     * @param annotations     all annotations on the injection point
+     * @param factory         the provider factory used to look up {@link ParamConverter ParamConverters} and other
+     *                        conversion mechanisms
+     *
+     * @return a converter for extracting and converting string parameter values
+     *
+     * @throws RuntimeException if no suitable conversion mechanism can be found for the target type
+     */
+    static StringParameterConverter of(final Class<?> injectionType, final Type genericType,
+            final Class<? extends Annotation> paramAnnotation,
+            final String paramName, final String defaultValue, final Set<Annotation> annotations,
+            final ResteasyProviderFactory factory) {
+        return of(injectionType, genericType, paramAnnotation, paramName, defaultValue, annotations, factory,
+                BadRequestException::new);
+    }
+
+    /**
+     * Creates a converter for the given injection type and annotations.
+     *
+     * @param injectionType   the target type to convert to (may be a collection, array, or scalar)
+     * @param genericType     the generic type of the injection point, used to resolve collection element types
+     * @param paramAnnotation the parameter annotation type (e.g. {@code @PathParam}, {@code @QueryParam}), or {@code null}
+     * @param paramName       the parameter name, used in error messages
+     * @param defaultValue    the default value to use when no request value is present, or {@code null}
+     * @param annotations     all annotations on the injection point
+     * @param factory         the provider factory used to look up {@link ParamConverter ParamConverters} and other
+     *                        conversion mechanisms
+     * @param exceptionMapper maps conversion errors to a {@link WebApplicationException}, or {@code null} to default to
+     *                        {@link BadRequestException}
+     *
+     * @return a converter for extracting and converting string parameter values
+     *
+     * @throws RuntimeException if no suitable conversion mechanism can be found for the target type
+     */
+    static StringParameterConverter of(final Class<?> injectionType, final Type genericType,
+            final Class<? extends Annotation> paramAnnotation,
+            final String paramName, final String defaultValue, final Set<Annotation> annotations,
+            final ResteasyProviderFactory factory,
+            final BiFunction<String, Throwable, WebApplicationException> exceptionMapper) {
+
+        final Annotation[] annotationArray = annotations.toArray(new Annotation[0]);
+
+        // Try the raw injection type first. This gives ParamConverterProviders (e.g.
+        // MultiValuedParamConverterProvider for @Separator) a chance to handle the
+        // full collection/array type before we decompose it into a component type.
+        final ParamConverter<?> rawConverter = factory.getParamConverter(injectionType, genericType, annotationArray);
+        if (rawConverter != null) {
+            return new StringParameterConverter(injectionType, paramName, paramAnnotation,
+                    defaultValue, false, null, rawConverter::fromString, exceptionMapper);
+        }
+
+        final boolean isArray = injectionType.isArray();
+        Class<?> baseType = isArray ? injectionType.getComponentType() : injectionType;
+        Type baseGenericType = genericType;
+        CollectionHandler collectionHandler = null;
+
+        if (!isArray) {
+            collectionHandler = CollectionHandler.of(injectionType);
+            if (collectionHandler != null) {
+                if (genericType instanceof ParameterizedType) {
+                    final ParameterizedType parameterizedType = (ParameterizedType) baseGenericType;
+                    baseType = Types.getRawType(parameterizedType.getActualTypeArguments()[0]);
+                    baseGenericType = parameterizedType.getActualTypeArguments()[0];
+                } else {
+                    baseType = String.class;
+                    baseGenericType = null;
+                }
+            }
+        }
+
+        final StringConverter converter = resolveConverter(baseType, baseGenericType, paramAnnotation,
+                annotationArray, factory);
+        if (converter == null) {
+            final String signature = (paramAnnotation != null ? paramAnnotation.getName() : "") + "(\"" + paramName + "\")";
+            throw Messages.MESSAGES.unableToFindStringConstructor(signature, baseType.getName());
+        }
+        return new StringParameterConverter(baseType, paramName, paramAnnotation, defaultValue,
+                isArray, collectionHandler, converter, exceptionMapper);
+    }
+
+    /**
+     * Extracts and converts multiple string values into the target type. For array or collection targets, each string
+     * is individually converted and collected. For scalar targets, only the first value is used.
+     *
+     * @param value the raw string values from the request, or {@code null} if the parameter was absent
+     *
+     * @return the converted value (scalar, array, or collection), or {@code null} if no value and no default
+     */
+    Object extractValues(final List<String> value) {
+        List<String> valueToConvert = value;
+        if (valueToConvert == null && (isArray || collectionHandler != null) && defaultValue != null) {
+            valueToConvert = Collections.singletonList(defaultValue);
+        } else if (valueToConvert == null) {
+            valueToConvert = Collections.emptyList();
+        }
+
+        if (isArray) {
+            final Object vals = Array.newInstance(baseType, valueToConvert.size());
+            for (int i = 0; i < valueToConvert.size(); i++) {
+                Array.set(vals, i, extractValue(valueToConvert.get(i)));
+            }
+            return vals;
+        } else if (collectionHandler != null) {
+            final Collection<Object> collection = collectionHandler.create();
+            for (final String str : valueToConvert) {
+                collection.add(extractValue(str));
+            }
+            return collectionHandler.finish(collection);
+        } else {
+            return extractValue(valueToConvert.isEmpty() ? null : valueToConvert.get(0));
+        }
+    }
+
+    /**
+     * Converts a single string value into the target type. Falls back to the configured default value when
+     * {@code value} is {@code null}.
+     *
+     * @param value the raw string value, or {@code null}
+     *
+     * @return the converted value, or {@code null} if both the value and default are absent
+     */
+    Object extractValue(final String value) {
+        String valueToConvert = value;
+        if (valueToConvert == null) {
+            if (defaultValue == null) {
+                return StringToPrimitive.isPrimitive(baseType)
+                        ? StringToPrimitive.stringToPrimitiveBoxType(baseType, null)
+                        : null;
+            }
+            valueToConvert = defaultValue;
+        }
+
+        try {
+            return converter.convert(valueToConvert);
+        } catch (WebApplicationException wae) {
+            throw wae;
+        } catch (Exception e) {
+            handleException(e, valueToConvert);
+        }
+        return null;
+    }
+
+    /**
+     * Returns {@code true} if the target type is either a collection or an array.
+     *
+     * @return {@code true} if this is a collection or array, otherwise {@code false}
+     */
+    boolean isCollectionOrArray() {
+        return collectionHandler != null || isArray;
+    }
+
+    private void handleException(final Throwable e, final String strVal) {
+        Throwable targetException = e;
+        if (targetException instanceof InvocationTargetException) {
+            final InvocationTargetException ite = (InvocationTargetException) targetException;
+            targetException = ite.getTargetException();
+        }
+        // Passed null for the AccessibleObject target since it has been removed
+        LogMessages.LOGGER.unableToExtractParameter(targetException, signature, strVal, null);
+        if (converter.allowNullOrBlank() && e instanceof InvocationTargetException) {
+            if (strVal != null && strVal.isBlank()) {
+                return;
+            }
+        }
+        if (targetException instanceof WebApplicationException) {
+            throw (WebApplicationException) targetException;
+        }
+        throw exceptionMapper.apply(Messages.MESSAGES.unableToExtractParameter(signature, encode(strVal)), targetException);
+    }
+
+    private String encode(final String strVal) {
+        return strVal == null ? "null" : URLEncoder.encode(strVal, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Resolves a {@link StringConverter} for the given component type by walking the conversion priority chain.
+     *
+     * @return the resolved converter, or {@code null} if no conversion mechanism was found
+     */
+    private static StringConverter resolveConverter(
+            final Class<?> baseType, final Type baseGenericType, final Class<?> paramAnnotation,
+            final Annotation[] annotations, final ResteasyProviderFactory factory) {
+
+        final ParamConverter<?> paramConverter = factory.getParamConverter(baseType, baseGenericType, annotations);
+        if (paramConverter != null) {
+            return new StringConverter() {
+                @Override
+                public Object convert(final String value) {
+                    return paramConverter.fromString(value);
+                }
+
+                @Override
+                public boolean allowNullOrBlank() {
+                    return false;
+                }
+            };
+        }
+
+        final StringParameterUnmarshaller<?> unmarshaller = factory.createStringParameterUnmarshaller(baseType);
+        if (unmarshaller != null) {
+            unmarshaller.setAnnotations(annotations);
+            return unmarshaller::fromString;
+        }
+
+        for (final Annotation annotation : annotations) {
+            final StringParameterUnmarshallerBinder binder = annotation.annotationType()
+                    .getAnnotation(StringParameterUnmarshallerBinder.class);
+            if (binder != null) {
+                try {
+                    final StringParameterUnmarshaller<?> boundUnmarshaller = binder.value().getDeclaredConstructor()
+                            .newInstance();
+                    factory.injectProperties(boundUnmarshaller);
+                    boundUnmarshaller.setAnnotations(annotations);
+                    return boundUnmarshaller::fromString;
+                } catch (final Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        if (HeaderParam.class.equals(paramAnnotation)
+                || org.jboss.resteasy.annotations.jaxrs.HeaderParam.class.equals(paramAnnotation)) {
+            final RuntimeDelegate.HeaderDelegate<?> delegate = factory.getHeaderDelegate(baseType);
+            if (delegate != null) {
+                return delegate::fromString;
+            }
+        }
+
+        try {
+            final Constructor<?> constructor = baseType.getConstructor(String.class);
+            if (Modifier.isPublic(constructor.getModifiers())) {
+                return createFastConstructor(constructor);
+            }
+        } catch (final NoSuchMethodException ignored) {
+        }
+
+        Method valueOf = null;
+        Method fromString = null;
+        try {
+            final Method fromValue = baseType.getDeclaredMethod("fromValue", String.class);
+            if (Modifier.isPublic(fromValue.getModifiers())) {
+                for (final Annotation ann : baseType.getAnnotations()) {
+                    if (ann.annotationType().getName().equals("jakarta.xml.bind.annotation.XmlEnum")) {
+                        valueOf = fromValue;
+                    }
+                }
+            }
+        } catch (final NoSuchMethodException ignored) {
+        }
+
+        if (StringToPrimitive.isPrimitive(baseType)) {
+            return val -> StringToPrimitive.stringToPrimitiveBoxType(baseType, val);
+        }
+
+        if (valueOf == null) {
+            try {
+                final Method fs = baseType.getDeclaredMethod("fromString", String.class);
+                if (Modifier.isStatic(fs.getModifiers()))
+                    fromString = fs;
+            } catch (final NoSuchMethodException ignored) {
+            }
+            try {
+                final Method vo = baseType.getDeclaredMethod("valueOf", String.class);
+                if (Modifier.isStatic(vo.getModifiers()))
+                    valueOf = vo;
+            } catch (final NoSuchMethodException ignored) {
+            }
+        }
+
+        if (baseType.isEnum()) {
+            // Enums need to prefer fromString(String) over valueOf(String)
+            final Method chosen = fromString != null ? fromString : valueOf;
+            if (chosen != null) {
+                return createFastMethodInvoker(chosen);
+            }
+        } else {
+            // Other types prefer valueOf(String) over fromString(value)
+            final Method chosen = valueOf != null ? valueOf : fromString;
+            if (chosen != null) {
+                return createFastMethodInvoker(chosen);
+            }
+        }
+
+        if (Character.class.equals(baseType)) {
+            return CHARACTER_PARAM_CONVERTER::fromString;
+        }
+
+        return null;
+    }
+
+    /**
+     * Creates a {@link StringConverter} backed by a static method, using {@link LambdaMetafactory} for near-direct
+     * invocation speed. Falls back to reflective invocation if metafactory linkage fails.
+     */
+    private static StringConverter createFastMethodInvoker(final Method method) {
+        try {
+            final MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+            final MethodHandle handle = lookup.unreflect(method);
+            final CallSite site = LambdaMetafactory.metafactory(
+                    lookup,
+                    "convert",
+                    MethodType.methodType(StringConverter.class),
+                    MethodType.methodType(Object.class, String.class),
+                    handle,
+                    MethodType.methodType(method.getReturnType(), String.class));
+            return (StringConverter) site.getTarget().invokeExact();
+        } catch (final Throwable t) {
+            return val -> method.invoke(null, val);
+        }
+    }
+
+    /**
+     * Creates a {@link StringConverter} backed by a single-{@link String} constructor, using
+     * {@link LambdaMetafactory} for near-direct invocation speed. Falls back to reflective invocation if metafactory
+     * linkage fails.
+     */
+    private static StringConverter createFastConstructor(final Constructor<?> constructor) {
+        try {
+            final MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+            final MethodHandle handle = lookup.unreflectConstructor(constructor);
+            final CallSite site = LambdaMetafactory.metafactory(
+                    lookup,
+                    "convert",
+                    MethodType.methodType(StringConverter.class),
+                    MethodType.methodType(Object.class, String.class),
+                    handle,
+                    MethodType.methodType(constructor.getDeclaringClass(), String.class));
+            return (StringConverter) site.getTarget().invokeExact();
+        } catch (final Throwable t) {
+            return constructor::newInstance;
+        }
+    }
+
+    /**
+     * Encapsulates the creation and post-processing of a collection for a given target type. For interface types
+     * ({@link List}, {@link Set}, {@link SortedSet}), the finisher wraps the collection as unmodifiable. For concrete
+     * types ({@link ArrayList}, {@link HashSet}, {@link TreeSet}), the mutable collection is returned as-is.
+     */
+    private static final class CollectionHandler {
+        private final Supplier<Collection<Object>> factory;
+        private final Function<Collection<Object>, Collection<?>> finisher;
+
+        private CollectionHandler(final Supplier<Collection<Object>> factory,
+                final Function<Collection<Object>, Collection<?>> finisher) {
+            this.factory = factory;
+            this.finisher = finisher;
+        }
+
+        static CollectionHandler of(final Class<?> type) {
+            if (List.class.equals(type)) {
+                return new CollectionHandler(ArrayList::new,
+                        c -> Collections.unmodifiableList((List<?>) c));
+            }
+            if (ArrayList.class.equals(type)) {
+                return new CollectionHandler(ArrayList::new, c -> c);
+            }
+            if (SortedSet.class.equals(type)) {
+                return new CollectionHandler(TreeSet::new,
+                        c -> Collections.unmodifiableSortedSet((SortedSet<?>) c));
+            }
+            if (TreeSet.class.equals(type)) {
+                return new CollectionHandler(TreeSet::new, c -> c);
+            }
+            if (Set.class.equals(type)) {
+                return new CollectionHandler(HashSet::new,
+                        c -> Collections.unmodifiableSet((Set<?>) c));
+            }
+            if (HashSet.class.equals(type)) {
+                return new CollectionHandler(HashSet::new, c -> c);
+            }
+            return null;
+        }
+
+        Collection<Object> create() {
+            return factory.get();
+        }
+
+        Collection<?> finish(final Collection<Object> collection) {
+            return finisher.apply(collection);
+        }
+    }
+
+    /**
+     * Converts a single string value into the target type. Resolved once at construction time and invoked per-request.
+     */
+    @FunctionalInterface
+    private interface StringConverter {
+        Object convert(String value) throws Exception;
+
+        /**
+         * Indicates that if a string value is {@code null} or an {@linkplain String#isBlank() blank} string that no
+         * exception is thrown when the converter cannot invoke its method or constructor.
+         * <p>
+         * The default is {@code true} allowing failed invocations to pass and not throw an exception
+         * </p>
+         *
+         * @return {@code true} if exceptions should not be thrown on failed blank or null strings, otherwise
+         *         {@code false} will throw an exception if an {@link InvocationTargetException} is thrown
+         */
+        default boolean allowNullOrBlank() {
+            return true;
+        }
+    }
+}

--- a/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/setup/SystemPropertySetupTask.java
+++ b/testsuite/arquillian-utils/src/main/java/org/jboss/resteasy/setup/SystemPropertySetupTask.java
@@ -19,10 +19,14 @@
 
 package org.jboss.resteasy.setup;
 
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Map;
 
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
 import org.jboss.dmr.ModelNode;
@@ -35,6 +39,7 @@ import org.jboss.dmr.ModelNode;
 public abstract class SystemPropertySetupTask implements ServerSetupTask {
 
     private final Map<String, String> properties;
+    private final Deque<ModelNode> tearDownOps;
 
     /**
      * Creates a new setup task which defines the provided properties.
@@ -43,33 +48,63 @@ public abstract class SystemPropertySetupTask implements ServerSetupTask {
      */
     protected SystemPropertySetupTask(final Map<String, String> properties) {
         this.properties = properties;
+        this.tearDownOps = new ArrayDeque<>();
     }
 
     @Override
     public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+        boolean opsAdded = false;
         final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             final ModelNode address = Operations.createAddress("system-property", entry.getKey());
-            final ModelNode op = Operations.createAddOperation(address);
-            op.get("value").set(entry.getValue());
-            builder.addStep(op);
+            if (createAddOrUpdateOp(managementClient.getControllerClient(), address, builder, entry.getValue())) {
+                opsAdded = true;
+            }
         }
-        executeOperation(managementClient, builder.build(),
-                (result) -> String.format("Failed to add system properties %s%n%s", properties,
-                        Operations.getFailureDescription(result)
-                                .asString()));
+        if (opsAdded) {
+            executeOperation(managementClient, builder.build(),
+                    (result) -> String.format("Failed to add system properties %s%n%s", properties,
+                            Operations.getFailureDescription(result)
+                                    .asString()));
+        }
     }
 
     @Override
     public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
         final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-            final ModelNode address = Operations.createAddress("system-property", entry.getKey());
-            builder.addStep(Operations.createRemoveOperation(address));
+        ModelNode revertOp;
+        while ((revertOp = tearDownOps.pollLast()) != null) {
+            builder.addStep(revertOp);
         }
         executeOperation(managementClient, builder.build(),
                 (result) -> String.format("Failed to remove system properties %s%n%s", properties,
                         Operations.getFailureDescription(result)
                                 .asString()));
+    }
+
+    private boolean createAddOrUpdateOp(final ModelControllerClient client, final ModelNode address,
+            final CompositeOperationBuilder builder, final String value) throws IOException {
+        ModelNode op = Operations.createReadResourceOperation(address);
+        final ModelNode response = client.execute(op);
+        if (Operations.isSuccessfulOutcome(response)) {
+            final ModelNode model = Operations.readResult(response);
+            if (model.hasDefined("value")) {
+                final String currentValue = model.get("value").asString();
+                if (!currentValue.equals(value)) {
+                    builder.addStep(Operations.createWriteAttributeOperation(address, "value", value));
+                    tearDownOps.add(Operations.createWriteAttributeOperation(address, "value", currentValue));
+                    return true;
+                }
+                return false;
+            } else {
+                throw new RuntimeException(String.format("Could not find value in %s", response));
+            }
+        } else {
+            op = Operations.createAddOperation(address);
+            op.get("value").set(value);
+            builder.addStep(op);
+            tearDownOps.add(Operations.createRemoveOperation(address));
+            return true;
+        }
     }
 }

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -54,6 +54,11 @@
                 <plugin>
                     <groupId>org.wildfly.plugins</groupId>
                     <artifactId>wildfly-maven-plugin</artifactId>
+                    <configuration>
+                        <system-properties>
+                            <maven.repo.local>${settings.localRepository}</maven.repo.local>
+                        </system-properties>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>server-provisioning</id>
@@ -438,6 +443,29 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>enhanced-cdi-enabled</id>
+            <activation>
+                <property>
+                    <name>enhanced.cdi.enabled</name>
+                </property>
+            </activation>
+            <properties>
+                <wildfly.system.properties>-Ddev.resteasy.cdi.enhanced.enabled=true</wildfly.system.properties>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <dev.resteasy.cdi.enhanced.enabled>true</dev.resteasy.cdi.enhanced.enabled>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <dependencies>
@@ -560,7 +588,7 @@
             <artifactId>resteasy-wadl</artifactId>
             <scope>test</scope>
         </dependency>
-
+        
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-wadl-undertow-connector</artifactId>
@@ -661,10 +689,23 @@
             <artifactId>resteasy-rxjava2</artifactId>
             <scope>test</scope>
         </dependency>
+
         <!-- Used as a slf4j binder -->
         <dependency>
             <groupId>org.jboss.slf4j</groupId>
             <artifactId>slf4j-jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!--
+            WildFly and WildFly Arquillian both require this newer version of JBoss Logging. RESTEasy still uses
+            the older version for backwards compatibility issues. For now, we will need override the dependency for
+            the test suite.
+        -->
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.6.3.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/AbstractParamTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/AbstractParamTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params;
+
+import java.net.URI;
+import java.util.Map;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonValue;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.resteasy.test.cdi.params.resources.CdiQualifierResource;
+import org.jboss.resteasy.test.cdi.params.resources.ParamApplication;
+import org.jboss.resteasy.test.cdi.params.resources.ParamDescriptor;
+import org.jboss.resteasy.test.cdi.params.resources.ParamResource;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.wildfly.arquillian.junit.annotations.RequiresModule;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@ServerSetup(EnableEnhancedCdiSupportSetupTask.class)
+@RequiresModule(value = "org.jboss.resteasy.resteasy-cdi", minVersion = "6.2.17")
+abstract class AbstractParamTest {
+
+    private final String contextPath;
+    private final JsonValue expectedBooleanValue;
+
+    @ArquillianResource
+    protected URI baseUri;
+
+    AbstractParamTest(final String contextPath) {
+        this(contextPath, JsonValue.TRUE);
+    }
+
+    AbstractParamTest(final String contextPath, final JsonValue expectedBooleanValue) {
+        this.contextPath = contextPath;
+        this.expectedBooleanValue = expectedBooleanValue;
+    }
+
+    static WebArchive defaultDeployment(final Class<? extends AbstractParamTest> testClass) {
+        return ShrinkWrap.create(WebArchive.class, testClass.getSimpleName() + ".war")
+                .addClasses(ParamApplication.class, ParamDescriptor.class, ParamResource.class, CdiQualifierResource.class)
+                .addAsWebInfResource(TestUtil.createBeansXml(), "beans.xml");
+    }
+
+    @Test
+    void constructorParameters() {
+        final ParamDescriptor param = invokeRequest("constructor");
+        // Check the parameters
+        Assertions.assertEquals("cookieParamValue", param.getCookieParam(),
+                () -> String.format("@CookieParam parameter was not set on the constructor: %s", param));
+        Assertions.assertEquals("formParamValue", param.getFormParam(),
+                () -> String.format("@FormParam parameter was not set on the constructor: %s", param));
+        Assertions.assertEquals("headerParamValue", param.getHeaderParam(),
+                () -> String.format("@HeaderParam parameter was not set on the constructor: %s", param));
+        Assertions.assertEquals(10, param.getMatrixParam(),
+                () -> String.format("@MatrixParam parameter was not set on the constructor: %s", param));
+        Assertions.assertEquals("constructorParameters", param.getPathParam(),
+                () -> String.format("@PathParam parameter was not set on the constructor: %s", param));
+        Assertions.assertEquals(100, param.getQueryParam(),
+                () -> String.format("@QueryParam parameter was not set on the constructor: %s", param));
+    }
+
+    @Test
+    void fieldParameters() {
+        final ParamDescriptor param = invokeRequest("field/fieldParamValue");
+        // Check the parameters
+        Assertions.assertEquals("fieldCookieParamValue", param.getCookieParam(),
+                () -> String.format("@CookieParam parameter was not set on the field: %s", param));
+        Assertions.assertEquals("fieldFormParamValue", param.getFormParam(),
+                () -> String.format("@FormParam parameter was not set on the field: %s", param));
+        Assertions.assertEquals("fieldHeaderParamValue", param.getHeaderParam(),
+                () -> String.format("@HeaderParam parameter was not set on the field: %s", param));
+        Assertions.assertEquals(20, param.getMatrixParam(),
+                () -> String.format("@MatrixParam parameter was not set on the field: %s", param));
+        Assertions.assertEquals("fieldParamValue", param.getPathParam(),
+                () -> String.format("@PathParam parameter was not set on the field: %s", param));
+        Assertions.assertEquals(200, param.getQueryParam(),
+                () -> String.format("@QueryParam parameter was not set on the field: %s", param));
+    }
+
+    @Test
+    void methodParameters() {
+        final ParamDescriptor param = invokeRequest("method/methodParamValue");
+        // Check the parameters
+        Assertions.assertEquals("methodCookieParamValue", param.getCookieParam(),
+                () -> String.format("@CookieParam parameter was not set on the method: %s", param));
+        Assertions.assertEquals("methodFormParamValue", param.getFormParam(),
+                () -> String.format("@FormParam parameter was not set on the method: %s", param));
+        Assertions.assertEquals("methodHeaderParamValue", param.getHeaderParam(),
+                () -> String.format("@HeaderParam parameter was not set on the method: %s", param));
+        Assertions.assertEquals(30, param.getMatrixParam(),
+                () -> String.format("@MatrixParam parameter was not set on the method: %s", param));
+        Assertions.assertEquals("methodParamValue", param.getPathParam(),
+                () -> String.format("@PathParam parameter was not set on the method: %s", param));
+        Assertions.assertEquals(300, param.getQueryParam(),
+                () -> String.format("@QueryParam parameter was not set on the method: %s", param));
+    }
+
+    @Test
+    void methodParametersAnnotated() {
+        final ParamDescriptor param = invokeRequest("method-param/methodParamValuePa");
+        // Check the parameters
+        Assertions.assertEquals("methodCookieParamValuePa", param.getCookieParam(),
+                () -> String.format("@CookieParam parameter was not set on the method: %s", param));
+        Assertions.assertEquals("methodFormParamValuePa", param.getFormParam(),
+                () -> String.format("@FormParam parameter was not set on the method: %s", param));
+        Assertions.assertEquals("methodHeaderParamValuePa", param.getHeaderParam(),
+                () -> String.format("@HeaderParam parameter was not set on the method: %s", param));
+        Assertions.assertEquals(40, param.getMatrixParam(),
+                () -> String.format("@MatrixParam parameter was not set on the method: %s", param));
+        Assertions.assertEquals("methodParamValuePa", param.getPathParam(),
+                () -> String.format("@PathParam parameter was not set on the method: %s", param));
+        Assertions.assertEquals(400, param.getQueryParam(),
+                () -> String.format("@QueryParam parameter was not set on the method: %s", param));
+    }
+
+    @Test
+    void qualifierRegistered() {
+        try (Client client = ClientBuilder.newClient()) {
+            final URI uri = UriBuilder.fromUri(baseUri)
+                    .path("check-qualifier")
+                    .build();
+            final JsonArray jsonArray = client.target(uri)
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(JsonArray.class);
+            for (JsonValue value : jsonArray) {
+                for (Map.Entry<String, JsonValue> entry : value.asJsonObject().entrySet()) {
+                    final String expectation = (entry.getValue() == JsonValue.TRUE) ? "be" : "not be";
+                    Assertions.assertTrue((entry.getValue() == expectedBooleanValue),
+                            () -> String.format("Annotation @%s should %s marked as a qualifier.", entry.getKey(),
+                                    expectation));
+                }
+            }
+        }
+    }
+
+    private ParamDescriptor invokeRequest(final String path) {
+        try (Client client = ClientBuilder.newClient()) {
+            final UriBuilder uriBuilder = UriBuilder.fromUri(baseUri)
+                    .path(contextPath + "/constructorParameters/" + path)
+                    .matrixParam("matrixParam", 10)
+                    .matrixParam("fieldMatrixParam", 20)
+                    .matrixParam("methodMatrixParam", 30)
+                    .matrixParam("methodMatrixParamPa", 40)
+                    .queryParam("queryParam", 100)
+                    .queryParam("fieldQueryParam", 200)
+                    .queryParam("methodQueryParam", 300)
+                    .queryParam("methodQueryParamPa", 400);
+            final Form form = new Form()
+                    .param("formParam", "formParamValue")
+                    .param("fieldFormParam", "fieldFormParamValue")
+                    .param("methodFormParam", "methodFormParamValue")
+                    .param("methodFormParamPa", "methodFormParamValuePa");
+            final WebTarget target = client.target(uriBuilder);
+            final ParamDescriptor param = target.request(MediaType.APPLICATION_JSON_TYPE)
+                    .cookie("cookieParam", "cookieParamValue")
+                    .cookie("fieldCookieParam", "fieldCookieParamValue")
+                    .cookie("methodCookieParam", "methodCookieParamValue")
+                    .cookie("methodCookieParamPa", "methodCookieParamValuePa")
+                    .header("headerParam", "headerParamValue")
+                    .header("fieldHeaderParam", "fieldHeaderParamValue")
+                    .header("methodHeaderParam", "methodHeaderParamValue")
+                    .header("methodHeaderParamPa", "methodHeaderParamValuePa")
+                    .post(Entity.form(form), ParamDescriptor.class);
+            Assertions.assertNotNull(param,
+                    () -> String.format("Failed to find the parameters with URI %s", uriBuilder.build()));
+            return param;
+        }
+    }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/CdiBeanParamTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/CdiBeanParamTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params;
+
+import java.net.URI;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.container.annotation.ArquillianTest;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.resteasy.test.cdi.params.resources.CdiBeanParamResource;
+import org.jboss.resteasy.test.cdi.params.resources.ParamApplication;
+import org.jboss.resteasy.test.cdi.params.resources.SearchParams;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.wildfly.arquillian.junit.annotations.RequiresModule;
+
+/**
+ * Tests that a {@link jakarta.ws.rs.BeanParam @BeanParam} works with CDI.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@ArquillianTest
+@RequiresModule(value = "org.jboss.resteasy.resteasy-cdi", minVersion = "6.2.17")
+@ServerSetup(EnableEnhancedCdiSupportSetupTask.class)
+class CdiBeanParamTest {
+
+    @ArquillianResource
+    private URI baseUri;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, CdiBeanParamTest.class.getSimpleName() + ".war")
+                .addClasses(ParamApplication.class, CdiBeanParamResource.class, SearchParams.class)
+                .addAsWebInfResource(TestUtil.createBeansXml(), "beans.xml");
+    }
+
+    @Test
+    void beanParam() {
+        try (Client client = ClientBuilder.newClient()) {
+            final UriBuilder uriBuilder = UriBuilder.fromUri(baseUri)
+                    .path("bean-param")
+                    .queryParam("q", "resteasy")
+                    .queryParam("limit", 25);
+            final SearchParams result = client.target(uriBuilder)
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .header("Accept-Language", "en-US")
+                    .get(SearchParams.class);
+            Assertions.assertNotNull(result);
+            Assertions.assertEquals("resteasy", result.getQuery(),
+                    () -> String.format("Expected a result of 'resteasy' in the query parameter: %s", result));
+            Assertions.assertEquals(25, result.getLimit(),
+                    () -> String.format("Expected a result of '25' in the limit parameter: %s", result));
+            Assertions.assertEquals("en-US", result.getLanguage(),
+                    () -> String.format("Expected a result of 'en-US' in the Accepted-Language parameter: %s", result));
+        }
+    }
+
+    @Test
+    void beanParamDefaults() {
+        try (Client client = ClientBuilder.newClient()) {
+            final UriBuilder uriBuilder = UriBuilder.fromUri(baseUri)
+                    .path("bean-param")
+                    .queryParam("q", "test");
+            final SearchParams result = client.target(uriBuilder)
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(SearchParams.class);
+            Assertions.assertNotNull(result);
+            Assertions.assertEquals("test", result.getQuery(),
+                    () -> String.format("Expected a result of 'test' in the query parameter: %s", result));
+            Assertions.assertEquals(10, result.getLimit(),
+                    () -> String.format("Expected a result of '10', @DefaultValue, in the limit parameter: %s", result));
+            Assertions.assertNull(result.getLanguage(),
+                    () -> String.format("Accept-Language header should be null: %s", result));
+        }
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/CdiEmptyNameParamTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/CdiEmptyNameParamTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.container.annotation.ArquillianTest;
+import org.jboss.resteasy.test.cdi.params.resources.CdiParamEmptyNamesResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ * Test that {@code @*Param} annotated fields, constructor parameters and method parameters are injected. The names are
+ * left empty and the name for the annotation is resolved from the annotated element.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@ArquillianTest
+class CdiEmptyNameParamTest extends AbstractParamTest {
+
+    CdiEmptyNameParamTest() {
+        super("empty-names");
+    }
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return defaultDeployment(CdiEmptyNameParamTest.class).addClass(CdiParamEmptyNamesResource.class);
+    }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/CdiParamEncodedTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/CdiParamEncodedTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params;
+
+import java.net.URI;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.container.annotation.ArquillianTest;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.resteasy.test.cdi.params.resources.CdiParamEncodedResource;
+import org.jboss.resteasy.test.cdi.params.resources.CdiParamNotEncodedResource;
+import org.jboss.resteasy.test.cdi.params.resources.EncodedDescriptor;
+import org.jboss.resteasy.test.cdi.params.resources.ParamApplication;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.wildfly.arquillian.junit.annotations.RequiresModule;
+
+/**
+ * Tests that CDI injected parameters work with {@link jakarta.ws.rs.Encoded @Encoded}
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@ArquillianTest
+@RequiresModule(value = "org.jboss.resteasy.resteasy-cdi", minVersion = "6.2.17")
+@ServerSetup(EnableEnhancedCdiSupportSetupTask.class)
+class CdiParamEncodedTest {
+
+    @ArquillianResource
+    private URI baseUri;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, CdiParamEncodedTest.class.getSimpleName() + ".war")
+                .addClasses(ParamApplication.class, CdiParamEncodedResource.class,
+                        CdiParamNotEncodedResource.class, EncodedDescriptor.class)
+                .addAsWebInfResource(TestUtil.createBeansXml(), "beans.xml");
+    }
+
+    @Test
+    void classLevelEncoded() {
+        try (Client client = ClientBuilder.newClient()) {
+            final UriBuilder uriBuilder = UriBuilder.fromUri(baseUri)
+                    .path("encoded/hello%20world")
+                    .queryParam("q", "hello%20world");
+            final EncodedDescriptor result = client.target(uriBuilder)
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(EncodedDescriptor.class);
+            Assertions.assertNotNull(result);
+            Assertions.assertTrue(result.getQueryValue().contains("%20"),
+                    () -> String.format("Class-level @Encoded query should retain %%20, got: %s", result.getQueryValue()));
+            Assertions.assertTrue(result.getPathValue().contains("%20"),
+                    () -> String.format("Class-level @Encoded path should retain %%20, got: %s", result.getPathValue()));
+        }
+    }
+
+    @Test
+    void fieldLevelEncoded() {
+        try (Client client = ClientBuilder.newClient()) {
+            final UriBuilder uriBuilder = UriBuilder.fromUri(baseUri)
+                    .path("not-encoded/hello%20world")
+                    .queryParam("q", "hello%20world")
+                    .queryParam("q2", "hello%20world");
+            final EncodedDescriptor result = client.target(uriBuilder)
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(EncodedDescriptor.class);
+            Assertions.assertNotNull(result);
+            Assertions.assertTrue(result.getQueryValue().contains("%20"),
+                    () -> String.format("Field-level @Encoded query should retain %%20, got: %s", result.getQueryValue()));
+            Assertions.assertEquals("hello world", result.getDecodedQuery(),
+                    () -> String.format("non-encoded query should decode %%20 to space: %s", result));
+            Assertions.assertEquals("hello world", result.getPathValue(),
+                    () -> String.format("non-encoded path should decode %%20 to space: %s", result));
+        }
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/CdiParamMixedTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/CdiParamMixedTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params;
+
+import java.net.URI;
+
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.container.annotation.ArquillianTest;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.resteasy.test.cdi.params.resources.CdiParamMixedResource;
+import org.jboss.resteasy.test.cdi.params.resources.ParamApplication;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.wildfly.arquillian.junit.annotations.RequiresModule;
+
+/**
+ * Tests that CDI injection works on a constructor with both {@code @*Param} annotations and standard CDI beans.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@ArquillianTest
+@RequiresModule(value = "org.jboss.resteasy.resteasy-cdi", minVersion = "6.2.17")
+@ServerSetup(EnableEnhancedCdiSupportSetupTask.class)
+class CdiParamMixedTest {
+
+    @ArquillianResource
+    private URI baseUri;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, CdiParamMixedTest.class.getSimpleName() + ".war")
+                .addClasses(ParamApplication.class, CdiParamMixedResource.class)
+                .addAsWebInfResource(TestUtil.createBeansXml(), "beans.xml");
+    }
+
+    @Test
+    void mixedConstructor() {
+        try (Client client = ClientBuilder.newClient()) {
+            final UriBuilder uriBuilder = UriBuilder.fromUri(baseUri)
+                    .path("mixed")
+                    .queryParam("q", "resteasy");
+            final JsonObject result = client.target(uriBuilder)
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .header("Custom", "custom-value")
+                    .get(JsonObject.class);
+            Assertions.assertNotNull(result);
+            Assertions.assertEquals("resteasy", result.getString("query"),
+                    () -> String.format("@QueryParam should be injected in mixed constructor: %s", result));
+            Assertions.assertFalse(result.getString("path").isEmpty(),
+                    () -> String.format("UriInfo should be injected in mixed constructor: %s", result));
+            Assertions.assertEquals("custom-value", result.getString("customHeader"),
+                    () -> String.format("@HeaderParam should be injected in mixed constructor: %s", result));
+        }
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/CdiParamTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/CdiParamTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.container.annotation.ArquillianTest;
+import org.jboss.resteasy.test.cdi.params.resources.CdiParamResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ * Test that {@code @*Param} annotated fields, constructor parameters and method parameters are injected.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@ArquillianTest
+class CdiParamTest extends AbstractParamTest {
+
+    CdiParamTest() {
+        super("params");
+    }
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return defaultDeployment(CdiParamTest.class).addClass(CdiParamResource.class);
+    }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/CdiParamTypesTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/CdiParamTypesTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.container.annotation.ArquillianTest;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.resteasy.test.cdi.params.resources.CdiParamTypesResource;
+import org.jboss.resteasy.test.cdi.params.resources.ParamApplication;
+import org.jboss.resteasy.test.cdi.params.resources.ParamEnum;
+import org.jboss.resteasy.test.cdi.params.resources.TypesDescriptor;
+import org.jboss.resteasy.utils.TestUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.wildfly.arquillian.junit.annotations.RequiresModule;
+
+/**
+ * Tests various {@code @*Param} injections work with various required types.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@ArquillianTest
+@RequiresModule(value = "org.jboss.resteasy.resteasy-cdi", minVersion = "6.2.17")
+@ServerSetup(EnableEnhancedCdiSupportSetupTask.class)
+class CdiParamTypesTest {
+
+    @ArquillianResource
+    private URI baseUri;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, CdiParamTypesTest.class.getSimpleName() + ".war")
+                .addClasses(ParamApplication.class, CdiParamTypesResource.class,
+                        TypesDescriptor.class, ParamEnum.class)
+                .addAsWebInfResource(TestUtil.createBeansXml(), "beans.xml");
+    }
+
+    @Test
+    void allTypes() {
+        try (Client client = ClientBuilder.newClient()) {
+            final UriBuilder uriBuilder = UriBuilder.fromUri(baseUri)
+                    .path("types/path1/path2")
+                    .queryParam("list", "a", "b", "c")
+                    .queryParam("set", "x", "y", "z")
+                    .queryParam("sortedSet", "c", "a", "b")
+                    .queryParam("array", "one", "two")
+                    .queryParam("wrapper", 99)
+                    .queryParam("bool", true)
+                    .queryParam("enum", "VALUE_ONE")
+                    .queryParam("default", "explicit")
+                    .queryParam("defaultInt", 7);
+            final TypesDescriptor result = client.target(uriBuilder)
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(TypesDescriptor.class);
+            Assertions.assertNotNull(result);
+
+            // Collection types
+            Assertions.assertNotNull(result.getListParam(), () -> String.format("List should not be null: %s", result));
+            Assertions.assertEquals(3, result.getListParam().size(),
+                    () -> String.format("Expected list size of 3: %s", result));
+            Assertions.assertTrue(result.getListParam().containsAll(List.of("a", "b", "c")),
+                    () -> String.format("Expected list to contain [a, b, c]: %s", result));
+
+            Assertions.assertNotNull(result.getSetParam(),
+                    () -> String.format("Set should not be null: %s", result));
+            Assertions.assertEquals(3, result.getSetParam().size(),
+                    () -> String.format("Expected set size of 3: %s", result));
+            Assertions.assertTrue(result.getSetParam().containsAll(Set.of("x", "y", "z")),
+                    () -> String.format("Expected set to contain [x, y, z]: %s", result));
+
+            Assertions.assertNotNull(result.getSortedSetParam(),
+                    () -> String.format("SortedSet should not be null: %s", result));
+            Assertions.assertEquals(3, result.getSortedSetParam().size(),
+                    () -> String.format("Expected sortedSet size of 3: %s", result));
+            Assertions.assertEquals("a", result.getSortedSetParam().first(),
+                    () -> String.format("SortedSet should be sorted, expected 'a' first: %s", result));
+
+            // Array
+            Assertions.assertNotNull(result.getArrayParam(),
+                    () -> String.format("Array should not be null: %s", result));
+            Assertions.assertArrayEquals(new String[] { "one", "two" }, result.getArrayParam(),
+                    () -> String.format("Expected array [one, two]: %s", result));
+
+            // Wrapper and primitive types
+            Assertions.assertEquals(99, result.getWrapperParam(),
+                    () -> String.format("Expected wrapper value of 99: %s", result));
+            Assertions.assertEquals(true, result.getBooleanParam(),
+                    () -> String.format("Expected boolean value of true: %s", result));
+
+            // Enum
+            Assertions.assertEquals(ParamEnum.VALUE_ONE, result.getEnumParam(),
+                    () -> String.format("Expected enum VALUE_ONE: %s", result));
+
+            // Explicit values override @DefaultValue
+            Assertions.assertEquals("explicit", result.getDefaultParam(),
+                    () -> String.format("Expected default string to be 'explicit': %s", result));
+            Assertions.assertEquals(7, result.getDefaultIntParam(),
+                    () -> String.format("Expected default int to be 7: %s", result));
+
+            // PathSegment
+            final List<String> listPaths = result.getListPaths();
+            Assertions.assertEquals(2, listPaths.size(), () -> String.format("Expected two PathSegments in %s", result));
+            Assertions.assertEquals("path1", listPaths.get(0),
+                    () -> String.format("Expected the first PathSegment to be path1 in %s", result));
+            Assertions.assertEquals("path2", listPaths.get(1),
+                    () -> String.format("Expected the first PathSegment to be path2 in %s", result));
+            Assertions.assertEquals("path2", result.getSinglePath(),
+                    () -> String.format("Expected the single PathSegment to be path2 in %s", result));
+        }
+    }
+
+    @Test
+    void defaultValues() {
+        try (Client client = ClientBuilder.newClient()) {
+            final UriBuilder uriBuilder = UriBuilder.fromUri(baseUri)
+                    .path("types/ignored");
+            final TypesDescriptor result = client.target(uriBuilder)
+                    .request(MediaType.APPLICATION_JSON_TYPE)
+                    .get(TypesDescriptor.class);
+            Assertions.assertNotNull(result);
+
+            // @DefaultValue should apply when params are absent
+            Assertions.assertEquals("fallback", result.getDefaultParam(),
+                    () -> String.format("Expected default string 'fallback' when param is absent: %s", result));
+            Assertions.assertEquals(42, result.getDefaultIntParam(),
+                    () -> String.format("Expected default int 42 when param is absent: %s", result));
+
+            // Absent optional params without @DefaultValue
+            Assertions.assertNull(result.getWrapperParam(),
+                    () -> String.format("Absent wrapper should be null: %s", result));
+            Assertions.assertNull(result.getBooleanParam(),
+                    () -> String.format("Absent boolean should be null: %s", result));
+            Assertions.assertNull(result.getEnumParam(),
+                    () -> String.format("Absent enum should be null: %s", result));
+        }
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/DisabledEnhancedCdiTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/DisabledEnhancedCdiTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params;
+
+import java.util.Map;
+
+import jakarta.json.JsonValue;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.container.annotation.ArquillianTest;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.resteasy.setup.SystemPropertySetupTask;
+import org.jboss.resteasy.test.cdi.params.resources.DisabledEnhancedCdiResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
+import org.wildfly.arquillian.junit.annotations.RequiresModule;
+
+/**
+ * Tests that when the {@code dev.resteasy.cdi.enhanced.enabled} configuration property is set to {@code false},
+ * standard Jakarta REST parameter injection still works and {@code @*Param} annotations are not registered as CDI
+ * qualifiers.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@ArquillianTest
+@RunAsClient
+@ServerSetup(DisabledEnhancedCdiTest.DisableEnhancedCdiSupportSetupTask.class)
+@RequiresModule(value = "org.jboss.resteasy.resteasy-cdi", minVersion = "6.2.17")
+class DisabledEnhancedCdiTest extends AbstractParamTest {
+
+    DisabledEnhancedCdiTest() {
+        super("disabled", JsonValue.FALSE);
+    }
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return defaultDeployment(DisabledEnhancedCdiTest.class).addClass(DisabledEnhancedCdiResource.class);
+    }
+
+    @Override
+    @Disabled("Setter method parameters annotated with @*Param do not work without CDI")
+    void methodParametersAnnotated() {
+        super.methodParametersAnnotated();
+    }
+
+    public static class DisableEnhancedCdiSupportSetupTask extends SystemPropertySetupTask {
+
+        public DisableEnhancedCdiSupportSetupTask() {
+            super(Map.of("dev.resteasy.cdi.enhanced.enabled", "false"));
+        }
+    }
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/EnableEnhancedCdiSupportSetupTask.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/EnableEnhancedCdiSupportSetupTask.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params;
+
+import java.util.Map;
+
+import org.jboss.resteasy.setup.SystemPropertySetupTask;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+public class EnableEnhancedCdiSupportSetupTask extends SystemPropertySetupTask {
+
+    public EnableEnhancedCdiSupportSetupTask() {
+        super(Map.of("dev.resteasy.cdi.enhanced.enabled", "true"));
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/InvalidCdiBeanParamTest.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/InvalidCdiBeanParamTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.container.annotation.ArquillianTest;
+import org.jboss.resteasy.test.cdi.params.resources.InvalidCdiParamResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@ArquillianTest
+class InvalidCdiBeanParamTest extends AbstractParamTest {
+
+    InvalidCdiBeanParamTest() {
+        super("invalid-bean");
+    }
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return defaultDeployment(InvalidCdiBeanParamTest.class).addClass(InvalidCdiParamResource.class);
+    }
+
+    @Disabled("Setter method parameters annotated with @*Param are not required by the specification and RESTEasy does not currently allow it.")
+    @Override
+    void methodParametersAnnotated() {
+        super.methodParametersAnnotated();
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiBeanParamResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiBeanParamResource.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/bean-param")
+@RequestScoped
+public class CdiBeanParamResource {
+
+    @Inject
+    @BeanParam
+    private SearchParams params;
+
+    CdiBeanParamResource() {
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public SearchParams get() {
+        return params;
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiParamEmptyNamesResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiParamEmptyNamesResource.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+import java.io.InputStream;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@Path("/empty-names/{pathParam}")
+@RequestScoped
+public class CdiParamEmptyNamesResource implements ParamResource {
+    private final String cookieParam;
+    private final String formParam;
+    private final String headerParam;
+    private final long matrixParam;
+    private final String pathParam;
+    private final int queryParam;
+
+    @Inject
+    @CookieParam("")
+    private String fieldCookieParam;
+    @Inject
+    @FormParam("")
+    private String fieldFormParam;
+    @Inject
+    @HeaderParam("")
+    private String fieldHeaderParam;
+    @Inject
+    @MatrixParam("")
+    private int fieldMatrixParam;
+    @Inject
+    @PathParam("")
+    private String fieldPathParam;
+    @Inject
+    @QueryParam("")
+    private int fieldQueryParam;
+
+    private String methodCookieParam;
+    private String methodFormParam;
+    private String methodHeaderParam;
+    private int methodMatrixParam;
+    private String methodPathParam;
+    private int methodQueryParam;
+
+    private String methodCookieParamPa;
+    private String methodFormParamPa;
+    private String methodHeaderParamPa;
+    private int methodMatrixParamPa;
+    private String methodPathParamPa;
+    private int methodQueryParamPa;
+
+    CdiParamEmptyNamesResource() {
+        cookieParam = null;
+        formParam = null;
+        headerParam = null;
+        matrixParam = -1;
+        pathParam = null;
+        queryParam = -1;
+    }
+
+    @Inject
+    public CdiParamEmptyNamesResource(@CookieParam("") final String cookieParam,
+            @FormParam("") final String formParam,
+            @HeaderParam("") final String headerParam,
+            @MatrixParam("") final long matrixParam,
+            @PathParam("") final String pathParam,
+            @QueryParam("") final int queryParam) {
+        this.cookieParam = cookieParam;
+        this.formParam = formParam;
+        this.headerParam = headerParam;
+        this.matrixParam = matrixParam;
+        this.pathParam = pathParam;
+        this.queryParam = queryParam;
+    }
+
+    @Override
+    public ParamDescriptor constructor(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(cookieParam)
+                .setFormParam(formParam)
+                .setHeaderParam(headerParam)
+                .setMatrixParam(matrixParam)
+                .setPathParam(pathParam)
+                .setQueryParam(queryParam);
+    }
+
+    @Override
+    public ParamDescriptor field(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(fieldCookieParam)
+                .setFormParam(fieldFormParam)
+                .setHeaderParam(fieldHeaderParam)
+                .setMatrixParam(fieldMatrixParam)
+                .setPathParam(fieldPathParam)
+                .setQueryParam(fieldQueryParam);
+    }
+
+    @Override
+    public ParamDescriptor method(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(methodCookieParam)
+                .setFormParam(methodFormParam)
+                .setHeaderParam(methodHeaderParam)
+                .setMatrixParam(methodMatrixParam)
+                .setPathParam(methodPathParam)
+                .setQueryParam(methodQueryParam);
+    }
+
+    @Override
+    public ParamDescriptor methodParamsAnnotated(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(methodCookieParamPa)
+                .setFormParam(methodFormParamPa)
+                .setHeaderParam(methodHeaderParamPa)
+                .setMatrixParam(methodMatrixParamPa)
+                .setPathParam(methodPathParamPa)
+                .setQueryParam(methodQueryParamPa);
+    }
+
+    @Inject
+    @CookieParam("")
+    public void setMethodCookieParam(final String methodCookieParam) {
+        this.methodCookieParam = methodCookieParam;
+    }
+
+    @Inject
+    @FormParam("")
+    public void setMethodFormParam(final String methodFormParam) {
+        this.methodFormParam = methodFormParam;
+    }
+
+    @Inject
+    @HeaderParam("")
+    public void setMethodHeaderParam(final String methodHeaderParam) {
+        this.methodHeaderParam = methodHeaderParam;
+    }
+
+    @Inject
+    @MatrixParam("")
+    public void setMethodMatrixParam(final int methodMatrixParam) {
+        this.methodMatrixParam = methodMatrixParam;
+    }
+
+    @Inject
+    @PathParam("")
+    public void setMethodPathParam(final String methodPathParam) {
+        this.methodPathParam = methodPathParam;
+    }
+
+    @Inject
+    @QueryParam("")
+    public void setMethodQueryParam(final int methodQueryParam) {
+        this.methodQueryParam = methodQueryParam;
+    }
+
+    @Inject
+    public void setCookieParam(@CookieParam("") final String methodCookieParamPa) {
+        this.methodCookieParamPa = methodCookieParamPa;
+    }
+
+    @Inject
+    public void setFormParam(@FormParam("") final String methodFormParamPa) {
+        this.methodFormParamPa = methodFormParamPa;
+    }
+
+    @Inject
+    public void setHeaderParam(@HeaderParam("") final String methodHeaderParamPa) {
+        this.methodHeaderParamPa = methodHeaderParamPa;
+    }
+
+    @Inject
+    public void setMatrixParam(@MatrixParam("") final int methodMatrixParamPa) {
+        this.methodMatrixParamPa = methodMatrixParamPa;
+    }
+
+    @Inject
+    public void setPathParam(@PathParam("") final String methodPathParamPa) {
+        this.methodPathParamPa = methodPathParamPa;
+    }
+
+    @Inject
+    public void setQueryParam(@QueryParam("") final int methodQueryParamPa) {
+        this.methodQueryParamPa = methodQueryParamPa;
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiParamEncodedResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiParamEncodedResource.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Encoded;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/encoded/{p}")
+@RequestScoped
+@Encoded
+public class CdiParamEncodedResource {
+
+    @Inject
+    @QueryParam("q")
+    private String queryValue;
+
+    @Inject
+    @PathParam("p")
+    private String pathValue;
+
+    CdiParamEncodedResource() {
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public EncodedDescriptor get() {
+        return EncodedDescriptor.of()
+                .setQueryValue(queryValue)
+                .setPathValue(pathValue);
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiParamMixedResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiParamMixedResource.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+
+@Path("/mixed")
+@RequestScoped
+public class CdiParamMixedResource {
+
+    private final String query;
+    private final UriInfo uriInfo;
+    private final String customHeader;
+
+    CdiParamMixedResource() {
+        this.query = null;
+        this.uriInfo = null;
+        this.customHeader = null;
+    }
+
+    @Inject
+    public CdiParamMixedResource(@QueryParam("q") final String query,
+            final UriInfo uriInfo,
+            @HeaderParam("Custom") final String customHeader) {
+        this.query = query;
+        this.uriInfo = uriInfo;
+        this.customHeader = customHeader;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject get() {
+        return Json.createObjectBuilder()
+                .add("query", query != null ? query : "")
+                .add("path", uriInfo != null ? uriInfo.getPath() : "")
+                .add("customHeader", customHeader != null ? customHeader : "")
+                .build();
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiParamNotEncodedResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiParamNotEncodedResource.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Encoded;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/not-encoded/{p}")
+@RequestScoped
+public class CdiParamNotEncodedResource {
+
+    @Inject
+    @Encoded
+    @QueryParam("q")
+    private String encodedQuery;
+
+    @Inject
+    @QueryParam("q2")
+    private String decodedQuery;
+
+    @Inject
+    @PathParam("p")
+    private String pathValue;
+
+    CdiParamNotEncodedResource() {
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public EncodedDescriptor get() {
+        return EncodedDescriptor.of()
+                .setQueryValue(encodedQuery)
+                .setDecodedQuery(decodedQuery)
+                .setPathValue(pathValue);
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiParamResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiParamResource.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+import java.io.InputStream;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@Path("/params/{pathParam}")
+@RequestScoped
+public class CdiParamResource implements ParamResource {
+    private final String cookieParam;
+    private final String formParam;
+    private final String headerParam;
+    private final long matrixParam;
+    private final String pathParam;
+    private final int queryParam;
+
+    @Inject
+    @CookieParam("fieldCookieParam")
+    private String fieldCookieParam;
+    @Inject
+    @FormParam("fieldFormParam")
+    private String fieldFormParam;
+    @Inject
+    @HeaderParam("fieldHeaderParam")
+    private String fieldHeaderParam;
+    @Inject
+    @MatrixParam("fieldMatrixParam")
+    private int fieldMatrixParam;
+    @Inject
+    @PathParam("fieldPathParam")
+    private String fieldPathParam;
+    @Inject
+    @QueryParam("fieldQueryParam")
+    private int fieldQueryParam;
+
+    private String methodCookieParam;
+    private String methodFormParam;
+    private String methodHeaderParam;
+    private int methodMatrixParam;
+    private String methodPathParam;
+    private int methodQueryParam;
+
+    private String methodCookieParamPa;
+    private String methodFormParamPa;
+    private String methodHeaderParamPa;
+    private int methodMatrixParamPa;
+    private String methodPathParamPa;
+    private int methodQueryParamPa;
+
+    CdiParamResource() {
+        cookieParam = null;
+        formParam = null;
+        headerParam = null;
+        matrixParam = -1;
+        pathParam = null;
+        queryParam = -1;
+    }
+
+    @Inject
+    public CdiParamResource(@CookieParam("cookieParam") final String cookieParam,
+            @FormParam("formParam") final String formParam,
+            @HeaderParam("headerParam") final String headerParam,
+            @MatrixParam("matrixParam") final long matrixParam,
+            @PathParam("pathParam") final String pathParam,
+            @QueryParam("queryParam") final int queryParam) {
+        this.cookieParam = cookieParam;
+        this.formParam = formParam;
+        this.headerParam = headerParam;
+        this.matrixParam = matrixParam;
+        this.pathParam = pathParam;
+        this.queryParam = queryParam;
+    }
+
+    @Override
+    public ParamDescriptor constructor(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(cookieParam)
+                .setFormParam(formParam)
+                .setHeaderParam(headerParam)
+                .setMatrixParam(matrixParam)
+                .setPathParam(pathParam)
+                .setQueryParam(queryParam);
+    }
+
+    @Override
+    public ParamDescriptor field(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(fieldCookieParam)
+                .setFormParam(fieldFormParam)
+                .setHeaderParam(fieldHeaderParam)
+                .setMatrixParam(fieldMatrixParam)
+                .setPathParam(fieldPathParam)
+                .setQueryParam(fieldQueryParam);
+    }
+
+    @Override
+    public ParamDescriptor method(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(methodCookieParam)
+                .setFormParam(methodFormParam)
+                .setHeaderParam(methodHeaderParam)
+                .setMatrixParam(methodMatrixParam)
+                .setPathParam(methodPathParam)
+                .setQueryParam(methodQueryParam);
+    }
+
+    @Override
+    public ParamDescriptor methodParamsAnnotated(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(methodCookieParamPa)
+                .setFormParam(methodFormParamPa)
+                .setHeaderParam(methodHeaderParamPa)
+                .setMatrixParam(methodMatrixParamPa)
+                .setPathParam(methodPathParamPa)
+                .setQueryParam(methodQueryParamPa);
+    }
+
+    @Inject
+    @CookieParam("methodCookieParam")
+    public void setCookieParam(final String methodCookieParam) {
+        this.methodCookieParam = methodCookieParam;
+    }
+
+    @Inject
+    @FormParam("methodFormParam")
+    public void setFormParam(final String methodFormParam) {
+        this.methodFormParam = methodFormParam;
+    }
+
+    @Inject
+    @HeaderParam("methodHeaderParam")
+    public void setHeaderParam(final String methodHeaderParam) {
+        this.methodHeaderParam = methodHeaderParam;
+    }
+
+    @Inject
+    @MatrixParam("methodMatrixParam")
+    public void setMatrixParam(final int methodMatrixParam) {
+        this.methodMatrixParam = methodMatrixParam;
+    }
+
+    @Inject
+    @PathParam("methodPathParam")
+    public void setPathParam(final String methodPathParam) {
+        this.methodPathParam = methodPathParam;
+    }
+
+    @Inject
+    @QueryParam("methodQueryParam")
+    public void setQueryParam(final int methodQueryParam) {
+        this.methodQueryParam = methodQueryParam;
+    }
+
+    @Inject
+    public void setCookieParamPa(@CookieParam("methodCookieParamPa") final String cookieParam) {
+        this.methodCookieParamPa = cookieParam;
+    }
+
+    @Inject
+    public void setFormParamPa(@FormParam("methodFormParamPa") final String formParam) {
+        this.methodFormParamPa = formParam;
+    }
+
+    @Inject
+    public void setHeaderParamPa(@HeaderParam("methodHeaderParamPa") final String headerParam) {
+        this.methodHeaderParamPa = headerParam;
+    }
+
+    @Inject
+    public void setMatrixParamPa(@MatrixParam("methodMatrixParamPa") final int matrixParam) {
+        this.methodMatrixParamPa = matrixParam;
+    }
+
+    @Inject
+    public void setPathParamPa(@PathParam("methodPathParamPa") final String pathParam) {
+        this.methodPathParamPa = pathParam;
+    }
+
+    @Inject
+    public void setQueryParamPa(@QueryParam("methodQueryParamPa") final int queryParam) {
+        this.methodQueryParamPa = queryParam;
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiParamTypesResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiParamTypesResource.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.PathSegment;
+
+@Path("/types/{paths:.+}")
+@RequestScoped
+public class CdiParamTypesResource {
+
+    @Inject
+    @QueryParam("list")
+    private List<String> listParam;
+
+    @Inject
+    @QueryParam("set")
+    private Set<String> setParam;
+
+    @Inject
+    @QueryParam("sortedSet")
+    private SortedSet<String> sortedSetParam;
+
+    @Inject
+    @QueryParam("array")
+    private String[] arrayParam;
+
+    @Inject
+    @QueryParam("wrapper")
+    private Integer wrapperParam;
+
+    @Inject
+    @QueryParam("bool")
+    private Boolean booleanParam;
+
+    @Inject
+    @QueryParam("enum")
+    private ParamEnum enumParam;
+
+    @Inject
+    @QueryParam("default")
+    @DefaultValue("fallback")
+    private String defaultParam;
+
+    @Inject
+    @QueryParam("defaultInt")
+    @DefaultValue("42")
+    private int defaultIntParam;
+
+    @Inject
+    @PathParam("paths")
+    private List<PathSegment> listPaths;
+
+    @Inject
+    @PathParam("paths")
+    private PathSegment singlePath;
+
+    CdiParamTypesResource() {
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public TypesDescriptor get() {
+        return TypesDescriptor.of()
+                .setListParam(listParam)
+                .setSetParam(setParam)
+                .setSortedSetParam(sortedSetParam)
+                .setArrayParam(arrayParam)
+                .setWrapperParam(wrapperParam)
+                .setBooleanParam(booleanParam)
+                .setEnumParam(enumParam)
+                .setDefaultParam(defaultParam)
+                .setDefaultIntParam(defaultIntParam)
+                .setListPaths(listPaths.stream().map(PathSegment::getPath).collect(Collectors.toList()))
+                .setSinglePath(singlePath.getPath());
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiQualifierResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/CdiQualifierResource.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@RequestScoped
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/check-qualifier")
+public class CdiQualifierResource {
+    private static final Set<Class<? extends Annotation>> SPEC_ANNOTATIONS = Set.of(
+            BeanParam.class,
+            CookieParam.class,
+            FormParam.class,
+            HeaderParam.class,
+            MatrixParam.class,
+            PathParam.class,
+            QueryParam.class);
+
+    @Inject
+    private BeanManager beanManager;
+
+    @GET
+    public JsonArray checkAnnotations() {
+        final JsonArrayBuilder builder = Json.createArrayBuilder();
+        for (Class<? extends Annotation> annotation : SPEC_ANNOTATIONS) {
+            builder.add(Json.createObjectBuilder().add(annotation.getName(), beanManager.isQualifier(annotation)));
+        }
+        return builder.build();
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/DisabledEnhancedCdiResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/DisabledEnhancedCdiResource.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+import java.io.InputStream;
+
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+/**
+ * A Jakarta REST resource used to verify behavior when enhanced CDI support is disabled. This resource uses standard
+ * Jakarta REST parameter annotations on resource method parameters (not CDI-injected fields).
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@Path("/disabled/{pathParam}")
+public class DisabledEnhancedCdiResource implements ParamResource {
+    private final String cookieParam;
+    private final String formParam;
+    private final String headerParam;
+    private final long matrixParam;
+    private final String pathParam;
+    private final int queryParam;
+
+    @CookieParam("fieldCookieParam")
+    private String fieldCookieParam;
+    @FormParam("fieldFormParam")
+    private String fieldFormParam;
+    @HeaderParam("fieldHeaderParam")
+    private String fieldHeaderParam;
+    @MatrixParam("fieldMatrixParam")
+    private int fieldMatrixParam;
+    @PathParam("fieldPathParam")
+    private String fieldPathParam;
+    @QueryParam("fieldQueryParam")
+    private int fieldQueryParam;
+
+    private String methodCookieParam;
+    private String methodFormParam;
+    private String methodHeaderParam;
+    private int methodMatrixParam;
+    private String methodPathParam;
+    private int methodQueryParam;
+
+    private String methodCookieParamPa;
+    private String methodFormParamPa;
+    private String methodHeaderParamPa;
+    private int methodMatrixParamPa;
+    private String methodPathParamPa;
+    private int methodQueryParamPa;
+
+    public DisabledEnhancedCdiResource(@CookieParam("cookieParam") final String cookieParam,
+            @FormParam("formParam") final String formParam,
+            @HeaderParam("headerParam") final String headerParam,
+            @MatrixParam("matrixParam") final long matrixParam,
+            @PathParam("pathParam") final String pathParam,
+            @QueryParam("queryParam") final int queryParam) {
+        this.cookieParam = cookieParam;
+        this.formParam = formParam;
+        this.headerParam = headerParam;
+        this.matrixParam = matrixParam;
+        this.pathParam = pathParam;
+        this.queryParam = queryParam;
+    }
+
+    @Override
+    public ParamDescriptor constructor(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(cookieParam)
+                .setFormParam(formParam)
+                .setHeaderParam(headerParam)
+                .setMatrixParam(matrixParam)
+                .setPathParam(pathParam)
+                .setQueryParam(queryParam);
+    }
+
+    @Override
+    public ParamDescriptor field(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(fieldCookieParam)
+                .setFormParam(fieldFormParam)
+                .setHeaderParam(fieldHeaderParam)
+                .setMatrixParam(fieldMatrixParam)
+                .setPathParam(fieldPathParam)
+                .setQueryParam(fieldQueryParam);
+    }
+
+    @Override
+    public ParamDescriptor method(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(methodCookieParam)
+                .setFormParam(methodFormParam)
+                .setHeaderParam(methodHeaderParam)
+                .setMatrixParam(methodMatrixParam)
+                .setPathParam(methodPathParam)
+                .setQueryParam(methodQueryParam);
+    }
+
+    @Override
+    public ParamDescriptor methodParamsAnnotated(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(methodCookieParamPa)
+                .setFormParam(methodFormParamPa)
+                .setHeaderParam(methodHeaderParamPa)
+                .setMatrixParam(methodMatrixParamPa)
+                .setPathParam(methodPathParamPa)
+                .setQueryParam(methodQueryParamPa);
+    }
+
+    @CookieParam("methodCookieParam")
+    public void setCookieParam(final String methodCookieParam) {
+        this.methodCookieParam = methodCookieParam;
+    }
+
+    @FormParam("methodFormParam")
+    public void setFormParam(final String methodFormParam) {
+        this.methodFormParam = methodFormParam;
+    }
+
+    @HeaderParam("methodHeaderParam")
+    public void setHeaderParam(final String methodHeaderParam) {
+        this.methodHeaderParam = methodHeaderParam;
+    }
+
+    @MatrixParam("methodMatrixParam")
+    public void setMatrixParam(final int methodMatrixParam) {
+        this.methodMatrixParam = methodMatrixParam;
+    }
+
+    @PathParam("methodPathParam")
+    public void setPathParam(final String methodPathParam) {
+        this.methodPathParam = methodPathParam;
+    }
+
+    @QueryParam("methodQueryParam")
+    public void setQueryParam(final int methodQueryParam) {
+        this.methodQueryParam = methodQueryParam;
+    }
+
+    public void setCookieParamPa(@CookieParam("methodCookieParamPa") final String cookieParam) {
+        this.methodCookieParamPa = cookieParam;
+    }
+
+    public void setFormParamPa(@FormParam("methodFormParamPa") final String formParam) {
+        this.methodFormParamPa = formParam;
+    }
+
+    public void setHeaderParamPa(@HeaderParam("methodHeaderParamPa") final String headerParam) {
+        this.methodHeaderParamPa = headerParam;
+    }
+
+    public void setMatrixParamPa(@MatrixParam("methodMatrixParamPa") final int matrixParam) {
+        this.methodMatrixParamPa = matrixParam;
+    }
+
+    public void setPathParamPa(@PathParam("methodPathParamPa") final String pathParam) {
+        this.methodPathParamPa = pathParam;
+    }
+
+    public void setQueryParamPa(@QueryParam("methodQueryParamPa") final int queryParam) {
+        this.methodQueryParamPa = queryParam;
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/EncodedDescriptor.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/EncodedDescriptor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+public class EncodedDescriptor {
+    private String queryValue;
+    private String pathValue;
+    private String decodedQuery;
+
+    public static EncodedDescriptor of() {
+        return new EncodedDescriptor();
+    }
+
+    public String getQueryValue() {
+        return queryValue;
+    }
+
+    public EncodedDescriptor setQueryValue(final String queryValue) {
+        this.queryValue = queryValue;
+        return this;
+    }
+
+    public String getPathValue() {
+        return pathValue;
+    }
+
+    public EncodedDescriptor setPathValue(final String pathValue) {
+        this.pathValue = pathValue;
+        return this;
+    }
+
+    public String getDecodedQuery() {
+        return decodedQuery;
+    }
+
+    public EncodedDescriptor setDecodedQuery(final String decodedQuery) {
+        this.decodedQuery = decodedQuery;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "EncodedDescriptor{" + "queryValue='" + queryValue + '\'' +
+                ", pathValue='" + pathValue + '\'' +
+                ", decodedQuery='" + decodedQuery + '\'' +
+                '}';
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/InvalidCdiParamResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/InvalidCdiParamResource.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+import java.io.InputStream;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+
+/**
+ * Test that {@code @*Param} annotated fields, constructor parameters and method parameters are injected. The REST
+ * resource is defined as an invalid CDI bean, though annotated with {@link RequestScoped}. This means the resource
+ * will not be managed by the CDI container, but instead RESTEasy itself.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@Path("/invalid-bean/{pathParam}")
+@RequestScoped
+public class InvalidCdiParamResource implements ParamResource {
+    private final String cookieParam;
+    private final String formParam;
+    private final String headerParam;
+    private final long matrixParam;
+    private final String pathParam;
+    private final int queryParam;
+
+    @CookieParam("fieldCookieParam")
+    private String fieldCookieParam;
+    @FormParam("fieldFormParam")
+    private String fieldFormParam;
+    @HeaderParam("fieldHeaderParam")
+    private String fieldHeaderParam;
+    @MatrixParam("fieldMatrixParam")
+    private int fieldMatrixParam;
+    @PathParam("fieldPathParam")
+    private String fieldPathParam;
+    @QueryParam("fieldQueryParam")
+    private int fieldQueryParam;
+
+    private String methodCookieParam;
+    private String methodFormParam;
+    private String methodHeaderParam;
+    private int methodMatrixParam;
+    private String methodPathParam;
+    private int methodQueryParam;
+
+    private String methodCookieParamPa;
+    private String methodFormParamPa;
+    private String methodHeaderParamPa;
+    private int methodMatrixParamPa;
+    private String methodPathParamPa;
+    private int methodQueryParamPa;
+
+    public InvalidCdiParamResource(@CookieParam("cookieParam") final String cookieParam,
+            @FormParam("formParam") final String formParam,
+            @HeaderParam("headerParam") final String headerParam,
+            @MatrixParam("matrixParam") final long matrixParam,
+            @PathParam("pathParam") final String pathParam,
+            @QueryParam("queryParam") final int queryParam) {
+        this.cookieParam = cookieParam;
+        this.formParam = formParam;
+        this.headerParam = headerParam;
+        this.matrixParam = matrixParam;
+        this.pathParam = pathParam;
+        this.queryParam = queryParam;
+    }
+
+    @Override
+    public ParamDescriptor constructor(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(cookieParam)
+                .setFormParam(formParam)
+                .setHeaderParam(headerParam)
+                .setMatrixParam(matrixParam)
+                .setPathParam(pathParam)
+                .setQueryParam(queryParam);
+    }
+
+    @Override
+    public ParamDescriptor field(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(fieldCookieParam)
+                .setFormParam(fieldFormParam)
+                .setHeaderParam(fieldHeaderParam)
+                .setMatrixParam(fieldMatrixParam)
+                .setPathParam(fieldPathParam)
+                .setQueryParam(fieldQueryParam);
+    }
+
+    @Override
+    public ParamDescriptor method(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(methodCookieParam)
+                .setFormParam(methodFormParam)
+                .setHeaderParam(methodHeaderParam)
+                .setMatrixParam(methodMatrixParam)
+                .setPathParam(methodPathParam)
+                .setQueryParam(methodQueryParam);
+    }
+
+    @Override
+    public ParamDescriptor methodParamsAnnotated(final InputStream body) {
+        return ParamDescriptor.of()
+                .setCookieParam(methodCookieParamPa)
+                .setFormParam(methodFormParamPa)
+                .setHeaderParam(methodHeaderParamPa)
+                .setMatrixParam(methodMatrixParamPa)
+                .setPathParam(methodPathParamPa)
+                .setQueryParam(methodQueryParamPa);
+    }
+
+    @CookieParam("methodCookieParam")
+    public void setCookieParam(final String methodCookieParam) {
+        this.methodCookieParam = methodCookieParam;
+    }
+
+    @FormParam("methodFormParam")
+    public void setFormParam(final String methodFormParam) {
+        this.methodFormParam = methodFormParam;
+    }
+
+    @HeaderParam("methodHeaderParam")
+    public void setHeaderParam(final String methodHeaderParam) {
+        this.methodHeaderParam = methodHeaderParam;
+    }
+
+    @MatrixParam("methodMatrixParam")
+    public void setMatrixParam(final int methodMatrixParam) {
+        this.methodMatrixParam = methodMatrixParam;
+    }
+
+    @PathParam("methodPathParam")
+    public void setPathParam(final String methodPathParam) {
+        this.methodPathParam = methodPathParam;
+    }
+
+    @QueryParam("methodQueryParam")
+    public void setQueryParam(final int methodQueryParam) {
+        this.methodQueryParam = methodQueryParam;
+    }
+
+    public void setCookieParamPa(@CookieParam("methodCookieParamPa") final String cookieParam) {
+        this.methodCookieParamPa = cookieParam;
+    }
+
+    public void setFormParamPa(@FormParam("methodFormParamPa") final String formParam) {
+        this.methodFormParamPa = formParam;
+    }
+
+    public void setHeaderParamPa(@HeaderParam("methodHeaderParamPa") final String headerParam) {
+        this.methodHeaderParamPa = headerParam;
+    }
+
+    public void setMatrixParamPa(@MatrixParam("methodMatrixParamPa") final int matrixParam) {
+        this.methodMatrixParamPa = matrixParam;
+    }
+
+    public void setPathParamPa(@PathParam("methodPathParamPa") final String pathParam) {
+        this.methodPathParamPa = pathParam;
+    }
+
+    public void setQueryParamPa(@QueryParam("methodQueryParamPa") final int queryParam) {
+        this.methodQueryParamPa = queryParam;
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/ParamApplication.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/ParamApplication.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@ApplicationPath("/")
+public class ParamApplication extends Application {
+
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/ParamDescriptor.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/ParamDescriptor.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+public class ParamDescriptor {
+    private String cookieParam;
+    private String formParam;
+    private String headerParam;
+    private long matrixParam;
+    private String pathParam;
+    private int queryParam;
+
+    public static ParamDescriptor of() {
+        return new ParamDescriptor();
+    }
+
+    public String getCookieParam() {
+        return cookieParam;
+    }
+
+    public ParamDescriptor setCookieParam(final String cookieParam) {
+        this.cookieParam = cookieParam;
+        return this;
+    }
+
+    public String getFormParam() {
+        return formParam;
+    }
+
+    public ParamDescriptor setFormParam(final String formParam) {
+        this.formParam = formParam;
+        return this;
+    }
+
+    public String getHeaderParam() {
+        return headerParam;
+    }
+
+    public ParamDescriptor setHeaderParam(final String headerParam) {
+        this.headerParam = headerParam;
+        return this;
+    }
+
+    public long getMatrixParam() {
+        return matrixParam;
+    }
+
+    public ParamDescriptor setMatrixParam(final long matrixParam) {
+        this.matrixParam = matrixParam;
+        return this;
+    }
+
+    public String getPathParam() {
+        return pathParam;
+    }
+
+    public ParamDescriptor setPathParam(final String pathParam) {
+        this.pathParam = pathParam;
+        return this;
+    }
+
+    public int getQueryParam() {
+        return queryParam;
+    }
+
+    public ParamDescriptor setQueryParam(final int queryParam) {
+        this.queryParam = queryParam;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "ParamDescriptor{" + "cookieParam='" + cookieParam + '\'' +
+                ", formParam='" + formParam + '\'' +
+                ", headerParam='" + headerParam + '\'' +
+                ", matrixParam=" + matrixParam +
+                ", pathParam='" + pathParam + '\'' +
+                ", queryParam=" + queryParam +
+                '}';
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/ParamEnum.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/ParamEnum.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+public enum ParamEnum {
+    VALUE_ONE,
+    VALUE_TWO
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/ParamResource.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/ParamResource.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+import java.io.InputStream;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+@Produces(MediaType.APPLICATION_JSON)
+public interface ParamResource {
+
+    @Path("constructor")
+    @POST
+    ParamDescriptor constructor(InputStream body);
+
+    @Path("field/{fieldPathParam}")
+    @POST
+    ParamDescriptor field(InputStream body);
+
+    @Path("method/{methodPathParam}")
+    @POST
+    ParamDescriptor method(InputStream body);
+
+    @Path("method-param/{methodPathParamPa}")
+    @POST
+    ParamDescriptor methodParamsAnnotated(InputStream body);
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/SearchParams.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/SearchParams.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.QueryParam;
+
+@RequestScoped
+public class SearchParams {
+
+    @Inject
+    @QueryParam("q")
+    private String query;
+
+    @Inject
+    @QueryParam("limit")
+    @DefaultValue("10")
+    private int limit;
+
+    @Inject
+    @HeaderParam("Accept-Language")
+    private String language;
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(final String query) {
+        this.query = query;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public void setLimit(final int limit) {
+        this.limit = limit;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(final String language) {
+        this.language = language;
+    }
+
+    @Override
+    public String toString() {
+        return "SearchParams{" + "query='" + query + '\'' +
+                ", limit=" + limit +
+                ", language='" + language + '\'' +
+                '}';
+    }
+}

--- a/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/TypesDescriptor.java
+++ b/testsuite/integration-tests/src/test/java/org/jboss/resteasy/test/cdi/params/resources/TypesDescriptor.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.test.cdi.params.resources;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+public class TypesDescriptor {
+    private List<String> listParam;
+    private Set<String> setParam;
+    private SortedSet<String> sortedSetParam;
+    private String[] arrayParam;
+    private Integer wrapperParam;
+    private Boolean booleanParam;
+    private ParamEnum enumParam;
+    private String defaultParam;
+    private int defaultIntParam;
+    private List<String> listPaths;
+    private String singlePath;
+
+    public static TypesDescriptor of() {
+        return new TypesDescriptor();
+    }
+
+    public List<String> getListParam() {
+        return listParam;
+    }
+
+    public TypesDescriptor setListParam(final List<String> listParam) {
+        this.listParam = listParam;
+        return this;
+    }
+
+    public Set<String> getSetParam() {
+        return setParam;
+    }
+
+    public TypesDescriptor setSetParam(final Set<String> setParam) {
+        this.setParam = setParam;
+        return this;
+    }
+
+    public SortedSet<String> getSortedSetParam() {
+        return sortedSetParam;
+    }
+
+    public TypesDescriptor setSortedSetParam(final SortedSet<String> sortedSetParam) {
+        this.sortedSetParam = sortedSetParam;
+        return this;
+    }
+
+    public String[] getArrayParam() {
+        return arrayParam;
+    }
+
+    public TypesDescriptor setArrayParam(final String[] arrayParam) {
+        this.arrayParam = arrayParam;
+        return this;
+    }
+
+    public Integer getWrapperParam() {
+        return wrapperParam;
+    }
+
+    public TypesDescriptor setWrapperParam(final Integer wrapperParam) {
+        this.wrapperParam = wrapperParam;
+        return this;
+    }
+
+    public Boolean getBooleanParam() {
+        return booleanParam;
+    }
+
+    public TypesDescriptor setBooleanParam(final Boolean booleanParam) {
+        this.booleanParam = booleanParam;
+        return this;
+    }
+
+    public ParamEnum getEnumParam() {
+        return enumParam;
+    }
+
+    public TypesDescriptor setEnumParam(final ParamEnum enumParam) {
+        this.enumParam = enumParam;
+        return this;
+    }
+
+    public String getDefaultParam() {
+        return defaultParam;
+    }
+
+    public TypesDescriptor setDefaultParam(final String defaultParam) {
+        this.defaultParam = defaultParam;
+        return this;
+    }
+
+    public int getDefaultIntParam() {
+        return defaultIntParam;
+    }
+
+    public TypesDescriptor setDefaultIntParam(final int defaultIntParam) {
+        this.defaultIntParam = defaultIntParam;
+        return this;
+    }
+
+    public List<String> getListPaths() {
+        return listPaths;
+    }
+
+    public TypesDescriptor setListPaths(final List<String> listPaths) {
+        this.listPaths = listPaths;
+        return this;
+    }
+
+    public String getSinglePath() {
+        return singlePath;
+    }
+
+    public TypesDescriptor setSinglePath(final String singlePath) {
+        this.singlePath = singlePath;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "TypesDescriptor{" + "listParam=" + listParam +
+                ", setParam=" + setParam +
+                ", sortedSetParam=" + sortedSetParam +
+                ", arrayParam=" + Arrays.toString(arrayParam) +
+                ", wrapperParam=" + wrapperParam +
+                ", booleanParam=" + booleanParam +
+                ", enumParam=" + enumParam +
+                ", defaultParam='" + defaultParam + '\'' +
+                ", defaultIntParam=" + defaultIntParam +
+                ", listPaths=" + listPaths +
+                ", singlePath=" + singlePath +
+                '}';
+    }
+}

--- a/testsuite/integration-tests/src/test/resources/arquillian.xml
+++ b/testsuite/integration-tests/src/test/resources/arquillian.xml
@@ -9,7 +9,7 @@
                 <property name="jbossHome">${jboss.home}</property>
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
-                <property name="javaVmArguments">${debugJvmArgs} -server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.managed} -Djboss.server.base.dir=${container.base.dir.managed}
+                <property name="javaVmArguments">${debugJvmArgs} -server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${wildfly.system.properties} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.managed} -Djboss.server.base.dir=${container.base.dir.managed}
                 </property>
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.managed}</property>
@@ -21,7 +21,7 @@
                 <property name="jbossArguments">${securityManagerArg}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
                 <!-- Forcing file.encoding=us-ascii in order to test RESTEASY-2171 -->
-                <property name="javaVmArguments">-Dorg.jboss.resteasy.port=15080 -Dfile.encoding=us-ascii -server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.managed.encoding} -Djboss.server.base.dir=${container.base.dir.managed.encoding}
+                <property name="javaVmArguments">-Dorg.jboss.resteasy.port=15080 -Dfile.encoding=us-ascii -server -Xms256m -Xmx1G -Djboss.bind.address=${node} -Djboss.bind.address.management=${node} -Dnode=${node} -Dipv6=${ipv6} ${additionalJvmArgs} ${ipv6ArquillianSettings} ${wildfly.system.properties} ${jacoco.agent} -Djboss.socket.binding.port-offset=${container.offset.managed.encoding} -Djboss.server.base.dir=${container.base.dir.managed.encoding}
                 </property>
                 <property name="managementAddress">${node}</property>
                 <property name="managementPort">${container.management.port.managed.encoding}</property>


### PR DESCRIPTION
Upstream: #4933 

### [RESTEASY-3755](https://redhat.atlassian.net/browse/RESTEASY-3755)

Enable injection of @*Param annotated parameters with CDI. Ensure invalid CDI resource beans are ignored by the CDI extension and processed by RESTEasy.

#### CDI Integration Changes

A new CDI extension, `ResteasyParamCdiExtension`, registers Jakarta REST parameter annotations (`@CookieParam`, `@FormParam`, `@HeaderParam`, `@MatrixParam`, `@PathParam`, `@QueryParam`, and `@BeanParam`) as CDI qualifiers. This allows Jakarta REST resources to receive parameter values via CDI injection — including constructor injection — without requiring a public no-arg constructor (provided
the class is still proxyable).

For any proxyable Jakarta REST resource or provider:
- `@Inject` is implicitly added to `@Context`-annotated fields, setter methods, and constructors (`ResteasyCdiExtension`)
- `@Inject` is implicitly added to `@*Param`-annotated fields, setter methods, and constructors (`ResteasyParamCdiExtension`)
- Synthetic CDI beans are registered to produce parameter values at request time by delegating to `ParameterExtractors`

Resources that are not proxyable (final class, final methods, or no non-private no-arg constructor) are excluded from CDI management and handled by RESTEasy directly. This resolves the deployment regression in RESTEASY-3752 where resources with only a parameterized constructor would fail.

#### Other Changes

- `StringParameterConverter` — new extraction/conversion system used by the CDI synthetic producers
- `CdiProxyUnwrapper` — utility for unwrapping Weld and OpenWebBeans client proxies via reflective method handles
- `PropertyInjectorImpl` — skips @Inject-annotated members to avoid double injection when CDI is managing the bean

### [RESTEASY-3754](https://redhat.atlassian.net/browse/RESTEASY-3754)

This fixes a bug in the `PriorityServiceLoader` which did not include all services if the services had the same priority.