### PR TITLE
[RESTEASY-3313] Reuse the provider factory's ThreadContexts when a thread has none

### DIFF
--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/concurrent/ContextualExecutors.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/concurrent/ContextualExecutors.java
@@ -420,16 +420,31 @@ public class ContextualExecutors {
     private static Map<ThreadContext<Object>, Object> getContexts() {
         final Map<ThreadContext<Object>, Object> contexts = new LinkedHashMap<>();
         // Load any registered providers
-        ThreadContexts threadContexts = ResteasyProviderFactory.getInstance()
-                .getContextData(ThreadContexts.class);
-        // Create a new ThreadContexts which will load at least the ones from services
+        final ResteasyProviderFactory factory = ResteasyProviderFactory.getInstance();
+        ThreadContexts threadContexts = factory.getContextData(ThreadContexts.class);
         if (threadContexts == null) {
-            threadContexts = new ThreadContexts();
+            threadContexts = fallbackContexts(factory);
         }
         for (ThreadContext<Object> context : threadContexts.getThreadContexts()) {
             contexts.put(context, context.capture());
         }
         return contexts;
+    }
+
+    /**
+     * Returns the source of thread contexts for a thread with no {@link ThreadContexts} in its context data. When the
+     * thread's context class loader sees the services of the class loader that defined the provider factory, the
+     * factory's cached contexts are used. Otherwise a new {@link ThreadContexts} is created, as before, so that a
+     * shared factory does not cache one deployment's provider view, or retain one deployment's class loader, for all
+     * others.
+     */
+    private static ThreadContexts fallbackContexts(final ResteasyProviderFactory factory) {
+        final ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        final ClassLoader factoryLoader = factory.getClass().getClassLoader();
+        if (tccl == factoryLoader || (tccl == null && factoryLoader == ClassLoader.getSystemClassLoader())) {
+            return factory.getThreadContexts();
+        }
+        return new ThreadContexts();
     }
 
     private static void reset(final Map<ThreadContext<Object>, Object> contexts) {

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java
@@ -28,6 +28,7 @@ import jakarta.ws.rs.ext.ReaderInterceptor;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 import jakarta.ws.rs.ext.WriterInterceptor;
 
+import org.jboss.resteasy.spi.concurrent.ThreadContexts;
 import org.jboss.resteasy.spi.interception.JaxrsInterceptorRegistry;
 import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.spi.statistics.StatisticsController;
@@ -42,6 +43,8 @@ public abstract class ResteasyProviderFactory extends RuntimeDelegate
     private static volatile ResteasyProviderFactory instance;
 
     private static boolean registerBuiltinByDefault = true;
+
+    private volatile ThreadContexts threadContexts;
 
     public abstract Set<DynamicFeature> getServerDynamicFeatures();
 
@@ -87,6 +90,31 @@ public abstract class ResteasyProviderFactory extends RuntimeDelegate
             instance = factory;
         }
         RuntimeDelegate.setInstance(factory);
+    }
+
+    /**
+     * Returns the {@link ThreadContexts} associated with this provider factory. This is the source of thread
+     * contexts for threads whose {@linkplain #getContextData(Class) context data} does not contain a
+     * {@code ThreadContexts} entry and whose context class loader is the class loader that defined this provider
+     * factory. The instance is created lazily; creation {@linkplain java.util.ServiceLoader loads} the
+     * {@link org.jboss.resteasy.spi.concurrent.ThreadContext ThreadContext} providers from the defining class loader
+     * once for the lifetime of this provider factory. Binding the providers to the defining class loader keeps this
+     * cache from holding another deployment's class loader, and from fixing one deployment's provider view for all
+     * others, when the factory is shared.
+     *
+     * @return the thread contexts for this provider factory
+     */
+    public ThreadContexts getThreadContexts() {
+        ThreadContexts result = threadContexts;
+        if (result == null) {
+            synchronized (this) {
+                result = threadContexts;
+                if (result == null) {
+                    threadContexts = result = new ThreadContexts(getClass().getClassLoader());
+                }
+            }
+        }
+        return result;
     }
 
     static final Object RD_LOCK = new Object();

