### PR TITLE
[RESTEASY-3794] Lookup the CDI extension via the BeanManager.getExten…

### DIFF
--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiAwareRegistry.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiAwareRegistry.java
@@ -5,11 +5,7 @@
 
 package org.jboss.resteasy.cdi;
 
-import java.util.Set;
-
 import jakarta.annotation.Priority;
-import jakarta.enterprise.context.spi.CreationalContext;
-import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 
 import org.jboss.resteasy.cdi.i18n.LogMessages;
@@ -138,14 +134,12 @@ public class CdiAwareRegistry extends ResourceMethodRegistry implements Registry
             synchronized (this) {
                 if (beanContainer == null) {
                     final BeanManager manager = getBeanManager();
-                    final Set<Bean<?>> beans = manager.getBeans(ResteasyBeanContainer.class);
-                    final Bean<?> bean = manager.resolve(beans);
-                    if (bean == null) {
+                    final ResteasyCdiExtension extension = manager.getExtension(ResteasyCdiExtension.class);
+                    final ResteasyBeanContainer container = extension.beanContainer();
+                    if (container == null) {
                         throw Messages.MESSAGES.unableToResolveBean(ResteasyBeanContainer.class.getName());
                     }
-                    final CreationalContext<?> creationalContext = beanManager.createCreationalContext(bean);
-                    beanContainer = (ResteasyBeanContainer) beanManager.getReference(bean, ResteasyBeanContainer.class,
-                            creationalContext);
+                    beanContainer = container;
                 }
             }
         }

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiInjectorFactory.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/CdiInjectorFactory.java
@@ -10,10 +10,7 @@ import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Type;
 import java.util.Map;
-import java.util.Set;
 
-import jakarta.enterprise.context.spi.CreationalContext;
-import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.CDI;
 
@@ -166,12 +163,6 @@ public class CdiInjectorFactory implements InjectorFactory {
      * @return ResteasyCdiExtension instance
      */
     private ResteasyCdiExtension lookupResteasyCdiExtension() {
-        Set<Bean<?>> beans = manager.getBeans(ResteasyCdiExtension.class);
-        Bean<?> bean = manager.resolve(beans);
-        if (bean == null) {
-            throw new IllegalStateException(Messages.MESSAGES.unableToObtainResteasyCdiExtension());
-        }
-        CreationalContext<?> context = manager.createCreationalContext(bean);
-        return (ResteasyCdiExtension) manager.getReference(bean, ResteasyCdiExtension.class, context);
+        return manager.getExtension(ResteasyCdiExtension.class);
     }
 }

--- a/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/ResteasyCdiExtension.java
+++ b/resteasy-cdi/src/main/java/org/jboss/resteasy/cdi/ResteasyCdiExtension.java
@@ -89,6 +89,7 @@ public class ResteasyCdiExtension implements Extension {
     private boolean generateClientBean = true;
     private boolean addContextProducers = true;
     private boolean noApplicationFound = true;
+    private volatile ResteasyBeanContainer resteasyBeanContainer;
 
     public ResteasyCdiExtension() {
         enhancedCdiSupportEnabled = CdiOptions.ENHANCED_CDI_SUPPORT.getValue();
@@ -134,10 +135,7 @@ public class ResteasyCdiExtension implements Extension {
         }
         final Set<Class<?>> resources = Set.copyOf(beanContainer);
         beanContainer.clear();
-        final ResteasyBeanContainer instance = resources::contains;
-        event.addBean().addType(ResteasyBeanContainer.class)
-                .scope(ApplicationScoped.class)
-                .createWith(ctx -> instance);
+        resteasyBeanContainer = resources::contains;
     }
 
     /**
@@ -335,6 +333,10 @@ public class ResteasyCdiExtension implements Extension {
 
     public Map<Class<?>, Type> getSessionBeanInterface() {
         return sessionBeanInterface;
+    }
+
+    ResteasyBeanContainer beanContainer() {
+        return resteasyBeanContainer;
     }
 
     private boolean isSessionBean(AnnotatedType<?> annotatedType) {


### PR DESCRIPTION
…sion() instead of using a reference lookup.

Also, don't register a ResteasyBeanContainer as a bean. Just expose it via the ResteasyCdiExtension.

https://redhat.atlassian.net/browse/RESTEASY-3794

Upstream: #5012 