### PR TITLE
Tolerate a recycled servlet exchange when finishing an async response

### DIFF
--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/HttpServletResponseWrapper.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/HttpServletResponseWrapper.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.core.NewCookie;
 
 import org.jboss.resteasy.core.ResteasyContext;
 import org.jboss.resteasy.core.ResteasyContext.CloseableContext;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
 import org.jboss.resteasy.spi.AsyncOutputStream;
 import org.jboss.resteasy.spi.HttpRequest;
@@ -464,7 +465,18 @@ public class HttpServletResponseWrapper implements HttpResponse {
     }
 
     public boolean isCommitted() {
-        return response.isCommitted();
+        try {
+            return response.isCommitted();
+        } catch (IllegalStateException e) {
+            // A servlet container may recycle the exchange once the async cycle completes or the
+            // connection is torn down (Jetty ee11 does this), after which isCommitted() throws
+            // instead of reporting the state. A recycled exchange can no longer take a response, so
+            // report it as committed. This keeps SynchronousDispatcher.writeException from
+            // attempting a doomed write and logging a spurious unhandled 500. Recycled exchanges are
+            // routine under client disconnects, so trace rather than debug to keep the log quiet.
+            LogMessages.LOGGER.trace(e.getMessage(), e);
+            return true;
+        }
     }
 
     public void reset() {

--- a/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/Servlet3AsyncHttpRequest.java
+++ b/resteasy-core/src/main/java/org/jboss/resteasy/plugins/server/servlet/Servlet3AsyncHttpRequest.java
@@ -53,6 +53,24 @@ public class Servlet3AsyncHttpRequest extends HttpServletInputMessage {
         return asynchronousContext;
     }
 
+    /**
+     * Completes the async cycle, tolerating a container that has already recycled the exchange.
+     *
+     * <p>
+     * When a resumed response is delivered after the client has disconnected, the servlet
+     * container may recycle the exchange before the completion callback runs (Jetty ee11 does
+     * this). {@link AsyncContext#complete()} then throws {@link IllegalStateException}. The request
+     * is already finished, so there is nothing left to complete and the exception is ignored.
+     */
+    static void completeRecycleSafe(AsyncContext asyncContext) {
+        try {
+            asyncContext.complete();
+        } catch (IllegalStateException e) {
+            // Recycled exchanges are routine under client disconnects, so trace rather than debug.
+            LogMessages.LOGGER.trace(e.getMessage(), e);
+        }
+    }
+
     private class Servlet3ExecutionContext extends AbstractExecutionContext {
         protected final ServletRequest servletRequest;
         protected volatile boolean done;
@@ -89,7 +107,7 @@ public class Servlet3AsyncHttpRequest extends HttpServletInputMessage {
                     done = true;
                     return internalResume(entity, t -> {
                         try {
-                            asyncContext.complete();
+                            completeRecycleSafe(asyncContext);
                         } finally {
                             close();
                         }
@@ -108,7 +126,7 @@ public class Servlet3AsyncHttpRequest extends HttpServletInputMessage {
                     try {
                         AsyncContext asyncContext = getAsyncContext();
                         done = true;
-                        asyncContext.complete();
+                        completeRecycleSafe(asyncContext);
                     } finally {
                         close();
                     }
@@ -127,7 +145,7 @@ public class Servlet3AsyncHttpRequest extends HttpServletInputMessage {
                     done = true;
                     return internalResume(exc, t -> {
                         try {
-                            asyncContext.complete();
+                            completeRecycleSafe(asyncContext);
                         } finally {
                             close();
                         }
@@ -184,7 +202,7 @@ public class Servlet3AsyncHttpRequest extends HttpServletInputMessage {
                     LogMessages.LOGGER.debug(Messages.MESSAGES.cancellingWith503());
                     return internalResume(Response.status(Response.Status.SERVICE_UNAVAILABLE).build(), t -> {
                         try {
-                            asyncContext.complete();
+                            completeRecycleSafe(asyncContext);
                         } finally {
                             close();
                         }
@@ -207,7 +225,7 @@ public class Servlet3AsyncHttpRequest extends HttpServletInputMessage {
                                     .build(),
                             t -> {
                                 try {
-                                    asyncContext.complete();
+                                    completeRecycleSafe(asyncContext);
                                 } finally {
                                     close();
                                 }
@@ -230,7 +248,7 @@ public class Servlet3AsyncHttpRequest extends HttpServletInputMessage {
                                     .build(),
                             t -> {
                                 try {
-                                    asyncContext.complete();
+                                    completeRecycleSafe(asyncContext);
                                 } finally {
                                     close();
                                 }

--- a/resteasy-core/src/test/java/org/jboss/resteasy/plugins/server/servlet/RecycledExchangeTest.java
+++ b/resteasy-core/src/test/java/org/jboss/resteasy/plugins/server/servlet/RecycledExchangeTest.java
@@ -1,0 +1,82 @@
+package org.jboss.resteasy.plugins.server.servlet;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl;
+import org.junit.jupiter.api.Test;
+
+/**
+ * When an async request is resumed after the client has disconnected, a servlet container may
+ * recycle the exchange before RESTEasy finishes delivering the response (Jetty ee11 does this).
+ * Both {@link HttpServletResponse#isCommitted()} and {@link AsyncContext#complete()} then throw
+ * {@link IllegalStateException}. The servlet plugin must treat a recycled exchange as finished
+ * instead of raising an unhandled asynchronous exception and logging a spurious 500.
+ */
+public class RecycledExchangeTest {
+
+    private HttpServletResponseWrapper wrap(final HttpServletResponse response) {
+        return new HttpServletResponseWrapper(response, mock(HttpServletRequest.class),
+                new ResteasyProviderFactoryImpl());
+    }
+
+    @Test
+    public void isCommittedReportsRecycledExchangeAsCommitted() {
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(response.isCommitted())
+                .thenThrow(new IllegalStateException("Request/Response does not exist (likely recycled)"));
+
+        assertTrue(wrap(response).isCommitted());
+    }
+
+    @Test
+    public void isCommittedDelegatesForLiveExchange() {
+        HttpServletResponse committed = mock(HttpServletResponse.class);
+        when(committed.isCommitted()).thenReturn(true);
+        assertTrue(wrap(committed).isCommitted());
+
+        HttpServletResponse open = mock(HttpServletResponse.class);
+        when(open.isCommitted()).thenReturn(false);
+        assertFalse(wrap(open).isCommitted());
+    }
+
+    @Test
+    public void completeIgnoresRecycledExchange() {
+        AsyncContext asyncContext = mock(AsyncContext.class);
+        doThrow(new IllegalStateException("AsyncContext completed and/or Request lifecycle recycled"))
+                .when(asyncContext).complete();
+
+        Servlet3AsyncHttpRequest.completeRecycleSafe(asyncContext);
+
+        verify(asyncContext, times(1)).complete();
+    }
+
+    @Test
+    public void completeDelegatesForLiveExchange() {
+        AsyncContext asyncContext = mock(AsyncContext.class);
+        Servlet3AsyncHttpRequest.completeRecycleSafe(asyncContext);
+        verify(asyncContext, times(1)).complete();
+    }
+
+    @Test
+    public void completeDoesNotSwallowUnrelatedFailures() {
+        AsyncContext asyncContext = mock(AsyncContext.class);
+        RuntimeException boom = new RuntimeException("write failed");
+        doThrow(boom).when(asyncContext).complete();
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> Servlet3AsyncHttpRequest.completeRecycleSafe(asyncContext));
+        assertSame(boom, thrown);
+    }
+}


### PR DESCRIPTION
This investigation started as an exception-review task, seeing ~20/day unexpected failures matching the same shape.
I set Claude Fable 5 on a "find the root cause and fix" mission: the analysis produced a local workaround, and we're hoping to fix the issue upstream so we can drop our local fix.

I explored a more "structural" fix rather than just swallowing the failure, but as best as I can tell, the servlet spec does not give you sufficient primitives to safely write in a way that does not race with async-close.

The problem was identified and confirmed by humans (me) and the diagnosis and fix is Claude below:

When an async request is resumed after the client has disconnected, the response body write can fail once the response has already committed. On Jetty ee11 the servlet exchange is recycled at that point, so the two servlet calls RESTEasy makes to finish the request both throw `IllegalStateException`:

  - `HttpServletResponse.isCommitted()`, which `SynchronousDispatcher.writeException` calls to decide whether a 500 can still be written; and
  - `AsyncContext.complete()`, called from the resume completion callbacks.

Per the Servlet spec the container may recycle the request and response once the async cycle ends, and accessing them afterward is undefined; Jetty ee11 surfaces this as IllegalStateException rather than returning a value. RESTEasy should not assume isCommitted() and complete() remain safe on the async path, so it tolerates the recycled exchange rather than relying on container-specific behavior.

RESTEasy has no guard for either, so it logs a spurious RESTEASY002020 "Unhandled asynchronous exception, sending back 500" for a request the client has already received or abandoned. Seen in production behind a pre-match `ContainerRequestFilter` that suspends the request and resumes it from a foreign thread once an outbound call completes:

```
  ERROR ... RESTEASY002020: Unhandled asynchronous exception, sending back 500
  java.lang.IllegalStateException: Request/Response does not exist (likely recycled)
    at org.eclipse.jetty.ee11.servlet.ServletChannel.getServletContextResponse(ServletChannel.java:295)
    at org.eclipse.jetty.ee11.servlet.ServletChannel.isCommitted(ServletChannel.java:819)
    at org.eclipse.jetty.ee11.servlet.ServletApiResponse.isCommitted(ServletApiResponse.java:476)
    at org.jboss.resteasy.plugins.server.servlet.HttpServletResponseWrapper.isCommitted(HttpServletResponseWrapper.java:467)
    at org.jboss.resteasy.core.SynchronousDispatcher.writeException(SynchronousDispatcher.java:205)
    at org.jboss.resteasy.core.SynchronousDispatcher.asynchronousExceptionDelivery(SynchronousDispatcher.java:509)
    at org.jboss.resteasy.core.AbstractAsynchronousResponse.internalResume(AbstractAsynchronousResponse.java:208)
    at ...Servlet3AsynchronousResponse.resume(Servlet3AsyncHttpRequest.java:90)
    at org.jboss.resteasy.core.ResourceMethodInvoker.afterInvoke(ResourceMethodInvoker.java:484)
```

A recycled exchange is past the point where a response can be written, so:

  - `HttpServletResponseWrapper.isCommitted()` now reports a recycled exchange as committed. This makes writeException short-circuit through its existing "response is committed" guard instead of attempting the doomed write.
  - `Servlet3AsyncHttpRequest` completes the async cycle through a `completeRecycleSafe()` helper that ignores the `IllegalStateException` from `AsyncContext.complete()` on an already-finished request.

Both guards are needed: fixing only `isCommitted()` moves the failure to the subsequent `complete()` call. Each change only swallows the recycle `IllegalStateException` and otherwise delegates unchanged, so containers that do not recycle the exchange eagerly are unaffected.

This covers the default configuration. An application that disables suppression via `setSuppressExceptionDuringChunkedTransfer(false)` still enters the write path, so a recycled exchange can still surface RESTEASY002020 from writeNomapResponse; fully covering that opt-out would mean abandoning the write inside `writeNomapResponse` and is out of scope here.

`RecycledExchangeTest` covers `isCommitted()` reporting a recycled exchange as committed while still delegating for a live one, `completeRecycleSafe()` ignoring the recycle exception while still completing a live context, and `completeRecycleSafe()` not swallowing unrelated failures.