--- a/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/concurrent/ThreadContexts.java
+++ b/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/concurrent/ThreadContexts.java
@@ -37,10 +37,22 @@ public class ThreadContexts {
     private final List<ThreadContext<Object>> contexts;
 
     /**
-     * Creates a new collection instance.
+     * Creates a new collection instance. The {@link ThreadContext} providers are loaded from the current thread's
+     * context class loader.
      */
     public ThreadContexts() {
-        contexts = createContexts();
+        this(Thread.currentThread().getContextClassLoader());
+    }
+
+    /**
+     * Creates a new collection instance. The {@link ThreadContext} providers are loaded from the given class loader,
+     * or from the {@linkplain ClassLoader#getSystemClassLoader() system class loader} if the given class loader is
+     * {@code null}.
+     *
+     * @param classLoader the class loader used to load the {@code ThreadContext} providers
+     */
+    public ThreadContexts(final ClassLoader classLoader) {
+        contexts = createContexts(classLoader);
     }
 
     /**
@@ -87,9 +99,9 @@ public class ThreadContexts {
         return this;
     }
 
-    private static List<ThreadContext<Object>> createContexts() {
+    private static List<ThreadContext<Object>> createContexts(final ClassLoader classLoader) {
         final List<ThreadContext<Object>> contexts = new ArrayList<>();
-        ServiceLoader.load(ThreadContext.class).forEach(contexts::add);
+        ServiceLoader.load(ThreadContext.class, classLoader).forEach(contexts::add);
         return contexts;
     }
 }

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/ThreadLocalResteasyProviderFactory.java
@@ -40,6 +40,7 @@ import org.jboss.resteasy.spi.InjectorFactory;
 import org.jboss.resteasy.spi.ProviderFactoryDelegate;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.spi.StringParameterUnmarshaller;
+import org.jboss.resteasy.spi.concurrent.ThreadContexts;
 import org.jboss.resteasy.spi.interception.JaxrsInterceptorRegistry;
 import org.jboss.resteasy.util.ThreadLocalStack;
 
@@ -476,6 +477,11 @@ public final class ThreadLocalResteasyProviderFactory extends ResteasyProviderFa
     @Override
     public <T> T getContextData(Class<T> rawType, Type genericType, Annotation[] annotations, boolean unwrapAsync) {
         return getDelegate().getContextData(rawType, genericType, annotations, unwrapAsync);
+    }
+
+    @Override
+    public ThreadContexts getThreadContexts() {
+        return getDelegate().getThreadContexts();
     }
 
     @Override

--- a/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ResteasyProviderFactoryDelegate.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/core/providerfactory/ResteasyProviderFactoryDelegate.java
@@ -62,6 +62,7 @@ import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.InjectorFactory;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.spi.StringParameterUnmarshaller;
+import org.jboss.resteasy.spi.concurrent.ThreadContexts;
 import org.jboss.resteasy.spi.interception.JaxrsInterceptorRegistry;
 import org.jboss.resteasy.spi.metadata.ResourceBuilder;
 import org.jboss.resteasy.spi.statistics.StatisticsController;
@@ -266,6 +267,11 @@ public class ResteasyProviderFactoryDelegate extends ResteasyProviderFactory {
     @Override
     public <T> T getContextData(Class<T> rawType, Type genericType, Annotation[] annotations, boolean unwrapAsync) {
         return resteasyProviderFactoryDelegator.getContextData(rawType, genericType, annotations, unwrapAsync);
+    }
+
+    @Override
+    public ThreadContexts getThreadContexts() {
+        return resteasyProviderFactoryDelegator.getThreadContexts();
     }
 
     @Override

--- a/resteasy-core/src/test/java/org/jboss/resteasy/core/ContextualExecutorsFallbackTest.java
+++ b/resteasy-core/src/test/java/org/jboss/resteasy/core/ContextualExecutorsFallbackTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jboss.resteasy.concurrent.ContextualExecutors;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.concurrent.ThreadContexts;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that wrapping tasks on a thread with no {@link ThreadContexts} in its context data uses the provider
+ * factory's thread contexts instead of loading the providers again for each task.
+ *
+ * @see <a href="https://issues.redhat.com/browse/RESTEASY-3313">RESTEASY-3313</a>
+ */
+class ContextualExecutorsFallbackTest {
+
+    /**
+     * The provider factory should hand out one {@link ThreadContexts} instance for its lifetime, from any thread.
+     * A single instance means the {@code ThreadContext} providers are loaded once, not once per wrapped task.
+     */
+    @Test
+    void factoryThreadContextsIsStable() throws Exception {
+        final ResteasyProviderFactory factory = ResteasyProviderFactory.getInstance();
+        final ThreadContexts first = factory.getThreadContexts();
+        final AtomicReference<ThreadContexts> fromOtherThread = new AtomicReference<>();
+        runOnBareThread(() -> fromOtherThread.set(factory.getThreadContexts()));
+        assertSame(first, fromOtherThread.get());
+    }
+
+    /**
+     * A context registered with the provider factory's thread contexts must be captured by tasks wrapped on threads
+     * without a {@code ThreadContexts} entry in their context data.
+     */
+    @Test
+    void fallbackContextsComeFromFactory() throws Exception {
+        final ResteasyProviderFactory factory = ResteasyProviderFactory.getInstance();
+        final CountingThreadContext counting = new CountingThreadContext();
+        factory.getThreadContexts().add(counting);
+
+        runOnBareThread(() -> ContextualExecutors.runnable(() -> {
+        }).run());
+        runOnBareThread(() -> ContextualExecutors.runnable(() -> {
+        }).run());
+
+        assertEquals(2, counting.captures(),
+                "Each wrapped task should capture the contexts registered with the provider factory");
+    }
+
+    /**
+     * A thread whose context class loader is not the class loader that defined the provider factory must not use the
+     * factory's cached contexts. A shared factory must not fix one deployment's provider view for all others.
+     */
+    @Test
+    void foreignContextClassLoaderDoesNotUseFactoryContexts() throws Exception {
+        final ResteasyProviderFactory factory = ResteasyProviderFactory.getInstance();
+        final CountingThreadContext counting = new CountingThreadContext();
+        factory.getThreadContexts().add(counting);
+
+        try (URLClassLoader foreignLoader = new URLClassLoader(new URL[0], null)) {
+            runOnBareThread(() -> {
+                Thread.currentThread().setContextClassLoader(foreignLoader);
+                ContextualExecutors.runnable(() -> {
+                }).run();
+            });
+        }
+
+        assertEquals(0, counting.captures(),
+                "A task wrapped under a foreign context class loader should not capture the factory's contexts");
+    }
+
+    private static void runOnBareThread(final Runnable task) throws Exception {
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final Thread thread = new Thread(task);
+        thread.setUncaughtExceptionHandler((t, e) -> failure.set(e));
+        thread.start();
+        thread.join(10_000L);
+        final Throwable thrown = failure.get();
+        if (thrown != null) {
+            throw new AssertionError("Task on bare thread failed", thrown);
+        }
+    }
+}

--- a/resteasy-core/src/test/java/org/jboss/resteasy/core/CountingThreadContext.java
+++ b/resteasy-core/src/test/java/org/jboss/resteasy/core/CountingThreadContext.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.resteasy.core;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jboss.resteasy.spi.concurrent.ThreadContext;
+
+/**
+ * A no-op {@link ThreadContext} which counts how often its context is captured.
+ */
+class CountingThreadContext implements ThreadContext<Object> {
+
+    private final AtomicInteger captures = new AtomicInteger();
+
+    @Override
+    public Object capture() {
+        captures.incrementAndGet();
+        return new Object();
+    }
+
+    @Override
+    public void push(final Object context) {
+    }
+
+    @Override
+    public void reset(final Object context) {
+    }
+
+    int captures() {
+        return captures.get();
+    }
+}


### PR DESCRIPTION
`ContextualExecutors.getContexts()` created a new `ThreadContexts`, and with it a full `ServiceLoader` scan of the `ThreadContext` providers, each time it wrapped a task on a thread whose context data holds no `ThreadContexts` entry. A client application that submits requests from its own threads pays that classpath scan on every request submission (RESTEASY-3313).

Cache a lazily created `ThreadContexts` on the `ResteasyProviderFactory` instance and use it as the fallback source of contexts for threads whose context class loader is the loader that defined the factory. The cached providers load from that defining loader, so a factory shared across deployments cannot cache one deployment's provider view for the others, and cannot retain an undeployed application's class loader. A thread with a different context class loader keeps the previous behavior, a fresh `ThreadContexts` per wrapped task. The cache follows the lifecycle of the factory, and no static classloader-keyed state is added. `ResteasyProviderFactoryDelegate` and
`ThreadLocalResteasyProviderFactory` forward `getThreadContexts()` to their delegate, so the cache lives on the real factory.

The new accessor also gives applications a supported point to register a `ThreadContext` that all same-loader threads can see. Before, a registration was visible only to threads that hold a `ThreadContexts` entry in their context data.

Fix built with Claude Fable.