### PR TITLE
Make wildfly-maven-plugin GAV configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,10 @@
         <version.org.jacoco.plugin>0.8.15</version.org.jacoco.plugin>
         <version.org.wildfly.galleon-plugins>7.0.0.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.plugins.wildfly-maven-plugin>5.1.5.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
-        <version.org.wildfly.jar.plugin>11.0.2.Final</version.org.wildfly.jar.plugin>
+        <!-- Default wildfly-maven-plugin GAV for executions other than those running goal execute-commands -->
+        <groupId.org.wildfly.plugins.wildfly-maven-plugin.bootable-jar>org.wildfly.plugins</groupId.org.wildfly.plugins.wildfly-maven-plugin.bootable-jar>
+        <artifactId.org.wildfly.plugins.wildfly-maven-plugin.bootable-jar>wildfly-maven-plugin</artifactId.org.wildfly.plugins.wildfly-maven-plugin.bootable-jar>
+        <version.org.wildfly.plugins.wildfly-maven-plugin.bootable-jar>${version.org.wildfly.plugins.wildfly-maven-plugin}</version.org.wildfly.plugins.wildfly-maven-plugin.bootable-jar>
 
         <!-- Override the checkstyle version to be compatible with Java 11, see https://checkstyle.org/#JRE_and_JDK -->
         <version.checkstyle>10.26.1</version.checkstyle>

--- a/testsuite/integration-tests/pom.xml
+++ b/testsuite/integration-tests/pom.xml
@@ -29,6 +29,8 @@
         <!-- Skip deploying tests -->
         <maven.deploy.skip>true</maven.deploy.skip>
         <central.skipPublishing>${maven.deploy.skip}</central.skipPublishing>
+
+        <configure-test-server.phase>process-test-resources</configure-test-server.phase>
     </properties>
 
     <artifactId>resteasy-integration-tests</artifactId>
@@ -210,6 +212,10 @@
                     <name>ts.bootable</name>
                 </property>
             </activation>
+            <properties>
+                <!-- Disable configure-test-server for bootable JAR tests -->
+                <configure-test-server.phase>none</configure-test-server.phase>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
@@ -235,14 +241,10 @@
                     </plugin>
                     <!-- Provisions WildFly for bootable JAR tests -->
                     <plugin>
-                        <groupId>org.wildfly.plugins</groupId>
-                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <groupId>${groupId.org.wildfly.plugins.wildfly-maven-plugin.bootable-jar}</groupId>
+                        <artifactId>${artifactId.org.wildfly.plugins.wildfly-maven-plugin.bootable-jar}</artifactId>
+                        <version>${version.org.wildfly.plugins.wildfly-maven-plugin.bootable-jar}</version>
                         <executions>
-                            <!-- Disable configure-test-server for bootable JAR tests -->
-                            <execution>
-                                <id>configure-test-server</id>
-                                <phase>none</phase>
-                            </execution>
                             <!-- Package a jaxrs-server layer with a few other layers to be tested as a bootable jar -->
                             <execution>
                                 <id>bootable-jar-observability-packaging</id>
@@ -797,7 +799,7 @@
                 <executions>
                     <execution>
                         <id>configure-test-server</id>
-                        <phase>process-test-resources</phase>
+                        <phase>${configure-test-server.phase}</phase>
                         <goals>
                             <goal>execute-commands</goal>
                         </goals>


### PR DESCRIPTION
Make `wildfly-maven-plugin` GAV configurable with one notable exception: the `<goal>execute-commands</goal>` execution since the productized `wildfly-maven-plugin` doesn't have the `execute-commands` goal