### PR TITLE
Cancel async timeout watchdogs and stop keeping them past shutdown

### DIFF
--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/concurrent/ContextualExecutors.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/concurrent/ContextualExecutors.java
@@ -242,8 +242,10 @@ public class ContextualExecutors {
      */
     public static ContextualScheduledExecutorService newScheduledThreadPool() {
         final int poolSize = CoreThreads.getCoreThreads("resteasy.async.timeout.scheduler.min.pool.size");
-        final ScheduledExecutorService delegate = Executors.newScheduledThreadPool(poolSize,
+        final ScheduledThreadPoolExecutor delegate = new ScheduledThreadPoolExecutor(poolSize,
                 new ContextualThreadFactory("contextual-scheduled-pool"));
+        // Cancelled timeout watchdogs must not sit in the queue until their delay elapses.
+        delegate.setRemoveOnCancelPolicy(true);
         return new ContextualScheduledExecutorService(delegate, false);
     }
 

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/Servlet3AsyncHttpRequest.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/Servlet3AsyncHttpRequest.java
@@ -258,6 +258,7 @@ public class Servlet3AsyncHttpRequest extends HttpServletInputMessage {
                 LogMessages.LOGGER.debug(Messages.MESSAGES.onComplete());
                 synchronized (responseLock) {
                     done = true;
+                    cancelTimeout();
                     close();
                 }
             }
@@ -293,6 +294,7 @@ public class Servlet3AsyncHttpRequest extends HttpServletInputMessage {
                 synchronized (responseLock) {
                     cancelled = true;
                     done = true;
+                    cancelTimeout();
                     close();
                 }
             }
@@ -304,6 +306,20 @@ public class Servlet3AsyncHttpRequest extends HttpServletInputMessage {
             @Override
             public void close() {
                 asyncScheduler.shutdown();
+            }
+
+            /**
+             * Cancels the pending timeout watchdog when the async cycle ends. This must not run
+             * on the timeout dispatch path itself: a {@link jakarta.ws.rs.container.TimeoutHandler}
+             * may extend the timeout instead of resuming, and the watchdog it re-arms has to
+             * survive. Without the cancel, the watchdog of every completed request stays queued
+             * on the scheduler until its delay elapses.
+             */
+            private void cancelTimeout() {
+                final ScheduledFuture<?> timeout = timeoutFuture;
+                if (timeout != null) {
+                    timeout.cancel(false);
+                }
             }
         }
 

--- a/server-adapters/resteasy-undertow/src/test/java/org/jboss/resteasy/test/undertow/AsyncTimeoutExtensionTest.java
+++ b/server-adapters/resteasy-undertow/src/test/java/org/jboss/resteasy/test/undertow/AsyncTimeoutExtensionTest.java
@@ -1,0 +1,107 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2026 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.test.undertow;
+
+import static org.jboss.resteasy.test.undertow.TestSupport.generateURL;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.Application;
+
+import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A {@link jakarta.ws.rs.container.TimeoutHandler} may extend the timeout by calling
+ * {@link AsyncResponse#setTimeout(long, TimeUnit)} instead of resuming. The watchdog the
+ * handler re-arms must survive the timeout dispatch, and the second timeout must fire.
+ *
+ * @author <a href="mailto:stevenschlansker@gmail.com">Steven Schlansker</a>
+ */
+public class AsyncTimeoutExtensionTest {
+
+    static Client client;
+    static UndertowJaxrsServer server;
+
+    @ApplicationPath("/")
+    public static class MyApp extends Application {
+        @Override
+        public Set<Class<?>> getClasses() {
+            return Set.of(TimeoutExtensionResource.class);
+        }
+    }
+
+    @Path("timeout-extension")
+    public static class TimeoutExtensionResource {
+        private static final AtomicBoolean EXTENDED = new AtomicBoolean(false);
+
+        @GET
+        @Path("extended")
+        public void extendedTimeout(@Suspended final AsyncResponse response) {
+            EXTENDED.set(false);
+            response.setTimeoutHandler(ar -> {
+                if (EXTENDED.getAndSet(true)) {
+                    ar.resume("extended");
+                } else {
+                    ar.setTimeout(1, TimeUnit.SECONDS);
+                }
+            });
+            response.setTimeout(1, TimeUnit.SECONDS);
+        }
+    }
+
+    @BeforeAll
+    public static void init() throws Exception {
+        server = new UndertowJaxrsServer().start();
+        server.deploy(MyApp.class);
+        // A broken re-arm hangs the request forever; the read timeout turns that into a
+        // bounded failure instead of a hung build.
+        client = ClientBuilder.newBuilder().readTimeout(15, TimeUnit.SECONDS).build();
+    }
+
+    @AfterAll
+    public static void stop() throws Exception {
+        try {
+            client.close();
+        } catch (Exception ignored) {
+        }
+        server.stop();
+    }
+
+    @Test
+    public void timeoutHandlerExtendsTheTimeout() {
+        final String val = client.target(generateURL("/timeout-extension/extended"))
+                .request()
+                .get(String.class);
+        Assertions.assertEquals("extended", val);
+    }
+}


### PR DESCRIPTION
Note: I tried to file a RESTEASY-XXXXX issue for this, but somehow seem to have lost my Jira Reporter status since I last visited here. Apologies if I somehow missed on this one. Thanks for considering this report!

**Observed**: a service with long-poll `@Suspended` endpoints (30-second timeouts, a few requests per second) took a constant extra 10.1 seconds on every deployment stop; a thread dump shows the stopping thread parked in `ContextualExecutorService.awaitTermination` with uncancelled watchdogs in the queue.


`Servlet3AsynchronousResponse` schedules a timeout watchdog per suspended request and only cancels it when a timeout is re-set. `resume()`, `complete()`, `cancel()`, and `close()` leave the watchdog queued until its delay elapses. With a deployment in context, the watchdogs accumulate on the deployment's shared scheduled executor; without one, each response's private pool thread survives until the watchdog fires.

That pool also keeps delayed tasks after shutdown() (the `ScheduledThreadPoolExecutor` default), so `ResteasyDeploymentImpl.stop()` waits out its full 10-second awaitTermination on any deployment that recently served suspended requests, and only a debug log mentions it.

Cancel the watchdog in `close()`, the funnel for every terminal transition, and create the pool with
`executeExistingDelayedTasksAfterShutdownPolicy(false)` and `removeOnCancelPolicy(true)`.

(Analysis produced using Claude Fable)